### PR TITLE
Simplify build_testapps.py flags

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -672,7 +672,7 @@ jobs:
         python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
     - name: Build integration tests
       run: |
-        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --sdk_dir firebase_cpp_sdk --output_directory "${{ github.workspace }}" --noadd_timestamp
+        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --packaged_sdk firebase_cpp_sdk --output_directory "${{ github.workspace }}" --noadd_timestamp
     
     - name: Run desktop integration tests
       if: matrix.target_platform == 'Desktop' && !cancelled()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -136,7 +136,7 @@ jobs:
           if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then
             ssl_option=--cmake_flag=-DFIREBASE_USE_BORINGSSL=ON
           fi
-          python scripts/gha/build_testapps.py --t ${{ github.event.inputs.apis }} --p ${{ matrix.target_platform }} --output_directory "${{ github.workspace }}" --use_vcpkg --noadd_timestamp ${ssl_option}
+          python scripts/gha/build_testapps.py --t ${{ github.event.inputs.apis }} --p ${{ matrix.target_platform }} --output_directory "${{ github.workspace }}" --noadd_timestamp ${ssl_option}
 
       - name: Run desktop integration tests
         if: matrix.target_platform == 'Desktop' && !cancelled()


### PR DESCRIPTION
The following changes have been made to make the build_testapps.py script easier to use.

1. Renamed "sdk_dir" to "packaged_sdk", and "root_dir" to "repo_dir", to be more intuitive.

2. packaged_sdk now set to None by default, instead of the current directory. This provides a more reliable way to tell if the intent is to build from source or from a packaged sdk.

3. --use_vcpkg flag removed. When building from source, vcpkg will be used, and when building from a packaged sdk, it will not. This is the intended behaviour: the flag was not providing a real option, just an opportunity to make mistakes when running the tool.