### PR TITLE
Feature/fix firestore integration tests build

### DIFF
--- a/database/src/desktop/util_desktop_macos.mm
+++ b/database/src/desktop/util_desktop_macos.mm
@@ -41,7 +41,7 @@ static std::vector<std::string> split_string(const std::string& s,
     return split_parts;
   }
 
-  while( (pos = s.find(delimiter, delimiter_search_start)) != std::string::npos) {
+  while((pos = s.find(delimiter, delimiter_search_start)) != std::string::npos) {
     split_parts.push_back(s.substr(delimiter_search_start, pos-delimiter_search_start));
 
     while(s[pos] == delimiter && pos<len) {
@@ -52,8 +52,9 @@ static std::vector<std::string> split_string(const std::string& s,
 
   // If the input string doesn't end with a delimiter we need to push the last
   // token into our return vector
-  if (delimiter_search_start != len)
+  if (delimiter_search_start != len) {
     split_parts.push_back(s.substr(delimiter_search_start, len-delimiter_search_start));
+  }
 
   return split_parts;
 }
@@ -68,14 +69,14 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     if (retval != 0 && errno != EEXIST) return "";
     // App name might contain path separators. Split it to get list of subdirs
     std::vector<std::string> app_name_parts = split_string(app_name, '/');
-    if(app_name_parts.empty()) return "";
+    if (app_name_parts.empty()) return "";
     std::string dir_path = path;
     // Recursively create entire tree of directories
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
                                             it != app_name_parts.end(); it++) {
-          dir_path = dir_path + "/" + *it;
-          retval = mkdir(dir_path.c_str(), 0700);
-          if (retval != 0 && errno != EEXIST) return "";
+      dir_path = dir_path + "/" + *it;
+      retval = mkdir(dir_path.c_str(), 0700);
+      if (retval != 0 && errno != EEXIST) return "";
     }
   }
   return path + "/" + app_name;

--- a/database/src/desktop/util_desktop_macos.mm
+++ b/database/src/desktop/util_desktop_macos.mm
@@ -73,7 +73,7 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     std::string dir_path = path;
     // Recursively create entire tree of directories
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
-                                            it != app_name_parts.end(); it++) {
+         it != app_name_parts.end(); it++) {
       dir_path = dir_path + "/" + *it;
       retval = mkdir(dir_path.c_str(), 0700);
       if (retval != 0 && errno != EEXIST) return "";

--- a/database/src/desktop/util_desktop_macos.mm
+++ b/database/src/desktop/util_desktop_macos.mm
@@ -17,10 +17,54 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include "database/src/desktop/util_desktop.h"
+#include <string>
 
 namespace firebase {
 namespace database {
 namespace internal {
+
+// Given a directory path, and a directory creation mode with an option delimiter,
+// recursively create directories. mkdir doesn't create directories recursively
+// This is similar to `mkdir -p` on the command line
+static int mkdir_recursive(const char* dir_path, const mode_t mode) {
+  std::string dir_path_string(dir_path);
+  const char path_delimiter = '/';
+
+  // This index will be used to track the positions of path_delimiters in the path string
+  size_t pos = 0;
+  // This index is used as the starting index to search the path_delimiters from.
+  size_t path_delimiter_search_start = 0;
+  // Skip any leading path_delimiters
+  while(dir_path_string[path_delimiter_search_start] == path_delimiter) {
+    path_delimiter_search_start++;
+  }
+  size_t len = dir_path_string.size();
+  // Invalid path if it consists of just path_delimiters
+  if (pos >= len) {
+    return -1;
+  }
+  std::string sub_directory;
+  int retval;
+  while( (pos = dir_path_string.find(path_delimiter, path_delimiter_search_start))
+                                                             != std::string::npos) {
+    sub_directory = dir_path_string.substr(0, pos);
+    retval = mkdir(sub_directory.c_str(), mode);
+    if (retval != 0 && errno != EEXIST) return -1;
+    while(dir_path_string[pos] == path_delimiter && pos<len) {
+      pos++;
+      path_delimiter_search_start = pos;
+    }
+  }
+
+  // If the path does not have trailing delimiter, we still have to create the
+  // last subdirectory
+  if (dir_path_string[len-1] != path_delimiter) {
+    retval = mkdir(dir_path_string.c_str(), mode);
+    if (retval != 0 && errno != EEXIST) return -1;
+  }
+  return 0;
+}
+
 
 std::string GetAppDataPath(const char* app_name, bool should_create) {
   NSArray<NSString*>* directories =
@@ -30,7 +74,8 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     int retval;
     retval = mkdir(path.c_str(), 0700);
     if (retval != 0 && errno != EEXIST) return "";
-    retval = mkdir((path + "/" + app_name).c_str(), 0700);
+    // app_name could have a path delimiter "/" in it. Use custom recursive mkdir.
+    retval = mkdir_recursive((path + "/" + app_name).c_str(), 0700);
     if (retval != 0 && errno != EEXIST) return "";
   }
   return path + "/" + app_name;

--- a/database/src/desktop/util_desktop_windows.cc
+++ b/database/src/desktop/util_desktop_windows.cc
@@ -90,8 +90,9 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
                                             it != app_name_parts.end(); it++) {
           dir_path = dir_path + "\\" + *it;
-          retval = _mkdir(dir_path.c_str(), 0700);
+          retval = _mkdir(dir_path.c_str());
           if (retval != 0 && errno != EEXIST) return "";
+    }
   }
   return path + "\\" + app_name;
 }

--- a/database/src/desktop/util_desktop_windows.cc
+++ b/database/src/desktop/util_desktop_windows.cc
@@ -44,7 +44,7 @@ static std::vector<std::string> split_string(const std::string& s,
     return split_parts;
   }
 
-  while( (pos = s.find(delimiter, delimiter_search_start)) != std::string::npos) {
+  while((pos = s.find(delimiter, delimiter_search_start)) != std::string::npos) {
     split_parts.push_back(s.substr(delimiter_search_start, pos-delimiter_search_start));
 
     while(s[pos] == delimiter && pos<len) {
@@ -55,8 +55,9 @@ static std::vector<std::string> split_string(const std::string& s,
 
   // If the input string doesn't end with a delimiter we need to push the last
   // token into our return vector
-  if (delimiter_search_start != len)
+  if (delimiter_search_start != len) {
     split_parts.push_back(s.substr(delimiter_search_start, len-delimiter_search_start));
+  }
 
   return split_parts;
 }
@@ -84,14 +85,14 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
   if (should_create) {
     // App name might contain path separators. Split it to get list of subdirs
     std::vector<std::string> app_name_parts = split_string(app_name, '/');
-    if(app_name_parts.empty()) return "";
+    if (app_name_parts.empty()) return "";
     std::string dir_path = path;
     // Recursively create the entire tree of directories
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
-                                            it != app_name_parts.end(); it++) {
-          dir_path = dir_path + "\\" + *it;
-          int retval = _mkdir(dir_path.c_str());
-          if (retval != 0 && errno != EEXIST) return "";
+                                           it != app_name_parts.end(); it++) {
+      dir_path = dir_path + "\\" + *it;
+      int retval = _mkdir(dir_path.c_str());
+      if (retval != 0 && errno != EEXIST) return "";
     }
   }
   return path + "\\" + app_name;

--- a/database/src/desktop/util_desktop_windows.cc
+++ b/database/src/desktop/util_desktop_windows.cc
@@ -89,7 +89,7 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     std::string dir_path = path;
     // Recursively create the entire tree of directories
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
-                                           it != app_name_parts.end(); it++) {
+         it != app_name_parts.end(); it++) {
       dir_path = dir_path + "\\" + *it;
       int retval = _mkdir(dir_path.c_str());
       if (retval != 0 && errno != EEXIST) return "";

--- a/database/src/desktop/util_desktop_windows.cc
+++ b/database/src/desktop/util_desktop_windows.cc
@@ -90,7 +90,7 @@ std::string GetAppDataPath(const char* app_name, bool should_create) {
     for (std::vector<std::string>::const_iterator it = app_name_parts.begin();
                                             it != app_name_parts.end(); it++) {
           dir_path = dir_path + "\\" + *it;
-          retval = _mkdir(dir_path.c_str());
+          int retval = _mkdir(dir_path.c_str());
           if (retval != 0 && errno != EEXIST) return "";
     }
   }

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -179,13 +179,13 @@ target_link_libraries(firebase_firestore
   PUBLIC
     firebase_app
     firebase_auth
-    absl_variant
 )
 
 if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)
   target_link_libraries(firebase_firestore
     PRIVATE
       firestore_core
+      absl_variant
   )
 endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -179,6 +179,7 @@ target_link_libraries(firebase_firestore
   PUBLIC
     firebase_app
     firebase_auth
+    absl_variant
 )
 
 if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)


### PR DESCRIPTION
Fixes linker symbol missing errors discovered when building firestore's integration tests. This dependency `absl_types` is used just by the C++ part of Firestore and hence was not pushed to "firebase-ios-sdk" repo. 

We were seeing errors like these,
undefined reference to `absl::lts_2020_02_25::variant_internal::ThrowBadVariantAccess()