### PR TITLE
Change integration test log level to "debug"

### DIFF
--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -208,7 +208,7 @@ std::ostream& operator<<(std::ostream& os, const Variant& v) {
 extern "C" int common_main(int argc, char* argv[]) {
   ::testing::InitGoogleTest(&argc, argv);
   firebase_test_framework::FirebaseTest::SetArgs(argc, argv);
-  app_framework::SetLogLevel(app_framework::kInfo);
+  app_framework::SetLogLevel(app_framework::kDebug);
   // Anything below the given log level will be preserved, and printed out in
   // the event of test failure.
   app_framework::SetPreserveFullLog(true);


### PR DESCRIPTION
Currently the logging behaviour for "debug" level logs is set to show them at the end of the integration test, if there were any failures. If the integration test prematurely ends (crash, failed assertion, or timeout), this results in them not showing up at all. In practice, this often leads to a lack of relevant logs to understand why a test didn't complete.

To fix this, the overall log level is changed from info to debug. This ensures debug logs are logged immediately, so a prematurely ended test won't prevent them from appearing.

This includes a fix to the desktop_tester script to capture logs in the event of a process timeout: previously, result.stdout was used, which doesn't get populated if the process timed out (resulting in missing logs). Instead, we access output from the error. Experimentation revealed that this output will sometimes be text, and sometimes binary: it's unclear what's responsible for this difference (possibly the encoding settings of the environment running the script). Thus we try to decode the binary, and store it as-is if it's already text. 