### PR TITLE
Build all Android ABIs available in NDK r16b.

### DIFF
--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -24,13 +24,13 @@ android {
       // Default list of ABIs available in up-to-date NDK.
       abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
     }
+    if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
+        // Additional ABIs are added to the list when building using NDK r16b only.
+        ndk.abiFilters.add("armeabi")
+        ndk.abiFilters.add("armeabi-v7a-hard")
+        ndk.abiFilters.add("mips")
+        ndk.abiFilters.add("mips64")
+    }
   }
 }
 
-if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
-    // Additional ABIs are added to the list when building using NDK r16b only.
-    ndk.abiFilters.add("armeabi")
-    ndk.abiFilters.add("armeabi-v7a-hard")
-    ndk.abiFilters.add("mips")
-    ndk.abiFilters.add("mips64")
-}

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -1,0 +1,36 @@
+// Copyright 2018 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Set the list of Android ABIs depending on whether we the NDK_ROOT environment
+// variable contains the text 'r16b' in it. This will generally only occur
+// during C++ packaging, which uses /tmp/android-ndk-r16b as the NDK directory.
+// When using this NDK version, add a few additional ABIs that are only
+// supported in r16b and earlier.
+
+android {
+  defaultConfig {
+    ndk {
+      // Default list of ABIs available in up-to-date NDK.
+      abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+    }
+  }
+}
+
+if (System.getenv(NDK_ROOT) && System.getenv(NDK_ROOT).contains('r16b')) {
+    // Additional ABIs are added to the list when building using NDK r16b only.
+    ndk.abiFilters.add("armeabi")
+    ndk.abiFilters.add("armeabi-v7a-hard")
+    ndk.abiFilters.add("mips")
+    ndk.abiFilters.add("mips64")
+}

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -23,19 +23,19 @@ android {
     ndk {
       // Default list of ABIs available in up-to-date NDK.
       abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
+      
+      if (System.getenv('NDK_ROOT').contains('r16b') ||
+          System.getenv('NDK_ROOT').contains('r11c')) {
+        // Deprecated ABIs are added to the list when building using older NDKs only.
+        // Rather than an exhaustive list, we only support r11c and r16b.
+        abiFilters.add("armeabi")
+        abiFilters.add("mips")
+        abiFilters.add("mips64")
+        if (System.getenv('NDK_ROOT').contains('r11c')) {
+          abiFilters.add("armeabi-v7a-hard")  // Removed after r11c.
+        }
+      }
     }
   }
 }
 
-if (System.getenv('NDK_ROOT')) {
-  if (System.getenv('NDK_ROOT').contains('r16b') || System.getenv('NDK_ROOT').contains('r11c')) {
-    // Deprecated ABIs are added to the list when building using older NDKs only.
-    // Rather than an exhaustive list, we only support r11c and r16b.
-    android.defaultConfig.ndk.abiFilters.add("armeabi")
-    android.defaultConfig.ndk.abiFilters.add("mips")
-    android.defaultConfig.ndk.abiFilters.add("mips64")
-    if (System.getenv('NDK_ROOT').contains('r11c')) {
-      android.defaultConfig.ndk.abiFilters.add("armeabi-v7a-hard")  // Removed after r11c.
-    }
-  }
-}

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -24,13 +24,12 @@ android {
       // Default list of ABIs available in up-to-date NDK.
       abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
     }
-    if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
-        // Additional ABIs are added to the list when building using NDK r16b only.
-        ndk.abiFilters.add("armeabi")
-        ndk.abiFilters.add("armeabi-v7a-hard")
-        ndk.abiFilters.add("mips")
-        ndk.abiFilters.add("mips64")
-    }
   }
 }
 
+if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
+    // Additional ABIs are added to the list when building using NDK r16b only.
+    android.defaultConfig.ndk.abiFilters.add("armeabi")
+    android.defaultConfig.ndk.abiFilters.add("mips")
+    android.defaultConfig.ndk.abiFilters.add("mips64")
+}

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -27,9 +27,15 @@ android {
   }
 }
 
