### PR TITLE
Change iOS device used by integration tests to iphone8, version 11.4

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -667,8 +667,8 @@ jobs:
       apis: admob,analytics,auth,database,dynamic_links,firestore,functions,instance_id,messaging,remote_config,storage
       android_device: flame
       android_api: 29
-      ios_device: iphone11pro
-      ios_version: 13.3
+      ios_device: iphone8
+      ios_version: 11.4
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2.3.1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -27,10 +27,10 @@ on:
         default: '29'
       ios_device:
         description: 'iOS device model'
-        default: 'iphone11pro'
+        default: 'iphone8'
       ios_version:
         description: 'iOS device version'
-        default: '13.3'
+        default: '11.4'
 
 jobs:
   # To feed input into the job matrix, we first need to convert to a JSON


### PR DESCRIPTION
FTL is experiencing internal issues on certain iOS devices. For Googlers, this is b/178654295.

From experimentation, this appears to affect iOS 12+. This change picks iphone8, iOS 11.4. The default device for FTL is iphone8, 11.2. 11.2 is deprecated, so we pick 11.4.

Test run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/518690509