### PR TITLE
Remove 'push' trigger for workflows

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -1,8 +1,8 @@
 name: Desktop Builds
 
 on: 
-  push:
   pull_request:
+    types: [opened, reopened, synchronize]
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,8 +1,8 @@
 name: Windows Builds
 
 on: 
-  push:
   pull_request:
+    types: [opened, reopened, synchronize]
 
 jobs:
   build:


### PR DESCRIPTION
Remove 'push' trigger for workflows, as it is causing double the jobs to run.
Also explicitly restrict push_request to opened, reopened, and synchronize rather than relying on those being the default.
