### PR TITLE
Fix for a curl download error when installing NDK for Android Builds.

### DIFF
--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -20,7 +20,7 @@ else
     # Github runners.
     for retry in {1..10} error; do
 	if [[ $retry == "error" ]]; then exit 5; fi
-	curl --http1.1 -LSs \
+	curl -LSs \
              "https://download.sysinternals.com/files/Strings.zip" \
              --output Strings.zip && break
 	sleep 300
@@ -74,7 +74,7 @@ if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.p
 	# Github runners.
 	for retry in {1..10} error; do
 	    if [[ $retry == "error" ]]; then exit 5; fi
-	    curl -LSs \
+	    curl --http1.1 -LSs \
 		 "https://dl.google.com/android/repository/android-ndk-r16b-${platform}-x86_64.zip" \
 		 --output /tmp/android-ndk-r16b.zip && break
 	    sleep 300

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -20,7 +20,7 @@ else
     # Github runners.
     for retry in {1..10} error; do
 	if [[ $retry == "error" ]]; then exit 5; fi
-	curl -LSs \
+	curl --http1.1 -LSs \
              "https://download.sysinternals.com/files/Strings.zip" \
              --output Strings.zip && break
 	sleep 300


### PR DESCRIPTION
The Packaging Builds were failing to download the Android NDK properly in a manner [similar to this other external issue](https://github.com/CircleCI-Public/circleci-cli/issues/382).  

Updated the install prereqs script to add --http1.1 to the curl command line parameters.  This seems to have solved the problem.