### PR TITLE
Update to a newer version of LevelDB that no longer uses std::call_once on Windows.

### DIFF
--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -18,7 +18,7 @@ if(TARGET leveldb)
   return()
 endif()
 
-set(version 1.22)
+set(version e0d5f83a4f80060fe5b5d80025f0ad049bca430e)
 
 ExternalProject_Add(
   leveldb
@@ -26,7 +26,6 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
   DOWNLOAD_NAME leveldb-${version}.tar.gz
   URL https://github.com/google/leveldb/archive/${version}.tar.gz
-  URL_HASH SHA256=55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2
 
   PREFIX ${PROJECT_BINARY_DIR}
 

--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -112,6 +112,11 @@ function(download_external_sources)
         "\n#include <stdlib.h>\n")
       endif()
     endif()
+    if (FIREBASE_INCLUDE_FIRESTORE)
+      # Tweak Firestore's included version of leveldb to match our own.
+      file(INSTALL "${PROJECT_SOURCE_DIR}/cmake/external/leveldb.cmake"
+           DESTINATION "${PROJECT_BINARY_DIR}/external/src/firestore/cmake/external")
+    endif()
   endif()
 endfunction()
 


### PR DESCRIPTION
This fixes a linker error in Realtime Database on Windows.

Also, if we are using leveldb from Firestore, force it to use this same version by copying over our leveldb.cmake into Firestore in the post-external-download step. 
