### PR TITLE
Firestore: Translate Java exceptions to C++ exceptions of the right type

### DIFF
--- a/firestore/src/android/exception_android.cc
+++ b/firestore/src/android/exception_android.cc
@@ -1,5 +1,8 @@
 #include "firestore/src/android/exception_android.h"
 
+#include <stdexcept>
+
+#include "firestore/src/common/macros.h"
 #include "firestore/src/jni/env.h"
 #include "firestore/src/jni/loader.h"
 #include "firestore/src/jni/throwable.h"
@@ -40,12 +43,18 @@ StaticMethod<Object> kFromValue(
     "fromValue",
     "(I)Lcom/google/firebase/firestore/FirebaseFirestoreException$Code;");
 
-// IllegalStateException
-constexpr char kIllegalStateExceptionClassName[] =
-    PROGUARD_KEEP_CLASS "java/lang/IllegalStateException";
-Constructor<Throwable> kNewIllegalStateException("()V");
-
+jclass g_illegal_argument_exception_class = nullptr;
 jclass g_illegal_state_exception_class = nullptr;
+
+/** Returns true if the given object is an IllegalArgumentException. */
+bool IsIllegalArgumentException(jni::Env& env, const jni::Object& exception) {
+  return env.IsInstanceOf(exception, g_illegal_argument_exception_class);
+}
+
+/** Returns true if the given object is an IllegalStateException. */
+bool IsIllegalStateException(jni::Env& env, const jni::Object& exception) {
+  return env.IsInstanceOf(exception, g_illegal_state_exception_class);
+}
 
 }  // namespace
 
