### PR TITLE
update firestore version

### DIFF
--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -18,7 +18,7 @@ if(TARGET firestore)
   return()
 endif()
 
-set(version CocoaPods-7.7.0)
+set(version 5f6febab5e133960ca8fc6d2639ea460253bc43a)
 ExternalProject_Add(
   firestore
 


### PR DESCRIPTION
Using firestore version that has a fix for compiler errors seen on newer versions of gcc (sign-compare).
https://github.com/firebase/firebase-ios-sdk/commit/5f6febab5e133960ca8fc6d2639ea460253bc43a