### PR TITLE
Fixed issue with integration tests finding google-services.json

### DIFF
--- a/admob/integration_test/CMakeLists.txt
+++ b/admob/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/analytics/integration_test/CMakeLists.txt
+++ b/analytics/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/app/integration_test/CMakeLists.txt
+++ b/app/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/auth/integration_test/CMakeLists.txt
+++ b/auth/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/database/integration_test/CMakeLists.txt
+++ b/database/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/dynamic_links/integration_test/CMakeLists.txt
+++ b/dynamic_links/integration_test/CMakeLists.txt
@@ -202,11 +202,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -202,11 +202,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/functions/integration_test/CMakeLists.txt
+++ b/functions/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/installations/integration_test/CMakeLists.txt
+++ b/installations/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/instance_id/integration_test/CMakeLists.txt
+++ b/instance_id/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/messaging/integration_test/CMakeLists.txt
+++ b/messaging/integration_test/CMakeLists.txt
@@ -203,11 +203,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/remote_config/integration_test/CMakeLists.txt
+++ b/remote_config/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()

--- a/storage/integration_test/CMakeLists.txt
+++ b/storage/integration_test/CMakeLists.txt
@@ -201,11 +201,11 @@ else()
   # possible to create the default Firebase app.
   set(FOUND_JSON_FILE FALSE)
   foreach(config "google-services-desktop.json" "google-services.json")
-    if (EXISTS ${config})
+    if (EXISTS "${CMAKE_CURRENT_LIST_DIR}/${config}")
       add_custom_command(
         TARGET ${integration_test_target_name} POST_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy
-          ${config} $<TARGET_FILE_DIR:${integration_test_target_name}>)
+          "${CMAKE_CURRENT_LIST_DIR}/${config}" $<TARGET_FILE_DIR:${integration_test_target_name}>)
       set(FOUND_JSON_FILE TRUE)
       break()
     endif()


### PR DESCRIPTION
Changed the search paths for the google-services.json file in
CMakeLists.txt files to use full paths instead of relative paths.

According to the CMake documentation, the `if (EXISTS ...)` condition is
only well defined for full paths. This might work on some platforms but
it failed in my tests on Windows.