### PR TITLE
Feature/cmake ios framework

### DIFF
--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -119,6 +119,10 @@ elseif(IOS)
   # AdMob expects the header files to be in a subfolder, so set up a symlink to
   # accomplish that.
   symlink_pod_headers(firebase_admob Google-Mobile-Ads-SDK GoogleMobileAds)
+
+  set_target_properties(firebase_admob PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 cpp_pack_library(firebase_admob "")

--- a/analytics/CMakeLists.txt
+++ b/analytics/CMakeLists.txt
@@ -127,6 +127,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseAnalytics
   )
+
+  set_target_properties(firebase_analytics PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -464,7 +464,6 @@ if (IOS)
 
   # Generate Framewrok Headers
   foreach(hfile ${internal_HDRS})
-    message(STATUS "hfile: ${hfile}")
     string(FIND ${hfile} "firebase/" pos_firebase)
     string(COMPARE NOTEQUAL ${pos_firebase} -1 find)
     if(${find})
@@ -472,7 +471,6 @@ if (IOS)
       math(EXPR pos_s "${pos_firebase} + 8")
       math(EXPR len "${pos_e} - ${pos_s}")
       string(SUBSTRING ${hfile} ${pos_s} ${len} dir)
-      message(STATUS "subDir: ${dir}")
       # file(COPY ${hfile} DESTINATION Headers/${dir})
       set_property(SOURCE ${hfile} PROPERTY 
                   MACOSX_PACKAGE_LOCATION Headers/${dir})

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -290,12 +290,12 @@ endif()
 
 if(IOS)
   set(admob_HDRS
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/native_express_ad_view.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_video.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h")
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/native_express_ad_view.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_video.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h)
 
   # Generate the analytics header file
   # Copy from analytics/CMakeList.txt
@@ -310,8 +310,8 @@ if(IOS)
     )
   endfunction()
   set(analytics_generated_headers_dir
-    "${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics")
-  file(MAKE_DIRECTORY "${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics")
+    ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
+  file(MAKE_DIRECTORY ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
   generate_analytics_header(
     "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIREventNames.h"
     "${analytics_generated_headers_dir}/event_names.h"
@@ -325,85 +325,85 @@ if(IOS)
     "${analytics_generated_headers_dir}/user_property_names.h"
   )
   set(analytics_HDRS
-    "${FIREBASE_SOURCE_DIR}/analytics/src/include/firebase/analytics.h"
-    "${analytics_generated_headers_dir}/event_names.h"
-    "${analytics_generated_headers_dir}/parameter_names.h"
-    "${analytics_generated_headers_dir}/user_property_names.h")
+    ${FIREBASE_SOURCE_DIR}/analytics/src/include/firebase/analytics.h
+    ${analytics_generated_headers_dir}/event_names.h
+    ${analytics_generated_headers_dir}/parameter_names.h
+    ${analytics_generated_headers_dir}/user_property_names.h)
 
   set(auth_HDRS
-    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h"
-    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/credential.h"
-    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/types.h"
-    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/user.h")
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/credential.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/types.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/user.h)
   set(database_HDRS
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/common.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/data_snapshot.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/database_reference.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/disconnection.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/listener.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/mutable_data.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/query.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/transaction.h")
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/common.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/data_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/database_reference.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/disconnection.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/listener.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/mutable_data.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/query.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/transaction.h)
   set(dynamic_links_HDRS
-    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h"
-    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/components.h")
+    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h
+    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/components.h)
   set(firestore_HDRS
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/collection_reference.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_change.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_reference.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_snapshot.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/event_listener.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_path.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_value.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/listener_registration.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/map_field_value.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/metadata_changes.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query_snapshot.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/set_options.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/settings.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/snapshot_metadata.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/source.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/transaction.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/write_batch.h"
-    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_errors.h"
-    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_version.h"
-    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/geo_point.h"
-    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/timestamp.h")
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/collection_reference.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_change.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_reference.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/event_listener.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_path.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_value.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/listener_registration.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/map_field_value.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/metadata_changes.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/set_options.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/settings.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/snapshot_metadata.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/source.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/transaction.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/write_batch.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_errors.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_version.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/geo_point.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/timestamp.h)
   set(functions_HDRS
-    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h"
-    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_reference.h"
-    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_result.h"
-    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/common.h")
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_reference.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_result.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/common.h)
   set(instance_id_HDRS
-    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h")
+    ${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h)
   set(messaging_HDRS
-    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h")
+    ${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h)
   set(remote_config_HDRS
-    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h")
+    ${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h)
   set(storage_HDRS
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/common.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/controller.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/listener.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/metadata.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/storage_reference.h")
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/common.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/controller.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/listener.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/metadata.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/storage_reference.h)
   
   list(APPEND internal_HDRS
-      src/include/firebase/internal/platform.h
-      "${admob_HDRS}"
-      "${analytics_HDRS}"
-      "${auth_HDRS}"
-      "${database_HDRS}"
-      "${dynamic_links_HDRS}"
-      "${firestore_HDRS}"
-      "${functions_HDRS}"
-      "${instance_id_HDRS}"
-      "${messaging_HDRS}"
-      "${remote_config_HDRS}"
-      "${storage_HDRS}")
+    src/include/firebase/internal/platform.h
+    ${admob_HDRS}
+    ${analytics_HDRS}
+    ${auth_HDRS}
+    ${database_HDRS}
+    ${dynamic_links_HDRS}
+    ${firestore_HDRS}
+    ${functions_HDRS}
+    ${instance_id_HDRS}
+    ${messaging_HDRS}
+    ${remote_config_HDRS}
+    ${storage_HDRS})
 endif()
 
 add_library(firebase_app STATIC

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -288,124 +288,6 @@ else()
       "${app_desktop_HDRS}")
 endif()
 
-if(IOS)
-  set(admob_HDRS
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/native_express_ad_view.h
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_video.h
-    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h)
-
-  # Generate the analytics header file
-  # Copy from analytics/CMakeList.txt
-  function(generate_analytics_header OBJC_FILE CPP_FILE)
-    add_custom_command(
-      OUTPUT ${CPP_FILE}
-      COMMAND python "${FIREBASE_SOURCE_DIR}/analytics/generate_constants.py"
-        "--objc_header=${OBJC_FILE}"
-        "--cpp_header=${CPP_FILE}"
-      DEPENDS ${OBJC_FILE}
-      COMMENT "Generating ${CPP_FILE}"
-    )
-  endfunction()
-  set(analytics_generated_headers_dir
-    ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
-  file(MAKE_DIRECTORY ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
-  generate_analytics_header(
-    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIREventNames.h"
-    "${analytics_generated_headers_dir}/event_names.h"
-  )
-  generate_analytics_header(
-    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRParameterNames.h"
-    "${analytics_generated_headers_dir}/parameter_names.h"
-  )
-  generate_analytics_header(
-    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRUserPropertyNames.h"
-    "${analytics_generated_headers_dir}/user_property_names.h"
-  )
-  set(analytics_HDRS
-    ${FIREBASE_SOURCE_DIR}/analytics/src/include/firebase/analytics.h
-    ${analytics_generated_headers_dir}/event_names.h
-    ${analytics_generated_headers_dir}/parameter_names.h
-    ${analytics_generated_headers_dir}/user_property_names.h)
-
-  set(auth_HDRS
-    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h
-    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/credential.h
-    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/types.h
-    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/user.h)
-  set(database_HDRS
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/common.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/data_snapshot.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/database_reference.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/disconnection.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/listener.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/mutable_data.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/query.h
-    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/transaction.h)
-  set(dynamic_links_HDRS
-    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h
-    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/components.h)
-  set(firestore_HDRS
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/collection_reference.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_change.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_reference.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_snapshot.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/event_listener.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_path.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_value.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/listener_registration.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/map_field_value.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/metadata_changes.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query_snapshot.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/set_options.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/settings.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/snapshot_metadata.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/source.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/transaction.h
-    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/write_batch.h
-    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_errors.h
-    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_version.h
-    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/geo_point.h
-    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/timestamp.h)
-  set(functions_HDRS
-    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h
-    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_reference.h
-    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_result.h
-    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/common.h)
-  set(instance_id_HDRS
-    ${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h)
-  set(messaging_HDRS
-    ${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h)
-  set(remote_config_HDRS
-    ${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h)
-  set(storage_HDRS
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/common.h
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/controller.h
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/listener.h
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/metadata.h
-    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/storage_reference.h)
-  
-  list(APPEND internal_HDRS
-    src/include/firebase/internal/platform.h
-    ${admob_HDRS}
-    ${analytics_HDRS}
-    ${auth_HDRS}
-    ${database_HDRS}
-    ${dynamic_links_HDRS}
-    ${firestore_HDRS}
-    ${functions_HDRS}
-    ${instance_id_HDRS}
-    ${messaging_HDRS}
-    ${remote_config_HDRS}
-    ${storage_HDRS})
-endif()
-
 add_library(firebase_app STATIC
     ${log_SRCS}
     ${log_HDRS}
@@ -494,13 +376,134 @@ if (NOT ANDROID AND NOT IOS)
 endif()
 
 if (IOS)
+  # IOS build framework
   set_target_properties(firebase_app PROPERTIES
     FRAMEWORK TRUE
   )
 
-  # Generate Framework Headers from ${internal_HDRS}
+  # framework header files
+  set(admob_HDRS
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/native_express_ad_view.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_video.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h)
+
+  # Generate the analytics header file
+  # Copy from analytics/CMakeList.txt
+  function(generate_analytics_header OBJC_FILE CPP_FILE)
+    add_custom_command(
+      OUTPUT ${CPP_FILE}
+      COMMAND python "${FIREBASE_SOURCE_DIR}/analytics/generate_constants.py"
+        "--objc_header=${OBJC_FILE}"
+        "--cpp_header=${CPP_FILE}"
+      DEPENDS ${OBJC_FILE}
+      COMMENT "Generating ${CPP_FILE}"
+    )
+  endfunction()
+  set(analytics_generated_headers_dir
+    ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
+  file(MAKE_DIRECTORY ${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics)
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIREventNames.h"
+    "${analytics_generated_headers_dir}/event_names.h"
+  )
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRParameterNames.h"
+    "${analytics_generated_headers_dir}/parameter_names.h"
+  )
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRUserPropertyNames.h"
+    "${analytics_generated_headers_dir}/user_property_names.h"
+  )
+  set(analytics_HDRS
+    ${FIREBASE_SOURCE_DIR}/analytics/src/include/firebase/analytics.h
+    ${analytics_generated_headers_dir}/event_names.h
+    ${analytics_generated_headers_dir}/parameter_names.h
+    ${analytics_generated_headers_dir}/user_property_names.h)
+  set(auth_HDRS
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/credential.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/types.h
+    ${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/user.h)
+  set(database_HDRS
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/common.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/data_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/database_reference.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/disconnection.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/listener.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/mutable_data.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/query.h
+    ${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/transaction.h)
+  set(dynamic_links_HDRS
+    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h
+    ${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/components.h)
+  set(firestore_HDRS
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/collection_reference.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_change.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_reference.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/event_listener.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_path.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_value.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/listener_registration.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/map_field_value.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/metadata_changes.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query_snapshot.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/set_options.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/settings.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/snapshot_metadata.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/source.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/transaction.h
+    ${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/write_batch.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_errors.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_version.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/geo_point.h
+    ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/timestamp.h)
+  set(functions_HDRS
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_reference.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_result.h
+    ${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/common.h)
+  set(instance_id_HDRS
+    ${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h)
+  set(messaging_HDRS
+    ${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h)
+  set(remote_config_HDRS
+    ${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h)
+  set(storage_HDRS
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/common.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/controller.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/listener.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/metadata.h
+    ${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/storage_reference.h)
+
+  list(APPEND framework_HDRS
+    src/include/firebase/internal/platform.h
+    ${admob_HDRS}
+    ${analytics_HDRS}
+    ${auth_HDRS}
+    ${database_HDRS}
+    ${dynamic_links_HDRS}
+    ${firestore_HDRS}
+    ${functions_HDRS}
+    ${instance_id_HDRS}
+    ${messaging_HDRS}
+    ${remote_config_HDRS}
+    ${storage_HDRS})
+
+  # add framework header files to target
+  target_sources(firebase_app PRIVATE ${framework_HDRS})
+
+  # Generate Framework Headers from ${framework_HDRS}
   # Copy header from source dir "src/include/firebase/*" to destination dir "Headers/*"
-  foreach(hfile ${internal_HDRS})
+  list(APPEND framework_HDRS ${internal_HDRS})
+  foreach(hfile ${framework_HDRS})
     string(FIND ${hfile} "firebase/" pos_firebase)
     string(COMPARE NOTEQUAL ${pos_firebase} -1 find)
     if(${find})

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -514,7 +514,7 @@ if (IOS)
     endif()
   endforeach(hfile)
   # Copy header from source dir "src/include/google_play_services/*" 
-  # to destination dir "Headers/google_play_services?*"
+  # to destination dir "Headers/google_play_services/*"
   set_property(SOURCE "src/include/google_play_services/availability.h" PROPERTY 
                   MACOSX_PACKAGE_LOCATION Headers/google_play_services)
 endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -289,9 +289,13 @@ else()
 endif()
 
 if(IOS)
-  file(GLOB admob_HDRS
+  set(admob_HDRS
     "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h"
-    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/*.h")
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h"
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h"
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/native_express_ad_view.h"
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_video.h"
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h")
 
   # Generate the analytics header file
   # Copy from analytics/CMakeList.txt
@@ -326,34 +330,66 @@ if(IOS)
     "${analytics_generated_headers_dir}/parameter_names.h"
     "${analytics_generated_headers_dir}/user_property_names.h")
 
-  file(GLOB auth_HDRS
+  set(auth_HDRS
     "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h"
-    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/*.h")
-  file(GLOB database_HDRS
+    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/credential.h"
+    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/types.h"
+    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/user.h")
+  set(database_HDRS
     "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h"
-    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/*.h")
-  file(GLOB dynamic_links_HDRS
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/common.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/data_snapshot.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/database_reference.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/disconnection.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/listener.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/mutable_data.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/query.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/transaction.h")
+  set(dynamic_links_HDRS
     "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h"
-    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/*.h")
-  file(GLOB firestore_HDRS
+    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/components.h")
+  set(firestore_HDRS
     "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h"
-    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/*.h"
-    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/*.h")
-  file(GLOB functions_HDRS
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/collection_reference.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_change.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_reference.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/document_snapshot.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/event_listener.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_path.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/field_value.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/listener_registration.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/map_field_value.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/metadata_changes.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query_snapshot.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/query.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/set_options.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/settings.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/snapshot_metadata.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/source.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/transaction.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/write_batch.h"
+    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_errors.h"
+    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/firestore_version.h"
+    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/geo_point.h"
+    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/timestamp.h")
+  set(functions_HDRS
     "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h"
-    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/*.h")
-  file(GLOB instance_id_HDRS
-    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h"
-    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id/*.h") #??
-  file(GLOB messaging_HDRS
-    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h"
-    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging/*.h")
-  file(GLOB remote_config_HDRS
-    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h"
-    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config/*.h")
-  file(GLOB storage_HDRS
+    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_reference.h"
+    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/callable_result.h"
+    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/common.h")
+  set(instance_id_HDRS
+    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h")
+  set(messaging_HDRS
+    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h")
+  set(remote_config_HDRS
+    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h")
+  set(storage_HDRS
     "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h"
-    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/*.h")
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/common.h"
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/controller.h"
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/listener.h"
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/metadata.h"
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/storage_reference.h")
   
   list(APPEND internal_HDRS
       src/include/firebase/internal/platform.h
@@ -462,7 +498,8 @@ if (IOS)
     FRAMEWORK TRUE
   )
 
-  # Generate Framewrok Headers
+  # Generate Framework Headers from ${internal_HDRS}
+  # Copy header from source dir "src/include/firebase/*" to destination dir "Headers/*"
   foreach(hfile ${internal_HDRS})
     string(FIND ${hfile} "firebase/" pos_firebase)
     string(COMPARE NOTEQUAL ${pos_firebase} -1 find)
@@ -476,6 +513,8 @@ if (IOS)
                   MACOSX_PACKAGE_LOCATION Headers/${dir})
     endif()
   endforeach(hfile)
+  # Copy header from source dir "src/include/google_play_services/*" 
+  # to destination dir "Headers/google_play_services?*"
   set_property(SOURCE "src/include/google_play_services/availability.h" PROPERTY 
                   MACOSX_PACKAGE_LOCATION Headers/google_play_services)
 endif()

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -288,6 +288,88 @@ else()
       "${app_desktop_HDRS}")
 endif()
 
+if(IOS)
+  file(GLOB admob_HDRS
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h"
+    "${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/*.h")
+
+  # Generate the analytics header file
+  # Copy from analytics/CMakeList.txt
+  function(generate_analytics_header OBJC_FILE CPP_FILE)
+    add_custom_command(
+      OUTPUT ${CPP_FILE}
+      COMMAND python "${FIREBASE_SOURCE_DIR}/analytics/generate_constants.py"
+        "--objc_header=${OBJC_FILE}"
+        "--cpp_header=${CPP_FILE}"
+      DEPENDS ${OBJC_FILE}
+      COMMENT "Generating ${CPP_FILE}"
+    )
+  endfunction()
+  set(analytics_generated_headers_dir
+    "${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics")
+  file(MAKE_DIRECTORY "${FIREBASE_GEN_FILE_DIR}/analytics/src/include/firebase/analytics")
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIREventNames.h"
+    "${analytics_generated_headers_dir}/event_names.h"
+  )
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRParameterNames.h"
+    "${analytics_generated_headers_dir}/parameter_names.h"
+  )
+  generate_analytics_header(
+    "${FIREBASE_SOURCE_DIR}/analytics/ios_headers/FIRUserPropertyNames.h"
+    "${analytics_generated_headers_dir}/user_property_names.h"
+  )
+  set(analytics_HDRS
+    "${FIREBASE_SOURCE_DIR}/analytics/src/include/firebase/analytics.h"
+    "${analytics_generated_headers_dir}/event_names.h"
+    "${analytics_generated_headers_dir}/parameter_names.h"
+    "${analytics_generated_headers_dir}/user_property_names.h")
+
+  file(GLOB auth_HDRS
+    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth.h"
+    "${FIREBASE_SOURCE_DIR}/auth/src/include/firebase/auth/*.h")
+  file(GLOB database_HDRS
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database.h"
+    "${FIREBASE_SOURCE_DIR}/database/src/include/firebase/database/*.h")
+  file(GLOB dynamic_links_HDRS
+    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links.h"
+    "${FIREBASE_SOURCE_DIR}/dynamic_links/src/include/firebase/dynamic_links/*.h")
+  file(GLOB firestore_HDRS
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore.h"
+    "${FIREBASE_SOURCE_DIR}/firestore/src/include/firebase/firestore/*.h"
+    "${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include/firebase/firestore/*.h")
+  file(GLOB functions_HDRS
+    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions.h"
+    "${FIREBASE_SOURCE_DIR}/functions/src/include/firebase/functions/*.h")
+  file(GLOB instance_id_HDRS
+    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id.h"
+    "${FIREBASE_SOURCE_DIR}/instance_id/src/include/firebase/instance_id/*.h") #??
+  file(GLOB messaging_HDRS
+    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging.h"
+    "${FIREBASE_SOURCE_DIR}/messaging/src/include/firebase/messaging/*.h")
+  file(GLOB remote_config_HDRS
+    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config.h"
+    "${FIREBASE_SOURCE_DIR}/remote_config/src/include/firebase/remote_config/*.h")
+  file(GLOB storage_HDRS
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage.h"
+    "${FIREBASE_SOURCE_DIR}/storage/src/include/firebase/storage/*.h")
+  
+  list(APPEND internal_HDRS
+      src/include/firebase/internal/platform.h
+      "${admob_HDRS}"
+      "${analytics_HDRS}"
+      "${auth_HDRS}"
+      "${database_HDRS}"
+      "${dynamic_links_HDRS}"
+      "${firestore_HDRS}"
+      "${functions_HDRS}"
+      "${instance_id_HDRS}"
+      "${messaging_HDRS}"
+      "${remote_config_HDRS}"
+      "${storage_HDRS}")
+endif()
+
 add_library(firebase_app STATIC
     ${log_SRCS}
     ${log_HDRS}
@@ -373,4 +455,29 @@ cpp_pack_library(firebase_app "")
 cpp_pack_public_headers()
 if (NOT ANDROID AND NOT IOS)
   cpp_pack_library(flatbuffers "deps/app/external")
+endif()
+
+if (IOS)
+  set_target_properties(firebase_app PROPERTIES
+    FRAMEWORK TRUE
+  )
+
+  # Generate Framewrok Headers
+  foreach(hfile ${internal_HDRS})
+    message(STATUS "hfile: ${hfile}")
+    string(FIND ${hfile} "firebase/" pos_firebase)
+    string(COMPARE NOTEQUAL ${pos_firebase} -1 find)
+    if(${find})
+      string(FIND ${hfile} "/" pos_e REVERSE)
+      math(EXPR pos_s "${pos_firebase} + 8")
+      math(EXPR len "${pos_e} - ${pos_s}")
+      string(SUBSTRING ${hfile} ${pos_s} ${len} dir)
+      message(STATUS "subDir: ${dir}")
+      # file(COPY ${hfile} DESTINATION Headers/${dir})
+      set_property(SOURCE ${hfile} PROPERTY 
+                  MACOSX_PACKAGE_LOCATION Headers/${dir})
+    endif()
+  endforeach(hfile)
+  set_property(SOURCE "src/include/google_play_services/availability.h" PROPERTY 
+                  MACOSX_PACKAGE_LOCATION Headers/google_play_services)
 endif()

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -200,6 +200,9 @@ elseif(IOS)
       FirebaseCore
       FirebaseAuth
   )
+  set_target_properties(firebase_auth PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -248,6 +248,9 @@ elseif(IOS)
       FirebaseCore
       FirebaseDatabase
   )
+  set_target_properties(firebase_database PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/dynamic_links/CMakeLists.txt
+++ b/dynamic_links/CMakeLists.txt
@@ -85,6 +85,10 @@ elseif(IOS)
     POD_NAMES
       FirebaseDynamicLinks
   )
+
+  set_target_properties(firebase_dynamic_links PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 cpp_pack_library(firebase_dynamic_links "")

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -261,6 +261,10 @@ elseif(IOS)
       abseil
       nanopb
   )
+
+  set_target_properties(firebase_firestore PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 cpp_pack_library(firebase_firestore "")

--- a/functions/CMakeLists.txt
+++ b/functions/CMakeLists.txt
@@ -102,6 +102,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseFunctions
   )
+
+  set_target_properties(firebase_functions PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 cpp_pack_library(firebase_functions "")

--- a/instance_id/CMakeLists.txt
+++ b/instance_id/CMakeLists.txt
@@ -99,6 +99,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseInstanceID
   )
+  
+  set_target_properties(firebase_instance_id PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/messaging/CMakeLists.txt
+++ b/messaging/CMakeLists.txt
@@ -122,6 +122,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseMessaging
   )
+
+  set_target_properties(firebase_messaging PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/remote_config/CMakeLists.txt
+++ b/remote_config/CMakeLists.txt
@@ -126,6 +126,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseRemoteConfig
   )
+
+  set_target_properties(firebase_remote_config PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -132,6 +132,10 @@ elseif(IOS)
       FirebaseCore
       FirebaseStorage
   )
+
+  set_target_properties(firebase_storage PROPERTIES
+    FRAMEWORK TRUE
+  )
 endif()
 
 if(FIREBASE_CPP_BUILD_TESTS)


### PR DESCRIPTION
Currently, CMake builds library for iOS. This PR modifies the CMake to build Framework for iOS.

The [build cmd](https://github.com/firebase/firebase-cpp-sdk#building-with-cmake-for-ios) is the same as it use to be.

[Design Doc](https://docs.google.com/document/d/18FEitEefi6vaK1VtzU7FtJjDnj6Xj8ijb0JqIRpUVB8/edit#heading=h.xzptrog8pyxf)