### PR TITLE
Deduplicate vcpkg logic in testapp builder

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -69,10 +69,10 @@ modify your bashrc file to automatically set these variables.
 import datetime
 from distutils import dir_util
 import os
-import pathlib
 import platform
 import shutil
 import subprocess
+import sys
 
 from absl import app
 from absl import flags
@@ -81,8 +81,8 @@ from absl import logging
 import attr
 
 from integration_testing import config_reader
-from integration_testing import provisioning
 from integration_testing import xcodebuild
+import utils
 
 # Environment variables
 _JAVA_HOME = "JAVA_HOME"
@@ -195,14 +195,18 @@ def main(argv):
 
   if update_pod_repo and _IOS in platforms:
     _run(["pod", "repo", "update"])
-    
+
   config = config_reader.read_config()
   cmake_flags = _get_desktop_compiler_flags(FLAGS.compiler, config.compilers)
   if _DESKTOP in platforms and FLAGS.use_vcpkg:
-    _run(["git", "submodule", "update", "--init"])
-    vcpkg = Vcpkg.generate(os.path.join(sdk_dir, config.vcpkg_dir))
-    vcpkg.install_and_run()
-    cmake_flags.extend(vcpkg.cmake_flags)
+    installer = os.path.join(sdk_dir, "scripts", "gha", "build_desktop.py")
+    _run([sys.executable, installer, "--vcpkg_step_only"])
+    toolchain_file = os.path.join(
+        sdk_dir, "external", "vcpkg", "scripts", "buildsystems", "vcpkg.cmake")
+    cmake_flags.extend((
+        "-DCMAKE_TOOLCHAIN_FILE=%s" % toolchain_file,
+        "-DVCPKG_TARGET_TRIPLET=%s" % utils.get_vcpkg_triplet(arch="x64")
+    ))
 
   failures = []
   for testapp in testapps:
@@ -226,7 +230,7 @@ def main(argv):
 
 
 def _build(
-    testapp, platforms, api_config, output_dir, sdk_dir, ios_framework_exist, 
+    testapp, platforms, api_config, output_dir, sdk_dir, ios_framework_exist,
     timestamp, root_dir, ios_sdk, cmake_flags, execute_desktop_testapp):
   """Builds one testapp on each of the specified platforms."""
   testapp_dir = os.path.join(root_dir, api_config.testapp_path)
@@ -382,7 +386,7 @@ def _validate_android_environment_variables():
           "Neither %s nor %s is set", _ANDROID_SDK_HOME, _ANDROID_HOME)
 
 
