### PR TITLE
Feature/android builds on windows clean

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,8 +1,11 @@
 name: Android Builds
 
-on: 
+on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - feature/android-builds-on-windows-clean
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,9 +3,6 @@ name: Android Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
-    branches:
-      - feature/android-builds-on-windows-clean
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -21,6 +21,8 @@ jobs:
           architecture: "x64"
         - os: macos-latest
           architecture: "x64"
+        - os: windows-latest
+          architecture: "x64"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         architecture: ["x64",]
         include:
         - os: ubuntu-latest
@@ -38,10 +38,15 @@ jobs:
           python-version: 3.7
           architecture: ${{ matrix.architecture }}
 
+      - name: Add msbuild to PATH
+        if: startsWith(matrix.os, 'windows')
+        uses: microsoft/setup-msbuild@v1.0.1
+
       - name: Install prerequisites
+        shell: bash
         run: |
           build_scripts/android/install_prereqs.sh
-      
+
       - name: Cache ccache files
         id: cache_ccache
         uses: actions/cache@v2
@@ -50,6 +55,7 @@ jobs:
           key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
 
       - name: Build SDK
+        shell: bash
         run: |
           build_scripts/android/build.sh android_build .
 

--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -20,8 +20,6 @@ if [[ -n $(ls) ]]; then
     exit 2
 fi
 cd -
-# Turn buildpath into an absolute path for use later with rsync.
-buildpath=$( cd "${buildpath}" ; pwd -P )
 
 # If NDK_ROOT is not set or is the wrong version, use to the version in /tmp.
 if [[ -z "${NDK_ROOT}" || ! $(grep -q "Pkg\.Revision = 16\." "${NDK_ROOT}/source.properties") ]]; then
@@ -54,6 +52,12 @@ for lib in *; do
     fi
 done
 set -x
-# Use rsync to copy the relevent paths to the destination directory.
-rsync -aR "${paths[@]}" "${buildpath}/"
 
+if [[ $(uname) == "Linux" ]] || [[ $(uname) == "Darwin" ]]; then
+  # Turn buildpath into an absolute path for use later with rsync.
+  buildpath=$( cd "${buildpath}" ; pwd -P )
+  # Use rsync to copy the relevent paths to the destination directory.
+  rsync -aR "${paths[@]}" "${buildpath}/"
+else
+  cp -R "${paths[@]}" ${buildpath}
+fi

--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -59,5 +59,8 @@ if [[ $(uname) == "Linux" ]] || [[ $(uname) == "Darwin" ]]; then
   # Use rsync to copy the relevent paths to the destination directory.
   rsync -aR "${paths[@]}" "${buildpath}/"
 else
-  cp -R "${paths[@]}" ${buildpath}
+  # rsync has to be specifically installed on windows bash (including github runners)
+  # Also, rsync with absolute destination path doesn't work on Windows.
+  # Using a simple copy instead of rsync on Windows.
+  cp -R --parents "${paths[@]}" "${buildpath}"
 fi

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -35,7 +35,7 @@ else
       echo "Installing python packages."
       set -x
       # On Windows bash shell, sudo doesn't exist
-      if [[ $(uname) == "Linux" ] || [ $(uname) == "Darwin" ]]; then
+      if [[ $(uname) == "Linux" ]] || [[ $(uname) == "Darwin" ]]; then
         sudo python -m pip install --upgrade pip
       else
         python -m pip install  --upgrade pip

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -13,8 +13,12 @@ elif [[ $(uname) == "Linux" ]]; then
         echo "::set-env name=CCACHE_INSTALLED::1"
     fi
 else
-    echo "Unsupported platform, this script must run on a MacOS or Linux machine."
-    exit 1
+    platform=windows
+    # On Windows, we have an additional dependency for Strings
+    curl -LSs \	    curl -LSs \
+        "https://download.sysinternals.com/files/Strings.zip" \
+         --output Strings.zip
+    unzip -q Strings.zip && rm -f Strings.zip
 fi
 
 if [[ -z $(which cmake) ]]; then
@@ -28,11 +32,16 @@ if [[ -z $(which python) ]]; then
 else
     updated_pip=0
     if ! $(echo "import absl"$'\n'"import google.protobuf" | python - 2> /dev/null); then
-	echo "Installing python packages."
-	set -x
-	sudo python -m pip install --upgrade pip
-	pip install absl-py protobuf
-	set +x
+      echo "Installing python packages."
+      set -x
+      # On Windows bash shell, sudo doesn't exist
+      if [[ $(uname) == "Linux" ] || [ $(uname) == "Darwin" ]]; then
+        sudo python -m pip install --upgrade pip
+      else
+        python -m pip install  --upgrade pip
+      fi
+      pip install absl-py protobuf
+      set +x
     fi
 fi
 


### PR DESCRIPTION
Changes to build android libraries on Windows
- Added an action to install msbuild tools before our build step (msbuild tools are required to download and install external dependencies like flatbuffers, firestore etc. Without this step, the build step fails silently without any obvious errors)
- Using simple cp on Windows instead of rsync as that would have required and additional download/install of rsync. 
- Downloading and unpacking "strings" (a tool required only for Windows builds) at the root of the repo.