### PR TITLE
Feature/gha workflow base

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -138,7 +138,7 @@ jobs:
             -B build \
             -G "${{ matrix.generator }}" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=external/vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
 
       - name: Build

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -51,6 +51,7 @@ jobs:
           echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
           echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
           echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}-${{ matrix.generator }}"
+          echo "test if ccache cache works"
 
       - name: Install Ninja (windows)
         if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'windows')

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Install system level applications (linux)
         if: startsWith(matrix.os, 'ubuntu')
-        id: ubuntu-brew-install
+        id: ubuntu-apt-install
         run: |
           sudo apt install ccache
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -51,7 +51,6 @@ jobs:
           echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
           echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
           echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}-${{ matrix.generator }}"
-          echo "test if ccache cache works"
 
       - name: Install Ninja (windows)
         if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'windows')
@@ -73,12 +72,14 @@ jobs:
         id: macos-brew-install
         run: |
           brew install ccache
+          echo "::set-env name=CCACHE_INSTALLED::1"
 
       - name: Install system level applications (linux)
         if: startsWith(matrix.os, 'ubuntu')
         id: ubuntu-apt-install
         run: |
           sudo apt install ccache
+          echo "::set-env name=CCACHE_INSTALLED::1"
 
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg
@@ -122,8 +123,8 @@ jobs:
           python -m pip install --upgrade pip
           pip install -r ${{ env.PIP_REQUIREMENTS_FILE }}
 
-      - name: Cache ccache files (mac and linux)
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+      - name: Cache ccache files
+        if: env.CCACHE_INSTALLED
         id: cache_ccache
         uses: actions/cache@v2
         with:
@@ -147,7 +148,7 @@ jobs:
         run: cmake --build build --config ${{ matrix.build_type }} -j 8
 
       - name: Stats for ccache (mac and linux)
