### PR TITLE
Improve how we deal with artifacts

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -491,6 +491,22 @@ jobs:
           name: firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix}}-package
           path: firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix}}-package.tgz
 
+      - name: cleanup build artifacts
+        if: |
+          (
+            (github.event.inputs.preserveIntermediateArtifacts == 0 || github.event.inputs.preserveIntermediateArtifacts == '')
+            && github.event.inputs.downloadPublicVersion == ''
+            && github.event.inputs.downloadPreviousRun == ''
+          )
+        # Remove the build artifacts that were consumed during this step of packaging.
+        uses: geekyeggo/delete-artifact@v1-glob-support
+        with:
+          name: |
+            firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}*-build
+          failOnError: false
+          useGlob: true
+
+
   download_sdk_package:
     name: download-sdk-package
     runs-on: ubuntu-latest
@@ -545,7 +561,7 @@ jobs:
     name: final-merge-packages
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
-    needs: [build_and_package_ios, build_and_package_android, package_desktop, cleanup_build_artifacts, log_inputs]
+    needs: [build_and_package_ios, build_and_package_android, package_desktop, log_inputs]
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1
@@ -603,26 +619,6 @@ jobs:
         with:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
-
-  cleanup_build_artifacts:
-    # Clean up intermediate artifacts from build steps.
-    # This can happen after the individual packaging steps are finished.
-    name: cleanup-build-artifacts
-    runs-on: ubuntu-latest
-    needs: [build_and_package_ios, build_and_package_android, package_desktop]
-    if: |
-      (
-        (github.event.inputs.preserveIntermediateArtifacts == 0 || github.event.inputs.preserveIntermediateArtifacts == '')
-        && github.event.inputs.downloadPublicVersion == ''
-        && github.event.inputs.downloadPreviousRun == ''
-      )
-    steps:
-    - uses: geekyeggo/delete-artifact@v1-glob-support
-      with:
-        name: |
-          firebase-cpp-sdk-*-build
-        failOnError: false
-        useGlob: true
 
   cleanup_packaging_artifacts:
     # Clean up intermediate artifacts from packaging step.

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -617,23 +617,12 @@ jobs:
         && github.event.inputs.downloadPreviousRun == ''
       )
     steps:
-    - uses: geekyeggo/delete-artifact@v1
+    - uses: geekyeggo/delete-artifact@v1-glob-support
       with:
         name: |
-          firebase-cpp-sdk-windows-x86-Release-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x64-Release-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x86-Debug-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x64-Debug-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x86-Release-static-legacy-build
-          firebase-cpp-sdk-windows-x64-Release-static-legacy-build
-          firebase-cpp-sdk-windows-x86-Debug-static-legacy-build
-          firebase-cpp-sdk-windows-x64-Debug-static-legacy-build
-          firebase-cpp-sdk-linux-x86-Release-static-legacy-build
-          firebase-cpp-sdk-linux-x64-Release-static-legacy-build
-          firebase-cpp-sdk-linux-x86-Release-static-c++11-build
-          firebase-cpp-sdk-linux-x64-Release-static-c++11-build
-          firebase-cpp-sdk-darwin-x64-Release-static-legacy-build
+          firebase-cpp-sdk-*-build
         failOnError: false
+        useGlob: true
 
   cleanup_packaging_artifacts:
     # Clean up intermediate artifacts from packaging step.
@@ -648,26 +637,13 @@ jobs:
         && github.event.inputs.downloadPreviousRun == ''
       )
     steps:
-    - uses: geekyeggo/delete-artifact@v1
+    - uses: geekyeggo/delete-artifact@v1-glob-support
       with:
         name: |
-          packaging-tools-darwin
-          packaging-tools-linux
-          firebase-cpp-sdk-windows-x86-Release-dynamic-package
-          firebase-cpp-sdk-windows-x64-Release-dynamic-package
-          firebase-cpp-sdk-windows-x86-Debug-dynamic-package
-          firebase-cpp-sdk-windows-x64-Debug-dynamic-package
-          firebase-cpp-sdk-windows-x86-Release-static-package
-          firebase-cpp-sdk-windows-x64-Release-static-package
-          firebase-cpp-sdk-windows-x86-Debug-static-package
-          firebase-cpp-sdk-windows-x64-Debug-static-package
-          firebase-cpp-sdk-linux-package
-          firebase-cpp-sdk-ios-package
-          firebase-cpp-sdk-darwin-package
-          firebase-cpp-sdk-android-stlport-package
-          firebase-cpp-sdk-android-gnustl-package
-          firebase-cpp-sdk-android-c++-package
+          packaging-tools-*
+          firebase-cpp-sdk-*-package
         failOnError: false
