### PR TITLE
Remove several Windows test jobs from pull requests

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -14,15 +14,9 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        architecture: ["x64",]
-        include:
-        - os: ubuntu-latest
-          architecture: "x64"
-        - os: macos-latest
-          architecture: "x64"
-        - os: windows-latest
-          architecture: "x64"
+        # Windows temporarily removed while broken
+        os: [ubuntu-latest, macos-latest]
+        architecture: ["x64"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -22,16 +22,19 @@ jobs:
         architecture: ["x64", "x86"]
         python_version: [3.7]
         include:
+        # Add these Windows jobs.
         - os: windows-latest
           build_type: "Release"
           architecture: "x64"
           msvc_runtime: "static"
-          vcpkg_triplet: "windows-static"
+          vcpkg_triplet_suffix: "windows-static"
         - os: windows-latest
           build_type: "Debug"
           architecture: "x86"
           msvc_runtime: "dynamic"
-          vcpkg_triplet: "windows-static-md"
+          vcpkg_triplet_suffix: "windows-static-md"
+
+        # Specify additional parameters for these jobs.
         - os: ubuntu-latest
           msvc_runtime: "static"
           vcpkg_triplet_suffix: "linux"
@@ -39,6 +42,7 @@ jobs:
           msvc_runtime: "static"
           vcpkg_triplet_suffix: "osx"
 
+        # Don't build for x86 on MacOS.
         exclude:
         - os: macos-latest
           architecture: "x86"

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -17,32 +17,30 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86"]
-        msvc_runtime: ["static"]
         python_version: [3.7]
         include:
         - os: windows-latest
-          vcpkg_triplet_suffix: "windows-static"
+          build_type: "Release"
+          architecture: "x64"
+          msvc_runtime: "static"
+          vcpkg_triplet: "windows-static"
+        - os: windows-latest
+          build_type: "Debug"
+          architecture: "x86"
+          msvc_runtime: "dynamic"
+          vcpkg_triplet: "windows-static-md"
         - os: ubuntu-latest
+          msvc_runtime: "static"
           vcpkg_triplet_suffix: "linux"
         - os: macos-latest
+          msvc_runtime: "static"
           vcpkg_triplet_suffix: "osx"
 
         exclude:
         - os: macos-latest
-          architecture: "x86"
-        - os: macos-latest
-          msvc_runtime: "dynamic"
-        - os: ubuntu-latest
-          msvc_runtime: "dynamic"
-        # Windows currently takes too long. These are (possibly temporary)
-        # exclusions to mitigate queuing issues caused by excessive
-        # work done on GHA on every PR.
-        - os: windows-latest
-          build_type: "Release"
-        - os: windows-latest
           architecture: "x86"
 
     steps:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -20,15 +20,11 @@ jobs:
         os: [windows-latest, ubuntu-latest, macos-latest]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86"]
-        msvc_runtime: ["static", "dynamic"]
+        msvc_runtime: ["static"]
         python_version: [3.7]
         include:
         - os: windows-latest
           vcpkg_triplet_suffix: "windows-static"
-        - os: windows-latest
-          msvc_runtime: "dynamic"
-
-          vcpkg_triplet_suffix: "windows-static-md"
         - os: ubuntu-latest
           vcpkg_triplet_suffix: "linux"
         - os: macos-latest
@@ -41,6 +37,13 @@ jobs:
           msvc_runtime: "dynamic"
         - os: ubuntu-latest
           msvc_runtime: "dynamic"
+        # Windows currently takes too long. These are (possibly temporary)
+        # exclusions to mitigate queuing issues caused by excessive
+        # work done on GHA on every PR.
+        - os: windows-latest
+          build_type: "Release"
+        - os: windows-latest
+          architecture: "x86"
 
     steps:
       - name: setup Xcode version (macos)


### PR DESCRIPTION
We're experiencing queuing on GHA from trying to use too many machine resources. A disproportionate chunk of this is coming from Windows and its excessive build permutations.

Android on Windows has been broken for a while - temporarily removed until fixed.

For desktop, remove 6 of the permutations, leaving the two required ones: Release-x64-static and Debug-x86-dynamic.