### PR TITLE
Add desktop builds to C++ packaging workflow.

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -157,8 +157,8 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
-          tar -czf "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
+          tar -czf firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -96,3 +96,79 @@ jobs:
       with:
         name: firebase-cpp-sdk-android
         path: firebase-cpp-sdk-android.tgz
+
+  build_desktop:
+    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+        build_type: ["Release", "Debug"]
+        architecture: ["x64",]
+        python_version: [3.7]
+        include:
+        - os: windows-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-windows-static"
+          msbuild_platform: "x64"
+        - os: ubuntu-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-linux"
+        - os: macos-latest
+          architecture: "x64"
+          vcpkg_triplet: "x64-osx"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: true
+          ref: ${{ github.event.inputs.commitId }}
+
+      - name: Set env variables for subsequent steps (all)
+        run: |
+          echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
+          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}"
+
+      - name: Cache vcpkg C++ dependencies
+        id: cache_vcpkg
+        uses: actions/cache@v2
+        with:
+          path: external/vcpkg/installed
+          key: dev-vcpkg-${{ matrix.vcpkg_triplet }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
+
+      - name: Cache ccache files
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        id: cache_ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache_dir
+          key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
+
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python_version }}
+          architecture: ${{ matrix.architecture }}
+
+      - name: Install prerequisites
+        run: |
+          python scripts/gha/install_prereqs_desktop.py
+
+      - name: Build SDK
+        run: |
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+	  tar -czf ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+          path: firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz
+      
+
+      - name: Stats for ccache (mac and linux)
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: ccache -s
+
+

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -98,7 +98,7 @@ jobs:
         path: firebase-cpp-sdk-android.tgz
 
   build_desktop:
-    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -157,14 +157,14 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
-	  tar -czf "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz" "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
+	  tar -czf firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }} 
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
-          path: "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz"
+          name: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
+          path: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz
       
 
       - name: Stats for ccache (mac and linux)

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -157,8 +157,8 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
-	  tar -czf firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }} 
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
+	  tar -czf firebase-cpp-sdk-"${{ env.MATRIX_UNIQUE_NAME }}".tgz firebase-cpp-sdk-"${{ env.MATRIX_UNIQUE_NAME }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -158,7 +158,7 @@ jobs:
       - name: Build SDK
         run: |
           python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
-	  tar -czf "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
+          tar -czf "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -98,7 +98,7 @@ jobs:
           path: firebase-cpp-sdk-android.tgz
 
   build_desktop:
-    name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}
+    name: build-sdk-desktop-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -129,6 +129,7 @@ jobs:
         run: |
           echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
           echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}"
+          echo "::set-env name=SDK_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
 
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg
@@ -157,14 +158,14 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
-          tar -czf firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir ${{ env.SDK_NAME }}
+          tar -czf firebase-cpp-sdk-${{ env.SDK_NAME }}.tgz firebase-cpp-sdk-${{ env.SDK_NAME }}
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
-          path: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz
+          name: firebase-cpp-sdk-${{ env.SDK_NAME }}
+          path: firebase-cpp-sdk-${{ env.SDK_NAME }}.tgz
       
       - name: Stats for ccache (mac and linux)
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -157,14 +157,14 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
-	  tar -czf ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
+	  tar -czf "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz" "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}
-          path: firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz
+          name: "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
+          path: "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz"
       
 
       - name: Stats for ccache (mac and linux)

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -158,6 +158,7 @@ jobs:
       - name: Build SDK
         run: |
           python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
+	  tar -czf "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz" "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -158,7 +158,6 @@ jobs:
       - name: Build SDK
         run: |
           python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
-	  tar -czf "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}.tgz" "firebase-cpp-sdk-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -59,43 +59,43 @@ jobs:
       matrix:
         architecture: [arm64, x86_64]
     steps:
-    - name: fetch SDK
-      uses: actions/checkout@v2.3.1
-      with:
-        path: sdk-src
-        ref: ${{ github.event.inputs.commitId }}
-    - name: install prerequisites
-      run: sdk-src/build_scripts/ios/install_prereqs.sh
-    - name: build sdk
-      run: |
-        sdk-src/build_scripts/ios/build.sh firebase-cpp-sdk-ios-${{ matrix.architecture }} sdk-src ${{ matrix.architecture }}
-        tar -czf firebase-cpp-sdk-ios-${{ matrix.architecture }}.tgz firebase-cpp-sdk-ios-${{ matrix.architecture }}
-    - name: upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: firebase-cpp-sdk-ios-${{ matrix.architecture }}
-        path: firebase-cpp-sdk-ios-${{ matrix.architecture }}.tgz
+      - name: fetch SDK
+        uses: actions/checkout@v2.3.1
+        with:
+          path: sdk-src
+          ref: ${{ github.event.inputs.commitId }}
+      - name: install prerequisites
+        run: sdk-src/build_scripts/ios/install_prereqs.sh
+      - name: build sdk
+        run: |
+          sdk-src/build_scripts/ios/build.sh firebase-cpp-sdk-ios-${{ matrix.architecture }} sdk-src ${{ matrix.architecture }}
+          tar -czf firebase-cpp-sdk-ios-${{ matrix.architecture }}.tgz firebase-cpp-sdk-ios-${{ matrix.architecture }}
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase-cpp-sdk-ios-${{ matrix.architecture }}
+          path: firebase-cpp-sdk-ios-${{ matrix.architecture }}.tgz
 
   build_android:
     name: build-sdk-android
     runs-on: ubuntu-latest
     steps:
