### PR TITLE
Deflake tests by adding RunWithRetry and changing test timeouts

### DIFF
--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -161,11 +161,10 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
 
   // Try deleting the IID, but it can sometimes fail due to
   // sporadic network issues, so allow retrying.
-
   firebase::Future<void> del =
     RunWithRetry<void>([](firebase::instance_id::InstanceId* iid) {
-		   return iid->DeleteId();
-		 }, instance_id_);
+                   return iid->DeleteId();
+                 }, instance_id_);
   WaitForCompletion(del, "DeleteId");
 
   // Ensure that we now get a different IID.

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -161,9 +161,13 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
 
   // Try deleting the IID, but it can sometimes fail due to
   // sporadic network issues, so allow retrying.
-  WaitForCompletion(RunWithRetry([](firebase::instance_id::InstanceId* iid) {
-                                   return iid->DeleteId();
-                                 }, instance_id_), "DeleteId");
+
+  firebase::Future<void> del =
+    RunWithRetry<void>([](firebase::instance_id::InstanceId* iid) {
+		   return iid->DeleteId();
+		 }, instance_id_);
+  WaitForCompletion(del, "DeleteId");
+
   // Ensure that we now get a different IID.
   id = instance_id_->GetId();
   WaitForCompletion(id, "GetId 2");

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -152,7 +152,6 @@ TEST_F(FirebaseInstanceIdTest, TestGettingIdTwiceMatches) {
   WaitForCompletion(id, "GetId 2");
   EXPECT_EQ(*id.result(), first_id);
 }
-
 TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   firebase::Future<std::string> id = instance_id_->GetId();
   WaitForCompletion(id, "GetId");
@@ -163,7 +162,7 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   // sporadic network issues, so allow retrying.
   firebase::Future<void> del =
     RunWithRetry<void>([](firebase::instance_id::InstanceId* iid) {
-                   return iid->DeleteId();
+			 return iid->DeleteId();
                  }, instance_id_);
   WaitForCompletion(del, "DeleteId");
 

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -162,7 +162,7 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   // sporadic network issues, so allow retrying.
   firebase::Future<void> del =
     RunWithRetry<void>([](firebase::instance_id::InstanceId* iid) {
-			 return iid->DeleteId();
+                         return iid->DeleteId();
                  }, instance_id_);
   WaitForCompletion(del, "DeleteId");
 

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -162,8 +162,8 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   // Try deleting the IID, but it can sometimes fail due to
   // sporadic network issues, so allow retrying.
   WaitForCompletion(RunWithRetry([](firebase::instance_id::InstanceId* iid) {
-				   return iid->DeleteId();
-				 }, instance_id_), "DeleteId");
+                                   return iid->DeleteId();
+                                 }, instance_id_), "DeleteId");
   // Ensure that we now get a different IID.
   id = instance_id_->GetId();
   WaitForCompletion(id, "GetId 2");

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -163,7 +163,7 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   firebase::Future<void> del =
     RunWithRetry<void>([](firebase::instance_id::InstanceId* iid) {
                          return iid->DeleteId();
-                 }, instance_id_);
+                       }, instance_id_);
   WaitForCompletion(del, "DeleteId");
 
   // Ensure that we now get a different IID.

