### PR TITLE
Feature/ddb fix msg auth

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -390,10 +390,10 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
 
 static std::string GenerateEmailAddress() {
   char time_string[22];
-  snprintf(time_str, 22, "%d", app_framework::GetCurrentTimeInMicroseconds());
+  snprintf(time_string, 22, "%d", app_framework::GetCurrentTimeInMicroseconds());
   std::string email =
       "random_user_" +
-       + time_str +
+       + time_string +
       "@gmail.com";
   LogDebug("Generated email address: %s", email.c_str());
   return email;

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -391,10 +391,9 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
 static std::string GenerateEmailAddress() {
   char time_string[22];
   snprintf(time_string, 22, "%d", app_framework::GetCurrentTimeInMicroseconds());
-  std::string email =
-      "random_user_" +
-       + time_string +
-      "@gmail.com";
+  std::string email = "random_user_";
+  email.append(time_string);
+  email.append("@gmail.com");
   LogDebug("Generated email address: %s", email.c_str());
   return email;
 }

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -770,6 +770,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
 }
 #endif  // ! defined(__linux__)
 
+
 class PhoneListener : public firebase::auth::PhoneAuthProvider::Listener {
  public:
   PhoneListener()

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -713,6 +713,8 @@ TEST_F(FirebaseAuthTest, TestWithCustomEmailAndPassword) {
   EXPECT_NE(auth_->current_user(), nullptr);
 }
 
+#if ! defined(__linux__)
+// Test is disabled on linux due to the need to unlock the keystore.
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
   WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
   ASSERT_NE(auth_->current_user(), nullptr);
@@ -725,7 +727,10 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
   EXPECT_TRUE(auth_->current_user()->is_anonymous());
   DeleteUser();
 }
+#endif  // ! defined(__linux__)
 
+#if ! defined(__linux__)
+// Test is disabled on linux due to the need to unlock the keychain.
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   std::string email = GenerateEmailAddress();
   WaitForCompletion(
@@ -763,6 +768,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   EXPECT_NE(auth_->current_user(), nullptr);
   DeleteUser();
 }
+#endif  // ! defined(__linux__)
 
 class PhoneListener : public firebase::auth::PhoneAuthProvider::Listener {
  public:

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -389,9 +389,11 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
 }
 
 static std::string GenerateEmailAddress() {
+  char time_string[22];
+  snprintf(time_str, 22, "%d", app_framework::GetCurrentTimeInMicroseconds());
   std::string email =
       "random_user_" +
-      std::to_string(app_framework::GetCurrentTimeInMicroseconds()) +
+       + time_str +
       "@gmail.com";
   LogDebug("Generated email address: %s", email.c_str());
   return email;
@@ -712,8 +714,6 @@ TEST_F(FirebaseAuthTest, TestWithCustomEmailAndPassword) {
   EXPECT_NE(auth_->current_user(), nullptr);
 }
 
-#if ! defined(__linux__)
-// Test is disabled on linux due to the need to unlock the keystore.
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
   WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
   ASSERT_NE(auth_->current_user(), nullptr);
@@ -726,10 +726,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
   EXPECT_TRUE(auth_->current_user()->is_anonymous());
   DeleteUser();
 }
-#endif  // ! defined(__linux__)
 
-#if ! defined(__linux__)
-// Test is disabled on linux due to the need to unlock the keychain.
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   std::string email = GenerateEmailAddress();
   WaitForCompletion(
@@ -767,8 +764,6 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   EXPECT_NE(auth_->current_user(), nullptr);
   DeleteUser();
 }
-#endif  // ! defined(__linux__)
-
 
 class PhoneListener : public firebase::auth::PhoneAuthProvider::Listener {
  public:

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -386,7 +386,10 @@ static std::string ConstructHtmlToSendMessage(
        "document.write('<h1>Failed to send notification.</h1>');"
        "document.write('Status '+xhttp.status+': '+xhttp.response);"
        "}},";
-  h += std::to_string(delay_seconds * 1000) + ");}</script>";
+  char delay_seconds_string[22];
+  snprintf(delay_seconds_string, 22, "%d", delay_seconds);
+  h += delay_seconds_string;
+  h += ");}</script>";
   return h;
 }
 


### PR DESCRIPTION
Removed std::to_string from auth and messaging integration tests, as this is not currently supported by the GHA Linux VM Android build target toolchain.