### PR TITLE
Add hash for generated C++ SDK package so we can verify the file later

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -414,6 +414,7 @@ jobs:
   download_sdk_package:
     name: download-sdk-package
     runs-on: ubuntu-latest
+    needs: [log_inputs]
     if: ${{ github.event.inputs.downloadPublicVersion != '' || github.event.inputs.downloadPreviousRun != '' }}
     steps:
       - name: fetch artifact from previous run
@@ -461,7 +462,7 @@ jobs:
     name: final-merge-packages
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
-    needs: [build_and_package_ios, build_and_package_android, package_desktop]
+    needs: [build_and_package_ios, build_and_package_android, package_desktop, log_inputs]
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -29,9 +29,9 @@ jobs:
       - name: log run inputs
         run: |
           if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" ]]; then
-            echo "::warning ::Using public SDK package at https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_${{ github.event.inputs.downloadPublicVersion }}.zip"
+            echo "::warning ::Downloading public SDK package from https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_${{ github.event.inputs.downloadPublicVersion }}.zip"
           elif [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
-            echo "::warning ::Using SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
+            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
           fi
           if [[ -n "${{ github.event.inputs.commitIdToPackage }}" ]]; then
             if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" || -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -418,6 +418,7 @@ jobs:
     steps:
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.downloadPreviousRun != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -11,6 +11,9 @@ on:
         description: 'public version # to test against'
       downloadPreviousRun:
         description: 'previous run # to test against'
+    outputs:
+      sha256: # SHA256 of the resulting SDK package.
+        description: "SHA256 of the SDK zip file."
 
 env:
   # Packaging prerequisites
@@ -390,9 +393,6 @@ jobs:
     name: download-sdk-package
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion != '' || github.event.inputs.downloadPreviousRun != '' }}
-    outputs:
-      sha256: # SHA256 of the resulting SDK package.
-        description: "SHA256 of the SDK zip file."
     steps:
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
@@ -442,9 +442,6 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     needs: [build_and_package_ios, build_and_package_android, package_desktop]
-    outputs:
-      sha256: # SHA256 of the resulting SDK package.
-        description: "SHA256 of the SDK zip file."
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -390,13 +390,15 @@ jobs:
     name: download-sdk-package
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion != '' || github.event.inputs.downloadPreviousRun != '' }}
+    outputs:
+      sha256: # SHA256 of the resulting SDK package.
+        description: SHA256 of the SDK zip file.
     steps:
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
         if: ${{ github.event.inputs.downloadPreviousRun != '' }}
         with:
-          name: 'firebase_cpp_sdk'
-          path: 'firebase-cpp-sdk-final'
+          name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'
           run_id: ${{ github.event.inputs.downloadPreviousRun }}
 
@@ -407,7 +409,6 @@ jobs:
             echo Invalid version number: "${{ github.event.inputs.downloadPublicVersion }}"
             exit 1
           fi
-          mkdir firebase-cpp-sdk-final
           set +e
           # Retry up to 10 times because Curl has a tendency to timeout on
           # Github runners.
@@ -417,13 +418,24 @@ jobs:
             sleep 300
           done
           set -e
-          cd firebase-cpp-sdk-final
-          unzip ../firebase_cpp_sdk.zip
+
+      - name: log SHA256 hash
+        run: |
+          sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
+          # Set it as an output parameter too.
+          echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
+
+      - name: upload SHA256 hash
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase_cpp_sdk.sha256
+          path: firebase_cpp_sdk.sha256
+          
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: firebase_cpp_sdk
-          path: firebase-cpp-sdk-final
+          name: firebase_cpp_sdk.zip
+          path: firebase_cpp_sdk.zip
           
   merge_packages:
     name: final-merge-packages
@@ -473,16 +485,17 @@ jobs:
         run: |
           cd firebase-cpp-sdk-final
           find firebase_cpp_sdk -type f
-      - name: upload SDK zip
-        uses: actions/upload-artifact@v2
-        with:
-          name: firebase_cpp_sdk.zip
-          path: firebase_cpp_sdk.zip
+
       - name: upload SHA256 hash
         uses: actions/upload-artifact@v2
         with:
           name: firebase_cpp_sdk.sha256
           path: firebase_cpp_sdk.sha256
