### PR TITLE
Explicitly list the Flatbuffer source files

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -300,7 +300,11 @@ endif()
 
 if(ANDROID OR IOS)
   # If building for Android or iOS, include the Flatbuffers source files directly.
-  set(app_flatbuffers_srcs ${FlatBuffers_Library_SRCS})
+  set(app_flatbuffers_srcs
+      ${FLATBUFFERS_SOURCE_DIR}/src/idl_parser.cpp
+      ${FLATBUFFERS_SOURCE_DIR}/src/idl_gen_text.cpp
+      ${FLATBUFFERS_SOURCE_DIR}/src/reflection.cpp
+      ${FLATBUFFERS_SOURCE_DIR}/src/util.cpp)
   set(app_flatbuffers_lib)
 else()
   set(app_flatbuffers_srcs)


### PR DESCRIPTION
FlatBuffers_Library_SRCS is not always set, so just list the source files directly.