### PR TITLE
Modify integration tests so that they delete the anonymous user they created.

### DIFF
--- a/database/integration_test/src/integration_test.cc
+++ b/database/integration_test/src/integration_test.cc
@@ -137,6 +137,8 @@ class FirebaseDatabaseTest : public FirebaseTest {
   // Sign in an anonymous user.
   static void SignIn();
   // Sign out the current user, if applicable.
+  // If this is an anonymous user, deletes the user instead,
+  // to avoid polluting the user list.
   static void SignOut();
 
   // Initialize Firebase Database.
@@ -341,12 +343,19 @@ void FirebaseDatabaseTest::SignOut() {
     // Already signed out.
     return;
   }
+  if (shared_auth_->current_user()->is_anonymous()) {
+    // If signed in anonymously, delete the anonymous user.
+    WaitForCompletion(shared_auth_->current_user()->Delete(), "DeleteAnonymousUser");
+  }
+  else {
+    // If not signed in anonymously (e.g. if the tests were modified to sign in
+    // as an actual user), just sign out normally.
+    shared_auth_->SignOut();
 
-  shared_auth_->SignOut();
-
-  // Wait for the sign-out to finish.
-  while (shared_auth_->current_user() != nullptr) {
-    if (ProcessEvents(100)) break;
+    // Wait for the sign-out to finish.
+    while (shared_auth_->current_user() != nullptr) {
+      if (ProcessEvents(100)) break;
+    }
   }
   EXPECT_EQ(shared_auth_->current_user(), nullptr);
 }


### PR DESCRIPTION
This prevents us from leaving a ton of defunct anonymous users in the project for no reason.
