### PR TITLE
Use an older version of binutils on Mac

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -21,10 +21,6 @@ on:
 
 env:
   # Packaging prerequisites
-  # Binutils 2.35.1 released Sep 19, 2020
-  binutilsVerLinux: "2.35.1"
-  # On Mac, use an older Binutils to avoid corrupted libraries.
-  binutilsVerDarwin: "2.28.1"
   # Demumble 1.1.0 released Nov 13, 2018
   demumbleVer: "1.1.0"
   # Use SHA256 for hashing files.
@@ -69,10 +65,12 @@ jobs:
         include:
         - os: ubuntu-latest
           tools_platform: linux
-          binutils_version: ${{ env.binutilsVerLinux }}
+          # Binutils 2.35.1 released Sep 19, 2020
+          binutils_version: "2.35.1"
         - os: macos-latest
           tools_platform: darwin
-          binutils_version: ${{ env.binutilsVerDarwin }}
+          # On Mac, use an older Binutils to avoid corrupted libraries.
+          binutils_version: "2.28.1"
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -22,7 +22,9 @@ on:
 env:
   # Packaging prerequisites
   # Binutils 2.35.1 released Sep 19, 2020
-  binutilsVer: "2.35.1"
+  binutilsVerLinux: "2.35.1"
+  # On Mac, use an older Binutils to avoid corrupted libraries.
+  binutilsVerDarwin: "2.28.1"
   # Demumble 1.1.0 released Nov 13, 2018
   demumbleVer: "1.1.0"
   # Use SHA256 for hashing files.
@@ -67,8 +69,10 @@ jobs:
         include:
         - os: ubuntu-latest
           tools_platform: linux
+          binutils_version: ${{ env.binutilsVerLinux }}
         - os: macos-latest
           tools_platform: darwin
+          binutils_version: ${{ env.binutilsVerDarwin }}
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -81,13 +85,13 @@ jobs:
           # Github runners.
           for retry in {1..10} error; do
           if [[ $retry == "error" ]]; then exit 5; fi
-            curl -L https://ftpmirror.gnu.org/binutils/binutils-${{ env.binutilsVer }}.tar.xz --output binutils.tar.xz && break
+            curl -L https://ftpmirror.gnu.org/binutils/binutils-${{ matrix.binutils_version }}.tar.xz --output binutils.tar.xz && break
             sleep 300
           done
           set -e
 
           tar -xf binutils.tar.xz
-          mv ./binutils-${{ env.binutilsVer }} ./binutils-src
+          mv ./binutils-${{ matrix.binutils_version }} ./binutils-src
           cd binutils-src
           ./configure --enable-targets=all --prefix=/tmp/binutils
           make

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,7 +250,11 @@ if(DESKTOP)
 
   add_external_library(uWebSockets)
 
-  set(websockets_additional_defines "")
+  # Binutils on Mac doesn't support thread-local storage (required by
+  # websockets), but because we only use websockets via the scheduler,
+  # we don't need it.
+  
+  set(websockets_additional_defines "-D__thread=")
 
   # uWebSockets does not come with a CMakeLists file, so define the target.
   # Note that since it depends on OpenSSL, only do so if that was found.

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -199,7 +199,7 @@ readonly rename_string=f_b_
 
 readonly demangle_cmds=${tools_path}/c++filt,${tools_path}/demumble
 readonly binutils_objcopy=${tools_path}/objcopy
-if [[ -x ${tools_path}/nm-new ]] ;; then
+if [[ -x ${tools_path}/nm-new ]] ; then
     readonly binutils_nm=${tools_path}/nm-new
 else
     readonly binutils_nm=${tools_path}/nm

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -199,7 +199,11 @@ readonly rename_string=f_b_
 
 readonly demangle_cmds=${tools_path}/c++filt,${tools_path}/demumble
 readonly binutils_objcopy=${tools_path}/objcopy
-readonly binutils_nm=${tools_path}/nm
+if [[ -x ${tools_path}/nm-new ]] ;; then
+    readonly binutils_nm=${tools_path}/nm-new
+else
+    readonly binutils_nm=${tools_path}/nm
+fi
 readonly binutils_ar=${tools_path}/ar
 
 cache_file=/tmp/merge_libraries_cache.$$


### PR DESCRIPTION
Using the latest binutils causes blastdoor to create invalid Mac libraries that crash the linker. Until this is fixed in binutils, use an older version that is known to work.

Because this older version does not support thread-local storage on Mac, disable thread-local storage in our usage of websockets via a define at build time. This does not cause a problem because we only use websockets via the Firebase scheduler, which runs all websockets requests in a single worker thread.