### PR TITLE
Update the Unity Remote Config API

### DIFF
--- a/remote_config/src/common.cc
+++ b/remote_config/src/common.cc
@@ -23,56 +23,15 @@
 // Register the module initializer.
 FIREBASE_APP_REGISTER_CALLBACKS(remote_config,
                                 {
-                                  if (app == ::firebase::App::GetInstance()) {
-                                    return firebase::remote_config::Initialize(
-                                        *app);
-                                  }
+                                  // Nothing to do.
                                   return kInitResultSuccess;
                                 },
                                 {
-                                  if (app == ::firebase::App::GetInstance()) {
-                                    firebase::remote_config::Terminate();
-                                  }
+                                  // Nothing to do.
                                 });
 
 namespace firebase {
 namespace remote_config {
-
-namespace internal {
-
-const char kRemoteConfigModuleName[] = "remote_config";
-
-// Registers a cleanup task for this module if auto-initialization is disabled.
-void RegisterTerminateOnDefaultAppDestroy() {
-  if (!AppCallback::GetEnabledByName(kRemoteConfigModuleName)) {
-    CleanupNotifier* cleanup_notifier =
-        CleanupNotifier::FindByOwner(App::GetInstance());
-    assert(cleanup_notifier);
-    cleanup_notifier->RegisterObject(
-        const_cast<char*>(kRemoteConfigModuleName), [](void*) {
-          LogError(
-              "remote_config::Terminate() should be called before default app "
-              "is destroyed.");
-          if (firebase::remote_config::internal::IsInitialized()) {
-            firebase::remote_config::Terminate();
-          }
-        });
-  }
-}
-
-// Remove the cleanup task for this module if auto-initialization is disabled.
-void UnregisterTerminateOnDefaultAppDestroy() {
-  if (!AppCallback::GetEnabledByName(kRemoteConfigModuleName) &&
-      firebase::remote_config::internal::IsInitialized()) {
-    CleanupNotifier* cleanup_notifier =
-        CleanupNotifier::FindByOwner(App::GetInstance());
-    assert(cleanup_notifier);
-    cleanup_notifier->UnregisterObject(
-        const_cast<char*>(kRemoteConfigModuleName));
-  }
-}
-
-}  // namespace internal
 
 FutureData* FutureData::s_future_data_;
 

--- a/remote_config/src/common.h
+++ b/remote_config/src/common.h
@@ -69,12 +69,6 @@ namespace internal {
 // Implemented in each platform module.
 bool IsInitialized();
 
-// Registers a cleanup task for this module if auto-initialization is disabled.
-void RegisterTerminateOnDefaultAppDestroy();
-
-// Remove the cleanup task for this module if auto-initialization is disabled.
-void UnregisterTerminateOnDefaultAppDestroy();
-
 // Waits until the given future is complete and asserts that it completed with
 // the given error (no error by default). Returns the future's result.
 template <typename T>

--- a/remote_config/src/include/firebase/remote_config.h
+++ b/remote_config/src/include/firebase/remote_config.h
@@ -34,11 +34,13 @@ FIREBASE_APP_REGISTER_CALLBACKS_REFERENCE(remote_config)
 /// @brief Namespace that encompasses all Firebase APIs.
 namespace firebase {
 
+#ifndef SWIG
 /// @brief Firebase Remote Config API.
 ///
 /// Firebase Remote Config is a cloud service that lets you change the
 /// appearance and behavior of your app without requiring users to download an
 /// app update.
+#endif  // SWIG
 namespace remote_config {
 
 /// @brief Describes the most recent fetch request status.


### PR DESCRIPTION
Changes FirebaseRemoteConfig to be used as an instanced class. Because static and instance methods cannot share the same signature, all the deprecated functions have been moved to a different class, FirebaseRemoteConfigDeprecated, so that users have an easier fix.

PiperOrigin-RevId: 356606757