-    - name: fetch SDK
-      uses: actions/checkout@v2.3.1
-      with:
-        path: sdk-src
-        ref: ${{ github.event.inputs.commitId }}
-    - name: install prerequisites
-      run: sdk-src/build_scripts/android/install_prereqs.sh
-    - name: build sdk
-      run: |
-        sdk-src/build_scripts/android/build.sh firebase-cpp-sdk-android sdk-src
-        tar -czf firebase-cpp-sdk-android.tgz firebase-cpp-sdk-android
-    - name: upload artifacts
-      uses: actions/upload-artifact@v2
-      with:
-        name: firebase-cpp-sdk-android
-        path: firebase-cpp-sdk-android.tgz
+      - name: fetch SDK
+        uses: actions/checkout@v2.3.1
+        with:
+          path: sdk-src
+          ref: ${{ github.event.inputs.commitId }}
+      - name: install prerequisites
+        run: sdk-src/build_scripts/android/install_prereqs.sh
+      - name: build sdk
+        run: |
+          sdk-src/build_scripts/android/build.sh firebase-cpp-sdk-android sdk-src
+          tar -czf firebase-cpp-sdk-android.tgz firebase-cpp-sdk-android
+      - name: upload artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase-cpp-sdk-android
+          path: firebase-cpp-sdk-android.tgz
 
   build_desktop:
     name: ${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}
@@ -158,7 +158,7 @@ jobs:
       - name: Build SDK
         run: |
           python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
-	  tar -czf firebase-cpp-sdk-"${{ env.MATRIX_UNIQUE_NAME }}".tgz firebase-cpp-sdk-"${{ env.MATRIX_UNIQUE_NAME }}"
+	  tar -czf "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz "firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}"
 
       - name: upload artifacts
         uses: actions/upload-artifact@v2
@@ -166,7 +166,6 @@ jobs:
           name: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}
           path: firebase-cpp-sdk-${{ env.MATRIX_UNIQUE_NAME }}.tgz
       
-
       - name: Stats for ccache (mac and linux)
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
         run: ccache -s

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -158,7 +158,7 @@ jobs:
 
       - name: Build SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir ${{ env.SDK_NAME }}
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --build_dir firebase-cpp-sdk-${{ env.SDK_NAME }}
           tar -czf firebase-cpp-sdk-${{ env.SDK_NAME }}.tgz firebase-cpp-sdk-${{ env.SDK_NAME }}
 
       - name: upload artifacts

--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -19,6 +19,7 @@ if [[ -n $(ls) ]]; then
     echo "Error: build path '${buildpath}' not empty."
     exit 2
 fi
+absbuildpath=$( pwd -P )
 cd -
 
 # If NDK_ROOT is not set or is the wrong version, use to the version in /tmp.
@@ -55,13 +56,11 @@ set -x
 
 if [[ $(uname) == "Linux" ]] || [[ $(uname) == "Darwin" ]]; then
   # Turn buildpath into an absolute path for use later with rsync.
-  absbuildpath=$( mkdir -p "${buildpath}"; cd "${buildpath}" ; pwd -P )
   # Use rsync to copy the relevent paths to the destination directory.
   rsync -aR "${paths[@]}" "${absbuildpath}/"
 else
   # rsync has to be specifically installed on windows bash (including github runners)
   # Also, rsync with absolute destination path doesn't work on Windows.
   # Using a simple copy instead of rsync on Windows.
-  mkdir -p "${buildpath}"
-  cp -R --parents "${paths[@]}" "${buildpath}"
+  cp -R --parents "${paths[@]}" "${absbuildpath}"
 fi

--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 buildpath=$1
 sourcepath=$2
@@ -55,12 +55,13 @@ set -x
 
 if [[ $(uname) == "Linux" ]] || [[ $(uname) == "Darwin" ]]; then
   # Turn buildpath into an absolute path for use later with rsync.
-  buildpath=$( cd "${buildpath}" ; pwd -P )
+  absbuildpath=$( mkdir -p "${buildpath}"; cd "${buildpath}" ; pwd -P )
   # Use rsync to copy the relevent paths to the destination directory.
-  rsync -aR "${paths[@]}" "${buildpath}/"
+  rsync -aR "${paths[@]}" "${absbuildpath}/"
 else
   # rsync has to be specifically installed on windows bash (including github runners)
   # Also, rsync with absolute destination path doesn't work on Windows.
   # Using a simple copy instead of rsync on Windows.
+  mkdir -p "${buildpath}"
   cp -R --parents "${paths[@]}" "${buildpath}"
 fi

--- a/build_scripts/ios/build.sh
+++ b/build_scripts/ios/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -ex
 
 buildpath=$1
 sourcepath=$2


### PR DESCRIPTION
Add desktop build to C++ packaging workflow, using existing desktop python scripts. (This omits pre-packaging testing, as testing will be done on the *packaged* SDK.)