### PR TITLE
Use Pixel 3, API 28 instead of Pixel 4, API 29

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -620,8 +620,8 @@ jobs:
       fail-fast: false
     env:
       apis: admob,analytics,auth,database,dynamic_links,firestore,functions,instance_id,messaging,remote_config,storage
-      android_device: blueline
-      android_api: 28
+      android_device: walleye
+      android_api: 27
       ios_device: iphone11pro
       ios_version: 13.3
     steps:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -620,8 +620,8 @@ jobs:
       fail-fast: false
     env:
       apis: admob,analytics,auth,database,dynamic_links,firestore,functions,instance_id,messaging,remote_config,storage
-      android_device: flame
-      android_api: 29
+      android_device: blueline
+      android_api: 28
       ios_device: iphone11pro
       ios_version: 13.3
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,10 +17,10 @@ on:
         required: true
       android_device:
         description: 'Android device model'
-        default: 'blueline'
+        default: 'walleye'
       android_api:
         description: 'Android API level'
-        default: '28'
+        default: '27'
       ios_device:
         description: 'iOS device model'
         default: 'iphone11pro'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -17,10 +17,10 @@ on:
         required: true
       android_device:
         description: 'Android device model'
-        default: 'flame'
+        default: 'blueline'
       android_api:
         description: 'Android API level'
-        default: '29'
+        default: '28'
       ios_device:
         description: 'iOS device model'
         default: 'iphone11pro'


### PR DESCRIPTION
This pixel 4 device seems to be getting unusual and inconsistent gmscore issues not replicable on other devices, even on the same API level.

Switch to a different default device to avoid these, at least as a temporary workaround.