### PR TITLE
Run packaging integration tests by default

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -15,8 +15,8 @@ on:
         description: 'public version # to test against'
       downloadPreviousRun:
         description: 'previous run # to test against'
-      runIntegrationTests:
-        description: 'run integration tests?'
+      skipIntegrationTests:
+        description: 'skip integration tests?'
         default: 0
 
 env:
@@ -615,7 +615,7 @@ jobs:
 
   tests:
     needs: [merge_packages, download_sdk_package]
-    if: github.event.inputs.runIntegrationTests != 0 && !cancelled()
+    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -11,13 +11,13 @@ on:
       preserveIntermediateArtifacts:
         description: 'preserve intermediate artifacts?'
         default: 0
+      skipIntegrationTests:
+        description: 'skip integration tests?'
+        default: 0
       downloadPublicVersion:
         description: 'public version # to test against'
       downloadPreviousRun:
         description: 'previous run # to test against'
-      skipIntegrationTests:
-        description: 'skip integration tests?'
-        default: 0
 
 env:
   # Packaging prerequisites
@@ -34,6 +34,11 @@ jobs:
     name: log-inputs
     runs-on: ubuntu-latest
     steps:
+      - name: log if skipping integration tests
+        if: |
+          github.event.inputs.skipIntegrationTests != 0 && github.event.inputs.skipIntegrationTests != ''
+        run: echo "::warning ::Skipping integration tests."
+
       - name: log run inputs
         run: |
           if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -50,8 +50,7 @@ jobs:
           fi
 
       - name: log if skipping integration tests
-        if: |
-          !(github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '')
+        if: !(github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '')
         run: echo "::warning ::Skipping integration tests."
 
       - name: log if preserving intermediate artifacts

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -34,11 +34,6 @@ jobs:
     name: log-inputs
     runs-on: ubuntu-latest
     steps:
-      - name: log if skipping integration tests
-        if: |
-          github.event.inputs.skipIntegrationTests != 0 && github.event.inputs.skipIntegrationTests != ''
-        run: echo "::warning ::Skipping integration tests."
-
       - name: log run inputs
         run: |
           if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" ]]; then
@@ -53,6 +48,11 @@ jobs:
               echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building and packaging SDK and tests."
             fi
           fi
+
+      - name: log if skipping integration tests
+        if: |
+          github.event.inputs.skipIntegrationTests != 0 && github.event.inputs.skipIntegrationTests != ''
+        run: echo "::warning ::Skipping integration tests."
 
       - name: log if preserving intermediate artifacts
         if: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -51,7 +51,7 @@ jobs:
 
       - name: log if skipping integration tests
         if: |
-          github.event.inputs.skipIntegrationTests != 0 && github.event.inputs.skipIntegrationTests != ''
+          !(github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '')
         run: echo "::warning ::Skipping integration tests."
 
       - name: log if preserving intermediate artifacts


### PR DESCRIPTION
Set the C++ Packaging workflow to run integration tests by default. Log a message if tests are skipped.

(We also check for a blank value because when running on merge or cron, all input params are blank.)