+      - name: upload SDK zip
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase_cpp_sdk.zip
+          path: firebase_cpp_sdk.zip
 
   cleanup_artifacts:
     # Clean up intermediate artifacts.

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Add msbuild to PATH (windows)
         if: startsWith(matrix.os, 'windows')
-        uses: microsoft/setup-msbuild@v1.0.2
+        uses: microsoft/setup-msbuild@v1.0.1
 
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -392,7 +392,7 @@ jobs:
     if: ${{ github.event.inputs.downloadPublicVersion != '' || github.event.inputs.downloadPreviousRun != '' }}
     outputs:
       sha256: # SHA256 of the resulting SDK package.
-        description: SHA256 of the SDK zip file.
+        description: "SHA256 of the SDK zip file."
     steps:
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
@@ -444,7 +444,7 @@ jobs:
     needs: [build_and_package_ios, build_and_package_android, package_desktop]
     outputs:
       sha256: # SHA256 of the resulting SDK package.
-        description: SHA256 of the SDK zip file.
+        description: "SHA256 of the SDK zip file."
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -11,9 +11,6 @@ on:
         description: 'public version # to test against'
       downloadPreviousRun:
         description: 'previous run # to test against'
-    outputs:
-      sha256: # SHA256 of the resulting SDK package.
-        description: "SHA256 of the SDK zip file."
 
 env:
   # Packaging prerequisites
@@ -422,9 +419,7 @@ jobs:
       - name: log SHA256 hash
         run: |
           sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
-          # Set it as an output parameter too.
-          echo "::set-output name=sha256:$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
-          # echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
+          echo "::warning ::firebase_cpp_sdk.zip SHA256 hash = :$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
       - name: upload SHA256 hash
         uses: actions/upload-artifact@v2
         with:
@@ -475,9 +470,7 @@ jobs:
           # Save the SHA256 hash of the entire SDK package.
           cd ..
           sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
-          # Set it as an output parameter too.
-          echo "::set-output name=sha256:$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
-          # echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
+          echo "::warning ::firebase_cpp_sdk.zip SHA256 hash = :$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
       - name: Print final package contents
         shell: bash
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -546,7 +546,7 @@ jobs:
           path: .
       - name: List binary SDK files.
         run: |
