### PR TITLE
Remove the extra delay in storage integration test on mobile.

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -627,7 +627,7 @@ class StorageListener : public firebase::storage::Listener {
     // Let things be paused for a moment on desktop, since it typically has a
     // very fast connection.
     ProcessEvents(1000);
-#endif
+#endif  // FIREBASE_PLATFORM_DESKTOP
     on_paused_was_called_ = true;
     controller->Resume();
   }

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -623,8 +623,11 @@ class StorageListener : public firebase::storage::Listener {
 
   // Tracks whether OnPaused was ever called and resumes the transfer.
   void OnPaused(firebase::storage::Controller* controller) override {
-    // Let things be paused for a moment.
+#if FIREBASE_PLATFORM_DESKTOP
+    // Let things be paused for a moment on desktop, since it typically has a
+    // very fast connection.
     ProcessEvents(1000);
+#endif
     on_paused_was_called_ = true;
     controller->Resume();
   }


### PR DESCRIPTION
This delay broke the Storage integration test on mobile, though it helps with flakes on desktop.