### PR TITLE
Fix for Windows Storage Integration Test timeout

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -78,6 +78,8 @@ class FirebaseStorageTest : public FirebaseTest {
   void Terminate();
   // Sign in an anonymous user.
   void SignIn();
+  // Sign out the current user, if applicable.
+  void SignOut();
   // Create a unique working folder and return a reference to it.
   firebase::storage::StorageReference CreateFolder();
 
@@ -107,9 +109,8 @@ void FirebaseStorageTest::SetUp() {
 }
 
 void FirebaseStorageTest::TearDown() {
-  if (initialized_) {
-    Terminate();
-  }
+  SignOut();
+  Terminate();
   FirebaseTest::TearDown();
 }
 
@@ -200,6 +201,25 @@ void FirebaseStorageTest::SignIn() {
   }
   ProcessEvents(100);
 }
+
+void FirebaseStorageTest::SignOut() {
+  if (auth_ == nullptr) {
+    // Auth is not set up.
+    return;
+  }
+  if (auth_->current_user() == nullptr) {
+    // Already signed out.
+    return;
+  }
+  auth_->SignOut();
+  // Wait for the sign-out to finish.
+  while (auth_->current_user() != nullptr) {
+    if (ProcessEvents(100)) break;
+  }
+  ProcessEvents(100);
+  EXPECT_EQ(auth_->current_user(), nullptr);
+}
+
 
 firebase::storage::StorageReference FirebaseStorageTest::CreateFolder() {
   // Generate a folder for the test data based on the time in milliseconds.

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -220,7 +220,6 @@ void FirebaseStorageTest::SignOut() {
   EXPECT_EQ(auth_->current_user(), nullptr);
 }
 
-
 firebase::storage::StorageReference FirebaseStorageTest::CreateFolder() {
   // Generate a folder for the test data based on the time in milliseconds.
   int64_t time_in_microseconds = GetCurrentTimeInMicroseconds();


### PR DESCRIPTION
Fixes for the Storage integration test.  The test would timeout on Windows when attempting to sign in a user anonymously, though it would work for the first sign in attempt, just not subsequent ones.

I pulled in the auth teardown logic.

Additionally removed an unneeded check for app initialization in the teardown method.  This check is already being done by the sub-methods.