--- a/instance_id/integration_test/src/integration_test.cc
+++ b/instance_id/integration_test/src/integration_test.cc
@@ -159,9 +159,11 @@ TEST_F(FirebaseInstanceIdTest, TestDeleteIdGivesNewIdNextTime) {
   EXPECT_NE(*id.result(), "");
   std::string first_id = *id.result();
 
-  firebase::Future<void> del = instance_id_->DeleteId();
-  WaitForCompletion(del, "DeleteId");
-
+  // Try deleting the IID, but it can sometimes fail due to
+  // sporadic network issues, so allow retrying.
+  WaitForCompletion(RunWithRetry([](firebase::instance_id::InstanceId* iid) {
+				   return iid->DeleteId();
+				 }, instance_id_), "DeleteId");
   // Ensure that we now get a different IID.
   id = instance_id_->GetId();
   WaitForCompletion(id, "GetId 2");

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -51,8 +51,8 @@ const char kRestEndpoint[] = "https://fcm.googleapis.com/fcm/send";
 const char kNotificationLinkKey[] = "gcm.n.link";
 const char kTestLink[] = "https://this-is-a-test-link/";
 
-// Give each operation approximately 60 seconds before failing.
-const int kTimeoutSeconds = 60;
+// Give each operation approximately 120 seconds before failing.
+const int kTimeoutSeconds = 120;
 const char kTestingNotificationKey[] = "fcm_testing_notification";
 
 using app_framework::LogDebug;

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -546,7 +546,9 @@ TEST_F(FirebaseMessagingTest, TestChangingListener) {
   // WaitForMessage() uses whatever shared_listener_ is set to.
   shared_listener_ = new firebase::messaging::PollableListener();
   firebase::messaging::SetListener(shared_listener_);
-
+  // Pause a moment to make sure old listeners are deleted.
+  ProcessEvents(1000);
+  
   std::string unique_id = GetUniqueMessageId();
   const char kNotificationTitle[] = "New Listener Test";
   const char kNotificationBody[] = "New Listener Test notification body";

--- a/remote_config/integration_test/src/integration_test.cc
+++ b/remote_config/integration_test/src/integration_test.cc
@@ -83,6 +83,9 @@ class FirebaseRemoteConfigTest : public FirebaseTest {
 #endif  // TEST_DEPRECATED
 };
 
+const firebase::remote_config::LastFetchStatus kFetchSuccess =
+    firebase::remote_config::kLastFetchStatusSuccess;
+
 FirebaseRemoteConfigTest::FirebaseRemoteConfigTest() : initialized_(false) {
   FindFirebaseConfig(FIREBASE_CONFIG_STRING);
 }
@@ -484,7 +487,11 @@ TEST_F(FirebaseRemoteConfigTest, TestGetAll) {
   ASSERT_NE(rc_, nullptr);
 
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
-  EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
+  //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
+  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
+    return static_cast<firebase::FutureBase>(
+        static_cast<RemoteConfig*>(rc)->Fetch());
+  }, rc_, "Fetch"), "FetchWithRetry"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   std::map<std::string, firebase::Variant> key_values = rc_->GetAll();
   EXPECT_EQ(key_values.size(), 6);
@@ -509,7 +516,11 @@ TEST_F(FirebaseRemoteConfigTest, TestFetchV2) {
 
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
 
-  EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
+  //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
+  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
+    return static_cast<firebase::FutureBase>(
+        static_cast<RemoteConfig*>(rc)->Fetch());
+  }, rc_, "Fetch"), "FetchWithRetry"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   LogDebug("Fetch time: %lld", rc_->GetInfo().fetch_time);
   firebase::remote_config::ValueInfo value_info;

--- a/remote_config/integration_test/src/integration_test.cc
+++ b/remote_config/integration_test/src/integration_test.cc
@@ -83,9 +83,6 @@ class FirebaseRemoteConfigTest : public FirebaseTest {
 #endif  // TEST_DEPRECATED
 };
 
-const firebase::remote_config::LastFetchStatus kFetchSuccess =
-    firebase::remote_config::kLastFetchStatusSuccess;
-
 FirebaseRemoteConfigTest::FirebaseRemoteConfigTest() : initialized_(false) {
   FindFirebaseConfig(FIREBASE_CONFIG_STRING);
 }

--- a/remote_config/integration_test/src/integration_test.cc
+++ b/remote_config/integration_test/src/integration_test.cc
@@ -487,11 +487,9 @@ TEST_F(FirebaseRemoteConfigTest, TestGetAll) {
   ASSERT_NE(rc_, nullptr);
 
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
-  //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
-  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
-    return static_cast<firebase::FutureBase>(
-        static_cast<RemoteConfig*>(rc)->Fetch(0));
-  }, rc_, "Fetch"), "Fetch"));
+  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](RemoteConfig* rc) {
+    return rc->Fetch();
+  }, rc_, "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   std::map<std::string, firebase::Variant> key_values = rc_->GetAll();
   EXPECT_EQ(key_values.size(), 6);
