### PR TITLE
Updated Google Test dependency from 1.7 to 1.10

### DIFF
--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -1,4 +1,4 @@
-# Copyright 2017 Google LLC
+# Copyright 2020 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/cmake/external/googletest.cmake
+++ b/cmake/external/googletest.cmake
@@ -1,4 +1,4 @@
-# Copyright 2019 Google
+# Copyright 2017 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -18,19 +18,15 @@ if(TARGET googletest OR NOT DOWNLOAD_GOOGLETEST)
   return()
 endif()
 
-# Googletest 1.8.0 fails to build on VS 2017:
-# https://github.com/google/googletest/issues/1111.
-#
-# No release has been made since, so just pick a commit since then.
-set(commit ba96d0b1161f540656efdaed035b3c062b60e006)  # master@{2018-07-10}
+set(version 1.10.0)
 
 ExternalProject_Add(
   googletest
 
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME googletest-${commit}.tar.gz
-  URL https://github.com/google/googletest/archive/${commit}.tar.gz
-  URL_HASH SHA256=949c556896cf31ed52e53449e17a1276b8b26d3ee5932f5ca49ee929f4b35c51
+  DOWNLOAD_NAME googletest-${version}.tar.gz
+  URL https://github.com/google/googletest/archive/release-${version}.tar.gz
+  URL_HASH SHA256=9dc9157a9a1551ec7a7e43daea9a694a0bb5fb8bec81235d8a1e6ef64c716dcb
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
Tests from the main repo are depenent on MOCK_METHOD() calls that aren't supported in 1.7.  Updating our google test dependency to fix integration test compilation errors (b159716156).

