### PR TITLE
replace set-env commands with github env file

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -31,8 +31,8 @@ jobs:
 
       - name: Set env variables for subsequent steps (all)
         run: |
-          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.architecture }}"
-          echo "::set-env name=GHA_INSTALL_CCACHE::1"
+          echo "MATRIX_UNIQUE_NAME=${{ matrix.os }}-${{ matrix.architecture }}" >> $GITHUB_ENV
+          echo "GHA_INSTALL_CCACHE=1" >> $GITHUB_ENV
 
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -229,9 +229,9 @@ jobs:
 
       - name: Set env variables for subsequent steps (all)
         run: |
-          echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt"
-          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}"
-          echo "::set-env name=SDK_NAME::${{ matrix.sdk_platform }}-${{ matrix.architecture }}-${{ matrix.build_type }}-${{ matrix.linkage }}"
+          echo "VCPKG_RESPONSE_FILE=external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt" >> $GITHUB_ENV
+          echo "MATRIX_UNIQUE_NAME=${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}" >> $GITHUB_ENV
+          echo "SDK_NAME=${{ matrix.sdk_platform }}-${{ matrix.architecture }}-${{ matrix.build_type }}-${{ matrix.linkage }}" >> $GITHUB_ENV
 
       - name: Add msbuild to PATH (windows)
         if: startsWith(matrix.os, 'windows')

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -45,8 +45,8 @@ jobs:
 
       - name: Set env variables for subsequent steps (all)
         run: |
-          echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_custom_data/response_files/${{ matrix.architecture }}-${{ matrix.vcpkg_triplet_suffix }}.txt"
-          echo "::set-env name=MATRIX_UNIQUE_NAME::${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.msvc_runtime }}"
+          echo "VCPKG_RESPONSE_FILE=external/vcpkg_custom_data/response_files/${{ matrix.architecture }}-${{ matrix.vcpkg_triplet_suffix }}.txt" >> $GITHUB_ENV
+          echo "MATRIX_UNIQUE_NAME=${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.msvc_runtime }}" >> $GITHUB_ENV
 
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -66,20 +66,20 @@ jobs:
 
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
-        run: echo "::set-env name=VCPKG_TRIPLET::x64-linux"
+        run: echo "VCPKG_TRIPLET=x64-linux" >> $GITHUB_ENV
       - name: Set env vars (macos)
         if: startsWith(matrix.os, 'macos')
-        run: echo "::set-env name=VCPKG_TRIPLET::x64-osx"
+        run: echo "VCPKG_TRIPLET=x64-osx" >> $GITHUB_ENV
       - name: Set env vars (windows)
         if: startsWith(matrix.os, 'windows')
-        run: echo "::set-env name=VCPKG_TRIPLET::x64-windows-static"
+        run: echo "VCPKG_TRIPLET=x64-windows-static" >> $GITHUB_ENV
       - name: Set env vars(all)
-        run: echo "::set-env name=VCPKG_RESPONSE_FILE::external/vcpkg_${{ env.VCPKG_TRIPLET }}_response_file.txt"
+        run: echo "VCPKG_RESPONSE_FILE=external/vcpkg_${{ env.VCPKG_TRIPLET }}_response_file.txt" >> $GITHUB_ENV
 
       - name: Add msbuild to PATH (windows)
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.1
-  
+
       - name: Cache vcpkg C++ dependencies
         if: matrix.target_platform == 'Desktop'
         id: cache_vcpkg
@@ -97,7 +97,7 @@ jobs:
         if: matrix.target_platform == 'Desktop'
         run: |
           python scripts/gha/install_prereqs_desktop.py
-          
+
       - name: Install SDK Android prerequisites
         if: matrix.target_platform == 'Android'
         shell: bash
@@ -108,27 +108,27 @@ jobs:
         if: matrix.target_platform == 'iOS'
         run: |
           build_scripts/ios/install_prereqs.sh
-          
+
       - name: Prepare for integration tests
         run: |
           pip install -r scripts/gha/requirements.txt
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
-          
+
       - name: Build integration tests (and run Desktop tests)
         # The set up script for Android will download the NDK here.
         env:
           NDK_ROOT: '/tmp/android-ndk-r16b'
         run: |
           python scripts/gha/build_testapps.py --t ${{ github.event.inputs.apis }} --p ${{ matrix.target_platform }} --output_directory ${{ github.workspace }} --use_vcpkg --execute_desktop_testapp --noadd_timestamp
-      
+
       # Workaround for https://github.com/GoogleCloudPlatform/github-actions/issues/100
       # Must be run after the Python setup action
       - name: Set CLOUDSDK_PYTHON (Windows)
         if: startsWith(matrix.os, 'windows') && !cancelled()
-        run: echo "::set-env name=CLOUDSDK_PYTHON::${{env.pythonLocation}}\python.exe"
+        run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
       - name: Install Cloud SDK
         if: ${{ !cancelled() }}
-        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master 
+        uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
       - name: Upload Desktop Artifacts to GCS
         if: matrix.target_platform == 'Desktop' && !cancelled()
         run: |

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,6 +1,6 @@
 name: iOS Builds
 
-on: 
+on:
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -4,13 +4,13 @@ if [[ $(uname) == "Darwin" ]]; then
     platform=darwin
     if [[ ! -z "${GHA_INSTALL_CCACHE}" ]]; then
         brew install ccache
-        echo "::set-env name=CCACHE_INSTALLED::1"
+        echo "CCACHE_INSTALLED=1" >> $GITHUB_ENV
     fi
 elif [[ $(uname) == "Linux" ]]; then
     platform=linux
     if [[ ! -z "${GHA_INSTALL_CCACHE}" ]]; then
         sudo apt install ccache
-        echo "::set-env name=CCACHE_INSTALLED::1"
+        echo "CCACHE_INSTALLED=1" >> $GITHUB_ENV
     fi
 else
     platform=windows


### PR DESCRIPTION
Replaced "set-env" commands across our workflows with the Github Environment files syntax.

Fixes a security flaw outlined in,
https://github.com/actions/toolkit/security/advisories/GHSA-mfwh-5m23-j46w