### PR TITLE
Add a define to Firestore C++ to work around a grpc Windows compile error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)
   )
 
   add_subdirectory(${FIRESTORE_SOURCE_DIR} ${FIRESTORE_BINARY_DIR})
-	    
+
   copy_subdirectory_definition(${FIRESTORE_SOURCE_DIR} NANOPB_SOURCE_DIR)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -283,7 +283,7 @@ if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)
   )
 
   add_subdirectory(${FIRESTORE_SOURCE_DIR} ${FIRESTORE_BINARY_DIR})
-
+	    
   copy_subdirectory_definition(${FIRESTORE_SOURCE_DIR} NANOPB_SOURCE_DIR)
 endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -279,18 +279,16 @@ else()
   )
 endif()
 
+set(FIREBASE_FIRESTORE_CPP_DEFINES -DINTERNAL_EXPERIMENTAL=1)
+
 if (WIN32)
+  set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600
+endif()
+
 target_compile_definitions(firebase_firestore
   PRIVATE
-    -DINTERNAL_EXPERIMENTAL=1
-    -D_WIN32_WINNT=0x0600
+    ${FIREBASE_FIRESTORE_CPP_DEFINES}
 )
-else()
-  target_compile_definitions(firebase_firestore
-    PRIVATE
-      -DINTERNAL_EXPERIMENTAL=1
-  )
-endif()
 
 if(ANDROID)
   firebase_cpp_proguard_file(firestore)

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -279,11 +279,18 @@ else()
   )
 endif()
 
-
+if (WIN32)
+target_compile_definitions(firebase_firestore
+  PRIVATE
+    -DINTERNAL_EXPERIMENTAL=1
+    -D_WIN32_WINNT=0x0600
+)
+else()
 target_compile_definitions(firebase_firestore
   PRIVATE
     -DINTERNAL_EXPERIMENTAL=1
 )
+endif()
 
 if(ANDROID)
   firebase_cpp_proguard_file(firestore)

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -282,6 +282,8 @@ endif()
 set(FIREBASE_FIRESTORE_CPP_DEFINES -DINTERNAL_EXPERIMENTAL=1)
 
 if (WIN32)
+  # On Windows, gRPC gives a compiler error in firebase_metadata_provider_desktop.cc
+  # unless _WIN32_WINNT is defined to this value (0x0600, Windows Vista).
   set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600
 endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -281,10 +281,10 @@ endif()
 
 set(FIREBASE_FIRESTORE_CPP_DEFINES -DINTERNAL_EXPERIMENTAL=1)
 
-if (WIN32)
+if (WIN32 AND NOT ANDROID AND NOT IOS)
   # On Windows, gRPC gives a compiler error in firebase_metadata_provider_desktop.cc
   # unless _WIN32_WINNT is defined to this value (0x0600, Windows Vista).
-  set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600
+  set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600)
 endif()
 
 target_compile_definitions(firebase_firestore

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -286,10 +286,10 @@ target_compile_definitions(firebase_firestore
     -D_WIN32_WINNT=0x0600
 )
 else()
-target_compile_definitions(firebase_firestore
-  PRIVATE
-    -DINTERNAL_EXPERIMENTAL=1
-)
+  target_compile_definitions(firebase_firestore
+    PRIVATE
+      -DINTERNAL_EXPERIMENTAL=1
+  )
 endif()
 
 if(ANDROID)


### PR DESCRIPTION
Force -D_WIN32_WINNT=0x0600 to be defined if building Firestore C++ for Windows.

This fixes the build of Firestore on Windows with the newly-added source files.