### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,7 +1,7 @@
 ---
 name: "➕ Feature request"
 about: If you have a feature request for the Firebase C++ SDK, file it here.
-title: ''
+title: '[FR] '
 labels: 'new, type: question'
 assignees: ''
 

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -2,7 +2,7 @@
 name: "➕ Feature request"
 about: If you have a feature request for the Firebase C++ SDK, file it here.
 title: ''
-labels: 'new, type: feature request'
+labels: 'new, type: question'
 assignees: ''
 
 ---

--- a/.github/ISSUE_TEMPLATE/issue.md
+++ b/.github/ISSUE_TEMPLATE/issue.md
@@ -1,8 +1,8 @@
 ---
 name: "\U0001F41E Bug report"
 about: Please use this template to report bugs with the Firebase C++ SDK.
-title: ''
-labels: new
+title: '[Bug] '
+labels: 'new, type: question'
 assignees: ''
 
 ---


### PR DESCRIPTION
Update issue templates to add `type: question` to all issue by default.

The idea is that all issue should be marked as `type: question` before it is a confirmed bug or a valid feature request.