-        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+        if: env.CCACHE_INSTALLED
         run: ccache -s
 
       - name: Print built libraries

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,0 +1,159 @@
+name: Desktop Builds
+
+on: 
+  push:
+  pull_request:
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/ccache_dir
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}-${{ matrix.generator }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        build_type: ["Release"]
+        architecture: ["x64",]
+        python_version: [2.7]
+        generator: ["Visual Studio 16 2019", "Unix Makefiles", "Ninja"]
+        exclude:
+        - os: ubuntu-latest
+          generator: "Visual Studio 16 2019"
+        - os: macos-latest
+          generator: "Visual Studio 16 2019"
+        - os: windows-latest
+          generator: "Unix Makefiles"
+        - os: windows-latest
+          generator: "Ninja"
+
+        include:
+        - os: windows-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-windows-static"
+          msbuild_platform: "x64"
+        - os: ubuntu-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-linux"
+        - os: macos-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-osx"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Set env variables for subsequent steps (all)
+        run: |
+          echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
+          echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
+          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}-${{ matrix.generator }}"
+
+      - name: Install Ninja (windows)
+        if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'windows')
+        run: |
+          choco install ninja
+
+      - name: Install Ninja (mac)
+        if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'macos')
+        run: |
+          brew install ninja
+
+      - name: Install Ninja (linux)
+        if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'ubuntu')
+        run: |
+          sudo apt install ninja-build
+
+      - name: Install system level applications (mac)
+        if: startsWith(matrix.os, 'macos')
+        id: macos-brew-install
+        run: |
+          brew install ccache
+
+      - name: Install system level applications (linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        id: ubuntu-brew-install
+        run: |
+          sudo apt install ccache
+
+      - name: Cache vcpkg C++ dependencies
+        id: cache_vcpkg
+        uses: actions/cache@v2
+        with:
+          path: external/vcpkg/installed
+          key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
+
+      - name: Install vcpkg packages (windows)
+        if: steps.cache_vcpkg.outputs.cache-hit!='true' && startsWith(matrix.os, 'windows')
+        run: |
+          ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          ${{ github.workspace }}/external/vcpkg/vcpkg install @${{env.VCPKG_RESPONSE_FILE}}
+
+      - name: Install vcpkg packages (mac and linux)
+        if: steps.cache_vcpkg.outputs.cache-hit!='true' && startsWith(matrix.os, 'windows')!='true'
+        run: |
+          ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.sh -disableMetrics
+          ${{ github.workspace }}/external/vcpkg/vcpkg install @${{env.VCPKG_RESPONSE_FILE}}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Get pip cache dir
+        id: get_pip_cache_dir
+        run: |
+          echo "::set-output name=cachedir::$(pip cache dir)"
+
+      - name: pip cache
+        id: cache_pip
+        uses: actions/cache@v2
+        with:
+          path: ${{ steps.get_pip_cache_dir.outputs.cachedir }}
+          key: dev-pip-${{ runner.os }}-${{ matrix.python_version }}-${{ matrix.architecture }}-${{ hashFiles(format('{0}', env.PIP_REQUIREMENTS_FILE)) }}
+
+      - name: Install pip packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r ${{ env.PIP_REQUIREMENTS_FILE }}
+
+      - name: Cache ccache files (mac and linux)
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+        id: cache_ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache_dir
+          key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
+
+      - name: Configure 
+        shell: bash
+        run: |
+          mkdir build
+          cmake \
+            -S . \
+            -B build \
+            -G "${{ matrix.generator }}" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --config ${{ matrix.build_type }} -j 8
+
+      - name: Stats for ccache (mac and linux)
+        if: startsWith(matrix.os, 'macos') || startsWith(matrix.os, 'ubuntu')
+        run: ccache -s
+
+      - name: Print built libraries
+        shell: bash
+        run: |
+          find build -name "*.lib"
+          find build -name "*.dll"
+          find build -name "*.dylib"
+          find build -name "*.a"
+          find build -name "*.so"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: external/vcpkg/installed
-          key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/vcpkg/HEAD') }}
+          key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
 
       - name: Install vcpkg packages (windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -49,7 +49,7 @@ jobs:
           key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
 
       - name: Install vcpkg packages (windows)
-        if: startsWith(matrix.os, 'windows')
+        if: steps.cache_vcpkg.outputs.cache-hit!='true' && startsWith(matrix.os, 'windows')
         run: |
           ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.bat -disableMetrics
           ${{ github.workspace }}/external/vcpkg/vcpkg install @${{env.VCPKG_RESPONSE_FILE}}

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,79 @@
+name: Windows Builds
+
+on: 
+  push:
+  pull_request:
+
+jobs:
+  build:
+    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}-${{ matrix.generator }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # If any of the configurations fail, others will proceed to run
+      fail-fast: false
+      matrix:
+        os: [windows-latest,]
+        build_type: ["Release", "Debug"]
+        architecture: ["x64",]
+        python_version: [2.7]
+        generator: ["Visual Studio 16 2019",]
+        include:
+        - os: windows-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-windows-static"
+          # For x64, this variable probably doesnt make sense but
+          # for x86, the command line argument to pass to cmake is -A Win32 and not -A x86
+          msbuild_platform: "x64"
+
+    steps:
+      # Check out with submodule (vcpkg is a submodule)
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Install Ninja
+        if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'windows')
+        run: |
+          choco install ninja
+
+      - name: Install vcpkg packages (windows)
+        if: startsWith(matrix.os, 'windows')
+        run: |
+          ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.bat -disableMetrics
+          ${{ github.workspace }}/external/vcpkg/vcpkg install openssl protobuf zlib abseil --triplet ${{ matrix.vcpkg_triplet }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Install pip packages
+        run: |
+          python -m pip install --upgrade pip
+          pip install absl-py protobuf
+
+      - name: Configure
+        shell: bash
+        run: |
+          mkdir build
+          cmake \
+            -S . \
+            -B build \
+            -G "${{ matrix.generator }}" \
+            -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
+            -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
+
+      - name: Build
+        shell: bash
+        run: cmake --build build --config ${{ matrix.build_type }} -j 8
+
+      - name: Print built libraries
+        shell: bash
+        run: |
+          find build -name "*.lib"
+          find build -name "*.dll"
+          find build -name "*.dylib"
+          find build -name "*.a"
+          find build -name "*.so"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -62,7 +62,7 @@ jobs:
             -B build \
             -G "${{ matrix.generator }}" \
             -DCMAKE_BUILD_TYPE=${{ matrix.build_type }} \
-            -DCMAKE_TOOLCHAIN_FILE=vcpkg/scripts/buildsystems/vcpkg.cmake \
+            -DCMAKE_TOOLCHAIN_FILE=external/vcpkg/scripts/buildsystems/vcpkg.cmake \
             -DVCPKG_TARGET_TRIPLET=${{ matrix.vcpkg_triplet }} \
 
       - name: Build

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [windows-latest,]
-        build_type: ["Release", "Debug"]
+        build_type: ["Release"]
         architecture: ["x64",]
         python_version: [2.7]
         generator: ["Visual Studio 16 2019",]
@@ -31,16 +31,28 @@ jobs:
         with:
           submodules: true
 
+      - name: Set env variables for subsequent steps (all)
+        run: |
+          echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
+          echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
+
       - name: Install Ninja
         if: startsWith(matrix.generator, 'Ninja') && startsWith(matrix.os, 'windows')
         run: |
           choco install ninja
 
+      - name: Cache vcpkg C++ dependencies
+        id: cache_vcpkg
+        uses: actions/cache@v2
+        with:
+          path: external/vcpkg/installed
+          key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/vcpkg/HEAD') }}
+
       - name: Install vcpkg packages (windows)
         if: startsWith(matrix.os, 'windows')
         run: |
           ${{ github.workspace }}/external/vcpkg/bootstrap-vcpkg.bat -disableMetrics
-          ${{ github.workspace }}/external/vcpkg/vcpkg install openssl protobuf zlib abseil --triplet ${{ matrix.vcpkg_triplet }}
+          ${{ github.workspace }}/external/vcpkg/vcpkg install @${{env.VCPKG_RESPONSE_FILE}}
 
       - name: Setup python
         uses: actions/setup-python@v2
@@ -51,7 +63,7 @@ jobs:
       - name: Install pip packages
         run: |
           python -m pip install --upgrade pip
-          pip install absl-py protobuf
+          pip install -r ${{ env.PIP_REQUIREMENTS_FILE }}
 
       - name: Configure
         shell: bash

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "external/vcpkg"]
+	path = external/vcpkg
+	url = https://github.com/microsoft/vcpkg.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,15 @@ project (firebase NONE)
 enable_language(C)
 enable_language(CXX)
 
+set(compiler_cache_program ccache)
+
+find_program(compilercache_program ${compiler_cache_program})
+if(compilercache_program)
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_COMPILE "${compiler_cache_program}")
+  set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK "${compiler_cache_program}")
+  message( STATUS "Found compiler cache program : ${compiler_cache_program}" )
+endif()
+
 list(INSERT CMAKE_MODULE_PATH 0 ${CMAKE_CURRENT_LIST_DIR}/cmake)
 include(external_rules)
 include(cpp_pack)

