### PR TITLE
Remove extra inclusion of pb_common.c and pb_decode.c, to avoid multiple symbol definitions.

### DIFF
--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -219,7 +219,7 @@ endif()
 # Add the Firebase libraries to the target using the function from the SDK.
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 # Note that firebase_app needs to be last in the list.
-set(firebase_libs firebase_firestore firebase_auth firebase_app)
+set(firebase_libs firebase_remote_config firebase_firestore firebase_auth firebase_app)
 set(gtest_libs gtest gmock)
 target_link_libraries(${integration_test_target_name} ${firebase_libs}
   ${gtest_libs} ${ADDITIONAL_LIBS})

--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -219,7 +219,7 @@ endif()
 # Add the Firebase libraries to the target using the function from the SDK.
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 # Note that firebase_app needs to be last in the list.
-set(firebase_libs firebase_remote_config firebase_firestore firebase_auth firebase_app)
+set(firebase_libs firebase_firestore firebase_auth firebase_app)
 set(gtest_libs gtest gmock)
 target_link_libraries(${integration_test_target_name} ${firebase_libs}
   ${gtest_libs} ${ADDITIONAL_LIBS})

--- a/remote_config/CMakeLists.txt
+++ b/remote_config/CMakeLists.txt
@@ -66,6 +66,11 @@ if (NOT PROTOBUF_FOUND)
 else()
   # Generates config.pb.c and config.pb.h
   NANOPB_GENERATE_CPP(PROTO_SRCS PROTO_HDRS src_protos/config.proto)
+  # Remove pb_common.c and pb_decode.c from PROTO_SRCS, as they are
+  # provided by Firebase App. Including them here causes symbols to
+  # have multiple definitions.
+  list(FILTER PROTO_SRCS EXCLUDE REGEX "/pb_.*\\.c")
+
   set(desktop_SRCS
       ${PROTO_SRCS}
       ${PROTO_HDRS}

--- a/remote_config/CMakeLists.txt
+++ b/remote_config/CMakeLists.txt
@@ -116,6 +116,7 @@ else()
   set(additional_link_LIB
       firebase_rest_lib
       firebase_instance_id_desktop_impl
+      protobuf-nanopb-static
       flatbuffers)
 endif()
 


### PR DESCRIPTION
Fix for #271.