### PR TITLE
Rename the VS2015 directory to VS2019, since we now build the Windows libraries using VS 2019.

### DIFF
--- a/build_scripts/desktop/get_variant.sh
+++ b/build_scripts/desktop/get_variant.sh
@@ -30,11 +30,11 @@ arch=
 arch_win=
 debugmode=Release
 msvc_runtime_library=MD
-vs=VS2015
+vs=VS2019
 stl=c++
 linux_abi=legacy
 
-for c in $(echo "${filename}" | tr "_.-" "\n\n\n"); do
+for c in $(echo "${filename}" | tr "[:upper:]" "[:lower:]" | tr "_.-" "\n\n\n"); do
     case $c in
 	# Operating systems
 	ios)
@@ -115,13 +115,7 @@ for c in $(echo "${filename}" | tr "_.-" "\n\n\n"); do
 	release)
 	    debugmode=Release
 	;;
-	Release)
-	    debugmode=Release
-	;;
 	debug)
-	    debugmode=Debug
-	;;
-	Debug)
 	    debugmode=Debug
 	;;
 	# Android STL variant
@@ -142,6 +136,18 @@ for c in $(echo "${filename}" | tr "_.-" "\n\n\n"); do
         ;;
 	legacy)
 	    linux_abi=legacy
+        ;;
+	vs2019)
+	    vs=VS2019
+        ;;
+	vs2017)
+	    vs=VS2017
+        ;;
+	vs2015)
+	    vs=VS2015
+        ;;
+	vs2013)
+	    vs=VS2013
         ;;
     esac
 done

--- a/release_build_files/CMakeLists.txt
+++ b/release_build_files/CMakeLists.txt
@@ -45,7 +45,7 @@ elseif(MSVC)
   else()
     set(MSVC_CONFIG Debug)
   endif()
-  set(MSVC_VS_VERSION VS2015)
+  set(MSVC_VS_VERSION VS2019)
   set(FIREBASE_SDK_LIBDIR
       ${FIREBASE_CPP_SDK_DIR}/libs/windows/${MSVC_VS_VERSION}/${MSVC_RUNTIME_MODE}/${MSVC_CPU}/${MSVC_CONFIG})
 else()

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -564,9 +564,9 @@ code.
     -   General (iOS): iOS SDKs are now built using Xcode 11.7.
     -   General (Desktop): Windows libraries are now built using Visual
         Studio 2019. While VS 2019 is binary-compatible with VS 2015 and
-	VS 2017, you must use VS 2019 or newer to link the desktop SDK.
-	The libraries have been moved from libs/windows/VS2015 to
-	libs/windows/VS2019 to reflect this.
+        VS 2017, you must use VS 2019 or newer to link the desktop SDK.
+        The libraries have been moved from libs/windows/VS2015 to
+        libs/windows/VS2019 to reflect this.
     -   General (Desktop): Linux libraries are now built with both the
         C++11 ABI and the legacy ABI. The libraries have been moved
         from libs/linux/${arch} to libs/linux/${arch}/legacy and

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -563,8 +563,9 @@ code.
 -   Changes
     -   General (iOS): iOS SDKs are now built using Xcode 11.7.
     -   General (Desktop): Windows libraries are now built using Visual
-        Studio 2019, which remains ABI-compatible with 2015 and 2017. The
-        libraries have been moved from libs/windows/VS2015 to
+        Studio 2019. While VS 2019 is binary-compatible with VS 2015 and
+	VS 2017, you must use VS 2019 or newer to link the desktop SDK.
+	The libraries have been moved from libs/windows/VS2015 to
 	libs/windows/VS2019 to reflect this.
     -   General (Desktop): Linux libraries are now built with both the
         C++11 ABI and the legacy ABI. The libraries have been moved

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -413,7 +413,7 @@ Firebase Instance ID (stub)     | firebase_instance_id.lib
 Firebase Cloud Messaging (stub) | firebase_messaging.lib
                                 | firebase_app.lib
 
-The provided libraries have been tested using Visual Studio 2015 and 2017. When
+The provided libraries have been tested using Visual Studio 2019. When
 building C++ desktop apps on Windows, you will need to link the following
 Windows SDK libraries (consult your compiler documentation for more
 information):

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -562,6 +562,14 @@ code.
 ### 7.0.0
 -   Changes
     -   General (iOS): iOS SDKs are now built using Xcode 11.7.
+    -   General (Desktop): Windows libraries are now built using Visual
+        Studio 2019, which remains ABI-compatible with 2015 and 2017. The
+        libraries have been moved from libs/windows/VS2015 to
+	libs/windows/VS2019 to reflect this.
+    -   General (Desktop): Linux libraries are now built with both the
+        C++11 ABI and the legacy ABI. The libraries have been moved
+        from libs/linux/${arch} to libs/linux/${arch}/legacy and
+        libs/linux/${arch}/cxx11 to reflect this.
     -   AdMob (Android): Fix a JNI error when initializing without Firebase App.
     -   Analytics: Remove deprecated SetMinimumSessionDuration call.
     -   Installations: Added Installations SDK. See [Documentations](http://firebase.google.com/docs/reference/cpp/namespace/firebase/installations) for


### PR DESCRIPTION
Also add a note to the readme for this and the previous Linux legacy/c++11 ABI change.

Finally, simplified the get_variant script a bit by having it force lower-case before checking build variant segments.

Note on binary compatibility: https://docs.microsoft.com/en-us/cpp/porting/binary-compat-2015-2017