--- a/external/pip_requirements.txt
+++ b/external/pip_requirements.txt
@@ -1,0 +1,2 @@
+absl-py
+protobuf

--- a/external/vcpkg_x64-linux_response_file.txt
+++ b/external/vcpkg_x64-linux_response_file.txt
@@ -1,0 +1,6 @@
+openssl
+protobuf
+zlib
+abseil
+--triplet
+x64-linux

--- a/external/vcpkg_x64-osx_response_file.txt
+++ b/external/vcpkg_x64-osx_response_file.txt
@@ -1,0 +1,6 @@
+openssl
+protobuf
+zlib
+abseil
+--triplet
+x64-osx

--- a/external/vcpkg_x64-windows-static_response_file.txt
+++ b/external/vcpkg_x64-windows-static_response_file.txt
@@ -1,0 +1,6 @@
+openssl
+protobuf
+zlib
+abseil
+--triplet
+x64-windows-static


### PR DESCRIPTION
- "Windows only" github workflow for x64 Release desktop build using Visual Studio 2019
- Separate workflow for "linux/mac/win" desktop builds (x64 Release)
- using vcpkg as a cross-platform package manager for those dependencies that are not downloaded during cmake generation process
- using github actions caching for packages installed using vcpkg (saves around 10 to 20 mins depending on platform)
- ccache speed up for linux/mac builds (dramatically reduces build times 10 mins -> 2 mins on linux and 10 mins -> 5 mins on mac)
