### PR TITLE
Updating Integration tests to FTL iOS Version 12.4

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,7 +32,7 @@ on:
         default: 'iphone8'
       ios_version:
         description: 'iOS device version'
-        default: '11.4'
+        default: '12.0'
       use_expanded_matrix:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -32,7 +32,7 @@ on:
         default: 'iphone8'
       ios_version:
         description: 'iOS device version'
-        default: '12.0'
+        default: '12.4'
       use_expanded_matrix:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -102,7 +102,7 @@ PARAMETERS = {
       "android_device": "flame",
       "android_api": "29",
       "ios_device": "iphone8",
-      "ios_version": "12.0"
+      "ios_version": "12.4"
     }
   },
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -102,7 +102,7 @@ PARAMETERS = {
       "android_device": "flame",
       "android_api": "29",
       "ios_device": "iphone8",
-      "ios_version": "12"
+      "ios_version": "12.0"
     }
   },
 


### PR DESCRIPTION
Update our CI to run on FTL tests on iOS 12.4.

- Our minimum supported iOS version is now 12, so updating the CI from 11.7.
- The nightly build defaulted to iOS version "12" which is not available on the iphone8 FTL device. This caused or cron jobs to fail. Setting this to "12.4".