### PR TITLE
adding absl_variant as a dependency

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -185,6 +185,7 @@ if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)
   target_link_libraries(firebase_firestore
     PRIVATE
       firestore_core
+      absl_variant
   )
 endif()
 


### PR DESCRIPTION
Fixes linker symbol missing errors discovered when building firestore's integration tests. This dependency absl_types is used just by the C++ part of Firestore and hence was not pushed to "firebase-ios-sdk" repo.

We were seeing errors like these,
undefined reference to `absl::lts_2020_02_25::variant_internal::ThrowBadVariantAccess()
