### PR TITLE
Feature/linux x86 dont install if packages exist

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,6 +3,7 @@ name: Desktop Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,7 +3,6 @@ name: Desktop Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -59,7 +59,7 @@ def append_line_to_file(path, line):
 def install_x86_support_libraries():
   """Install support libraries needed to build x86 on x86_64 hosts."""
   if utils.is_linux_os():
-    packages = ('gcc-multilib', 'g++-multilib', 'libglib2.0-dev:i386', 'libsecret-1-dev:i386')
+    packages = ['gcc-multilib', 'g++-multilib', 'libglib2.0-dev:i386', 'libsecret-1-dev:i386']
 
     # First check if these packages exist on the machine already
     devnull = open(os.devnull, "w")


### PR DESCRIPTION
For linux x86 builds, we have to install some required i386 packages before proceeding with the build.
This is an optimization to only run these install commands if those packages dont exist already).
Avoids having the user to type in their password everytime as these commands require admin rights. 