### PR TITLE
Temporarily disable the multithreaded delete test in the AdMob integration test.

### DIFF
--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -510,6 +510,7 @@ static void* DeleteBannerViewOnSignal(void* args) {
 
 TEST_F(FirebaseAdMobTest, TestBannerViewMultithreadDeletion) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_MOBILE;  // TODO(b/172832275): This test is temporarily                                                                                                                                                                       // disabled on all platforms due to flakiness                                                                                                                                                                        // on Android. Once it's fixed, this test should                                                                                                                                                                     // be re-enabled on mobile.
 
   static const int kBannerWidth = 320;
   static const int kBannerHeight = 50;

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -510,7 +510,10 @@ static void* DeleteBannerViewOnSignal(void* args) {
 
 TEST_F(FirebaseAdMobTest, TestBannerViewMultithreadDeletion) {
   SKIP_TEST_ON_DESKTOP;
-  SKIP_TEST_ON_MOBILE;  // TODO(b/172832275): This test is temporarily                                                                                                                                                                       // disabled on all platforms due to flakiness                                                                                                                                                                        // on Android. Once it's fixed, this test should                                                                                                                                                                     // be re-enabled on mobile.
+  SKIP_TEST_ON_MOBILE;  // TODO(b/172832275): This test is temporarily
+                        // disabled on all platforms due to flakiness
+                        // on Android. Once it's fixed, this test should
+                        // be re-enabled on mobile.
 
   static const int kBannerWidth = 320;
   static const int kBannerHeight = 50;


### PR DESCRIPTION
The test is flaky and a proper fix is not forthcoming any time soon.

Any users affected by this issue can work around it by deleting BannerViews in the same thread in which they are created, so to get the tests green we are disabling this test until it can be properly fixed.