### PR TITLE
Firestore Dependency update & gmock include fix

### DIFF
--- a/app/tests/heartbeat_info_desktop_test.cc
+++ b/app/tests/heartbeat_info_desktop_test.cc
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "app/src/heartbeat_date_storage_desktop.h"
-#include "testing/base/public/gmock.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {

--- a/app/tests/util_test.cc
+++ b/app/tests/util_test.cc
@@ -16,7 +16,7 @@
 
 #include "app/src/util.h"
 
-#include "testing/base/public/gmock.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {

--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -21,7 +21,7 @@ endif()
 # Using a firestore version that has been updated to use 
 # nanopb 0.3.9.6 instead of 0.3.9.5. This was necessary 
 # because nanopb 0.3.9.5 doesn't build with python3.
-set(version f33276f5305bb81b67e006f50b14f4a2adc3cb60)
+set(version c887ea1a8de22bbd980e2aca0ac51bb074201b96)
 ExternalProject_Add(
   firestore
 

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -156,7 +156,7 @@ elseif(IOS)
       "${ios_SRCS}")
 else()
   set(database_platform_SRCS
-        "${desktop_SRCS}"
+        "${desktop_SRCS}")
 endif()
 
 if(ANDROID OR IOS)

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -155,18 +155,8 @@ elseif(IOS)
   set(database_platform_SRCS
       "${ios_SRCS}")
 else()
-  # Add platform-specific util files.
-  if(MSVC)
-    set(desktop_extra_SRCS src/desktop/util_desktop_windows.cc)
-  elseif(APPLE)
-    set(desktop_extra_SRCS src/desktop/util_desktop_macos.mm)
-  else()
-    # Linux
-    set(desktop_extra_SRCS src/desktop/util_desktop_linux.cc)
-  endif()
   set(database_platform_SRCS
         "${desktop_SRCS}"
-        "${desktop_extra_SRCS}")
 endif()
 
 if(ANDROID OR IOS)

--- a/testing/util_android_test.cc
+++ b/testing/util_android_test.cc
@@ -19,7 +19,7 @@
 
 #include "testing/run_all_tests.h"
 #include "testing/util_android.h"
-#include "testing/base/public/gmock.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {

--- a/testing/util_ios_test.mm
+++ b/testing/util_ios_test.mm
@@ -19,7 +19,7 @@
 #include "testing/config.h"
 #include "testing/ticker.h"
 #include "testing/util_ios.h"
-#include "testing/base/public/gmock.h"
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
 namespace firebase {


### PR DESCRIPTION
- Updated Firestore depenency in cmake external to a the checksum for 7.0.0.
- Fixed gmock header issues.