-          unzip firebase_cpp_sdk.zip
+          unzip -q firebase_cpp_sdk.zip
           find . -print
       - name: fetch integration test source
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -78,12 +78,14 @@ jobs:
           cd -
           mkdir -p packaging-tools
           cp -af /tmp/binutils/bin/* packaging-tools
+
       - name: fetch demumble
         uses: actions/checkout@v2.3.1
         with:
           repository: nico/demumble
           path: demumble-src
           ref: v${{ env.demumbleVer }}
+
       - name: build demumble
         run: |
           cd demumble-src
@@ -93,11 +95,13 @@ jobs:
           cd -
           mkdir -p packaging-tools-
           cp -af demumble-src/demumble packaging-tools
+
       - name: archive tools
         run: |
           cd packaging-tools
           ls
           tar -czhf ../packaging-tools.tgz .
+
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -114,14 +118,17 @@ jobs:
         with:
           path: sdk-src
           ref: ${{ github.event.inputs.commitIdToPackage }}
+
       - name: install prerequisites
         run: sdk-src/build_scripts/ios/install_prereqs.sh
+
       - name: build sdk
         run: |
           sdk-src/build_scripts/ios/build.sh -b firebase-cpp-sdk-ios-build -s sdk-src
           sdk-src/build_scripts/ios/package.sh firebase-cpp-sdk-ios-build firebase-cpp-sdk-ios-package
           cd firebase-cpp-sdk-ios-package
           tar -czhf ../firebase-cpp-sdk-ios-package.tgz .
+
       - name: Print built libraries
         shell: bash
         run: |
@@ -131,10 +138,12 @@ jobs:
           find firebase-cpp-sdk-*-build -name "*.a"
           find firebase-cpp-sdk-*-build -name "*.so"
           find firebase-cpp-sdk-*-build -name "*.framework"
+
       - name: Print package contents
         shell: bash
         run: |
           find firebase-cpp-sdk-*-package -type f
+
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -155,14 +164,17 @@ jobs:
         with:
           path: sdk-src
           ref: ${{ github.event.inputs.commitIdToPackage }}
+
       - name: install prerequisites
         run: sdk-src/build_scripts/android/install_prereqs.sh
+
       - name: build sdk
         run: |
           sdk-src/build_scripts/android/build.sh firebase-cpp-sdk-android-${{ matrix.stl }}-build sdk-src ${{ matrix.stl }}
           sdk-src/build_scripts/android/package.sh firebase-cpp-sdk-android-${{ matrix.stl }}-build firebase-cpp-sdk-android-${{ matrix.stl }}-package ${{ matrix.stl }}
           cd firebase-cpp-sdk-android-${{ matrix.stl }}-package
           tar -czhf ../firebase-cpp-sdk-android-${{ matrix.stl}}-package.tgz .
+
       - name: Print built libraries
         shell: bash
         run: |
@@ -172,10 +184,12 @@ jobs:
           find firebase-cpp-sdk-*-build -name "*.a"
           find firebase-cpp-sdk-*-build -name "*.so"
           find firebase-cpp-sdk-*-build -name "*.framework"
+
       - name: Print package contents
         shell: bash
         run: |
           find firebase-cpp-sdk-*-package -type f
+
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -294,6 +308,7 @@ jobs:
           cd firebase-cpp-sdk-${{ env.SDK_NAME }}-build
           find .. -type f -print > src_file_list.txt
           tar -czhf ../firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz .
+
       - name: Print built libraries
         shell: bash
         run: |
@@ -303,6 +318,7 @@ jobs:
           find firebase-cpp-sdk-*-build -name "*.a"
           find firebase-cpp-sdk-*-build -name "*.so"
           find firebase-cpp-sdk-*-build -name "*.framework"
+
       - name: upload artifacts
         uses: actions/upload-artifact@v2
         with:
@@ -363,21 +379,25 @@ jobs:
         with:
           path: sdk-src
           ref: ${{ github.event.inputs.commitIdToPackage }}
+
       - name: download artifact
         uses: actions/download-artifact@v2
         with:
           # download-artifact doesn't support wildcards, but by default
           # will download all artifacts. Sadly this is what we must do.
           path: artifacts
+
       - name: Setup python
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
+
       - name: Install prerequisites
         run: |
           cd sdk-src
           python scripts/gha/install_prereqs_desktop.py
           cd ..
+
       - name: postprocess and package built SDK
         run: |
           mkdir -p bin
@@ -401,10 +421,12 @@ jobs:
           fi
           cd firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package
           tar -czhf ../firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package.tgz .
+
       - name: Print package contents
         shell: bash
         run: |
           find firebase-cpp-sdk-*-package -type f
+
       - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
@@ -443,9 +465,11 @@ jobs:
           set -e
 
       - name: compute SDK hash
+        shell: bash
         run: |
           ${{ env.hashCommand }} --tag firebase_cpp_sdk.zip > firebase_cpp_sdk_hash.txt
           echo "::warning ::$(cat firebase_cpp_sdk_hash.txt)"
+
       - name: upload hash
         uses: actions/upload-artifact@v2
         with:
@@ -478,6 +502,7 @@ jobs:
           path: artifacts
 
       - name: merge SDK packages
+        shell: bash
         run: |
           set -ex
           mkdir -p firebase-cpp-sdk-final/firebase_cpp_sdk
@@ -496,9 +521,11 @@ jobs:
           zip -9 -r -y ../firebase_cpp_sdk.zip firebase_cpp_sdk
           cd ..
       - name: compute SDK hash
+        shell: bash
         run: |
           ${{ env.hashCommand }} --tag firebase_cpp_sdk.zip > firebase_cpp_sdk_hash.txt
           echo "::warning ::$(cat firebase_cpp_sdk_hash.txt)"
+
       - name: Print final package contents
         shell: bash
         run: |
@@ -510,6 +537,7 @@ jobs:
         with:
           name: firebase_cpp_sdk_hash.txt
           path: firebase_cpp_sdk_hash.txt
+
       - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
@@ -566,17 +594,20 @@ jobs:
         with:
           name: firebase_cpp_sdk.zip
           path: .
+
       - name: download hash
         uses: actions/download-artifact@v2
         with:
           name: firebase_cpp_sdk_hash.txt
           path: .
+
       - name: List binary SDK files.
         run: |
           # Verify zipfile hash first.
           ${{ env.hashCommand }} -c --quiet firebase_cpp_sdk_hash.txt
           unzip -q firebase_cpp_sdk.zip
           find . -print
+
       - name: Verify SDK package files.
         run: |
           if [[ -r firebase_cpp_sdk/file_hashes.txt ]]; then
@@ -584,6 +615,7 @@ jobs:
           else
             echo "::warning ::SDK package does not contain file_hashes.txt, cannot verify files in package."
           fi
+
       - name: fetch integration test source
         uses: actions/checkout@v2.3.1
         with:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -22,6 +22,28 @@ env:
   hashCommand: sha256sum
 
 jobs:
+  log_inputs:
+    name: log-inputs
+    runs-on: ubuntu-latest
+    steps:
+      - name: log run inputs
+        run: |
+          if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" ]]; then
+            echo "::warning ::Using public SDK package at https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_${{ github.event.inputs.downloadPublicVersion }}.zip"
+          elif [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]
+            echo "::warning ::Using SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
+          fi
+          if [[ -n "${{ github.event.inputs.commitIdToPackage }}" ]]; then
+            if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" || -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
+              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building tests.
+            else
+              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building and packaging SDK and tests.
+            fi
+          fi
+          if [[ "${{ github.event.inputs.preserveIntermediateArtifacts }}" != "0" ]]; then
+              echo "::warning ::Intermediate artifacts will be preserved.
+          fi
+
   build_tools:
     name: build-tools-${{ matrix.tools_platform }}
     runs-on: ${{ matrix.os }}
@@ -222,7 +244,7 @@ jobs:
           build_type: "Debug"
         - os: ubuntu-latest
           linkage: "dynamic"
-          
+
     steps:
       - uses: actions/checkout@v2
         with:
@@ -230,6 +252,7 @@ jobs:
           ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: Set env variables for subsequent steps (all)
+        shell: bash
         run: |
           echo "VCPKG_RESPONSE_FILE=external/vcpkg_${{ matrix.vcpkg_triplet }}_response_file.txt" >> $GITHUB_ENV
           echo "MATRIX_UNIQUE_NAME=${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}" >> $GITHUB_ENV
@@ -395,7 +418,6 @@ jobs:
     steps:
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.downloadPreviousRun != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'
@@ -427,13 +449,13 @@ jobs:
         with:
           name: firebase_cpp_sdk_hash.txt
           path: firebase_cpp_sdk_hash.txt
-          
+
       - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
-          
+
   merge_packages:
     name: final-merge-packages
     runs-on: ubuntu-latest

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -430,6 +430,9 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     needs: [build_and_package_ios, build_and_package_android, package_desktop]
+    outputs:
+      sha256: # SHA256 of the resulting SDK package.
+        description: SHA256 of the SDK zip file.
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1
@@ -453,16 +456,33 @@ jobs:
           done
           # Add the final files.
           sdk-src/build_scripts/other/package.sh sdk-src firebase-cpp-sdk-final/firebase_cpp_sdk
+
+          # Zip up the package and grab a SHA256 hash of the result.
+          cd firebase-cpp-sdk-final
+          # Save the SHA256 checksum of every file into the SDK package.
+          find firebase_cpp_sdk -type f -print0 | xargs -0 sha256sum > firebase_cpp_sdk/firebase_cpp_sdk.sha256
+          # Zip up the SDK package recursively, preserving symlinks.
+          zip -9 -r -y ../firebase_cpp_sdk.zip firebase_cpp_sdk
+          # Save the SHA256 hash of the entire SDK package.
+          cd ..
+          sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
+          # Set it as an output parameter too.
+          echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
       - name: Print final package contents
         shell: bash
         run: |
           cd firebase-cpp-sdk-final
-          find * -type f
-      - name: upload artifacts
+          find firebase_cpp_sdk -type f
+      - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
-          name: firebase_cpp_sdk
-          path: firebase-cpp-sdk-final
+          name: firebase_cpp_sdk.zip
+          path: firebase_cpp_sdk.zip
+      - name: upload SHA256 hash
+        uses: actions/upload-artifact@v2
+        with:
+          name: firebase_cpp_sdk.sha256
+          path: firebase_cpp_sdk.sha256
 
   cleanup_artifacts:
     # Clean up intermediate artifacts.
@@ -512,10 +532,11 @@ jobs:
       - name: download artifact
         uses: actions/download-artifact@v2
         with:
-          name: firebase_cpp_sdk
+          name: firebase_cpp_sdk.zip
           path: .
       - name: List binary SDK files.
         run: |
+          unzip firebase_cpp_sdk.zip
           find . -print
       - name: fetch integration test source
         uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -506,6 +506,7 @@ jobs:
           # Zip up the SDK package recursively, preserving symlinks.
           zip -9 -r -y ../firebase_cpp_sdk.zip firebase_cpp_sdk
           cd ..
+
       - name: compute SDK hash
         shell: bash
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -18,6 +18,8 @@ env:
   binutilsVer: 2.34
   # Demumble 1.1.0 released Nov 13, 2018
   demumbleVer: 1.1.0
+  # Use SHA256 for hashing files.
+  hashCommand: sha256sum
 
 jobs:
   build_tools:
@@ -380,7 +382,7 @@ jobs:
         shell: bash
         run: |
           find firebase-cpp-sdk-*-package -type f
-      - name: upload artifacts
+      - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
           name: firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix}}-package
@@ -416,17 +418,17 @@ jobs:
           done
           set -e
 
-      - name: log SHA256 hash
+      - name: compute SDK hash
         run: |
-          sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
-          echo "::warning ::firebase_cpp_sdk.zip SHA256 hash = :$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
-      - name: upload SHA256 hash
+          ${{ env.hashCommand }} --tag firebase_cpp_sdk.zip > firebase_cpp_sdk_hash.txt
+          echo "::warning ::$(cat firebase_cpp_sdk_hash.txt)"
+      - name: upload hash
         uses: actions/upload-artifact@v2
         with:
-          name: firebase_cpp_sdk.sha256
-          path: firebase_cpp_sdk.sha256
+          name: firebase_cpp_sdk_hash.txt
+          path: firebase_cpp_sdk_hash.txt
           
-      - name: upload artifacts
+      - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
           name: firebase_cpp_sdk.zip
@@ -461,27 +463,29 @@ jobs:
           # Add the final files.
           sdk-src/build_scripts/other/package.sh sdk-src firebase-cpp-sdk-final/firebase_cpp_sdk
 
-          # Zip up the package and grab a SHA256 hash of the result.
+          # Zip up the package and grab a hash of the result.
           cd firebase-cpp-sdk-final
-          # Save the SHA256 checksum of every file into the SDK package.
-          find firebase_cpp_sdk -type f -print0 | xargs -0 sha256sum > firebase_cpp_sdk/firebase_cpp_sdk.sha256
+          # Save the hash of every file into the SDK package.
+          find firebase_cpp_sdk -type f -print0 | xargs -0 ${{ env.hashCommand }} --tag > file_hashes.txt
+          mv file_hashes.txt firebase_cpp_sdk/
           # Zip up the SDK package recursively, preserving symlinks.
           zip -9 -r -y ../firebase_cpp_sdk.zip firebase_cpp_sdk
-          # Save the SHA256 hash of the entire SDK package.
           cd ..
-          sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
-          echo "::warning ::firebase_cpp_sdk.zip SHA256 hash = :$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
+      - name: compute SDK hash
+        run: |
+          ${{ env.hashCommand }} --tag firebase_cpp_sdk.zip > firebase_cpp_sdk_hash.txt
+          echo "::warning ::$(cat firebase_cpp_sdk_hash.txt)"
       - name: Print final package contents
         shell: bash
         run: |
           cd firebase-cpp-sdk-final
           find firebase_cpp_sdk -type f
 
-      - name: upload SHA256 hash
+      - name: upload hash
         uses: actions/upload-artifact@v2
         with:
-          name: firebase_cpp_sdk.sha256
-          path: firebase_cpp_sdk.sha256
+          name: firebase_cpp_sdk_hash.txt
+          path: firebase_cpp_sdk_hash.txt
       - name: upload SDK zip
         uses: actions/upload-artifact@v2
         with:
@@ -533,15 +537,29 @@ jobs:
     if: always()
     runs-on: ubuntu-latest
     steps:
-      - name: download artifact
+      - name: download SDK zip
         uses: actions/download-artifact@v2
         with:
           name: firebase_cpp_sdk.zip
           path: .
+      - name: download hash
+        uses: actions/download-artifact@v2
+        with:
+          name: firebase_cpp_sdk_hash.txt
+          path: .
       - name: List binary SDK files.
         run: |
+          # Verify zipfile hash first.
+          ${{ env.hashCommand }} -c --quiet firebase_cpp_sdk_hash.txt
           unzip -q firebase_cpp_sdk.zip
           find . -print
+      - name: Verify SDK package files.
+        run: |
+          if [[ -r firebase_cpp_sdk/file_hashes.txt ]]; then
+            ${{ env.hashCommand }} -c --quiet firebase_cpp_sdk/file_hashes.txt
+          else
+            echo "::warning ::SDK package does not contain file_hashes.txt, cannot verify files in package."
+          fi
       - name: fetch integration test source
         uses: actions/checkout@v2.3.1
         with:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" ]]; then
             echo "::warning ::Using public SDK package at https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_${{ github.event.inputs.downloadPublicVersion }}.zip"
-          elif [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]
+          elif [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
             echo "::warning ::Using SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
           fi
           if [[ -n "${{ github.event.inputs.commitIdToPackage }}" ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -35,13 +35,13 @@ jobs:
           fi
           if [[ -n "${{ github.event.inputs.commitIdToPackage }}" ]]; then
             if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" || -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
-              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building tests.
+              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building tests."
             else
-              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building and packaging SDK and tests.
+              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building and packaging SDK and tests."
             fi
           fi
           if [[ "${{ github.event.inputs.preserveIntermediateArtifacts }}" != "0" ]]; then
-              echo "::warning ::Intermediate artifacts will be preserved.
+            echo "::warning ::Intermediate artifacts will be preserved."
           fi
 
   build_tools:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -423,8 +423,8 @@ jobs:
         run: |
           sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
           # Set it as an output parameter too.
-          echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
-
+          echo "::set-output name=sha256:$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
+          # echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
       - name: upload SHA256 hash
         uses: actions/upload-artifact@v2
         with:
@@ -476,7 +476,8 @@ jobs:
           cd ..
           sha256sum firebase_cpp_sdk.zip > firebase_cpp_sdk.sha256
           # Set it as an output parameter too.
-          echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
+          echo "::set-output name=sha256:$(cut -f1 -d' ' firebase_cpp_sdk.sha256)"
+          # echo "sha256=$(cut -f1 -d' ' firebase_cpp_sdk.sha256)" >> $GITHUB_ENV
       - name: Print final package contents
         shell: bash
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -260,7 +260,7 @@ jobs:
 
       - name: Add msbuild to PATH (windows)
         if: startsWith(matrix.os, 'windows')
-        uses: microsoft/setup-msbuild@v1.0.1
+        uses: microsoft/setup-msbuild@v1.0.2
 
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg


### PR DESCRIPTION
This adds a file hash for the firebase_cpp_sdk.zip package, which will allow us to verify the generated package later (i.e. when it is put up for download):
- Log a SHA256 hash of the generated firebase_cpp_sdk.zip package, and add the hash as a downloadable artifact as well.
- Add a file to the generated package with a hash for every file contained in the package. In the integration test step, code has been added to verify every file's hash if this file exists and error out if any don't match.

Also, if the workflow is run with certain inputs to customize its behavior, this is now logged:
- If a run is made against a specific commit ID, log the commit ID.
- If a run is just to test an existing packaged SDK (public or from a previous run), log its source.
- If a run is set to preserve intermediate artifacts, log it.

*Important:* This PR changes the final C++ SDK package artifact from **firebase_cpp_sdk** to **firebase_cpp_sdk.zip**, so that the hash can be generated. Any subsequent step that uses that SDK package artifact will have to change the artifact name it downloads to firebase_cpp_sdk.zip and unzip it first before use.

Also note that because GitHub Actions does not yet support "::notice", we are logging these as "::warning" messages for now. This will be changed in the future when possible.
