### PR TITLE
Feature/fix windows vcpkg rename error

### DIFF
--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -202,6 +202,10 @@ def main():
                                         args.msvc_runtime_library,
                                         attempt_auto_fix=False)
 
+  if args.vcpkg_step_only:
+    print("Exiting without building the SDK as just vcpkg step was requested.")
+    return
+
   # CMake configure
   cmake_configure(args.build_dir, args.arch, args.msvc_runtime_library,
                   args.build_tests, args.config, args.target_format)
@@ -239,6 +243,7 @@ def parse_cmdline_args():
                       help='Runtime library for MSVC (static(/MT) or dynamic(/MD)')
   parser.add_argument('--build_dir', default='build', help='Output build directory')
   parser.add_argument('--build_tests', action='store_true', help='Build unit tests too')
+  parser.add_argument('--vcpkg_step_only', action='store_true', help='Just install cpp packages using vcpkg and exit.')
   parser.add_argument('--config', default='Release', help='Release/Debug config')
   parser.add_argument('--target', nargs='+', help='A list of CMake build targets (eg: firebase_app firebase_auth)')
   parser.add_argument('--target_format', default=None, help='(Mac only) whether to output frameworks (default) or libraries.')

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -198,6 +198,8 @@ def main():
   if not success:
     # If auto-fix was attempted, give it one more try.
     # If it fails again, a ValueError will be raised and script will exit.
+    print("Installation was not successful but auto fix was attempted. "
+          "Retrying installation...")
     install_cpp_dependencies_with_vcpkg(args.arch,
                                         args.msvc_runtime_library,
                                         attempt_auto_fix=False)

--- a/scripts/gha/utils.py
+++ b/scripts/gha/utils.py
@@ -193,8 +193,11 @@ def verify_vcpkg_build(vcpkg_triplet, attempt_auto_fix=False):
       # Manually renaming and re-running script makes it go through.
       tools_dir_path = os.path.join(vcpkg_root_dir_path, 'downloads', 'tools')
       for name in os.listdir(tools_dir_path):
+        # In the specific windows error that we noticed, the error occurs while
+        # trying to rename intermediate directories for donwloaded tools
+        # like "powershell.partial.<pid>" to "powershell". Renaming via python
+        # also runs into the same error. Workaround is to copy instead of rename.
         if '.partial.' in name and os.path.isdir(os.path.join(tools_dir_path, name)):
-          # Since we can't rename, lets copy the directory to one without partial in the name
           expected_name = name.split('.partial.')[0]
           shutil.copytree(os.path.join(tools_dir_path, name),
                           os.path.join(tools_dir_path, expected_name))


### PR DESCRIPTION
On Windows, we noticed a strange error thrown by vcpkg build step that complains of permissions errors for renaming temporary downloaded files. Manually renaming these directories on disk and re-running the script makes it go through.

Handling this special case in our build scripts now so users dont have to manually rename and run the script again.