-# If sdk_dir contains no framework, consider it is Github repo, then 
+# If sdk_dir contains no framework, consider it is Github repo, then
 # generate makefiles for ios frameworks
 def _generate_makefiles_from_repo(sdk_dir):
   ios_framework_builder = os.path.join(
@@ -401,14 +405,14 @@ def _generate_makefiles_from_repo(sdk_dir):
 def _build_ios_framework_from_repo(sdk_dir, api_config):
   ios_framework_builder = os.path.join(
     sdk_dir, "build_scripts", "ios", "build.sh")
-  
+
   # build only required targets to save time
   target = set()
   for framework in api_config.frameworks:
     target.add(os.path.splitext(framework)[0])
   # firebase is not a target in CMake, firebase_app is the target
-  # firebase_app will be built by other target as well 
-  target.remove("firebase") 
+  # firebase_app will be built by other target as well
+  target.remove("firebase")
 
   framework_builder_args = [
       ios_framework_builder,
@@ -444,7 +448,7 @@ def _build_ios(
   app_podfile_path = os.path.join(
       project_dir, "Podfile")
   podfile_patcher_args = [
-      "python", podfile_tool_path,
+      sys.executable, podfile_tool_path,
       "--sdk_podfile", sdk_podfile_path,
       "--app_podfile", app_podfile_path
   ]
@@ -496,7 +500,7 @@ def _run_setup_script(root_dir, testapp_dir):
   """Runs the setup_integration_tests.py script if needed."""
   script_path = os.path.join(root_dir, "setup_integration_tests.py")
   if os.path.isfile(script_path):
-    _run(["python", script_path, testapp_dir])
+    _run([sys.executable, script_path, testapp_dir])
   else:
     logging.info("setup_integration_tests.py not found")
 
@@ -527,55 +531,6 @@ def _rm_dir_safe(directory_path):
 def _fix_path(path):
   """Expands ~, normalizes slashes, and converts relative paths to absolute."""
   return os.path.abspath(os.path.expanduser(path))
-
-
-@attr.s(frozen=True, eq=False)
-class Vcpkg(object):
-  """Holds data related to the vcpkg tool used for managing dependent tools."""
-  installer = attr.ib()
-  binary = attr.ib()
-  triplet = attr.ib()
-  response_file = attr.ib()
-  toolchain_file = attr.ib()
-
-  @classmethod
-  def generate(cls, vcpkg_dir):
-    """Generates the vcpkg data based on the given vcpkg submodule path."""
-    installer = os.path.join(vcpkg_dir, "bootstrap-vcpkg")
-    binary = os.path.join(vcpkg_dir, "vcpkg")
-    response_file_fmt = vcpkg_dir + "_%s_response_file.txt"
-    if platform.system() == "Windows":
-      triplet = "x64-windows-static"
-      installer += ".bat"
-      binary += ".exe"
-    elif platform.system() == "Darwin":
-      triplet = "x64-osx"
-      installer += ".sh"
-    elif platform.system() == "Linux":
-      triplet = "x64-linux"
-      installer += ".sh"
-    else:
-      raise ValueError("Unrecognized system: %s" % platform.system())
-    return cls(
-        installer=installer,
-        binary=binary,
-        triplet=triplet,
-        response_file=response_file_fmt % triplet,
-        toolchain_file=os.path.join(
-            vcpkg_dir, "scripts", "buildsystems", "vcpkg.cmake"))
-
-  def install_and_run(self):
-    """Installs vcpkg (if needed) and runs it to install dependencies."""
-    if not os.path.exists(self.binary):
-      _run([self.installer])
-    _run([
-        self.binary, "install", "@" + self.response_file, "--disable-metrics"])
-
-  @property
-  def cmake_flags(self):
-    return [
-        "-DCMAKE_TOOLCHAIN_FILE=%s" % self.toolchain_file,
-        "-DVCPKG_TARGET_TRIPLET=%s" % self.triplet]
 
 
 @attr.s(frozen=True, eq=False)

--- a/scripts/gha/integration_testing/build_testapps.json
+++ b/scripts/gha/integration_testing/build_testapps.json
@@ -174,7 +174,6 @@
       "provision": "Google_Development.mobileprovision"
     }
   ],
-  "vcpkg_dir": "external/vcpkg",
   "apple_team_id": "REPLACE_ME_TEMP_INVALID_ID",
   "compiler_dict": {
     "gcc-4.8": [

--- a/scripts/gha/integration_testing/config_reader.py
+++ b/scripts/gha/integration_testing/config_reader.py
@@ -97,7 +97,6 @@ def read_config(path=None):
     return Config(
         apis=api_configs,
         apple_team_id=config["apple_team_id"],
-        vcpkg_dir=config["vcpkg_dir"],
         compilers=config["compiler_dict"])
   except (KeyError, TypeError, IndexError):
     # The error will be cryptic on its own, so we dump the JSON to
@@ -112,7 +111,6 @@ def read_config(path=None):
 class Config(object):
   apis = attr.ib()  # Mapping of str: APIConfig
   apple_team_id = attr.ib()
-  vcpkg_dir = attr.ib()  # Relative location of the vcpkg submodule in the repo.
   compilers = attr.ib()
 
   def get_api(self, api):


### PR DESCRIPTION
The testapp builder duplicated some vcpkg logic: this removes that duplication, instead relying on build_desktop.py's "vcpkg_step_only" mode, and some logic from utils.py

This fixes a break caused by a change in the structure of the vcpkg response files which was not reflected in this duplicated logic, and will prevent similar breakages in the future. 