@@ -56,8 +65,10 @@ void ExceptionInternal::Initialize(jni::Loader& loader) {
 
   loader.LoadClass(kCodeClassName, kValue, kFromValue);
 
-  g_illegal_state_exception_class = loader.LoadClass(
-      kIllegalStateExceptionClassName, kNewIllegalStateException);
+  g_illegal_argument_exception_class =
+      loader.LoadClass("java/lang/IllegalArgumentException");
+  g_illegal_state_exception_class =
+      loader.LoadClass("java/lang/IllegalStateException");
 }
 
 Error ExceptionInternal::GetErrorCode(Env& env, const Object& exception) {
@@ -122,11 +133,6 @@ bool ExceptionInternal::IsFirestoreException(Env& env,
   return env.IsInstanceOf(exception, g_firestore_exception_class);
 }
 
-bool ExceptionInternal::IsIllegalStateException(Env& env,
-                                                const Object& exception) {
-  return env.IsInstanceOf(exception, g_illegal_state_exception_class);
-}
-
 bool ExceptionInternal::IsAnyExceptionThrownByFirestore(
     Env& env, const Object& exception) {
   return IsFirestoreException(env, exception) ||
@@ -136,16 +142,32 @@ bool ExceptionInternal::IsAnyExceptionThrownByFirestore(
 void GlobalUnhandledExceptionHandler(jni::Env& env,
                                      jni::Local<jni::Throwable>&& exception,
                                      void* context) {
-#if __cpp_exceptions
-  // TODO(b/149105903): Handle different underlying Java exceptions differently.
+#if FIRESTORE_HAVE_EXCEPTIONS
+  std::string message = exception.GetMessage(env);
+
   env.ExceptionClear();
-  throw FirestoreException(exception.GetMessage(env), Error::kErrorInternal);
+  if (IsIllegalArgumentException(env, exception)) {
+    throw std::invalid_argument(message);
+  } else if (IsIllegalStateException(env, exception)) {
+    throw std::logic_error(message);
+  } else if (ExceptionInternal::IsFirestoreException(env, exception)) {
+    Error code = ExceptionInternal::GetErrorCode(env, exception);
+    throw FirestoreException(message, code);
+  } else {
+    // All other exceptions are internal errors.
+    //
+    // This includes NullPointerException which would normally indicate that a
+    // user has passed a null argument to a Java method that didn't allow it. In
+    // C++, arguments are taken by value or const reference and can't end up as
+    // a null Java reference unless there's an error in the argument conversion.
+    throw FirestoreException(exception.GetMessage(env), Error::kErrorInternal);
+  }
 
 #else
   // Just clear the pending exception. The exception was already logged when
   // first caught.
   env.ExceptionClear();
-#endif
+#endif  // FIRESTORE_HAVE_EXCEPTIONS
 }
 
 }  // namespace firestore

--- a/firestore/src/android/exception_android.h
+++ b/firestore/src/android/exception_android.h
@@ -29,10 +29,6 @@ class ExceptionInternal {
   /** Returns true if the given object is a FirestoreException. */
   static bool IsFirestoreException(jni::Env& env, const jni::Object& exception);
 
-  /** Returns true if the given object is an IllegalStateException. */
-  static bool IsIllegalStateException(jni::Env& env,
-                                      const jni::Object& exception);
-
   /**
    * Returns true if the given object is a FirestoreException or any other type
    * of exception thrown by a Firestore API.

--- a/firestore/src/tests/firestore_test.cc
+++ b/firestore/src/tests/firestore_test.cc
@@ -3,6 +3,7 @@
 #if !defined(__ANDROID__)
 #include <future>  // NOLINT(build/c++11)
 #endif
+#include <stdexcept>
 
 #if !defined(FIRESTORE_STUB_BUILD)
 #include "app/src/semaphore.h"
@@ -380,7 +381,7 @@ TEST_F(FirestoreIntegrationTest, TestFieldMaskCannotContainMissingFields) {
     document.Set(MapFieldValue{{"desc", FieldValue::String("NewDescription")}},
                  SetOptions::MergeFields({"desc", "owner"}));
     FAIL() << "should throw exception";
-  } catch (const FirestoreException& exception) {
+  } catch (const std::invalid_argument& exception) {
     EXPECT_STREQ(
         "Field 'owner' is specified in your field mask but not in your input "
         "data.",
@@ -1197,7 +1198,7 @@ TEST_F(FirestoreIntegrationTest, TestToString) {
 #if defined(__ANDROID__) && FIRESTORE_HAVE_EXCEPTIONS
 TEST_F(FirestoreIntegrationTest, ClientCallsAfterTerminateFails) {
   EXPECT_THAT(TestFirestore()->Terminate(), FutureSucceeds());
-  EXPECT_THROW(Await(TestFirestore()->DisableNetwork()), FirestoreException);
+  EXPECT_THROW(Await(TestFirestore()->DisableNetwork()), std::logic_error);
 }
 
 TEST_F(FirestoreIntegrationTest, NewOperationThrowsAfterFirestoreTerminate) {
@@ -1207,15 +1208,15 @@ TEST_F(FirestoreIntegrationTest, NewOperationThrowsAfterFirestoreTerminate) {
 
   EXPECT_THAT(instance->Terminate(), FutureSucceeds());
 
-  EXPECT_THROW(Await(reference.Get()), FirestoreException);
+  EXPECT_THROW(Await(reference.Get()), std::logic_error);
   EXPECT_THROW(Await(reference.Update({{"Field", FieldValue::Integer(1)}})),
-               FirestoreException);
+               std::logic_error);
   EXPECT_THROW(Await(reference.Set({{"Field", FieldValue::Integer(1)}})),
-               FirestoreException);
+               std::logic_error);
   EXPECT_THROW(Await(instance->batch()
                          .Set(reference, {{"Field", FieldValue::Integer(1)}})
                          .Commit()),
-               FirestoreException);
+               std::logic_error);
   EXPECT_THROW(Await(instance->RunTransaction(
                    [reference](Transaction& transaction,
                                std::string& error_message) -> Error {
@@ -1223,7 +1224,7 @@ TEST_F(FirestoreIntegrationTest, NewOperationThrowsAfterFirestoreTerminate) {
                      transaction.Get(reference, &error, &error_message);
                      return error;
                    })),
-               FirestoreException);
+               std::logic_error);
 }
 
 TEST_F(FirestoreIntegrationTest, TerminateCanBeCalledMultipleTimes) {
@@ -1233,13 +1234,13 @@ TEST_F(FirestoreIntegrationTest, TerminateCanBeCalledMultipleTimes) {
 
   EXPECT_THAT(instance->Terminate(), FutureSucceeds());
 
-  EXPECT_THROW(Await(reference.Get()), FirestoreException);
+  EXPECT_THROW(Await(reference.Get()), std::logic_error);
 
   // Calling a second time should go through and change nothing.
   EXPECT_THAT(instance->Terminate(), FutureSucceeds());
 
   EXPECT_THROW(Await(reference.Update({{"Field", FieldValue::Integer(1)}})),
-               FirestoreException);
+               std::logic_error);
 }
 #endif  // defined(__ANDROID__) && FIRESTORE_HAVE_EXCEPTIONS
 

--- a/firestore/src/tests/query_test.cc
+++ b/firestore/src/tests/query_test.cc
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <cmath>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -90,7 +91,7 @@ TEST_F(FirestoreIntegrationTest, TestLimitQueriesUsingDescendingSortOrder) {
 TEST_F(FirestoreIntegrationTest, TestLimitToLastMustAlsoHaveExplicitOrderBy) {
   CollectionReference collection = Collection();
 
-  EXPECT_THROW(Await(collection.LimitToLast(2).Get()), FirestoreException);
+  EXPECT_THROW(Await(collection.LimitToLast(2).Get()), std::logic_error);
 }
 #endif  // defined(__ANDROID__) && FIRESTORE_HAVE_EXCEPTIONS
 


### PR DESCRIPTION
See go/firestore-exceptions for details.

PiperOrigin-RevId: 357237099