### PR TITLE
Feature/support non standard vcpkg configs

### DIFF
--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -88,6 +88,8 @@ def cmake_configure(build_dir, arch, build_tests=True, config=None):
           If its not specified, cmake's default is used (most likely Debug).
   """
   cmd = ['cmake', '-S', '.', '-B', build_dir]
+  if utils.is_windows_os() and arch == 'x86':
+    cmd.extend(['-A', 'Win32'])
 
   # If generator is not specifed, default for platform is used by cmake, else
   # use the specified value
@@ -145,9 +147,9 @@ def parse_cmdline_args():
   parser.add_argument('--target', nargs='+', help='A list of CMake build targets (eg: firebase_app firebase_auth)')
   parser.add_argument('--vcpkg_step_only', action='store_true', help='Run vcpkg only and avoid subsequent cmake commands')
   args = parser.parse_args()
-  if utils.is_linux_os() or utils.is_mac_os():
+  # if utils.is_linux_os() or utils.is_mac_os():
     # Linux and mac vcpkg configurations error when we set runtime linkage to static
-    args.crt_linkage = 'dynamic'
+    # args.crt_linkage = 'dynamic'
   return args
 
 if __name__ == '__main__':

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -32,8 +32,11 @@ python scripts/gha/build_desktop.py --build_tests --arch x64
 # Build only firebase_app and firebase_auth
 python scripts/gha/build_desktop.py --target firebase_app firebase_auth
 
-# Build with /MD on Windows and MSVC and x86
+# /MT Build with static runtime libraries in MSVC (Windows) and x86.
 python scripts/gha/build_desktop.py --crt_linkage static --arch x86
+
+# /MD Build with dynamic runtime libraries in MSVC (Windows) and x86.
+python scripts/gha/build_desktop.py --crt_linkage dynamic --arch x86
 
 """
 
@@ -146,7 +149,7 @@ def main():
 def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='Install Prerequisites for building cpp sdk')
   parser.add_argument('-a', '--arch', default='x64', help='Platform architecture (x64, x86)')
-  parser.add_argument('--crt_linkage', default='dynamic', help='Runtime linkage (works only for MSVC)')
+  parser.add_argument('--crt_linkage', default='static', help='Runtime linkage (works only for MSVC)')
   parser.add_argument('--build_dir', default='build', help='Output build directory')
   parser.add_argument('--build_tests', action='store_true', help='Build unit tests too')
   parser.add_argument('--config', help='Release/Debug config')

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -109,13 +109,16 @@ def check_vcpkg_triplet(triplet_name, arch, crt_linkage):
 
   with open(triplet_file_path, 'r') as triplet_file:
     for line in triplet_file:
+      print("Orginal: {0}".format(line))
       # Eg: set(VCPKG_TARGET_ARCHITECTURE x86) ->
       #     set(VCPKG_TARGET_ARCHITECTURE x86
-      line = line.rstrip(')')
+      line = line.rstrip('\n').rstrip(')')
       if not line.startswith('set('):
         continue
+      print(line)
       # Eg: 'set(', 'VCPKG_TARGET_ARCHITECTURE x86'
       variable = line.split('set(')[-1]
+      print(variable)
       variable_name, variable_value = variable.split(' ')
       if variable_name == 'VCPKG_TARGET_ARCHITECTURE':
         _arch = variable_value
@@ -158,7 +161,7 @@ def get_vcpkg_triplet(arch='x64', crt_linkage='dynamic'):
 
   Args:
     arch (str): Architecture (eg: 'x86', 'x64').
-    crt_linkage (str): Runtime linkage for MSVC (eg: 'dynamic', 'static')
+    crt_linkage (str): C runtime library linkage for MSVC (eg: 'dynamic', 'static')
 
   Raises:
     ValueError: If current OS is not win,mac or linux.
@@ -181,6 +184,7 @@ def get_vcpkg_triplet(arch='x64', crt_linkage='dynamic'):
   triplet_name = '-'.join(triplet_name)
   ok = check_vcpkg_triplet(triplet_name, arch, crt_linkage)
   if not ok:
+    print("noooooooooo")
     triplet_name = create_vcpkg_triplet(arch, crt_linkage)
 
   print("Using vcpkg triplet: {0}".format(triplet_name))
