### PR TITLE
Updating android dependencies versions for firebase-cpp-sdk.

### DIFF
--- a/release_build_files/Android/firebase_dependencies.gradle
+++ b/release_build_files/Android/firebase_dependencies.gradle
@@ -38,7 +38,8 @@ def firebaseDependenciesMap = [
   'performance' : ['com.google.firebase:firebase-perf:19.1.0'],
   'remote_config' : ['com.google.firebase:firebase-config:20.0.3',
                      'com.google.android.gms:play-services-base:17.6.0'],
-  'storage' : ['com.google.firebase:firebase-storage:19.2.1']
+  'storage' : ['com.google.firebase:firebase-storage:19.2.1'],
+  'testlab' : []
 ]
 
 // Handles adding the Firebase C++ dependencies as properties.


### PR DESCRIPTION
Our public readme is slightly out of sync with the android dependency versions. This should fix the versions.

PiperOrigin-RevId: 356600386