### PR TITLE
Messaging IntegrationTest min Android sdk updated to v26

### DIFF
--- a/messaging/integration_test/build.gradle
+++ b/messaging/integration_test/build.gradle
@@ -1,3 +1,17 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
   repositories {
@@ -62,3 +76,15 @@ firebaseCpp.dependencies {
 }
 
 apply plugin: 'com.google.gms.google-services'
+
+task copyIntegrationTestFiles(type:Exec) {
+  // If this is running form inside the SDK directory, run the setup script.
+  if (project.file('../../setup_integration_tests.py').exists()) {
+    commandLine 'python', '../../setup_integration_tests.py', project.projectDir.toString()
+  }
+  else {
+    commandLine 'echo', ''
+  }
+}
+
+build.dependsOn(copyIntegrationTestFiles)

--- a/messaging/integration_test/build.gradle
+++ b/messaging/integration_test/build.gradle
@@ -1,17 +1,3 @@
-// Copyright 2020 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//      http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
   repositories {
@@ -50,7 +36,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.messaging.testapp'
-    minSdkVersion 16
+    minSdkVersion 26
     targetSdkVersion 28
     versionCode 1
     versionName '1.0'
@@ -76,15 +62,3 @@ firebaseCpp.dependencies {
 }
 
 apply plugin: 'com.google.gms.google-services'
-
-task copyIntegrationTestFiles(type:Exec) {
-  // If this is running form inside the SDK directory, run the setup script.
-  if (project.file('../../setup_integration_tests.py').exists()) {
-    commandLine 'python', '../../setup_integration_tests.py', project.projectDir.toString()
-  }
-  else {
-    commandLine 'echo', ''
-  }
-}
-
-build.dependsOn(copyIntegrationTestFiles)


### PR DESCRIPTION
Updated Messaging Integration Test build.gradle file to require Android SDK 26. 

`src/android/java/LibraryManifest` declares minSDK version 26 as a dependency due to its new  use of JobIntentService. As of Android O, background services can no longer spawn other background services, they must instead create JobIntentServices, which can queue up work for the OS to perform when it is ready. 