@@ -218,11 +222,14 @@ def get_vcpkg_response_file_path(triplet_name):
       # --triplet
       # <triplet_name>
       lines = existing_file.readlines()
+      print("Using x64-linux response file as template.\n")
+      print(lines)
       # Modify the line containing triplet name
       lines[-1] = triplet_name + '\n'
       with open(response_file_path, 'w') as response_file:
         response_file.writelines(lines)
-        print("Created new response file: {0}".format(response_file_path))
+        print("Created new response file: {0}\n".format(response_file_path))
+        print(lines)
   return response_file_path
 
 

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -137,7 +137,7 @@ def create_vcpkg_triplet(arch, crt_linkage):
       Eg: 'x86-windows-dynamic'
   """
   contents = [ 'VCPKG_TARGET_ARCHITECTURE {0}'.format(arch),
-               'VCPLG_CRT_LINKAGE {0}'.format(crt_linkage),
+               'VCPKG_CRT_LINKAGE {0}'.format(crt_linkage),
                'VCPKG_LIBRARY_LINKAGE static']
 
   contents = ['set({0})\n'.format(content) for content in contents]

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -52,7 +52,8 @@ def run_command(cmd, capture_output=False, cwd=None, check=False, as_root=False)
  print('Running cmd: {0}\n'.format(cmd_string))
  # If capture_output is requested, we also set text=True to store the returned value of the
  # command as a string instead of bytes object
- return subprocess.run(cmd, capture_output=capture_output, cwd=cwd, check=check, text=capture_output)
+ return subprocess.run(cmd, capture_output=capture_output, cwd=cwd, check=check,
+                       text=capture_output)
 
 
 def is_command_installed(tool):
@@ -89,15 +90,79 @@ def is_linux_os():
  return platform.system() == 'Linux'
 
 
-def get_vcpkg_triplet(arch):
-  """ Get vcpkg target triplet (platform definition).
+def check_vcpkg_triplet(triplet_name, arch, crt_linkage):
+  """Check if a vcpkg triplet exists that match our specification.
 
   Args:
     arch (str): Architecture (eg: 'x86', 'x64').
+    crt_linkage (str): Runtime linkage for MSVC (eg: 'dynamic', 'static')
+
+  Returns:
+    (bool): If the triplet is valid.
+  """
+  triplet_file_path = get_vcpkg_triplet_file_path(triplet_name)
+  if not os.path.exists(triplet_file_path):
+    return False
+
+  _arch = None
+  _crt_linkage = None
+
+  with open(triplet_file_path, 'r') as triplet_file:
+    for line in triplet_file.readlines():
+      # Eg: set(VCPKG_TARGET_ARCHITECTURE x86)\n
+      line = line.rstrip('\n').rstrip(')')
+      # Eg: set(VCPKG_TARGET_ARCHITECTURE x86
+      if not line.startswith('set('):
+        continue
+      # Eg: 'set(', 'VCPKG_TARGET_ARCHITECTURE x86'
+      variable = line.split('set(')[-1]
+      variable_name, variable_value = variable.split(' ')
+      if variable_name == 'VCPKG_TARGET_ARCHITECTURE':
+        _arch = variable_value
+      elif variable_name == 'VCPKG_CRT_LINKAGE':
+        _crt_linkage = variable_value
+
+  return (_arch == arch) and (_crt_linkage == crt_linkage)
+
+
+def create_vcpkg_triplet(arch, crt_linkage):
+  """Create a new triplet configuration.
+
+  Args:
+    arch (str): Architecture (eg: 'x86', 'x64').
+    crt_linkage (str): Runtime linkage for MSVC (eg: 'dynamic', 'static')
+
+  Returns:
+    (str): Triplet name
+      Eg: 'x86-windows-dynamic'
+  """
+  contents = [ 'VCPKG_TARGET_ARCHITECTURE {0}'.format(arch),
+               'VCPLG_CRT_LINKAGE {0}'.format(crt_linkage),
+               'VCPKG_LIBRARY_LINKAGE static']
+
+  contents = ['set({0})\n'.format(content) for content in contents]
+  if is_linux_os() or is_mac_os():
+    contents.append('\n')
+    contents.append('set(VCPKG_CMAKE_SYSTEM_NAME {0})\n'.format(platform.system()))
+
+  triplet_name = '{0}-{1}-{2}'.format(arch.lower(), platform.system().lower(), crt_linkage)
+  with open(get_vcpkg_triplet_file_path(triplet_name), 'w') as triplet_file:
+    triplet_file.writelines(contents)
+    print('Created new triplet: {0}'.format(triplet_name))
+
+  return triplet_name
+
+
+def get_vcpkg_triplet(arch='x64', crt_linkage='dynamic'):
+  """Get vcpkg target triplet (platform definition).
+
+  Args:
+    arch (str): Architecture (eg: 'x86', 'x64').
+    crt_linkage (str): Runtime linkage for MSVC (eg: 'dynamic', 'static')
 
   Raises:
     ValueError: If current OS is not win,mac or linux.
-  
+
   Returns:
     (str): Triplet name.
        Eg: "x64-windows-static".
@@ -114,8 +179,36 @@ def get_vcpkg_triplet(arch):
     triplet_name.append('linux')
 
   triplet_name = '-'.join(triplet_name)
+  ok = check_vcpkg_triplet(triplet_name, arch, crt_linkage)
+  if not ok:
+    triplet_name = create_vcpkg_triplet(arch, crt_linkage)
+
   print("Using vcpkg triplet: {0}".format(triplet_name))
   return triplet_name
+
+
+def get_vcpkg_triplet_file_path(triplet_name):
+  """Get absolute path to vcpkg triplet configuration file."""
+  triplet_file_path = os.path.join(get_vcpkg_root_path(), 'triplets',
+                                   triplet_name+'.cmake')
+  return triplet_file_path
+
+
+def get_vcpkg_response_file_path(triplet_name):
+  """Get absolute path to vcpkg response file containing packages to install"""
+  response_file_dir_path = os.path.join(os.getcwd(), 'external')
+  response_file_path = os.path.join(response_file_dir_path,
+                       'vcpkg_' + triplet_name + '_response_file.txt')
+  if not os.path.exists(response_file_path):
+    existing_response_file_path = os.path.join(response_file_dir_path,
+                         'vcpkg_x64-linux' + '_response_file.txt')
+    with open(existing_response_file_path, 'r') as existing_file:
+      lines = existing_file.readlines()
+      lines[-1] = triplet_name + '\n'
+      with open(response_file_path, 'w') as response_file:
+        response_file.writelines(lines)
+        print("Created new response file: {0}".format(response_file_path))
+  return response_file_path
 
 
 def get_vcpkg_root_path():
@@ -153,4 +246,6 @@ def clean_vcpkg_temp_data():
   delete_directory(buildtrees_dir_path)
   downloads_dir_path = os.path.join(vcpkg_root_dir_path, 'downloads')
   delete_directory(downloads_dir_path)
+
+
 

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -237,6 +237,12 @@ def get_vcpkg_installation_script_path():
   return script_absolute_path
 
 
+def get_vcpkg_cmake_toolchain_file_path():
+  """Get absolute path to toolchain file used for cmake builds"""
+  vcpkg_root_dir = get_vcpkg_root_path()
+  return os.path.join(vcpkg_root_dir, 'scripts', 'buildsystems', 'vcpkg.cmake')
+
+
 def clean_vcpkg_temp_data():
   """Delete files/directories that vcpkg uses during its build"""
   # Clear temporary directories and files created by vcpkg buildtrees


### PR DESCRIPTION
- Support configurations that do not ship with vcpkg by creating custom files on the fly and using those in the build process.
- Handle x86 on Windows (by appending -A Win32 to cmake configure)
- New flag "--crt_linkage" in `build_desktop.py` that sets the runtime linkage in MSVC (Windows only) for libraries built with vcpkg
```
  # /MD
   --crt_linkage dynamic
  # /MT
   --crt_linkage static
```

Context:
vcpkg ships with default configurations for different platforms,
eg: x64-linux, x64-osx, x64-windows, x64-windows-static

Each of these configurations is a file containing various options (example: contents of x64-linux.cmake),
```
set(VCPKG_TARGET_ARCHITECTURE x64)
set(VCPKG_CRT_LINKAGE dynamic)
set(VCPKG_LIBRARY_LINKAGE static)

set(VCPKG_CMAKE_SYSTEM_NAME Linux)
```

We can provide custom configuration files to the vcpkg and leverage these new files in our build process. 
