### PR TITLE
Firestore: Add JniRunnable, a Java Runnable class whose run() method invokes a C++ function.

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -91,6 +91,8 @@ set(android_SRCS
     src/android/geo_point_android.cc
     src/android/geo_point_android.h
     src/android/geo_point_portable.cc
+    src/android/jni_runnable_android.cc
+    src/android/jni_runnable_android.h
     src/android/lambda_event_listener.h
     src/android/lambda_transaction_function.h
     src/android/listener_registration_android.cc

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -21,6 +21,7 @@
 #include "firestore/src/android/field_path_android.h"
 #include "firestore/src/android/field_value_android.h"
 #include "firestore/src/android/geo_point_android.h"
+#include "firestore/src/android/jni_runnable_android.h"
 #include "firestore/src/android/lambda_event_listener.h"
 #include "firestore/src/android/lambda_transaction_function.h"
 #include "firestore/src/android/listener_registration_android.h"
@@ -269,6 +270,7 @@ bool FirestoreInternal::Initialize(App* app) {
     FieldPathConverter::Initialize(loader);
     FieldValueInternal::Initialize(loader);
     GeoPointInternal::Initialize(loader);
+    JniRunnableBase::Initialize(loader);
     ListenerRegistrationInternal::Initialize(loader);
     MetadataChangesInternal::Initialize(loader);
     QueryInternal::Initialize(loader);

--- a/firestore/src/android/jni_runnable_android.cc
+++ b/firestore/src/android/jni_runnable_android.cc
@@ -1,0 +1,76 @@
+#include "firestore/src/android/jni_runnable_android.h"
+
+#include "app/src/util_android.h"
+#include "firestore/src/jni/declaration.h"
+#include "firestore/src/jni/env.h"
+#include "firestore/src/jni/loader.h"
+#include "firestore/src/jni/object.h"
+#include "firestore/src/jni/ownership.h"
+#include "firestore/src/jni/task.h"
+
+namespace firebase {
+namespace firestore {
+namespace {
+
+using jni::Constructor;
+using jni::Env;
+using jni::ExceptionClearGuard;
+using jni::Local;
+using jni::Method;
+using jni::Object;
+using jni::Task;
+
+constexpr char kJniRunnableClassName[] =
+    "com/google/firebase/firestore/internal/cpp/JniRunnable";
+Method<void> kDetach("detach", "()V");
+Method<Task> kRunOnMainThread("runOnMainThread",
+                              "()Lcom/google/android/gms/tasks/Task;");
+Method<Task> kRunOnNewThread("runOnNewThread",
+                             "()Lcom/google/android/gms/tasks/Task;");
+Constructor<Object> kConstructor("(J)V");
+
+void NativeRun(JNIEnv* env, jobject java_object, jlong data) {
+  if (data == 0) {
+    return;
+  }
+  reinterpret_cast<JniRunnableBase*>(data)->Run();
+}
+
+}  // namespace
+
+void JniRunnableBase::Initialize(jni::Loader& loader) {
+  loader.LoadClass(kJniRunnableClassName, kConstructor, kDetach,
+                   kRunOnMainThread, kRunOnNewThread);
+  static const JNINativeMethod kJniRunnableNatives[] = {
+      {"nativeRun", "(J)V", reinterpret_cast<void*>(&NativeRun)}};
+  loader.RegisterNatives(kJniRunnableNatives,
+                         FIREBASE_ARRAYSIZE(kJniRunnableNatives));
+}
+
+JniRunnableBase::JniRunnableBase(Env& env)
+    : java_runnable_(env.New(kConstructor, reinterpret_cast<jlong>(this))) {}
+
+JniRunnableBase::~JniRunnableBase() {
+  Env env;
+  Detach(env);
+}
+
+void JniRunnableBase::Detach(Env& env) {
+  ExceptionClearGuard exception_clear_guard(env);
+  env.Call(java_runnable_, kDetach);
+}
+
+Local<Object> JniRunnableBase::GetJavaRunnable() const {
+  return java_runnable_;
+}
+
+Local<Task> JniRunnableBase::RunOnMainThread(Env& env) {
+  return env.Call(java_runnable_, kRunOnMainThread);
+}
+
+Local<Task> JniRunnableBase::RunOnNewThread(Env& env) {
+  return env.Call(java_runnable_, kRunOnNewThread);
+}
+
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/src/android/jni_runnable_android.h
+++ b/firestore/src/android/jni_runnable_android.h
@@ -1,0 +1,141 @@
+#ifndef FIREBASE_FIRESTORE_CLIENT_CPP_SRC_ANDROID_JNI_RUNNABLE_ANDROID_H_
+#define FIREBASE_FIRESTORE_CLIENT_CPP_SRC_ANDROID_JNI_RUNNABLE_ANDROID_H_
+
+#include "app/meta/move.h"
+#include "firestore/src/jni/jni_fwd.h"
+#include "firestore/src/jni/object.h"
+#include "firestore/src/jni/ownership.h"
+#include "firestore/src/jni/task.h"
+
+namespace firebase {
+namespace firestore {
+
+/**
+ * A proxy for a Java `Runnable` that calls a C++ function.
+ *
+ * Note: Typically, this class is not used directly but rather its templated
+ * subclass `JniRunnable`.
+ *
+ * Subclasses must implement the `Run()` method to perform the desired work when
+ * the Java `Runnable` object's `run()` method is invoked. `GetJavaRunnable()`
+ * will return the Java `Runnable` object whose `run()` method will invoke this
+ * object's `Run()` method. When this object is destroyed, or `Detach()` is
+ * invoked, then the Java `Runnable` will be "detached" from this C++ object and
+ * its `run()` method will do nothing.
+ */
+class JniRunnableBase {
+ public:
+  explicit JniRunnableBase(jni::Env& env);
+
+  /**
+   * Calls `Detach()`.
+   */
+  virtual ~JniRunnableBase();
+
+  /**
+   * Initializes this class.
+   *
+   * This method should be called once during application initialization.
+   */
+  static void Initialize(jni::Loader& loader);
+
+  /**
+   * Implements the logic to execute when the Java `Runnable` object's `run()`
+   * method is invoked.
+   */
+  virtual void Run() = 0;
+
+  /**
+   * Detaches this object from its companion Java `Runnable` object.
+   *
+   * After calling this method, all future invocations of the Java `Runnable`
+   * object's `run()` method will do nothing and complete as if successful.
+   *
+   * This method will block until all active invocations of `Run()` have
+   * completed, and will cause new invocations of the Java `Runnable` object's
+   * `run()` that occur while this method is blocked to also block until this
+   * method completes.
+   *
+   * Calling `Detach()` multiple times is allowed, but invocations after the
+   * first invocation have no effect.
+   */
+  void Detach(jni::Env& env);
+
+  /**
+   * Returns the companion Java `Runnable` object whose `run()` method will
+   * invoke this object's `Run()` method.
+   */
+  jni::Local<jni::Object> GetJavaRunnable() const;
+
+  /**
+   * Schedules this object's `Run()` method to be invoked asynchronously on the
+   * Android main event thread.
+   *
+   * If this method is invoked from the main thread then `Run()` will be invoked
+   * synchronously and the returned task will be in the "completed" state.
+   *
+   * The returned `Task` will complete after this object's `Run()` method has
+   * been invoked. If the `Run()` method throws a Java exception then the task
+   * will complete with that exception.
+   */
+  jni::Local<jni::Task> RunOnMainThread(jni::Env& env);
+
+  /**
+   * Schedules this object's `Run()` method to be invoked asynchronously on a
+   * newly-created thread.
+   *
+   * The returned `Task` will complete after this object's `Run()` method has
+   * been invoked. If the `Run()` method throws a Java exception then the task
+   * will complete with that exception.
+   */
+  jni::Local<jni::Task> RunOnNewThread(jni::Env& env);
+
+ private:
+  jni::Global<jni::Object> java_runnable_;
+};
+
+/**
+ * A proxy for a Java `Runnable` that calls a C++ function.
+ *
+ * The template parameter `CallbackT` is typically a lambda or function pointer;
+ * it can be anything that can be "invoked" with zero arguments.
+ *
+ * Example:
+ *
+ * jni::Env env;
+ * int invoke_count = 0;
+ * auto runnable = MakeJniRunnable(env, [&invoke_count] { invoke_count++; });
+ * jni::Local<jni::Object> java_runnable = runnable.GetJavaRunnable();
+ * for (int i=0; i<5; ++i) {
+ *   env.Call(java_runnable, kRunnableRun);
+ * }
+ * EXPECT_EQ(invoke_count, 5);
+ *
+ */
+template <typename CallbackT>
+class JniRunnable : public JniRunnableBase {
+ public:
+  JniRunnable(jni::Env& env, CallbackT callback)
+      : JniRunnableBase(env), callback_(firebase::Move(callback)) {}
+
+  void Run() override { callback_(); }
+
+ private:
+  CallbackT callback_;
+};
+
+/**
+ * Creates and returns a new instance of `JniRunnable`.
+ *
+ * TODO: Remove this function in favor of just using the constructor once C++17
+ * becomes the lowest-supported C++ version.
+ */
+template <typename CallbackT>
+JniRunnable<CallbackT> MakeJniRunnable(jni::Env& env, CallbackT callback) {
+  return JniRunnable<CallbackT>(env, firebase::Move(callback));
+}
+
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIREBASE_FIRESTORE_CLIENT_CPP_SRC_ANDROID_JNI_RUNNABLE_ANDROID_H_

--- a/firestore/src/tests/android/jni_runnable_android_test.cc
+++ b/firestore/src/tests/android/jni_runnable_android_test.cc
@@ -1,0 +1,257 @@
+#include "firestore/src/android/jni_runnable_android.h"
+
+#include "firestore/src/jni/declaration.h"
+#include "firestore/src/jni/object.h"
+#include "firestore/src/jni/ownership.h"
+#include "firestore/src/jni/task.h"
+#include "firestore/src/jni/throwable.h"
+#include "firestore/src/tests/android/firestore_integration_test_android.h"
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+
+namespace {
+
+using jni::Env;
+using jni::Global;
+using jni::Local;
+using jni::Method;
+using jni::Object;
+using jni::StaticMethod;
+using jni::Task;
+using jni::Throwable;
+
+StaticMethod<Object> kGetMainLooper("getMainLooper", "()Landroid/os/Looper;");
+Method<Object> kLooperGetThread("getThread", "()Ljava/lang/Thread;");
+Method<void> kRunnableRun("run", "()V");
+StaticMethod<Object> kCurrentThread("currentThread", "()Ljava/lang/Thread;");
+Method<jlong> kThreadGetId("getId", "()J");
+
+class JniRunnableTest : public FirestoreAndroidIntegrationTest {
+ public:
+  void SetUp() override {
+    FirestoreAndroidIntegrationTest::SetUp();
+    loader().LoadClass("android/os/Looper", kGetMainLooper, kLooperGetThread);
+    loader().LoadClass("java/lang/Runnable", kRunnableRun);
+    loader().LoadClass("java/lang/Thread", kCurrentThread, kThreadGetId);
+    ASSERT_TRUE(loader().ok());
+  }
+};
+
+/**
+ * Returns the ID of the current Java thread.
+ */
+jlong GetCurrentThreadId(Env& env) {
+  Local<Object> thread = env.Call(kCurrentThread);
+  return env.Call(thread, kThreadGetId);
+}
+
+/**
+ * Returns the ID of the Java main thread.
+ */
+jlong GetMainThreadId(Env& env) {
+  Local<Object> main_looper = env.Call(kGetMainLooper);
+  Local<Object> main_thread = env.Call(main_looper, kLooperGetThread);
+  return env.Call(main_thread, kThreadGetId);
+}
+
+TEST_F(JniRunnableTest, JavaRunCallsCppRun) {
+  Env env;
+  bool invoked = false;
+  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  env.Call(java_runnable, kRunnableRun);
+
+  EXPECT_TRUE(invoked);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, JavaRunCallsCppRunOncePerInvocation) {
+  Env env;
+  int invoke_count = 0;
+  auto runnable = MakeJniRunnable(env, [&invoke_count] { invoke_count++; });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  env.Call(java_runnable, kRunnableRun);
+  env.Call(java_runnable, kRunnableRun);
+  env.Call(java_runnable, kRunnableRun);
+  env.Call(java_runnable, kRunnableRun);
+  env.Call(java_runnable, kRunnableRun);
+
+  EXPECT_EQ(invoke_count, 5);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, JavaRunPropagatesExceptions) {
+  Env env;
+  Local<Throwable> exception = CreateException(env, "Forced exception");
+  auto runnable = MakeJniRunnable(env, [exception] {
+    Env env;
+    env.Throw(exception);
+  });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  env.Call(java_runnable, kRunnableRun);
+
+  Local<Throwable> thrown_exception = env.ClearExceptionOccurred();
+  EXPECT_TRUE(thrown_exception);
+  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+}
+
+TEST_F(JniRunnableTest, DetachCausesJavaRunToDoNothing) {
+  Env env;
+  bool invoked = false;
+  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  runnable.Detach(env);
+
+  env.Call(java_runnable, kRunnableRun);
+  EXPECT_FALSE(invoked);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, DetachCanBeInvokedMultipleTimes) {
+  Env env;
+  bool invoked = false;
+  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  runnable.Detach(env);
+  runnable.Detach(env);
+  runnable.Detach(env);
+
+  env.Call(java_runnable, kRunnableRun);
+  EXPECT_FALSE(invoked);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, DetachDetachesEvenIfAnExceptionIsPending) {
+  Env env;
+  bool invoked = false;
+  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+  Local<Throwable> exception = CreateException(env, "Forced exception");
+  env.Throw(exception);
+  EXPECT_FALSE(env.ok());
+
+  runnable.Detach(env);
+
+  env.ExceptionClear();
+  env.Call(java_runnable, kRunnableRun);
+  EXPECT_FALSE(invoked);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, DestructionCausesJavaRunToDoNothing) {
+  Env env;
+  bool invoked = false;
+  Local<Object> java_runnable;
+  {
+    auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+    java_runnable = runnable.GetJavaRunnable();
+  }
+
+  env.Call(java_runnable, kRunnableRun);
+
+  EXPECT_FALSE(invoked);
+  EXPECT_TRUE(env.ok());
+}
+
+TEST_F(JniRunnableTest, RunOnMainThreadRunsOnTheMainThread) {
+  Env env;
+  jlong captured_thread_id = 0;
+  auto runnable = MakeJniRunnable(env, [&captured_thread_id] {
+    Env env;
+    captured_thread_id = GetCurrentThreadId(env);
+  });
+
+  Local<Task> task = runnable.RunOnMainThread(env);
+
+  Await(env, task);
+  EXPECT_EQ(captured_thread_id, GetMainThreadId(env));
+}
+
+TEST_F(JniRunnableTest, RunOnMainThreadTaskFailsIfRunThrowsException) {
+  Env env;
+  Global<Throwable> exception = CreateException(env, "Forced exception");
+  auto runnable = MakeJniRunnable(env, [exception] {
+    Env env;
+    env.Throw(exception);
+  });
+
+  Local<Task> task = runnable.RunOnMainThread(env);
+
+  Await(env, task);
+  Local<Throwable> thrown_exception = task.GetException(env);
+  EXPECT_TRUE(thrown_exception);
+  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+}
+
+TEST_F(JniRunnableTest, RunOnMainThreadRunsSynchronouslyFromMainThread) {
+  class ChainedMainThreadJniRunnable : public JniRunnableBase {
+   public:
+    using JniRunnableBase::JniRunnableBase;
+
+    void Run() override {
+      Env env;
+      EXPECT_EQ(GetCurrentThreadId(env), GetMainThreadId(env));
+      if (is_nested_call_) {
+        return;
+      }
+      is_nested_call_ = true;
+      Local<Task> task = RunOnMainThread(env);
+      EXPECT_TRUE(task.IsComplete(env));
+      EXPECT_TRUE(task.IsSuccessful(env));
+      is_nested_call_ = false;
+    }
+
+   private:
+    bool is_nested_call_ = false;
+  };
+
+  Env env;
+  ChainedMainThreadJniRunnable runnable(env);
+
+  Local<Task> task = runnable.RunOnMainThread(env);
+
+  Await(env, task);
+}
+
+TEST_F(JniRunnableTest, RunOnNewThreadRunsOnANonMainThread) {
+  Env env;
+  jlong captured_thread_id = 0;
+  auto runnable = MakeJniRunnable(env, [&captured_thread_id] {
+    Env env;
+    captured_thread_id = GetCurrentThreadId(env);
+  });
+
+  Local<Task> task = runnable.RunOnNewThread(env);
+
+  Await(env, task);
+  EXPECT_NE(captured_thread_id, 0);
+  EXPECT_NE(captured_thread_id, GetMainThreadId(env));
+  EXPECT_NE(captured_thread_id, GetCurrentThreadId(env));
+}
+
+TEST_F(JniRunnableTest, RunOnNewThreadTaskFailsIfRunThrowsException) {
+  Env env;
+  Global<Throwable> exception = CreateException(env, "Forced exception");
+  auto runnable = MakeJniRunnable(env, [exception] {
+    Env env;
+    env.Throw(exception);
+  });
+
+  Local<Task> task = runnable.RunOnNewThread(env);
+
+  Await(env, task);
+  Local<Throwable> thrown_exception = task.GetException(env);
+  EXPECT_TRUE(thrown_exception);
+  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+}
+
+}  // namespace
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/src_java/com/google/firebase/firestore/internal/cpp/JniRunnable.java
+++ b/firestore/src_java/com/google/firebase/firestore/internal/cpp/JniRunnable.java
@@ -1,0 +1,142 @@
+package com.google.firebase.firestore.internal.cpp;
+
+import android.os.Handler;
+import android.os.Looper;
+import com.google.android.gms.tasks.Task;
+import com.google.android.gms.tasks.TaskCompletionSource;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+/** A {@link Runnable} whose {@link #run} method calls a native function. */
+public final class JniRunnable implements Runnable {
+
+  private final ReentrantReadWriteLock.ReadLock readLock;
+  private final ReentrantReadWriteLock.WriteLock writeLock;
+
+  private long data;
+
+  /**
+   * Creates a new instance of this class.
+   *
+   * @param data Opaque data used by the native code; must not be zero.
+   * @throws IllegalArgumentException if {@code data==0}.
+   */
+  public JniRunnable(long data) {
+    if (data == 0) {
+      throw new IllegalArgumentException(
+          "data==0 is forbidden because 0 is reserved to indicate that we are detached from the"
+              + " C++ function");
+    }
+    ReentrantReadWriteLock lock = new ReentrantReadWriteLock(/* fair= */ true);
+    readLock = lock.readLock();
+    writeLock = lock.writeLock();
+    this.data = data;
+  }
+
+  /**
+   * Invokes the C++ method encapsulated by this object.
+   *
+   * <p>If {@link #detach} has been invoked then this method does nothing and returns as if
+   * successful.
+   *
+   * <p>This method <em>will</em> block if there is a thread blocked in {@link #detach}; otherwise,
+   * it will call the C++ function without blocking. This may even result in concurrent/parallel
+   * calls to the C++ function if {@link #run} is invoked concurrently.
+   */
+  @Override
+  public void run() {
+    readLock.lock();
+    try {
+      nativeRun(data);
+    } finally {
+      readLock.unlock();
+    }
+  }
+
+  /**
+   * Releases the reference to native data.
+   *
+   * <p>After this method returns, all future invocations of {@link #run} will do nothing and return
+   * as if successful.
+   *
+   * <p>This method <em>will</em> block if there are active invocations of {@link #run}. Once all
+   * active invocations of {@link #run} have completed, then this method will proceed and return
+   * nearly instantly. Any invocations of {@link #run} that occur while {@link #detach} is blocked
+   * will also block, allowing the number of active invocations of {@link #run} to eventually reach
+   * zero and allow this method to proceed.
+   */
+  public void detach() {
+    writeLock.lock();
+    try {
+      data = 0;
+    } finally {
+      writeLock.unlock();
+    }
+  }
+
+  /**
+   * Invokes {@link #run} on the main event thread.
+   *
+   * <p>If the calling thread is the main event thread then {@link #run} is called synchronously.
+   *
+   * @return A {@link Task} that will complete after {@link #run} returns; if {@link #run} throws an
+   *     exception, then that exception will be set as the exception of the task.
+   */
+  Task<Void> runOnMainThread() {
+    TaskRunnable runnable = new TaskRunnable();
+    Looper mainLooper = Looper.getMainLooper();
+    if (Thread.currentThread() == mainLooper.getThread()) {
+      runnable.run();
+    } else {
+      Handler handler = new Handler(mainLooper);
+      boolean postSucceeded = handler.post(runnable);
+      if (!postSucceeded) {
+        runnable.setException(new RuntimeException("Handler.post() returned false"));
+      }
+    }
+    return runnable.getTask();
+  }
+
+  /**
+   * Invokes {@link #run} on a newly-created thread.
+   *
+   * @return A {@link Task} that will complete after {@link #run} returns; if {@link #run} throws an
+   *     exception, then that exception will be set as the exception of the task.
+   */
+  Task<Void> runOnNewThread() {
+    TaskRunnable runnable = new TaskRunnable();
+    new Thread(runnable).start();
+    return runnable.getTask();
+  }
+
+  /**
+   * Invokes the encapsulated C++ function.
+   *
+   * @param data The data that was specified to the constructor, or {@code 0} if {@link #detach} has
+   *     been called, in which case the native function should do nothing and return immediately.
+   */
+  private static native void nativeRun(long data);
+
+  private final class TaskRunnable implements Runnable {
+
+    private final TaskCompletionSource<Void> taskCompletionSource = new TaskCompletionSource<>();
+
+    @Override
+    public void run() {
+      try {
+        JniRunnable.this.run();
+      } catch (Exception e) {
+        taskCompletionSource.trySetException(e);
+      } finally {
+        taskCompletionSource.trySetResult(null);
+      }
+    }
+
+    Task<Void> getTask() {
+      return taskCompletionSource.getTask();
+    }
+
+    void setException(Exception exception) {
+      taskCompletionSource.setException(exception);
+    }
+  }
+}


### PR DESCRIPTION
Although there are no immediate uses of this class, it will be used by an upcoming unit test to verify the behavior of deleting a C++ Firestore instance on the main event thread (b/168628900).

PiperOrigin-RevId: 359263007