### PR TITLE
Fix firestore ios build

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -22,6 +22,8 @@ endif()
 set(common_SRCS
     src/common/cleanup.h
     src/common/collection_reference.cc
+    src/common/compiler_info.cc
+    src/common/compiler_info.h
     src/common/document_change.cc
     src/common/document_reference.cc
     src/common/document_snapshot.cc

--- a/firestore/integration_test/Podfile
+++ b/firestore/integration_test/Podfile
@@ -4,8 +4,8 @@ platform :ios, '8.0'
 # Firebase Realtime Firestore test application.
 
 target 'integration_test' do
-  pod 'Firebase/Firestore', '6.24.0'
-  pod 'Firebase/Auth', '6.24.0'
+  pod 'Firebase/Firestore', '6.32.2'
+  pod 'Firebase/Auth', '6.32.2'
 end
 
 post_install do |installer|

--- a/firestore/integration_test/src/integration_test.cc
+++ b/firestore/integration_test/src/integration_test.cc
@@ -360,8 +360,10 @@ TEST_F(FirebaseFirestoreBasicTest, TestDocumentListener) {
   firebase::firestore::ListenerRegistration registration =
       document.AddSnapshotListener(
           [&](const firebase::firestore::DocumentSnapshot& result,
-              firebase::firestore::Error error) {
-            EXPECT_EQ(error, firebase::firestore::kErrorOk);
+              firebase::firestore::Error error_code,
+              const std::string& error_message) {
+            EXPECT_EQ(error_code, firebase::firestore::kErrorOk);
+            EXPECT_EQ(error_message, "");
             document_snapshots.push_back(result.GetData());
           });
 


### PR DESCRIPTION
There are 3 reason causing the firestore ios integration testapp not build:
1. pod version (6.24.0 -> 6.32.2)
2. firestore library missing source files (at least for iOS Framework)
3. firestore api updated

Also, I believe we should update all /integration_test/Podfile as well. But that should be another PR. Is there a strategy to update /integration_test/Podfile after the /ios_pod/Podfile updated?