### PR TITLE
Feature/gha include firestore clean

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -103,7 +103,7 @@ jobs:
           LANG: en_US
         run: |
           cd build
-          ctest --verbose
+          ctest --verbose -E "firestore_(objc_spec|objc_integration)_test"
 
       - name: Run unit tests (linux)
         # Linux exists as its own standalone execution step in order to invoke
@@ -116,7 +116,7 @@ jobs:
         run: |
           ulimit -c unlimited 
           cd build
-          sudo ctest --verbose
+          sudo ctest --verbose -E "firestore_(objc_spec|objc_integration)_test"
       
       - name: Prep bins for achive (linux)
         # Copies all of the binary files into one directory for ease in

--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -18,12 +18,10 @@ if(TARGET firestore)
   return()
 endif()
 
-# Pin to the first revision that includes these changes:
-# https://github.com/firebase/firebase-ios-sdk/pull/5807.
-#
-# This should be released with the next version after Firestore-1.15.0.
-set(version 05026f3df92cdee7b91fccc72a7195be2618acdf)
-
+# Using a firestore version that has been updated to use 
+# nanopb 0.3.9.6 instead of 0.3.9.5. This was necessary 
+# because nanopb 0.3.9.5 doesn't build with python3.
+set(version f33276f5305bb81b67e006f50b14f4a2adc3cb60)
 ExternalProject_Add(
   firestore
 

--- a/external/vcpkg_x64-linux_response_file.txt
+++ b/external/vcpkg_x64-linux_response_file.txt
@@ -1,6 +1,5 @@
 openssl
 protobuf
 zlib
-abseil
 --triplet
 x64-linux

--- a/external/vcpkg_x64-osx_response_file.txt
+++ b/external/vcpkg_x64-osx_response_file.txt
@@ -1,6 +1,5 @@
 openssl
 protobuf
 zlib
-abseil
 --triplet
 x64-osx

--- a/external/vcpkg_x64-windows-static_response_file.txt
+++ b/external/vcpkg_x64-windows-static_response_file.txt
@@ -1,6 +1,5 @@
 openssl
 protobuf
 zlib
-abseil
 --triplet
 x64-windows-static

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -36,6 +36,7 @@ python scripts/gha/build_desktop.py --target firebase_app firebase_auth
 
 import argparse
 import os
+import shutil
 import utils
 
 
@@ -68,6 +69,17 @@ def install_cpp_dependencies_with_vcpkg(arch):
   # --disable-metrics
   utils.run_command([vcpkg_executable_file_path, 'install',
                      '@' + vcpkg_response_file_path, '--disable-metrics'])
+
+  vcpkg_root_dir_path = utils.get_vcpkg_root_dir_path()
+
+  # Clear temporary directories and files created by vcpkg buildtrees
+  # could be several GBs and cause github runners to run out of space
+  buildtrees_dir_path = os.path.join(vcpkg_root_dir_path, 'buildtrees')
+  if os.path.exists(buildtrees_dir_path):
+    shutil.rmtree(buildtrees_dir_path)
+  downloads_dir_path = os.path.join(vcpkg_root_dir_path, 'downloads')
+  if os.path.exists(downloads_dir_path):
+    shutil.rmtree(downloads_dir_path)
 
 
 def cmake_configure(build_dir, arch, build_tests=True, config=None):

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -101,8 +101,6 @@ def cmake_configure(build_dir, arch, build_tests=True, config=None):
   vcpkg_triplet = utils.get_vcpkg_triplet(arch)
   cmd.append('-DVCPKG_TARGET_TRIPLET={0}'.format(vcpkg_triplet))
   
-  # TODO: Remove this once firestore is included in the build and everything works
-  cmd.append('-DFIREBASE_INCLUDE_FIRESTORE=OFF')
   utils.run_command(cmd)
 
 

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -112,9 +112,14 @@ def get_vcpkg_triplet(arch):
   return triplet_name
 
 
+def get_vcpkg_root_path():
+  """Get absolute path to vcpkg root directory in repo."""
+  return os.path.join(os.getcwd(), 'external', 'vcpkg')
+
+
 def get_vcpkg_executable_file_path():
   """Get absolute path to vcpkg executable."""
-  vcpkg_root_dir = os.path.join(os.getcwd(), 'external', 'vcpkg')
+  vcpkg_root_dir = get_vcpkg_root_path()
   if is_windows_os():
     vcpkg_executable_file_path = os.path.join(vcpkg_root_dir, 'vcpkg.exe')
   elif is_linux_os() or is_mac_os():
@@ -124,7 +129,7 @@ def get_vcpkg_executable_file_path():
 
 def get_vcpkg_installation_script_path():
   """Get absolute path to the script used to build and install vcpkg."""
-  vcpkg_root_dir = os.path.join(os.getcwd(), 'external', 'vcpkg')
+  vcpkg_root_dir = get_vcpkg_root_path()
   if is_windows_os():
     script_absolute_path = os.path.join(vcpkg_root_dir, 'bootstrap-vcpkg.bat')
   elif is_linux_os() or is_mac_os():


### PR DESCRIPTION
Since we decided to support just Python3 for building our SDK, firestore's nanopb dependency had to be updated to 0.3.9.6 as 0.3.9.5 has build errors in Python3. nanopb is updated across all firebase open source sdks and google3.
This commit specifically fixes issues with finding modules with Python3.
https://github.com/nanopb/nanopb/commit/63f8e5e4946a5f8f0211b454bd37187871c3d023

Relevant PRs,
https://github.com/google/nanopb-podspec/pull/14
https://github.com/firebase/firebase-ios-sdk/pull/6214
cl/326682471