### PR TITLE
Add a workaround for an AdMob race condition to integration test.

### DIFF
--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -123,6 +123,11 @@ void FirebaseAdMobTest::SetUpTestSuite() {
 }
 
 void FirebaseAdMobTest::TearDownTestSuite() {
+  // Workaround: AdMob does some of its initialization in the main
+  // thread, so if you terminate it too quickly after initialization
+  // it can cause issues.  Add a small delay here in case most of the
+  // tests are skipped.
+  ProcessEvents(1000);
   LogDebug("Shutdown AdMob.");
   firebase::admob::Terminate();
   LogDebug("Shutdown Firebase App.");


### PR DESCRIPTION
The AdMob SDK crashes if you call Initialize and Terminate too quickly on a non-main thread. This happens in the integration test when skipping the interactive tests (e.g. when running on FTL).