-if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
-    // Additional ABIs are added to the list when building using NDK r16b only.
+if (System.getenv('NDK_ROOT')) {
+  if (System.getenv('NDK_ROOT').contains('r16b') || System.getenv('NDK_ROOT').contains('r11c')) {
+    // Deprecated ABIs are added to the list when building using older NDKs only.
+    // Rather than an exhaustive list, we only support r11c and r16b.
     android.defaultConfig.ndk.abiFilters.add("armeabi")
     android.defaultConfig.ndk.abiFilters.add("mips")
     android.defaultConfig.ndk.abiFilters.add("mips64")
+    if (System.getenv('NDK_ROOT').contains('r11c')) {
+      android.defaultConfig.ndk.abiFilters.add("armeabi-v7a-hard")  // Removed after r11c.
+    }
+  }
 }

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -27,9 +27,13 @@ android {
   }
 }
 
-if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
-    // Additional ABIs are added to the list when building using NDK r16b only.
+if (android.ndkVersion.startsWith("16.") || android.ndkVersion.startsWith("11.")) {
+    // Deprecated ABIs are added to the list when building using older NDKs only.
+    // Rather than an exhaustive list of older NDK versions, we only support r16b and r11c.
     android.defaultConfig.ndk.abiFilters.add("armeabi")
     android.defaultConfig.ndk.abiFilters.add("mips")
     android.defaultConfig.ndk.abiFilters.add("mips64")
+    if (android.ndkVersion.startsWith("11.")) {
+      android.defaultConfig.ndk.abiFilters.add("armeaby-v7a-hard")  // Removed after NDK r11c.
+    }
 }

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -27,7 +27,7 @@ android {
   }
 }
 
-if (System.getenv(NDK_ROOT) && System.getenv(NDK_ROOT).contains('r16b')) {
+if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
     // Additional ABIs are added to the list when building using NDK r16b only.
     ndk.abiFilters.add("armeabi")
     ndk.abiFilters.add("armeabi-v7a-hard")

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -27,13 +27,9 @@ android {
   }
 }
 
-if (android.ndkVersion.startsWith("16.") || android.ndkVersion.startsWith("11.")) {
-    // Deprecated ABIs are added to the list when building using older NDKs only.
-    // Rather than an exhaustive list of older NDK versions, we only support r16b and r11c.
+if (System.getenv('NDK_ROOT') && System.getenv('NDK_ROOT').contains('r16b')) {
+    // Additional ABIs are added to the list when building using NDK r16b only.
     android.defaultConfig.ndk.abiFilters.add("armeabi")
     android.defaultConfig.ndk.abiFilters.add("mips")
     android.defaultConfig.ndk.abiFilters.add("mips64")
-    if (android.ndkVersion.startsWith("11.")) {
-      android.defaultConfig.ndk.abiFilters.add("armeaby-v7a-hard")  // Removed after NDK r11c.
-    }
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,7 @@ android {
   }
 }
 
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/dynamic_links/build.gradle
+++ b/dynamic_links/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {
   generateProguardFile('dynamic_links')

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {
   generateProguardFile('functions')

--- a/instance_id/build.gradle
+++ b/instance_id/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {
   generateProguardFile('instance_id')

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -87,6 +87,7 @@ dependencies {
   implementation project(':app')
   implementation project(':messaging:messaging_java')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/remote_config/build.gradle
+++ b/remote_config/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -86,6 +86,7 @@ android {
 dependencies {
   implementation project(':app')
 }
+apply from: "$rootDir/android_build_files/android_abis.gradle"
 apply from: "$rootDir/android_build_files/extract_and_dex.gradle"
 apply from: "$rootDir/android_build_files/generate_proguard.gradle"
 project.afterEvaluate {


### PR DESCRIPTION
The most recent versions of the NDK don't support the "mips", "mips64", and "armeabi" ABIs, but we still do ship those with the binary C++ SDK to support older devices. This change adds a check to our Android gradle build, which determines whether a custom NDK is being used (as we do in our packaging step), and builds those additional ABIs if the NDK version is the one we expect.

Our custom Android build script supports building with NDK r16b to enable all 3 STL variants as well as the aforementioned older ABIs.

This change also includes an option to build the armeabi-v7a-hard ABI, which was removed a few years ago and subsumed into armeabi-v7a, and thus shouldn't normally be required. (But if you do need armeabi-v7a-hard for some reason, you can use NDK r11c.)
