### PR TITLE
Fixed race condition when removing listeners.

### DIFF
--- a/database/src/desktop/core/event_registration.cc
+++ b/database/src/desktop/core/event_registration.cc
@@ -20,6 +20,34 @@ namespace internal {
 
 EventRegistration::~EventRegistration() {}
 
+void EventRegistration::SafelyFireEvent(const Event& event) {
+  // Ensure that the listener has not already been removed.
+  //
+  // The main thread may remove listeners at any time, so we should not call any
+  // callbacks on a listener that has been removed. This does not protect
+  // callbacks that are currently running when the listener is removed: those
+  // must handled by a mutex from within the callback.
+  if (status_ == kRemoved) {
+    return;
+  }
+
+  FireEvent(event);
+}
+
+void EventRegistration::SafelyFireCancelEvent(Error error) {
+  // Ensure that the listener has not already been removed.
+  //
+  // The main thread may remove listeners at any time, so we should not call any
+  // callbacks on a listener that has been removed. This does not protect
+  // callbacks that are currently running when the listener is removed: those
+  // must handled by a mutex from within the callback.
+  if (status_ == kRemoved) {
+    return;
+  }
+
+  FireCancelEvent(error);
+}
+
 }  // namespace internal
 }  // namespace database
 }  // namespace firebase

--- a/database/src/desktop/core/event_registration.h
+++ b/database/src/desktop/core/event_registration.h
@@ -35,7 +35,7 @@ struct Event;
 class EventRegistration {
  public:
   explicit EventRegistration(const QuerySpec& query_spec)
-      : query_spec_(query_spec) {}
+      : status_(kActive), query_spec_(query_spec) {}
 
   virtual ~EventRegistration();
 
@@ -49,10 +49,10 @@ class EventRegistration {
 
   // Execute the event. Generally this means consuming the Event data and using
   // it to trigger a Listener.
-  virtual void FireEvent(const Event& event) = 0;
+  void SafelyFireEvent(const Event& event);
 
   // Cancel the event, passing along the given error code.
-  virtual void FireCancelEvent(Error error) = 0;
+  void SafelyFireCancelEvent(Error error);
 
   // Returns true if this EventRegistration contains the given listener.
   // Notes: This takes a void* because ValueListener and ChildListener do not
@@ -67,7 +67,29 @@ class EventRegistration {
     is_user_initiated_ = is_user_initiated;
   }
 
+  // Indicates whether this EventRegistration has been removed from the
+  // database. A removed EventRegistration will not fire any incoming Events.
+  enum Status {
+    kRemoved,
+    kActive,
+  };
+
+  // Returns the current status of this EventRegistration, indicating whether
+  // this registration has been removed from the database or not.
+  Status status() { return status_; }
+
+  // Set the status of this EventRegistration. When an EventRegistration is
+  // marked as kRemoved, it will no longer fire events.
+  void set_status(Status status) { status_ = status; }
+
+ protected:
+  virtual void FireEvent(const Event& event) = 0;
+
+  virtual void FireCancelEvent(Error error) = 0;
+
  private:
+  Status status_;
+
   QuerySpec query_spec_;
 
   bool is_user_initiated_;

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -527,9 +527,9 @@ void Repo::DeferredInitialization() {
 void Repo::PostEvents(const std::vector<Event>& events) {
   for (const Event& event : events) {
     if (event.type != kEventTypeError) {
-      event.event_registration->FireEvent(event);
+      event.event_registration->SafelyFireEvent(event);
     } else {
-      event.event_registration->FireCancelEvent(event.error);
+      event.event_registration->SafelyFireCancelEvent(event.error);
     }
   }
 }

--- a/database/src/desktop/query_desktop.h
+++ b/database/src/desktop/query_desktop.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <memory>
+
 #include "app/memory/unique_ptr.h"
 #include "app/src/include/firebase/future.h"
 #include "app/src/include/firebase/internal/common.h"
@@ -102,7 +103,8 @@ class QueryInternal {
   // Get the Future for the QueryInternal.
   ReferenceCountedFutureImpl* query_future();
 
-  void AddEventRegistration(UniquePtr<EventRegistration> registration);
+  void AddEventRegistration(UniquePtr<EventRegistration> registration,
+                            void* listener_ptr);
 
   void RemoveEventRegistration(void* listener_ptr, const QuerySpec& query_spec);
   void RemoveEventRegistration(ValueListener* listener,

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -576,6 +576,9 @@ code.
     -   General (iOS): iOS SDKs are now built using Xcode 12.
     -   General (iOS): iOS SDKs are now providing XCFrameworks instead of 
         Frameworks.
+    -   Database: Fixed a potential crash that can occur as a result of a race
+        condidtion when adding, removing and deleting `ValueListener`s or
+        `ChildListener`s rapidly.
 
 ### 7.1.1
 -   Changes


### PR DESCRIPTION
Fixed a crash that can occur as a result of a race condition when
rapidly removing and deleting a listener.

When a listener is added or removed, it doesn't get added or removed
immediately. Instead, a transaction is scheduled to run at some point in
the future. If the developer adds and removes a listener in quick
succession and then deletes it, those scheduled callbacks might not run
until after the listener has already been deleted, resulting in calling
a member function of a now garbage pointer and crashing.

The solution is to immediately mark a listener as having been removed
from the main thread (as well as scheduling it to be removed from the
background thread, as it was already doing). Any new event that come in
on a listener that has been marked removed will be ignored. The
developer is free to delete their Listener after that point without fear
that an event fire from the background thread after it has been deleted.