+        useGlob: true
 
   tests:
     needs: [merge_packages, download_sdk_package]

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -540,11 +540,12 @@ jobs:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
 
+
   merge_packages:
     name: final-merge-packages
     runs-on: ubuntu-latest
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
-    needs: [build_and_package_ios, build_and_package_android, package_desktop, log_inputs]
+    needs: [build_and_package_ios, build_and_package_android, package_desktop, cleanup_build_artifacts, log_inputs]
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1
@@ -603,9 +604,41 @@ jobs:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
 
-  cleanup_artifacts:
-    # Clean up intermediate artifacts.
-    name: cleanup-artifacts
+  cleanup_build_artifacts:
+    # Clean up intermediate artifacts from build steps.
+    # This can happen after the individual packaging steps are finished.
+    name: cleanup-build-artifacts
+    runs-on: ubuntu-latest
+    needs: [build_and_package_ios, build_and_package_android, package_desktop]
+    if: |
+      (
+        (github.event.inputs.preserveIntermediateArtifacts == 0 || github.event.inputs.preserveIntermediateArtifacts == '')
+        && github.event.inputs.downloadPublicVersion == ''
+        && github.event.inputs.downloadPreviousRun == ''
+      )
+    steps:
+    - uses: geekyeggo/delete-artifact@v1
+      with:
+        name: |
+          firebase-cpp-sdk-windows-x86-Release-dynamic-legacy-build
+          firebase-cpp-sdk-windows-x64-Release-dynamic-legacy-build
+          firebase-cpp-sdk-windows-x86-Debug-dynamic-legacy-build
+          firebase-cpp-sdk-windows-x64-Debug-dynamic-legacy-build
+          firebase-cpp-sdk-windows-x86-Release-static-legacy-build
+          firebase-cpp-sdk-windows-x64-Release-static-legacy-build
+          firebase-cpp-sdk-windows-x86-Debug-static-legacy-build
+          firebase-cpp-sdk-windows-x64-Debug-static-legacy-build
+          firebase-cpp-sdk-linux-x86-Release-static-legacy-build
+          firebase-cpp-sdk-linux-x64-Release-static-legacy-build
+          firebase-cpp-sdk-linux-x86-Release-static-c++11-build
+          firebase-cpp-sdk-linux-x64-Release-static-c++11-build
+          firebase-cpp-sdk-darwin-x64-Release-static-legacy-build
+        failOnError: false
+
+  cleanup_packaging_artifacts:
+    # Clean up intermediate artifacts from packaging step.
+    # This can happen after the final package merge is finished.
+    name: cleanup-packaging-artifacts
     runs-on: ubuntu-latest
     needs: [merge_packages]
     if: |
@@ -620,19 +653,6 @@ jobs:
         name: |
           packaging-tools-darwin
           packaging-tools-linux
-          firebase-cpp-sdk-windows-x86-Release-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x64-Release-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x86-Debug-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x64-Debug-dynamic-legacy-build
-          firebase-cpp-sdk-windows-x86-Release-static-legacy-build
-          firebase-cpp-sdk-windows-x64-Release-static-legacy-build
-          firebase-cpp-sdk-windows-x86-Debug-static-legacy-build
-          firebase-cpp-sdk-windows-x64-Debug-static-legacy-build
-          firebase-cpp-sdk-linux-x86-Release-static-legacy-build
-          firebase-cpp-sdk-linux-x64-Release-static-legacy-build
-          firebase-cpp-sdk-linux-x86-Release-static-c++11-build
-          firebase-cpp-sdk-linux-x64-Release-static-c++11-build
-          firebase-cpp-sdk-darwin-x64-Release-static-legacy-build
           firebase-cpp-sdk-windows-x86-Release-dynamic-package
           firebase-cpp-sdk-windows-x64-Release-dynamic-package
           firebase-cpp-sdk-windows-x86-Debug-dynamic-package
