### PR TITLE
Minor fixes to testing in the packaging workflow

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -653,7 +653,7 @@ jobs:
         python-version: '3.7'
     - name: Add msbuild to PATH (windows)
       if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v1.0.1
+      uses: microsoft/setup-msbuild@v1.0.2
     - name: Prepare for integration tests
       run: |
         pip install -r scripts/gha/requirements.txt

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -658,10 +658,14 @@ jobs:
       run: |
         pip install -r scripts/gha/requirements.txt
         python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
-    - name: Build integration tests (and run Desktop tests)
+    - name: Build integration tests
       run: |
-        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --sdk_dir firebase_cpp_sdk --output_directory ${{ github.workspace }} --execute_desktop_testapp --noadd_timestamp
-
+        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --sdk_dir firebase_cpp_sdk --output_directory ${{ github.workspace }} --noadd_timestamp
+    
+    - name: Run desktop integration tests
+      if: matrix.target_platform == 'Desktop' && !cancelled()
+      run: |
+        python scripts/gha/desktop_tester.py --testapp_dir testapps
     # Workaround for https://github.com/GoogleCloudPlatform/github-actions/issues/100
     # Must be run after the Python setup action
     - name: Set CLOUDSDK_PYTHON (Windows)

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -136,11 +136,11 @@ jobs:
       - name: Upload Desktop Artifacts to GCS
         if: matrix.target_platform == 'Desktop' && !cancelled()
         run: |
-          python scripts/gha/gcs_uploader.py --testapp_dir ${{ github.workspace }}/testapps --key_file ${{ github.workspace }}/scripts/gha-encrypted/gcs_key_file.json
+          python scripts/gha/gcs_uploader.py --testapp_dir testapps --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Run mobile integration tests
         if: matrix.target_platform != 'Desktop' && !cancelled()
         run: |
-          python scripts/gha/test_lab.py --android_model ${{ github.event.inputs.android_device }} --android_api ${{ github.event.inputs.android_api }} --ios_model ${{ github.event.inputs.ios_device }} --ios_version ${{ github.event.inputs.ios_version }} --testapp_dir ${{ github.workspace }}/testapps --code_platform cpp --key_file ${{ github.workspace }}/scripts/gha-encrypted/gcs_key_file.json
+          python scripts/gha/test_lab.py --android_model ${{ github.event.inputs.android_device }} --android_api ${{ github.event.inputs.android_api }} --ios_model ${{ github.event.inputs.ios_device }} --ios_version ${{ github.event.inputs.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Summarize build and test results
         if: ${{ !cancelled() }}
         shell: bash


### PR DESCRIPTION
Desktop integration testing was separated from the build script, but not applied to the testing in the packaging workflow (or possibly lost during merge conflict resolution). This applies it, consistent with the integration_tests.yml workflow.

Also updates the setup-msbuild action to 1.0.2 as 1.0.1 no longer works (this is consistent with other usages of the action in these workflows).

The change to integration_tests.yml removes redundant references to github.workspace (no behaviour change).