### PR TITLE
 desktop workflow config to create cores, and use upload-artfiacts@v2

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -167,5 +167,13 @@ jobs:
         env:
           LANG: en_US
         run: |
+          ulimit -c unlimited    # Enable crash dumps
           cd build
-          ctest --verbose
+          sudo ctest --verbose
+          sudo chmod -R +rwx /cores/*  
+    
+      - name: Archive crashes
+        uses: actions/upload-artifact@v2
+        with:
+          name: crashes
+          path: /cores

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -166,10 +166,9 @@ jobs:
       - name: test access to core dump directory
         shell: bash
         run: |
-          ls /var/crash
-          sudo touch /var/crash/test
-          ls /var/crash
+          coredumpctl
           cat /proc/sys/kernel/core_pattern
+          ls -l /var/lib/systemd/coredump/
           sudo touch /cores/test
           ls /cores
           sudo rm /cores/test

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -163,11 +163,11 @@ jobs:
           find build -name "*.a"
           find build -name "*.so"
 
-      - name: test access to core dump directory
+      - name: enable apport
         shell: bash
         run: |
-          cat /proc/sys/kernel/core_pattern
-          ls -l /var/crash/
+          sudo service apport start
+          sudo chmod -R +rwx /var/crash/*
      
       - name: Run tests
         env:
@@ -176,7 +176,7 @@ jobs:
           ulimit -c unlimited    # Enable crash dumps
           cd build
           sudo ctest --verbose
-          sudo chmod -R +rwx /var/crash/*
+          
     
       - name: Archive crashes
         uses: actions/upload-artifact@v2

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -167,6 +167,7 @@ jobs:
         shell: bash
         run: |
           cat /proc/sys/kernel/core_pattern
+          ls -l /var/crash/
      
       - name: Run tests
         env:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -165,6 +165,10 @@ jobs:
 
       - name: test access to core dump directory
         run: |
+          ls /var/crash
+          sudo touch /var/crash/test
+          ls /var/crash
+          cat /proc/sys/kernel/core_pattern
           sudo touch /cores/test
           ls /cores
           sudo rm /cores/test

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -164,6 +164,7 @@ jobs:
           find build -name "*.so"
 
       - name: test access to core dump directory
+        shell: bash
         run: |
           ls /var/crash
           sudo touch /var/crash/test

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -163,6 +163,11 @@ jobs:
           find build -name "*.a"
           find build -name "*.so"
 
+      - name: test access to core dump directory
+        sudo touch /cores/test
+        ls /cores
+        sudo rm /cores/test
+
       - name: Run tests
         env:
           LANG: en_US

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -164,9 +164,9 @@ jobs:
           find build -name "*.so"
 
       - name: test access to core dump directory
-        sudo touch /cores/test
-        ls /cores
-        sudo rm /cores/test
+          sudo touch /cores/test
+          ls /cores
+          sudo rm /cores/test
 
       - name: Run tests
         env:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -166,13 +166,8 @@ jobs:
       - name: test access to core dump directory
         shell: bash
         run: |
-          coredumpctl
           cat /proc/sys/kernel/core_pattern
-          ls -l /var/lib/systemd/coredump/
-          sudo touch /cores/test
-          ls /cores
-          sudo rm /cores/test
-
+     
       - name: Run tests
         env:
           LANG: en_US

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -176,10 +176,10 @@ jobs:
           ulimit -c unlimited    # Enable crash dumps
           cd build
           sudo ctest --verbose
-          sudo chmod -R +rwx /cores/*  
+          sudo chmod -R +rwx /var/crash/*
     
       - name: Archive crashes
         uses: actions/upload-artifact@v2
         with:
           name: crashes
-          path: /cores
+          path: /var/crash/

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -164,6 +164,7 @@ jobs:
           find build -name "*.so"
 
       - name: test access to core dump directory
+        run: |
           sudo touch /cores/test
           ls /cores
           sudo rm /cores/test

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -167,6 +167,7 @@ jobs:
         shell: bash
         run: |
           sudo service apport start
+          mkdir /var/crash
           sudo chmod -R +rwx /var/crash/*
      
       - name: Run tests


### PR DESCRIPTION
Attempting to upload crashes on MacOS and Linux unit test runs.  Not yet sure how this can be done for windows.