@@ -515,12 +513,9 @@ TEST_F(FirebaseRemoteConfigTest, TestFetchV2) {
   ASSERT_NE(rc_, nullptr);
 
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
-
-  //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
-  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
-    return static_cast<firebase::FutureBase>(
-        static_cast<RemoteConfig*>(rc)->Fetch(0));
-  }, rc_, "Fetch"), "Fetch"));
+  EXPECT_TRUE(WaitForCompletion(RunWithRetry([](RemoteConfig* rc) {
+    return rc->Fetch();
+  }, rc_, "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   LogDebug("Fetch time: %lld", rc_->GetInfo().fetch_time);
   firebase::remote_config::ValueInfo value_info;

--- a/remote_config/integration_test/src/integration_test.cc
+++ b/remote_config/integration_test/src/integration_test.cc
@@ -489,7 +489,7 @@ TEST_F(FirebaseRemoteConfigTest, TestGetAll) {
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
   EXPECT_TRUE(WaitForCompletion(RunWithRetry([](RemoteConfig* rc) {
     return rc->Fetch();
-  }, rc_, "Fetch"));
+  }, rc_), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   std::map<std::string, firebase::Variant> key_values = rc_->GetAll();
   EXPECT_EQ(key_values.size(), 6);
@@ -515,7 +515,7 @@ TEST_F(FirebaseRemoteConfigTest, TestFetchV2) {
   EXPECT_TRUE(WaitForCompletion(SetDefaultsV2(rc_), "SetDefaultsV2"));
   EXPECT_TRUE(WaitForCompletion(RunWithRetry([](RemoteConfig* rc) {
     return rc->Fetch();
-  }, rc_, "Fetch"));
+  }, rc_), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   LogDebug("Fetch time: %lld", rc_->GetInfo().fetch_time);
   firebase::remote_config::ValueInfo value_info;

--- a/remote_config/integration_test/src/integration_test.cc
+++ b/remote_config/integration_test/src/integration_test.cc
@@ -490,8 +490,8 @@ TEST_F(FirebaseRemoteConfigTest, TestGetAll) {
   //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
     return static_cast<firebase::FutureBase>(
-        static_cast<RemoteConfig*>(rc)->Fetch());
-  }, rc_, "Fetch"), "FetchWithRetry"));
+        static_cast<RemoteConfig*>(rc)->Fetch(0));
+  }, rc_, "Fetch"), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   std::map<std::string, firebase::Variant> key_values = rc_->GetAll();
   EXPECT_EQ(key_values.size(), 6);
