### PR TITLE
Fix builds of windows integration tests caused by messed up path

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -667,7 +667,7 @@ jobs:
         python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
     - name: Build integration tests
       run: |
-        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --sdk_dir firebase_cpp_sdk --output_directory ${{ github.workspace }} --noadd_timestamp
+        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --sdk_dir firebase_cpp_sdk --output_directory "${{ github.workspace }}" --noadd_timestamp
     
     - name: Run desktop integration tests
       if: matrix.target_platform == 'Desktop' && !cancelled()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -136,7 +136,7 @@ jobs:
           if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then
             ssl_option=--cmake_flag=-DFIREBASE_USE_BORINGSSL=ON
           fi
-          python scripts/gha/build_testapps.py --t ${{ github.event.inputs.apis }} --p ${{ matrix.target_platform }} --output_directory ${{ github.workspace }} --use_vcpkg --noadd_timestamp ${ssl_option}
+          python scripts/gha/build_testapps.py --t ${{ github.event.inputs.apis }} --p ${{ matrix.target_platform }} --output_directory "${{ github.workspace }}" --use_vcpkg --noadd_timestamp ${ssl_option}
 
       - name: Run desktop integration tests
         if: matrix.target_platform == 'Desktop' && !cancelled()


### PR DESCRIPTION
When ${{ github.workspace }} gets resolved, it has windows separators in it, which are getting lost when passed as a flag to the Python script.

i.e. what starts as
D:\a\firebase-cpp-sdk\firebase-cpp-sdk

turns into
afirebase-cpp-sdkfirebase-cpp-sdk

Wrapping the value in quotes prevents these slashes from being lost.