### PR TITLE
Add OpenSSL install step for windows builds

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -128,6 +128,13 @@ jobs:
           pip install -r scripts/gha/requirements.txt
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
 
+      - name: Install OpenSSL (windows)
+        if: matrix.target_platform == 'Desktop' &&
+            matrix.ssl_variant == 'openssl' &&
+            startsWith(matrix.os, 'windows')
+        run: |
+          choco install openssl -r
+
       - name: Build integration tests
         shell: bash
         run: |


### PR DESCRIPTION
The OpenSSL build on Windows, for Windows, was failing to execute due to the VM image missing an OpenSSL installation and its runtime DLLs.

Added a build step to the GHA worfklow to use Choco to install openssl.

The database integration test still fails, but now due to a logical error that we should fix independently.