@@ -519,8 +519,8 @@ TEST_F(FirebaseRemoteConfigTest, TestFetchV2) {
   //EXPECT_TRUE(WaitForCompletion(rc_->Fetch(), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(RunWithRetry([](void* rc) {
     return static_cast<firebase::FutureBase>(
-        static_cast<RemoteConfig*>(rc)->Fetch());
-  }, rc_, "Fetch"), "FetchWithRetry"));
+        static_cast<RemoteConfig*>(rc)->Fetch(0));
+  }, rc_, "Fetch"), "Fetch"));
   EXPECT_TRUE(WaitForCompletion(rc_->Activate(), "Activate"));
   LogDebug("Fetch time: %lld", rc_->GetInfo().fetch_time);
   firebase::remote_config::ValueInfo value_info;

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -623,6 +623,8 @@ class StorageListener : public firebase::storage::Listener {
 
   // Tracks whether OnPaused was ever called and resumes the transfer.
   void OnPaused(firebase::storage::Controller* controller) override {
+    // Let things be paused for a moment.
+    ProcessEvents(1000);
     on_paused_was_called_ = true;
     controller->Resume();
   }

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -102,7 +102,7 @@ const int kRetryDelaysMs[] = {
 };
 const int kMaxRetries = sizeof(kRetryDelaysMs) / sizeof(kRetryDelaysMs[0]);
 
-firebase::FutureBase FirebaseTest::RunWithRetry(
+firebase::FutureBase FirebaseTest::RunWithRetryBase(
     firebase::FutureBase (*run_future)(void* context),
     void* context, const char* name, int expected_error) {
 
@@ -122,12 +122,14 @@ firebase::FutureBase FirebaseTest::RunWithRetry(
     }
     if (future.status() != firebase::kFutureStatusComplete) {
       app_framework::LogDebug(
-          "RunWithRetry %s: Attempt %d returned invalid status",
+          "RunWithRetry%s%s: Attempt %d returned invalid status",
+	  *name?" ":"",
           name, attempt);
     }
     else if (future.error() != expected_error) {
       app_framework::LogDebug(
-          "RunWithRetry %s: Attempt %d returned error %d, expected %d",
+          "RunWithRetry%s%s: Attempt %d returned error %d, expected %d",
+	  *name?" ":"",
           name, attempt, future.error(), expected_error);
     }
     else {
@@ -137,7 +139,8 @@ firebase::FutureBase FirebaseTest::RunWithRetry(
     }
     int delay_ms = kRetryDelaysMs[attempt-1];
     app_framework::LogDebug(
-        "RunWithRetry %s: Pause %d milliseconds before retrying.",
+        "RunWithRetry%s%s: Pause %d milliseconds before retrying.",
+	*name?" ":"",
         name, delay_ms);
     app_framework::ProcessEvents(delay_ms);
   }

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -137,7 +137,7 @@ firebase::FutureBase FirebaseTest::RunWithRetry(
     }
     int delay_ms = kRetryDelaysMs[attempt-1];
     app_framework::LogDebug(
-        "RunWithRetry %s: Pause %d millseconds before retrying.",
+        "RunWithRetry %s: Pause %d milliseconds before retrying.",
         name, delay_ms);
     app_framework::ProcessEvents(delay_ms);
   }

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -123,13 +123,13 @@ firebase::FutureBase FirebaseTest::RunWithRetryBase(
     if (future.status() != firebase::kFutureStatusComplete) {
       app_framework::LogDebug(
           "RunWithRetry%s%s: Attempt %d returned invalid status",
-	  *name?" ":"",
+          *name?" ":"",
           name, attempt);
     }
     else if (future.error() != expected_error) {
       app_framework::LogDebug(
           "RunWithRetry%s%s: Attempt %d returned error %d, expected %d",
-	  *name?" ":"",
+          *name?" ":"",
           name, attempt, future.error(), expected_error);
     }
     else {
@@ -140,7 +140,7 @@ firebase::FutureBase FirebaseTest::RunWithRetryBase(
     int delay_ms = kRetryDelaysMs[attempt-1];
     app_framework::LogDebug(
         "RunWithRetry%s%s: Pause %d milliseconds before retrying.",
-	*name?" ":"",
+        *name?" ":"",
         name, delay_ms);
     app_framework::ProcessEvents(delay_ms);
   }

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -188,8 +188,8 @@ class FirebaseTest : public testing::Test {
        [](void*ctx) -> firebase::FutureBase {
          CallbackType callback = static_cast<RunData*>(ctx)->callback;
          ContextType* context = static_cast<RunData*>(ctx)->context;
-	 // The following line checks that the return type is correct.
-	 firebase::Future<ResultType> future_result = callback(context);
+         // The following line checks that the return type is correct.
+         firebase::Future<ResultType> future_result = callback(context);
          return static_cast<firebase::FutureBase>(future_result);
        },
        static_cast<void*>(&run_data),name, expected_error);

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -166,7 +166,7 @@ class FirebaseTest : public testing::Test {
     struct RunData { CallbackType callback; ContextType* context; };
     RunData run_data = { run_future_typed, context_typed };
     return RunWithRetryBase(
-       [](void*ctx) -> firebase::FutureBase {
+       [](void*ctx) {
          CallbackType callback = static_cast<RunData*>(ctx)->callback;
          ContextType* context = static_cast<RunData*>(ctx)->context;
          return static_cast<firebase::FutureBase>(callback(context));
@@ -187,7 +187,7 @@ class FirebaseTest : public testing::Test {
     struct RunData { CallbackType callback; ContextType* context; };
     RunData run_data = { run_future_typed, context_typed };
     firebase::FutureBase result_base = RunWithRetryBase(
-       [](void*ctx) -> firebase::FutureBase {
+       [](void*ctx) {
          CallbackType callback = static_cast<RunData*>(ctx)->callback;
          ContextType* context = static_cast<RunData*>(ctx)->context;
          // The following line checks that CallbackType actually returns a

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -148,13 +148,15 @@ class FirebaseTest : public testing::Test {
   //
   // For example, to add retry, you would change:
   //
-  // bool success = WaitForCompletion(auth_->DeleteUser(auth->current_user()),
-  //                                  "DeleteUser");
+  // bool success = WaitForCompletion(
+  //                      auth_->DeleteUser(auth->current_user()),
+  //                      "DeleteUser");
   // To this:
   //
-  // bool success = WaitForCompletion(RunWithRetry([](Auth* auth) {
-  //   return auth->DeleteUser(auth->current_user());
-  // }, auth_), "DeleteUser"));
+  // bool success = WaitForCompletion(RunWithRetry(
+  //                        [](Auth* auth) {
+  //                            return auth->DeleteUser(auth->current_user());
+  //                        }, auth_), "DeleteUser"));
   template<class CallbackType, class ContextType>
   static firebase::FutureBase RunWithRetry(
       CallbackType run_future_typed,
@@ -188,7 +190,9 @@ class FirebaseTest : public testing::Test {
        [](void*ctx) -> firebase::FutureBase {
          CallbackType callback = static_cast<RunData*>(ctx)->callback;
          ContextType* context = static_cast<RunData*>(ctx)->context;
-         // The following line checks that the return type is correct.
+         // The following line checks that CallbackType actually returns a
+         // Future<ResultType>. If it returns any other type, the compiler will
+         // complain about implicit conversion to Future<ResultType> here.
          firebase::Future<ResultType> future_result = callback(context);
          return static_cast<firebase::FutureBase>(future_result);
        },

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -162,9 +162,9 @@ class FirebaseTest : public testing::Test {
     RunData run_data = { run_future_typed, context_typed };
     return RunWithRetryBase(
        [](void*ctx) {
-	 CallbackType callback = static_cast<RunData*>(ctx)->callback;
-	 ContextType* context = static_cast<RunData*>(ctx)->context;
-	 return static_cast<firebase::FutureBase>(callback(context));
+         CallbackType callback = static_cast<RunData*>(ctx)->callback;
+         ContextType* context = static_cast<RunData*>(ctx)->context;
+         return static_cast<firebase::FutureBase>(callback(context));
        }, &run_data, name, expected_error);
   }
 

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -138,8 +138,6 @@ class FirebaseTest : public testing::Test {
   static bool WaitForCompletion(const firebase::FutureBase& future,
                                 const char* name, int expected_error = 0);
 
-  typedef firebase::FutureBase(*RetryCallbackBase)(void*);
-  
   // Run an operation that returns a Future (via a callback), retrying with
   // exponential backoff if the operation fails.
   //
@@ -148,8 +146,13 @@ class FirebaseTest : public testing::Test {
   // the Future returned may still be in progress). You should use
   // WaitForCompletion to await the results of this function in any case.
   //
-  // Example usage:
-  // bool deletion_successful = WaitForCompletion(RunWithRetry([](Auth* auth) {
+  // For example, to add retry, you would change:
+  //
+  // bool success = WaitForCompletion(auth_->DeleteUser(auth->current_user()),
+  //                                  "DeleteUser");
+  // To this:
+  //
+  // bool success = WaitForCompletion(RunWithRetry([](Auth* auth) {
   //   return auth->DeleteUser(auth->current_user());
   // }, auth_), "DeleteUser"));
   template<class CallbackType, class ContextType>
@@ -161,11 +164,37 @@ class FirebaseTest : public testing::Test {
     struct RunData { CallbackType callback; ContextType* context; };
     RunData run_data = { run_future_typed, context_typed };
     return RunWithRetryBase(
-       [](void*ctx) {
+       [](void*ctx) -> firebase::FutureBase {
          CallbackType callback = static_cast<RunData*>(ctx)->callback;
          ContextType* context = static_cast<RunData*>(ctx)->context;
          return static_cast<firebase::FutureBase>(callback(context));
-       }, &run_data, name, expected_error);
+       },
+       static_cast<void*>(&run_data),name, expected_error);
+  }
+
+  // Same as RunWithRetry, but templated to return a Future<ResultType>
+  // rather than a FutureBase, in case you want to use the result data
+  // of the Future. You need to explicitly provide the template parameter,
+  // e.g. RunWithRetry<int>(..) to return a Future<int>.
+  template<class ResultType, class CallbackType, class ContextType>
+  static firebase::Future<ResultType> RunWithRetry(
+      CallbackType run_future_typed,
+      ContextType* context_typed,
+      const char* name = "",
+      int expected_error = 0) {
+    struct RunData { CallbackType callback; ContextType* context; };
+    RunData run_data = { run_future_typed, context_typed };
+    firebase::FutureBase result_base = RunWithRetryBase(
+       [](void*ctx) -> firebase::FutureBase {
+         CallbackType callback = static_cast<RunData*>(ctx)->callback;
+         ContextType* context = static_cast<RunData*>(ctx)->context;
+	 // The following line checks that the return type is correct.
+	 firebase::Future<ResultType> future_result = callback(context);
+         return static_cast<firebase::FutureBase>(future_result);
+       },
+       static_cast<void*>(&run_data),name, expected_error);
+    // Future<T> and FutureBase are reinterpret_cast-compatible, by design.
+    return *reinterpret_cast<firebase::Future<ResultType>*>(&result_base);
   }
 
   // Blocking HTTP request helper function, for testing only.
@@ -191,16 +220,19 @@ class FirebaseTest : public testing::Test {
   // false if it failed.
   static bool Base64Decode(const std::string& input, std::string* output);
 
+
   firebase::App* app_;
   static int argc_;
   static char** argv_;
   static bool found_config_;
 
 private:
-  // Untyped version of RunWithRetry. The templated version should be used
-  // instead, for type safety.
+  // Untyped version of RunWithRetry, with implementation.
+  // This is kept private because the templated version should be used instead,
+  // for type safety.
   static firebase::FutureBase RunWithRetryBase(
-      RetryCallbackBase run_future, void* context,
+      firebase::FutureBase (*run_future)(void* context),
+      void* context,
       const char* name, int expected_error);
 };
 

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -138,13 +138,35 @@ class FirebaseTest : public testing::Test {
   static bool WaitForCompletion(const firebase::FutureBase& future,
                                 const char* name, int expected_error = 0);
 
-  // Run the future (via a callback), retrying with exponential backoff if it
-  // fails.
+  typedef firebase::FutureBase(*RetryCallbackBase)(void*);
+  
+  // Run an operation that returns a Future (via a callback), retrying with
+  // exponential backoff if the operation fails.
+  //
+  // Blocks until the operation succeeds (the Future completes, with error
+  // matching expected_error) or if the final attempt is started (in which case
+  // the Future returned may still be in progress). You should use
+  // WaitForCompletion to await the results of this function in any case.
+  //
+  // Example usage:
+  // bool deletion_successful = WaitForCompletion(RunWithRetry([](Auth* auth) {
+  //   return auth->DeleteUser(auth->current_user());
+  // }, auth_), "DeleteUser"));
+  template<class CallbackType, class ContextType>
   static firebase::FutureBase RunWithRetry(
-      firebase::FutureBase (*run_future)(void* context),
-      void* context,
-      const char* name,
-      int expected_error = 0);
+      CallbackType run_future_typed,
+      ContextType* context_typed,
+      const char* name = "",
+      int expected_error = 0) {
+    struct RunData { CallbackType callback; ContextType* context; };
+    RunData run_data = { run_future_typed, context_typed };
+    return RunWithRetryBase(
+       [](void*ctx) {
+	 CallbackType callback = static_cast<RunData*>(ctx)->callback;
+	 ContextType* context = static_cast<RunData*>(ctx)->context;
+	 return static_cast<firebase::FutureBase>(callback(context));
+       }, &run_data, name, expected_error);
+  }
 
   // Blocking HTTP request helper function, for testing only.
   static bool SendHttpGetRequest(
@@ -173,6 +195,13 @@ class FirebaseTest : public testing::Test {
   static int argc_;
   static char** argv_;
   static bool found_config_;
+
+private:
+  // Untyped version of RunWithRetry. The templated version should be used
+  // instead, for type safety.
+  static firebase::FutureBase RunWithRetryBase(
+      RetryCallbackBase run_future, void* context,
+      const char* name, int expected_error);
 };
 
 }  // namespace firebase_test_framework

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -138,6 +138,14 @@ class FirebaseTest : public testing::Test {
   static bool WaitForCompletion(const firebase::FutureBase& future,
                                 const char* name, int expected_error = 0);
 
+  // Run the future (via a callback), retrying with exponential backoff if it
+  // fails.
+  static firebase::FutureBase RunWithRetry(
+      firebase::FutureBase (*run_future)(void* context),
+      void* context,
+      const char* name,
+      int expected_error = 0);
+
   // Blocking HTTP request helper function, for testing only.
   static bool SendHttpGetRequest(
       const char* url, const std::map<std::string, std::string>& headers,


### PR DESCRIPTION
Allows you to retry Futures more than once, for handling transient failures.

Implemented in Remote Config integration test (for Fetch) and IID integration test (for DeleteId).

Also (not related to RunWithRetry), increase message timeout in Messaging test to help avoid flakes, and add a small delay in Storage's pause callback.