### PR TITLE
Bugfix/integration test boringssl windows error

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -310,7 +310,8 @@ def _summarize_results(testapps, platforms, failures, output_dir):
 
 
 def _build_desktop(sdk_dir, cmake_flags):
-  cmake_configure_cmd = ["cmake", ".", "-DFIREBASE_CPP_SDK_DIR=" + sdk_dir]
+  cmake_configure_cmd = ["cmake", ".", "-DCMAKE_BUILD_TYPE=Debug",
+                                       "-DFIREBASE_CPP_SDK_DIR=" + sdk_dir]
   if utils.is_windows_os():
     cmake_configure_cmd += ["-A", "x64"]
   _run(cmake_configure_cmd + cmake_flags)

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -310,7 +310,10 @@ def _summarize_results(testapps, platforms, failures, output_dir):
 
 
 def _build_desktop(sdk_dir, cmake_flags):
-  _run(["cmake", ".", "-DFIREBASE_CPP_SDK_DIR=" + sdk_dir] + cmake_flags)
+  cmake_configure_cmd = ["cmake", ".", "-DFIREBASE_CPP_SDK_DIR=" + sdk_dir]
+  if utils.is_windows_os():
+    cmake_configure_cmd += ["-A", "x64"]
+  _run(cmake_configure_cmd + cmake_flags)
   _run(["cmake", "--build", "."])
 
 

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -315,7 +315,7 @@ def _build_desktop(sdk_dir, cmake_flags):
   if utils.is_windows_os():
     cmake_configure_cmd += ["-A", "x64"]
   _run(cmake_configure_cmd + cmake_flags)
-  _run(["cmake", "--build", "."])
+  _run(["cmake", "--build", ".", "--config", "Debug"])
 
 
 def _get_desktop_compiler_flags(compiler, compiler_table):


### PR DESCRIPTION
This PR fixes an issue observed while building our integration tests with boringssl against the source sdk on Windows.
- Build integration tests specifically against the 64bit Windows build toolchain.
- Sync the config (Release/Debug) between cmake configure and cmake build. Using "Debug" as rest of the systems are using Debug as well.

This was the error we were seeing without these changes,

Without x64,
```
"D:\a\firebase-cpp-sdk\firebase-cpp-sdk\testapps\FirebaseStorage\integration_test\bin\external\src\boringssl-build\CMakeFiles\3.19.1\VCTargetsPath.vcxproj" (default target) (1) ->

1217      C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\Microsoft.Common.CurrentVersion.targets(3332,5): error MSB4184: The expression "[System.IO.Path]::Combine(obj\-DCMAKE_C_FLAGS_RELEASE="/MD"\Debug\, .NETFramework,Version=v4.0.AssemblyAttributes.cpp)" cannot be evaluated. Illegal characters in path.
```

Without syncing bulid config,
```
CMake Error at ../../../cmake/external_rules.cmake:250 (file):
  file INSTALL cannot find
-- Build of external project dependencies complete.
  "D:/a/firebase-cpp-sdk/firebase-cpp-sdk/testapps/FirebaseAdmob/integration_test/bin/external/src/boringssl-build/crypto/Debug/crypto.lib":
```

