### PR TITLE
Fix gCloud steps in integration tests on Windows

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -663,6 +663,7 @@ jobs:
     # Workaround for https://github.com/GoogleCloudPlatform/github-actions/issues/100
     # Must be run after the Python setup action
     - name: Set CLOUDSDK_PYTHON (Windows)
+      shell: bash
       if: runner.os == 'Windows' && !cancelled()
       run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
     - name: Install Cloud SDK

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -123,6 +123,7 @@ jobs:
       # Workaround for https://github.com/GoogleCloudPlatform/github-actions/issues/100
       # Must be run after the Python setup action
       - name: Set CLOUDSDK_PYTHON (Windows)
+        shell: bash
         if: startsWith(matrix.os, 'windows') && !cancelled()
         run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
       - name: Install Cloud SDK


### PR DESCRIPTION
The setting of these env vars was recently updated to use the new syntax. This does not work as-is on powershell due to encoding, as documented here:
https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-commands-for-github-actions#environment-files

As a result, the gCloud tools were not working on Windows as an env var needed to work around a known gCloud bug was not being set.

To fix this, we set the env var using bash.