### PR TITLE
Automatically expand summary step in failed jobs

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -691,6 +691,8 @@ jobs:
       run: |
         python scripts/gha/test_lab.py --android_model ${{ env.android_device }} --android_api ${{ env.android_api }} --ios_model ${{ env.ios_device }} --ios_version ${{ env.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
     - name: Summarize build and test results
-      if: ${{ !cancelled() }}
+      if: failure()
       shell: bash
-      run: cat testapps/summary.log
+      run: |
+        cat testapps/summary.log
+        exit 1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -691,8 +691,10 @@ jobs:
       run: |
         python scripts/gha/test_lab.py --android_model ${{ env.android_device }} --android_api ${{ env.android_api }} --ios_model ${{ env.ios_device }} --ios_version ${{ env.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
     - name: Summarize build and test results
-      if: failure()
+      if: ${{ !cancelled() }}
       shell: bash
       run: |
         cat testapps/summary.log
-        exit 1
+        if [[ "${{ job.status }}" != "success" ]]; then
+          exit 1
+        fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -160,8 +160,10 @@ jobs:
         run: |
           python scripts/gha/test_lab.py --android_model ${{ github.event.inputs.android_device }} --android_api ${{ github.event.inputs.android_api }} --ios_model ${{ github.event.inputs.ios_device }} --ios_version ${{ github.event.inputs.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Summarize build and test results
-        if: failure()
+        if: ${{ !cancelled() }}
         shell: bash
         run: |
           cat testapps/summary.log
-          exit 1
+          if [[ "${{ job.status }}" != "success" ]]; then
+            exit 1
+          fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -160,6 +160,8 @@ jobs:
         run: |
           python scripts/gha/test_lab.py --android_model ${{ github.event.inputs.android_device }} --android_api ${{ github.event.inputs.android_api }} --ios_model ${{ github.event.inputs.ios_device }} --ios_version ${{ github.event.inputs.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Summarize build and test results
-        if: ${{ !cancelled() }}
+        if: failure()
         shell: bash
-        run: cat testapps/summary.log
+        run: |
+          cat testapps/summary.log
+          exit 1


### PR DESCRIPTION
A small quality of life improvement. When opening the page to a failed job, Github Actions will automatically expand the last failing step. We can exploit this to automatically expand the summary step by forcing it to fail, which is the preferred starting point for figuring out what failed. Since we don't want to fail otherwise successful jobs, we only execute the summary step if a prior step failed. The summary is only needed when something fails.

This eliminates some navigation, as well as the knowledge burden of knowing to navigate to the summary step to get an overview of what went wrong.