### PR TITLE
Import ConfigureUtil explicitly

### DIFF
--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 // A map of library to the dependencies that need to be added for it.
-import org.gradle.util.*;
+import org.gradle.util.ConfigureUtil;
 def firebaseDependenciesMap = [
-  'app' : ['com.google.firebase:firebase-analytics:16.5.0'],
+  'app' : ['com.google.firebase:firebase-core:16.5.0'],
   'admob' : ['com.google.firebase:firebase-ads:17.2.1',
              'com.google.android.gms:play-services-measurement-sdk-api:16.5.0'],
   'analytics' : ['com.google.firebase:firebase-analytics:16.5.0'],

--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 // A map of library to the dependencies that need to be added for it.
+import org.gradle.util.*;
 def firebaseDependenciesMap = [
   'app' : ['com.google.firebase:firebase-analytics:16.5.0'],
   'admob' : ['com.google.firebase:firebase-ads:17.2.1',

--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -15,12 +15,12 @@
 // A map of library to the dependencies that need to be added for it.
 import org.gradle.util.ConfigureUtil;
 def firebaseDependenciesMap = [
-  'app' : ['com.google.firebase:firebase-core:16.5.0'],
-  'admob' : ['com.google.firebase:firebase-ads:17.2.1',
-             'com.google.android.gms:play-services-measurement-sdk-api:16.5.0'],
-  'analytics' : ['com.google.firebase:firebase-analytics:16.5.0'],
-  'auth' : ['com.google.firebase:firebase-auth:17.0.0'],
-  'database' : ['com.google.firebase:firebase-database:17.0.0'],
+  'app' : ['com.google.firebase:firebase-core:17.0.0'],
+  'admob' : ['com.google.firebase:firebase-ads:18.0.0',
+             'com.google.android.gms:play-services-measurement-sdk-api:17.0.0'],
+  'analytics' : ['com.google.firebase:firebase-analytics:17.0.0'],
+  'auth' : ['com.google.firebase:firebase-auth:18.0.0'],
+  'database' : ['com.google.firebase:firebase-database:18.0.0'],
   'dynamic_links' : ['com.google.firebase:firebase-invites:17.0.0'],
   'functions' : ['com.google.firebase:firebase-functions:17.0.0'],
   'instance_id' : ['com.google.firebase:firebase-iid:18.0.0'],


### PR DESCRIPTION
Gradle can't resolve ConfigureUtil implicitly.
Error:
Script 'firebase_cpp_sdk/Android/firebase_dependencies.gradle' line: 84
* What went wrong:
A problem occurred evaluating project ':Sample'.
> Could not get unknown property 'ConfigureUtil' for object of type FirebaseCppExtension.