### PR TITLE
Android GHA workflow

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,0 +1,79 @@
+name: Android Builds
+
+on: 
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+env:
+  CCACHE_DIR: ${{ github.workspace }}/ccache_dir
+
+jobs:
+  build:
+    name: android-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        architecture: ["x64",]
+        python_version: [3.7]
+        include:
+        - os: ubuntu-latest
+          architecture: "x64"
+        - os: macos-latest
+          architecture: "x64"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+
+      - name: Set env variables for subsequent steps (all)
+        run: |
+          echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
+          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.python_version }}"
+      
+      - name: Install system level applications (mac)
+        if: startsWith(matrix.os, 'macos')
+        id: macos-brew-install
+        run: |
+          brew install ccache
+          echo "::set-env name=CCACHE_INSTALLED::1"
+      
+      - name: Install system level applications (linux)
+        if: startsWith(matrix.os, 'ubuntu')
+        id: ubuntu-apt-install
+        run: |
+          sudo apt install ccache
+          echo "::set-env name=CCACHE_INSTALLED::1"
+
+      - name: Cache ccache files
+        id: cache_ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache_dir
+          key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Install prerequisites
+        run: |
+          build_scripts/android/install_prereqs.sh
+
+      - name: Build SDK
+        run: |
+          build_scripts/android/build.sh android_build .
+      
+      - name: Stats for ccache (mac and linux)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: ccache -s
+
+      - name: Print built libraries
+        shell: bash
+        run: |
+          find android_build -name "*.aar"
+          find android_build -name "*.jar"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -29,7 +29,7 @@ jobs:
 
       - name: Set env variables for subsequent steps (all)
         run: |
-          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}
+          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}"
           echo "::set-env name=GHA_INSTALL_CCACHE::1"
 
       - name: Setup python

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,27 +30,7 @@ jobs:
       - name: Set env variables for subsequent steps (all)
         run: |
           echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}
-      
-      - name: Install system level applications (mac)
-        if: startsWith(matrix.os, 'macos')
-        id: macos-brew-install
-        run: |
-          brew install ccache
-          echo "::set-env name=CCACHE_INSTALLED::1"
-      
-      - name: Install system level applications (linux)
-        if: startsWith(matrix.os, 'ubuntu')
-        id: ubuntu-apt-install
-        run: |
-          sudo apt install ccache
-          echo "::set-env name=CCACHE_INSTALLED::1"
-
-      - name: Cache ccache files
-        id: cache_ccache
-        uses: actions/cache@v2
-        with:
-          path: ccache_dir
-          key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
+          echo "::set-env name=GHA_INSTALL_CCACHE::1"
 
       - name: Setup python
         uses: actions/setup-python@v2
@@ -61,11 +41,18 @@ jobs:
       - name: Install prerequisites
         run: |
           build_scripts/android/install_prereqs.sh
+      
+      - name: Cache ccache files
+        id: cache_ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache_dir
+          key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
 
       - name: Build SDK
         run: |
           build_scripts/android/build.sh android_build .
-      
+
       - name: Stats for ccache (mac and linux)
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: ccache -s

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,6 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
         architecture: ["x64",]
-        python_version: [3.7]
         include:
         - os: ubuntu-latest
           architecture: "x64"
@@ -30,8 +29,7 @@ jobs:
 
       - name: Set env variables for subsequent steps (all)
         run: |
-          echo "::set-env name=PIP_REQUIREMENTS_FILE::external/pip_requirements.txt"
-          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.python_version }}"
+          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}
       
       - name: Install system level applications (mac)
         if: startsWith(matrix.os, 'macos')
@@ -57,7 +55,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: 3.7
           architecture: ${{ matrix.architecture }}
 
       - name: Install prerequisites

--- a/app/google_api_resources/build.gradle
+++ b/app/google_api_resources/build.gradle
@@ -50,6 +50,7 @@ android {
 
 dependencies {
   implementation 'com.google.firebase:firebase-analytics:17.4.4'
+  implementation 'com.google.android.gms:play-services-base:17.0.0'
   implementation project(':app:app_resources')
 }
 

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -2,8 +2,16 @@
 
 if [[ $(uname) == "Darwin" ]]; then
     platform=darwin
+    if [[ ! -z "${GHA_INSTALL_CCACHE}" ]]; then
+        brew install ccache
+        echo "::set-env name=CCACHE_INSTALLED::1"
+    fi
 elif [[ $(uname) == "Linux" ]]; then
     platform=linux
+    if [[ ! -z "${GHA_INSTALL_CCACHE}" ]]; then
+        sudo apt install ccache
+        echo "::set-env name=CCACHE_INSTALLED::1"
+    fi
 else
     echo "Unsupported platform, this script must run on a MacOS or Linux machine."
     exit 1
@@ -53,3 +61,13 @@ if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.p
 	echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
     fi
 fi
+
+if [[ ! -z "${INSTALL_CCACHE}" ]]; then
+    if ; then
+        echo "mac!"
+    else
+        echo "linux!"
+    fi
+fi
+    
+

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -61,13 +61,3 @@ if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.p
 	echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
     fi
 fi
-
-if [[ ! -z "${INSTALL_CCACHE}" ]]; then
-    if ; then
-        echo "mac!"
-    else
-        echo "linux!"
-    fi
-fi
-    
-

--- a/firestore/firestore_resources/build.gradle
+++ b/firestore/firestore_resources/build.gradle
@@ -43,11 +43,12 @@ android {
       }
     }
   }
+
+  lintOptions {
+    abortOnError false
+  }
 }
 
-lintOptions {
-  abortOnError false
-}
 
 dependencies {
   implementation 'com.google.firebase:firebase-analytics:17.4.4'

--- a/firestore/firestore_resources/build.gradle
+++ b/firestore/firestore_resources/build.gradle
@@ -45,6 +45,10 @@ android {
   }
 }
 
+lintOptions {
+  abortOnError false
+}
+
 dependencies {
   implementation 'com.google.firebase:firebase-analytics:17.4.4'
   implementation 'com.google.firebase:firebase-firestore:21.5.0'


### PR DESCRIPTION
Add Android as a GHA CI worfklow.  
 - added android.yml to our workflows
 - fixed an analytics build issue which now news to include play-services-base as an implementation dependency.
 - there's a lint failure in a firestore dependency.  Disabling abortOnError for that gradle build target for now. I've added an internal issue to the backlog to circle back on this issue later.