@@ -704,7 +724,7 @@ jobs:
     - name: Build integration tests
       run: |
         python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --packaged_sdk firebase_cpp_sdk --output_directory "${{ github.workspace }}" --noadd_timestamp
-    
+
     - name: Run desktop integration tests
       if: matrix.target_platform == 'Desktop' && !cancelled()
       run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -499,7 +499,7 @@ jobs:
             && github.event.inputs.downloadPreviousRun == ''
           )
         # Remove the build artifacts that were consumed during this step of packaging.
-        uses: geekyeggo/delete-artifact@v1-glob-support
+        uses: geekyeggo/delete-artifact@1-glob-support
         with:
           name: |
             firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}*-build
@@ -633,7 +633,7 @@ jobs:
         && github.event.inputs.downloadPreviousRun == ''
       )
     steps:
-    - uses: geekyeggo/delete-artifact@v1-glob-support
+    - uses: geekyeggo/delete-artifact@1-glob-support
       with:
         name: |
           packaging-tools-*

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -136,7 +136,7 @@ jobs:
           tar -czhf ../packaging-tools.tgz .
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: packaging-tools-${{ matrix.tools_platform }}
           path: packaging-tools.tgz
@@ -182,7 +182,7 @@ jobs:
           find firebase-cpp-sdk-*-package -type f
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase-cpp-sdk-ios-package
           path: firebase-cpp-sdk-ios-package.tgz
@@ -228,7 +228,7 @@ jobs:
           find firebase-cpp-sdk-*-package -type f
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase-cpp-sdk-android-${{ matrix.stl }}-package
           path: firebase-cpp-sdk-android-${{ matrix.stl }}-package.tgz
@@ -356,7 +356,7 @@ jobs:
         continue-on-error: true
 
       - name: upload artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase-cpp-sdk-${{ env.SDK_NAME }}-build
           path: firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz
@@ -421,7 +421,7 @@ jobs:
           ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.8
         with:
           # download-artifact doesn't support wildcards, but by default
           # will download all artifacts. Sadly this is what we must do.
@@ -486,7 +486,7 @@ jobs:
           find firebase-cpp-sdk-*-package -type f
 
       - name: upload SDK zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix}}-package
           path: firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix}}-package.tgz
@@ -498,7 +498,7 @@ jobs:
     if: ${{ github.event.inputs.downloadPublicVersion != '' || github.event.inputs.downloadPreviousRun != '' }}
     steps:
       - name: fetch artifact from previous run
-        uses: dawidd6/action-download-artifact@v2
+        uses: dawidd6/action-download-artifact@v2.0.8
         if: ${{ github.event.inputs.downloadPreviousRun != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
@@ -529,13 +529,13 @@ jobs:
           echo "::warning ::$(cat firebase_cpp_sdk_hash.txt)"
 
       - name: upload hash
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase_cpp_sdk_hash.txt
           path: firebase_cpp_sdk_hash.txt
 
       - name: upload SDK zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
@@ -554,7 +554,7 @@ jobs:
           ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: download artifact
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v2.0.8
         with:
           # download-artifact doesn't support wildcards, but by default
           # will download all artifacts. Sadly this is what we must do.
@@ -593,13 +593,13 @@ jobs:
           find firebase_cpp_sdk -type f
 
       - name: upload hash
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase_cpp_sdk_hash.txt
           path: firebase_cpp_sdk_hash.txt
 
       - name: upload SDK zip
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v2.2.2
         with:
           name: firebase_cpp_sdk.zip
           path: firebase_cpp_sdk.zip
@@ -698,7 +698,7 @@ jobs:
       if: runner.os == 'macOS'
       run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
     - name: Download Firebase C++ SDK
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v2.0.8
       with:
         name: firebase_cpp_sdk.zip
     - name: Unzip Firebase C++ SDK


### PR DESCRIPTION
Several enhancements to reduce transient failures in the packaging step, and just make the workflow cleaner in general:
1. Delete build artifacts sooner, after they are no longer needed, to reduce the number of artifacts final-merge-packages has to download.
2. Update to the latest upload-artifact and download-artifact versions, which add better HTTP retry logic.
3. Switch to a newer version of the delete-artifact action that allows wildcards.