### PR TITLE
Create dummy workflow for integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1,0 +1,16 @@
+# Dummy workflow file so that the corresponding workflow
+# can be manually triggered in branches other than master.
+name: Integration tests
+
+on:
+  workflow_dispatch:
+    inputs:
+      commitId:
+        description: 'description'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Dummy step
+        run: echo "Hello, World!"


### PR DESCRIPTION
To manually trigger a workflow in a branch, a workflow with the same name needs to exist in master. This adds such a workflow.