### PR TITLE
Change invalid default remote config namespace

### DIFF
--- a/remote_config/src/desktop/remote_config_desktop.cc
+++ b/remote_config/src/desktop/remote_config_desktop.cc
@@ -39,7 +39,7 @@ namespace internal {
 
 using callback::NewCallback;
 
-const char* const RemoteConfigInternal::kDefaultNamespace = "configns:firebase";
+const char* const RemoteConfigInternal::kDefaultNamespace = "firebase";
 const char* const RemoteConfigInternal::kDefaultValueForString = "";
 const int64_t RemoteConfigInternal::kDefaultValueForLong = 0L;
 const double RemoteConfigInternal::kDefaultValueForDouble = 0.0;


### PR DESCRIPTION
Previously was set to  "configns:firebase", now set to "firebase", which fixes a sporadic "Invalid Argument" error from the server.