### PR TITLE
Feature/android resources crash old devices

### DIFF
--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -28,9 +28,9 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":admob:admob_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/admob_resourcs_lib.jar")
 binary_to_array("admob_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/admob_resources_lib.jar"
     "firebase_admob"
     "${FIREBASE_GEN_FILE_DIR}/admob")
 

--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -28,7 +28,7 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":admob:admob_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/admob_resourcs_lib.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/admob_resources_lib.jar")
 binary_to_array("admob_resources"
     "${CMAKE_CURRENT_LIST_DIR}/admob_resources/build/admob_resources_lib.jar"
     "firebase_admob"

--- a/android_build_files/extract_and_dex.gradle
+++ b/android_build_files/extract_and_dex.gradle
@@ -43,7 +43,7 @@ def defineExtractionTasks(String resourceName, String buildType) {
       include "classes.jar"
     }
 
-    String dexedJar = "$buildDir/dexed.jar"
+    String dexedJar = "$buildDir/${resourceName}_lib.jar"
     String outPro = "$buildDir/${resourceName}.pro"
     Task dexJar = tasks.create(
         name: "generateDexJar$buildType",

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -22,21 +22,21 @@ binary_to_array("google_services_resource"
 
 # Define the resource builds needed for Android
 firebase_cpp_gradle(":app:app_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/app_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/app_resources/build/app_resources_lib.jar")
 binary_to_array("app_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/app_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/app_resources/build/app_resources_lib.jar"
     "firebase_app"
     "${FIREBASE_GEN_FILE_DIR}/app")
 firebase_cpp_gradle(":app:google_api_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/google_api_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/google_api_resources/build/google_api_resources_lib.jar")
 binary_to_array("google_api_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/google_api_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/google_api_resources/build/google_api_resources_lib.jar"
     "google_api"
     "${FIREBASE_GEN_FILE_DIR}/app")
 firebase_cpp_gradle(":app:invites_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/invites_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/invites_resources/build/invites_resources_lib.jar")
 binary_to_array("invites_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/invites_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/invites_resources/build/invites_resources_lib.jar"
     "firebase_invites"
     "${FIREBASE_GEN_FILE_DIR}/app")
 

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -58,9 +58,9 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":auth:auth_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/auth_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/auth_resources/build/auth_resources_lib.jar")
 binary_to_array("auth_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/auth_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/auth_resources/build/auth_resources_lib.jar"
     "firebase_auth"
     "${FIREBASE_GEN_FILE_DIR}/auth")
 

--- a/cmake/binary_to_array.cmake
+++ b/cmake/binary_to_array.cmake
@@ -17,7 +17,12 @@
 #
 # Args:
 #   NAME: The name to use for the generated files.
-#   INPUT: The input binary to embed into the source file.
+#   INPUT: The input binary to embed into the source file. Please ensure that
+#          the input binary is uniquely named across all embedded resources used
+#          in the project. This is because the generated C++ source files strip
+#          out the directories which can cause conflicts when caching these
+#          embedded resources in the C++ layer (observed on Android API <= 21).
+#          See https://github.com/firebase/firebase-cpp-sdk/pull/289.
 #   CPP_NAMESPACE: The namespace to use in the generated files.
 #   OUTPUT_DIRECTORY: Where the generated files should be written to.
 function(binary_to_array NAME INPUT CPP_NAMESPACE OUTPUT_DIRECTORY)

--- a/database/CMakeLists.txt
+++ b/database/CMakeLists.txt
@@ -27,9 +27,9 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":database:database_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/database_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/database_resources/build/database_resources_lib.jar")
 binary_to_array("database_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/database_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/database_resources/build/database_resources_lib.jar"
     "firebase_database_resources"
     "${FIREBASE_GEN_FILE_DIR}/database")
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -53,9 +53,9 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":firestore:firestore_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/firestore_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/firestore_resources/build/firestore_resources_lib.jar")
 binary_to_array("firestore_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/firestore_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/firestore_resources/build/firestore_resources_lib.jar"
     "firebase_firestore"
     "${FIREBASE_GEN_FILE_DIR}/firestore")
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -571,6 +571,12 @@ code.
 
 ## Release Notes
 
+### 7.1.1
+-   Changes
+    -   General (Android): Use non-conflicting file names for embedded resources
+        in Android builds. This fixes segfault crashes on old Android devices
+        (Android 5 and below).
+
 ### 7.1.0
 -   Changes
     -   General (iOS): Re-enabled Bitcode in iOS builds

--- a/storage/CMakeLists.txt
+++ b/storage/CMakeLists.txt
@@ -26,9 +26,9 @@ set(common_SRCS
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":storage:storage_resources:generateDexJarRelease"
-    "${CMAKE_CURRENT_LIST_DIR}/storage_resources/build/dexed.jar")
+    "${CMAKE_CURRENT_LIST_DIR}/storage_resources/build/storage_resources_lib.jar")
 binary_to_array("storage_resources"
-    "${CMAKE_CURRENT_LIST_DIR}/storage_resources/build/dexed.jar"
+    "${CMAKE_CURRENT_LIST_DIR}/storage_resources/build/storage_resources_lib.jar"
     "firebase_storage_resources"
     "${FIREBASE_GEN_FILE_DIR}/storage")
 


### PR DESCRIPTION
Fixes an issue on old Android devices (< Android 6.0) where we observed apps crashing on startup. This was happening because the various gradle "_resources" (app_resources, google_api_resources, database_resources etc) sub-projects' output dex files were being cached under the same file name in the C++ layer. 
This was causing a race condition amongst the threads handling each resources and the stack traces were inconsistent between runs. 
Separating each resource project's output into a non-conflicting file name fixes the problem.