### PR TITLE
Reduce Auth flake on MacOS

### DIFF
--- a/auth/tests/desktop/test_utils.cc
+++ b/auth/tests/desktop/test_utils.cc
@@ -28,13 +28,27 @@ void ListenerChangeCounter::ExpectChanges(const int num) {
   expected_changes_ = num;
 }
 void ListenerChangeCounter::VerifyAndReset() {
-  Verify();
+  int timeout_value = -1;
+#ifdef __APPLE__
+    timeout_value = 10000;
+#endif
+  Verify(timeout_value);
   expected_changes_ = -1;
   actual_changes_ = 0;
 }
 
-void ListenerChangeCounter::Verify() {
+void ListenerChangeCounter::Verify(int timeout) {
   if (expected_changes_ != -1) {
+    if (timeout >= 0) {
+      int elapsed_time = 0;
+      while( elapsed_time <= timeout ) {
+        if(expected_changes_ == actual_changes_) {
+          break;
+        }
+        firebase::internal::Sleep(100);
+        elapsed_time += 100; // only estimating elapsed time to simplfy portability.
+      }
+    }
     EXPECT_EQ(expected_changes_, actual_changes_);
   }
 }

--- a/auth/tests/desktop/test_utils.cc
+++ b/auth/tests/desktop/test_utils.cc
@@ -39,15 +39,17 @@ void ListenerChangeCounter::VerifyAndReset() {
 
 void ListenerChangeCounter::Verify(int timeout) {
   if (expected_changes_ != -1) {
-    if (timeout >= 0) {
+    if (timeout >= 0 && expected_changes_ != actual_changes_) {
       int elapsed_time = 0;
       while( elapsed_time <= timeout ) {
+        printf(".");
+        firebase::internal::Sleep(100);
+        elapsed_time += 100; // only estimating elapsed time to simplfy portability.
         if(expected_changes_ == actual_changes_) {
           break;
         }
-        firebase::internal::Sleep(100);
-        elapsed_time += 100; // only estimating elapsed time to simplfy portability.
       }
+      printf("\n");
     }
     EXPECT_EQ(expected_changes_, actual_changes_);
   }

--- a/auth/tests/desktop/test_utils.h
+++ b/auth/tests/desktop/test_utils.h
@@ -45,9 +45,9 @@ class ListenerChangeCounter {
   int actual_changes_;
 
  private:
-  void Verify();
+  void Verify(int timeout = -1);
 
-  int expected_changes_;
+  volatile int expected_changes_;
 };
 }  // namespace detail
 


### PR DESCRIPTION
- Updated test utils for auth state change and token change listener verification.
   - Added a overarching timeout value . The verifiers will tick to check the results until the timeout is reached.
   - Only APPLE platforms use the timeout values.  Other platforms (Linux, Windows, Android) continue to have direct verification flows without waiting for callbacks to be invoked.