### PR TITLE
Allow integration_tests workflow to run against a packaged SDK.

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -666,4 +666,8 @@ jobs:
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v
+        verbose_flag=
+        if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
+          verbose_flag=-v
+        fi
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -655,15 +655,16 @@ jobs:
       run: |
         echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
     - name: Generate token for GitHub API
+      uses: machine-learning-apps/actions-app-token@0.21
       uses: tibdex/github-app-token@v1
-      id: generate-token
+      id: get_token
       with:
-        app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
-        private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+        APP_PEM: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+        APP_ID: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
     - name: Use GitHub API to start workflow
       shell: bash
       run: |
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v
+        python scripts/gha/trigger_workflow.py -t ${{ steps.get_token.outputs.app_token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -677,4 +677,4 @@ jobs:
           verbose_flag=-v
         fi
         set -e
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -A ${verbose_flag}
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -s 10 -A ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -660,4 +660,4 @@ jobs:
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX}
+        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -669,12 +669,13 @@ jobs:
     - name: Use GitHub API to start workflow
       shell: bash
       run: |
-        if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
+        if [[ -z "${USE_EXPANDED_MATRIX}" ]]; then
           USE_EXPANDED_MATRIX=0
         fi
         verbose_flag=
         if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
           verbose_flag=-v
         fi
+        github_run_id=${{ github.run_id }} $(uuidgen)
         set -e
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -A ${verbose_flag}
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk "${github_run_id}" -p use_expanded_matrix "${USE_EXPANDED_MATRIX}" -A ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -669,13 +669,12 @@ jobs:
     - name: Use GitHub API to start workflow
       shell: bash
       run: |
-        if [[ -z "${USE_EXPANDED_MATRIX}" ]]; then
+        if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
         verbose_flag=
         if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
           verbose_flag=-v
         fi
-        github_run_id=${{ github.run_id }} $(uuidgen)
         set -e
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk "${github_run_id}" -p use_expanded_matrix "${USE_EXPANDED_MATRIX}" -A ${verbose_flag}
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -A ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -670,4 +670,5 @@ jobs:
         if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
           verbose_flag=-v
         fi
+        set -e
         python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -A ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -39,26 +39,9 @@ env:
   xcodeVersion: "12"
 
 jobs:
-  prepare_matrix:
-    runs-on: ubuntu-latest
-    env:
-      USE_EXPANDED_MATRIX: 0
-    outputs:
-      use_expanded_matrix: ${{ steps.export-result.outputs.use_expanded_matrix }}
-    steps:
-      - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
-        run: |
-          echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
-      - id: export-result
-        run: |
-          echo "USE_EXPANDED_MATRIX: ${USE_EXPANDED_MATRIX}"
-          echo "::set-output name=use_expanded_matrix::${USE_EXPANDED_MATRIX}"
-
   log_inputs:
     name: log-inputs
     runs-on: ubuntu-latest
-    needs: prepare_matrix
     steps:
       - name: log run inputs
         run: |
@@ -95,7 +78,6 @@ jobs:
   build_tools:
     name: build-tools-${{ matrix.tools_platform }}
     runs-on: ${{ matrix.os }}
-    needs: prepare_matrix
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     strategy:
       matrix:
@@ -168,7 +150,6 @@ jobs:
   build_and_package_ios:
     name: build-and-package-ios
     runs-on: macos-latest
-    needs: prepare_matrix
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     steps:
       - name: setup Xcode version (macos)
@@ -215,7 +196,6 @@ jobs:
   build_and_package_android:
     name: build-and-package-android-${{matrix.stl}}
     runs-on: ubuntu-latest
-    needs: prepare_matrix
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     strategy:
       fail-fast: false
@@ -262,7 +242,6 @@ jobs:
   build_desktop:
     name: build-${{ matrix.sdk_platform }}-${{ matrix.architecture }}-${{ matrix.build_type }}-${{ matrix.msvc_runtime }}-${{ matrix.linux_abi }}
     runs-on: ${{ matrix.os }}
-    needs: prepare_matrix
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -654,10 +654,15 @@ jobs:
       if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
       run: |
         echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
+    - uses: tibdex/github-app-token@v1
+      id: generate-token
+      with:
+        app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+        private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
     - name: Trigger integration tests.
       shell: bash
       run: |
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ github.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -670,4 +670,4 @@ jobs:
         if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
           verbose_flag=-v
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} ${verbose_flag}
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -A ${verbose_flag}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -670,7 +670,7 @@ jobs:
 
   trigger_integration_tests:
     # Trigger the integration_tests workflow.
-    needs: [merge_packages, download_sdk_package, cleanup-packaging-artifacts]
+    needs: [merge_packages, download_sdk_package, cleanup_packaging_artifacts]
     if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -672,6 +672,7 @@ jobs:
     # Trigger the integration_tests workflow.
     runs-on: ubuntu-latest
     needs: [merge_packages, download_sdk_package]
+    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2.3.1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -668,88 +668,18 @@ jobs:
         failOnError: false
         useGlob: true
 
-  tests:
+  trigger_integration_tests:
+    # Trigger the integration_tests workflow.
     needs: [merge_packages, download_sdk_package]
-    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
-        target_platform: [Desktop, Android, iOS]
-        exclude:
-          - os: ubuntu-latest
-            target_platform: iOS
-          - os: windows-latest
-            target_platform: iOS
-      fail-fast: false
-    env:
-      apis: admob,analytics,auth,database,dynamic_links,firestore,functions,installations,instance_id,messaging,remote_config,storage
-      android_device: flame
-      android_api: 29
-      ios_device: iphone8
-      ios_version: 11.4
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2.3.1
-      with:
-        ref: ${{ github.event.inputs.commitIdToPackage }}
-    - name: Setup Xcode version (macos)
-      if: runner.os == 'macOS'
-      run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
-    - name: Download Firebase C++ SDK
-      uses: actions/download-artifact@v2.0.8
-      with:
-        name: firebase_cpp_sdk.zip
-    - name: Unzip Firebase C++ SDK
-      shell: bash
-      run: |
-        ls
-        if [ "$RUNNER_OS" == "Windows" ]; then
-          7z x firebase_cpp_sdk.zip
-        else
-          unzip -q firebase_cpp_sdk.zip
-        fi
+
     - name: Setup python
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
-    - name: Add msbuild to PATH (windows)
-      if: runner.os == 'Windows'
-      uses: microsoft/setup-msbuild@v1.0.2
-    - name: Prepare for integration tests
-      run: |
-        pip install -r scripts/gha/requirements.txt
-        python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
-    - name: Build integration tests
-      run: |
-        python scripts/gha/build_testapps.py --t ${{ env.apis }} --p ${{ matrix.target_platform }} --packaged_sdk firebase_cpp_sdk --output_directory "${{ github.workspace }}" --noadd_timestamp
-
-    - name: Run desktop integration tests
-      if: matrix.target_platform == 'Desktop' && !cancelled()
-      run: |
-        python scripts/gha/desktop_tester.py --testapp_dir testapps
-    # Workaround for https://github.com/GoogleCloudPlatform/github-actions/issues/100
-    # Must be run after the Python setup action
-    - name: Set CLOUDSDK_PYTHON (Windows)
-      shell: bash
-      if: runner.os == 'Windows' && !cancelled()
-      run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
-    - name: Install Cloud SDK
-      if: ${{ !cancelled() }}
-      uses: google-github-actions/setup-gcloud@master
-    - name: Upload Desktop Artifacts to GCS
-      if: ${{ !cancelled() }}
-      run: |
-        python scripts/gha/gcs_uploader.py --testapp_dir testapps --key_file scripts/gha-encrypted/gcs_key_file.json
-    - name: Run mobile integration tests
-      if: matrix.target_platform != 'Desktop' && !cancelled()
-      run: |
-        python scripts/gha/test_lab.py --android_model ${{ env.android_device }} --android_api ${{ env.android_api }} --ios_model ${{ env.ios_device }} --ios_version ${{ env.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
-    - name: Summarize build and test results
-      if: ${{ !cancelled() }}
+    - name: Trigger integration tests.
       shell: bash
       run: |
-        cat testapps/summary.log
-        if [[ "${{ job.status }}" != "success" ]]; then
-          exit 1
-        fi
+        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix 1

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -75,6 +75,10 @@ jobs:
           github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == ''
         run: echo "::warning ::Verbose build enabled."
 
+      - name: log if expanded matrix enabled
+        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
+        run: echo "::warning ::Expanded test matrix enabled."
+
   build_tools:
     name: build-tools-${{ matrix.tools_platform }}
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -679,7 +679,14 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: '3.7'
+    - name: Use expanded matrix
+      if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
+      run: |
+        echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
     - name: Trigger integration tests.
       shell: bash
       run: |
-        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix 1
+        if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
+          USE_EXPANDED_MATRIX=0
+        fi
+        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -670,6 +670,7 @@ jobs:
 
   trigger_integration_tests:
     # Trigger the integration_tests workflow.
+    runs-on: ubuntu-latest
     needs: [merge_packages, download_sdk_package]
     steps:
     - name: Checkout repo

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -660,4 +660,4 @@ jobs:
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ secrets.GITHUB_TOKEN }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v
+        python scripts/gha/trigger_workflow.py -t ${{ github.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -8,8 +8,6 @@ on:
     - cron: "0 9 * * *"  # 9am UTC = 1am PST / 2am PDT
   workflow_dispatch:
     inputs:
-      commitIdToPackage:
-        description: 'commit ID to package'
       preserveIntermediateArtifacts:
         description: 'preserve intermediate artifacts?'
         default: 0
@@ -49,13 +47,6 @@ jobs:
             echo "::warning ::Downloading public SDK package from https://dl.google.com/firebase/sdk/cpp/firebase_cpp_sdk_${{ github.event.inputs.downloadPublicVersion }}.zip"
           elif [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
             echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
-          fi
-          if [[ -n "${{ github.event.inputs.commitIdToPackage }}" ]]; then
-            if [[ -n "${{ github.event.inputs.downloadPublicVersion }}" || -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
-              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building tests."
-            else
-              echo "::warning ::Using commit ID '${{ github.event.inputs.commitIdToPackage }}' for building and packaging SDK and tests."
-            fi
           fi
 
       - name: log if skipping integration tests
@@ -164,7 +155,6 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           path: sdk-src
-          ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: install prerequisites
         run: sdk-src/build_scripts/ios/install_prereqs.sh
@@ -210,7 +200,6 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           path: sdk-src
-          ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: install prerequisites
         run: sdk-src/build_scripts/android/install_prereqs.sh
@@ -299,7 +288,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-          ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: Set env variables for subsequent steps (all)
         shell: bash
@@ -428,7 +416,6 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           path: sdk-src
-          ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
@@ -577,7 +564,6 @@ jobs:
         uses: actions/checkout@v2.3.1
         with:
           path: sdk-src
-          ref: ${{ github.event.inputs.commitIdToPackage }}
 
       - name: download artifact
         uses: actions/download-artifact@v2.0.8

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -654,12 +654,13 @@ jobs:
       if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
       run: |
         echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
-    - uses: tibdex/github-app-token@v1
+    - name: Generate token for GitHub API
+      uses: tibdex/github-app-token@v1
       id: generate-token
       with:
         app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
         private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
-    - name: Trigger integration tests.
+    - name: Use GitHub API to start workflow
       shell: bash
       run: |
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -655,6 +655,12 @@ jobs:
       run: |
         echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
     - name: Generate token for GitHub API
+      # This step is necessary because the existing GITHUB_TOKEN cannot be used inside one workflow to trigger another.
+      # 
+      # Instead, generate a new token here, using our GitHub App's private key and App ID (saved as Secrets).
+      # 
+      # This method is preferred over the "personal access token" solution, as the GitHub App's scope is limited to just
+      # the firebase-cpp-sdk repository.
       uses: tibdex/github-app-token@v1
       id: generate-token
       with:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -655,16 +655,15 @@ jobs:
       run: |
         echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
     - name: Generate token for GitHub API
-      uses: machine-learning-apps/actions-app-token@0.21
       uses: tibdex/github-app-token@v1
-      id: get_token
+      id: generate-token
       with:
-        APP_PEM: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
-        APP_ID: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+        app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+        private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
     - name: Use GitHub API to start workflow
       shell: bash
       run: |
         if [[ -z ${USE_EXPANDED_MATRIX} ]]; then
           USE_EXPANDED_MATRIX=0
         fi
-        python scripts/gha/trigger_workflow.py -t ${{ steps.get_token.outputs.app_token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v
+        python scripts/gha/trigger_workflow.py -t ${{ steps.generate-token.outputs.token }} -w integration_tests.yml -p test_packaged_sdk ${{ github.run_id }} -p use_expanded_matrix ${USE_EXPANDED_MATRIX} -v

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -670,9 +670,9 @@ jobs:
 
   trigger_integration_tests:
     # Trigger the integration_tests workflow.
-    runs-on: ubuntu-latest
-    needs: [merge_packages, download_sdk_package]
+    needs: [merge_packages, download_sdk_package, cleanup-packaging-artifacts]
     if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout repo
       uses: actions/checkout@v2.3.1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -39,10 +39,6 @@ on:
         required: true
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
-      uuid:
-        # No purpose other than to identify this specific run by its inputs.
-        description: 'UUID (internal use only)'
-        default: 'n/a'
 
 jobs:
   # To feed input into the job matrix, we first need to convert to a JSON

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,7 +37,7 @@ on:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'
         required: true  
-      downloadPreviousRun:
+      test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
 
 jobs:
@@ -68,8 +68,8 @@ jobs:
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
           # If building against a packaged SDK, only use boringssl.
-          if [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
-            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
+          if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
+            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
             # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here but don't actually install openssl later.
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
@@ -108,11 +108,11 @@ jobs:
 
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.downloadPreviousRun != '' }}
+        if: ${{ github.event.inputs.test_packaged_sdk != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'
-          run_id: ${{ github.event.inputs.downloadPreviousRun }}
+          run_id: ${{ github.event.inputs.test_packaged_sdk }}
 
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
@@ -170,7 +170,7 @@ jobs:
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
             startsWith(matrix.os, 'windows') &&
-            ${{ github.event.inputs.downloadPreviousRun == '' }}
+            ${{ github.event.inputs.test_packaged_sdk == '' }}
         run: |
           choco install openssl -r
 
@@ -178,7 +178,7 @@ jobs:
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
             startsWith(matrix.os, 'macos') &&
-            ${{ github.event.inputs.downloadPreviousRun == '' }}
+            ${{ github.event.inputs.test_packaged_sdk == '' }}
         run: |
           brew install openssl
           # brew won't overwrite MacOS system default OpenSSL, so force it here.
@@ -188,7 +188,7 @@ jobs:
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
             startsWith(matrix.os, 'ubuntu') &&
-            ${{ github.event.inputs.downloadPreviousRun == '' }}
+            ${{ github.event.inputs.test_packaged_sdk == '' }}
         run: |
           sudo apt install openssl
 
@@ -196,7 +196,7 @@ jobs:
         shell: bash
         run: |
           declare -a additional_flags
-          if [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
+          if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             # Building integration tests against a packaged SDK.
             mkdir downloaded_sdk
             cd downloaded_sdk

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -105,15 +105,6 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
-
-      - name: fetch artifact from previous run
-        uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.test_packaged_sdk != '' }}
-        with:
-          name: 'firebase_cpp_sdk.zip'
-          workflow: 'cpp-packaging.yml'
-          run_id: ${{ github.event.inputs.test_packaged_sdk }}
-
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: echo "VCPKG_TRIPLET=x64-linux" >> $GITHUB_ENV
@@ -189,15 +180,24 @@ jobs:
         run: |
           sudo apt install openssl
 
+      - name: fetch artifact from previous run
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.test_packaged_sdk != '' }}
+        with:
+          name: 'firebase_cpp_sdk.zip'
+          workflow: 'cpp-packaging.yml'
+          run_id: ${{ github.event.inputs.test_packaged_sdk }}
+
       - name: Build integration tests
         shell: bash
         run: |
+          set -x
           declare -a additional_flags
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             # Building integration tests against a packaged SDK.
             mkdir downloaded_sdk
             cd downloaded_sdk
-            unzip ../firebase_cpp_sdk.zip
+            unzip -q ../firebase_cpp_sdk.zip
             cd ..
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           else

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -191,7 +191,6 @@ jobs:
       - name: Build integration tests
         shell: bash
         run: |
-          set -x
           declare -a additional_flags
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             # Building integration tests against a packaged SDK.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           submodules: false
       - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix != '0'
+        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
       - id: export-result
@@ -67,14 +67,9 @@ jobs:
         run: |
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
-          
-          # If building against a packaged SDK, log it and only use boringssl.
+          # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
-            # Take the first word of the test_packaged_sdk ID only. The rest can be discarded.
-            packaged_sdk=$(echo ${{ github.event.inputs.test_packaged_sdk }} | cut -d" " -f1)
-            echo "::set-output name=use_packaged_sdk::${packaged_sdk}
-            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${packaged_sdk}"
-            
+            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
             # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here but don't actually install openssl later.
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
@@ -187,17 +182,17 @@ jobs:
 
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
-        if: ${{ needs.prepare_matrix.output.use_packaged_sdk != '' }}
+        if: ${{ github.event.inputs.test_packaged_sdk != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'
-          run_id: ${{ needs.prepare_matrix.output.use_packaged_sdk }}
+          run_id: ${{ github.event.inputs.test_packaged_sdk }}
 
       - name: Build integration tests
         shell: bash
         run: |
           declare -a additional_flags
-          if [[ -n "${{ needs.prepare_matrix.output.packaged_sdk }}" ]]; then
+          if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             # Building integration tests against a packaged SDK.
             mkdir downloaded_sdk
             cd downloaded_sdk

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -62,6 +62,8 @@ jobs:
         if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
+          echo "::warning ::Expanded test matrix enabled."
+          
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
@@ -69,8 +71,8 @@ jobs:
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
-            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
-            # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here but don't actually install openssl later.
+            echo "::warning ::Downloading SDK package from previous run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
+            # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here. It won't actually matter later.
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -62,7 +62,6 @@ jobs:
         if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
-          echo "::warning ::Expanded test matrix enabled."
           
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -36,7 +36,7 @@ on:
       use_expanded_matrix:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'
-        required: true  
+        required: true
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
 
@@ -80,7 +80,7 @@ jobs:
           echo "::set-output name=android_api::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_api -o "${{github.event.inputs.android_api}}" )"
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{github.event.inputs.ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{github.event.inputs.ios_version}}" )"
-  
+
   tests:
     name: ${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
     needs: prepare_matrix
@@ -169,16 +169,14 @@ jobs:
       - name: Install OpenSSL (windows)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'windows') &&
-            ${{ github.event.inputs.test_packaged_sdk == '' }}
+            startsWith(matrix.os, 'windows')
         run: |
           choco install openssl -r
 
       - name: Install OpenSSL (MacOS)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'macos') &&
-            ${{ github.event.inputs.test_packaged_sdk == '' }}
+            startsWith(matrix.os, 'macos')
         run: |
           brew install openssl
           # brew won't overwrite MacOS system default OpenSSL, so force it here.
@@ -187,8 +185,7 @@ jobs:
       - name: Install OpenSSL (Linux)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'ubuntu') &&
-            ${{ github.event.inputs.test_packaged_sdk == '' }}
+            startsWith(matrix.os, 'ubuntu')
         run: |
           sudo apt install openssl
 
@@ -205,7 +202,7 @@ jobs:
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           else
             # Building integration tests against the SDK source.
-            # 
+            #
             # When building the SDK from source, the default SSL is openssl.
             # To build using boringssl, a cmake flag must be added:
             if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -39,6 +39,10 @@ on:
         required: true
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
+      uuid:
+        # No purpose other than to identify this specific run by its inputs.
+        description: 'UUID (internal use only)'
+        default: 'n/a'
 
 jobs:
   # To feed input into the job matrix, we first need to convert to a JSON

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -70,7 +70,8 @@ jobs:
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
             echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
-            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o boringssl )"
+            # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here but don't actually install openssl later.
+            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
           fi
@@ -168,14 +169,16 @@ jobs:
       - name: Install OpenSSL (windows)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'windows')
+            startsWith(matrix.os, 'windows') &&
+            ${{ github.event.inputs.downloadPreviousRun == '' }}
         run: |
           choco install openssl -r
 
       - name: Install OpenSSL (MacOS)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'macos')
+            startsWith(matrix.os, 'macos') &&
+            ${{ github.event.inputs.downloadPreviousRun == '' }}
         run: |
           brew install openssl
           # brew won't overwrite MacOS system default OpenSSL, so force it here.
@@ -184,7 +187,8 @@ jobs:
       - name: Install OpenSSL (Linux)
         if: matrix.target_platform == 'Desktop' &&
             matrix.ssl_variant == 'openssl' &&
-            startsWith(matrix.os, 'ubuntu')
+            startsWith(matrix.os, 'ubuntu') &&
+            ${{ github.event.inputs.downloadPreviousRun == '' }}
         run: |
           sudo apt install openssl
 
@@ -200,8 +204,10 @@ jobs:
             cd ..
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           else
-            # Building integration tests entirely from source.
-            # Default SSL is openssl.
+            # Building integration tests against the SDK source.
+            # 
+            # When building the SDK from source, the default SSL is openssl.
+            # To build using boringssl, a cmake flag must be added:
             if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then
               additional_flags+=(--cmake_flag=-DFIREBASE_USE_BORINGSSL=ON)
             fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -37,6 +37,8 @@ on:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'
         required: true  
+      downloadPreviousRun:
+        description: 'Optional: Packaging run # to build against?'
 
 jobs:
   # To feed input into the job matrix, we first need to convert to a JSON
@@ -65,7 +67,13 @@ jobs:
         run: |
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
-          echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
+          # If building against a packaged SDK, only use boringssl.
+          if [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
+            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.downloadPreviousRun }}"
+            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o boringssl )"
+          else
+            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
+          fi
           echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" )"
           echo "::set-output name=android_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_device -o "${{github.event.inputs.android_device}}" )"
           echo "::set-output name=android_api::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_api -o "${{github.event.inputs.android_api}}" )"
@@ -96,6 +104,14 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+
+      - name: fetch artifact from previous run
+        uses: dawidd6/action-download-artifact@v2
+        if: ${{ github.event.inputs.downloadPreviousRun != '' }}
+        with:
+          name: 'firebase_cpp_sdk.zip'
+          workflow: 'cpp-packaging.yml'
+          run_id: ${{ github.event.inputs.downloadPreviousRun }}
 
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
@@ -175,12 +191,22 @@ jobs:
       - name: Build integration tests
         shell: bash
         run: |
-          # Default SSL is openssl.
-          ssl_option=
-          if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then
-            ssl_option=--cmake_flag=-DFIREBASE_USE_BORINGSSL=ON
+          declare -a additional_flags
+          if [[ -n "${{ github.event.inputs.downloadPreviousRun }}" ]]; then
+            # Building integration tests against a packaged SDK.
+            mkdir downloaded_sdk
+            cd downloaded_sdk
+            unzip ../firebase_cpp_sdk.zip
+            cd ..
+            additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
+          else
+            # Building integration tests entirely from source.
+            # Default SSL is openssl.
+            if [[ "${{ matrix.ssl_variant }}" == "boringssl" ]]; then
+              additional_flags+=(--cmake_flag=-DFIREBASE_USE_BORINGSSL=ON)
+            fi
           fi
-          python scripts/gha/build_testapps.py --t ${{ needs.prepare_matrix.outputs.apis }} --p ${{ matrix.target_platform }} --output_directory "${{ github.workspace }}" --noadd_timestamp ${ssl_option}
+          python scripts/gha/build_testapps.py --t ${{ needs.prepare_matrix.outputs.apis }} --p ${{ matrix.target_platform }} --output_directory "${{ github.workspace }}" --noadd_timestamp ${additional_flags[*]}
 
       - name: Run desktop integration tests
         if: matrix.target_platform == 'Desktop' && !cancelled()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -59,7 +59,7 @@ jobs:
         with:
           submodules: false
       - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
+        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix != '0'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
       - id: export-result
@@ -67,9 +67,14 @@ jobs:
         run: |
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
-          # If building against a packaged SDK, only use boringssl.
+          
+          # If building against a packaged SDK, log it and only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
-            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
+            # Take the first word of the test_packaged_sdk ID only. The rest can be discarded.
+            packaged_sdk=$(echo ${{ github.event.inputs.test_packaged_sdk }} | cut -d" " -f1)
+            echo "::set-output name=use_packaged_sdk::${packaged_sdk}
+            echo "::warning ::Downloading SDK package from previous run at https://github.com/firebase/firebase-cpp-sdk/actions/runs/${packaged_sdk}"
+            
             # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here but don't actually install openssl later.
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
@@ -182,17 +187,17 @@ jobs:
 
       - name: fetch artifact from previous run
         uses: dawidd6/action-download-artifact@v2
-        if: ${{ github.event.inputs.test_packaged_sdk != '' }}
+        if: ${{ needs.prepare_matrix.output.use_packaged_sdk != '' }}
         with:
           name: 'firebase_cpp_sdk.zip'
           workflow: 'cpp-packaging.yml'
-          run_id: ${{ github.event.inputs.test_packaged_sdk }}
+          run_id: ${{ needs.prepare_matrix.output.use_packaged_sdk }}
 
       - name: Build integration tests
         shell: bash
         run: |
           declare -a additional_flags
-          if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
+          if [[ -n "${{ needs.prepare_matrix.output.packaged_sdk }}" ]]; then
             # Building integration tests against a packaged SDK.
             mkdir downloaded_sdk
             cd downloaded_sdk

--- a/database/integration_test/src/integration_test.cc
+++ b/database/integration_test/src/integration_test.cc
@@ -800,6 +800,8 @@ class LoggingValueListener : public firebase::database::ValueListener {
 };
 
 TEST_F(FirebaseDatabaseTest, TestAddAndRemoveListenerRace) {
+  SKIP_TEST_ON_MOBILE;
+
   const char* test_name = test_info_->name();
 
   SignIn();

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -66,8 +66,11 @@ def main():
                                           '-H', 'Authorization: token %s' % args.token,
                                           request_url, '-d', json_text]
                                         + ([] if not args.verbose else ['-v'])).decode('utf-8').rstrip('\n')
-    if not re.search('HTTP status 2[0-9][0-9]$', run_output):
+    if args.verbose:
       print(run_output)
+    if not re.search('HTTP status 2[0-9][0-9]$', run_output):
+      if not args.verbose:
+        print(run_output)
       print('Failure.')
       return(-1)
     else:

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -35,7 +35,6 @@ import re
 import subprocess
 import time
 
-
 def main():
   args = parse_cmdline_args()
   if args.repo is None:

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -53,9 +53,11 @@ def main():
   json_params = {}
   for param in args.param:
       json_params[param[0]] = param[1]
-  json_text = '{ "ref": %s, "inputs": "%s" }' % (json.dumps(args.commit), json.dumps(json_params))
+  json_text = '{"ref":%s,"inputs":%s}' % (json.dumps(args.commit), json.dumps(json_params))
   print(json_text)
-  subprocess.run([args.curl, '-X', 'POST', '-H', 'Accept: application/vnd.github.v3+json',
+  subprocess.run([args.curl, '-X', 'POST',
+                  '-H', 'Accept: application/vnd.github.v3+json',
+                  '-H', 'Authorization: token %s' % args.token,
                   request_url, '-d', json_text])
   
 

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -20,7 +20,7 @@ token. It uses the GitHub REST API documented here:
 https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
 
 Usage:
-python trigger_workflow.py -w workflow_name -t github_token [-b branch_name]
+python trigger_workflow.py -w workflow_filename -t github_token [-b branch_name]
        [-r git_repo_url] [-p <input1> <value1> -p <input2> <value2> ...]'
        [-C curl_command]
 
@@ -33,6 +33,7 @@ import json
 import os
 import re
 import subprocess
+import urllib.parse
 
 def main():
   args = parse_cmdline_args()
@@ -71,13 +72,15 @@ def main():
       print('Failure.')
       return(-1)
     else:
-      print('Success!')
+      print('Success! Find the workflow run here:')
+      print('https://github.com/%s/%s/actions/workflows/%s?query=event:workflow_dispatch+branch:%s' %
+            (repo_owner, repo_name, args.workflow, urllib.parse.quote(args.branch)))
 
 
 def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='Query matrix and config parameters used in Github workflows.')
   parser.add_argument('-d', '--dryrun', action='store_true', help='Just print the URL and JSON and exit.')
-  parser.add_argument('-w', '--workflow', required=True, help='Workflow name to run, e.g. "integration_test"')
+  parser.add_argument('-w', '--workflow', required=True, help='Workflow filename to run, e.g. "integration_tests.yml"')
   parser.add_argument('-t', '--token', required=True, help='GitHub access token')
   parser.add_argument('-b', '--branch', help='Branch name to trigger workflow on, default is current branch')
   parser.add_argument('-r', '--repo', help='GitHub repo to trigger workflow on, default is current repo')

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -20,7 +20,7 @@ token. It uses the GitHub REST API documented here:
 https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
 
 Usage:
-python trigger_workflow.py -w workflow_name -t github_token [-c commit_id]
+python trigger_workflow.py -w workflow_name -t github_token [-b branch_name]
        [-r git_repo_url] [-p <input1> <value1> -p <input2> <value2> ...]'
        [-C curl_command]
 
@@ -37,37 +37,52 @@ import subprocess
 def main():
   args = parse_cmdline_args()
   if args.repo is None:
-      args.repo=subprocess.check_output(['git', 'config', '--get', 'remote.origin.url']).decode('utf-8').rstrip("\n").lower()
-      print('autodetect repo: %s' % args.repo)
-  if args.commit is None:
-      args.commit=subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('utf-8').rstrip("\n").lower()
-      print('autodetect commit: %s' % args.commit)
+      args.repo=subprocess.check_output(['git', 'config', '--get', 'remote.origin.url']).decode('utf-8').rstrip('\n').lower()
+      print('autodetected repo: %s' % args.repo)
+  if args.branch is None:
+      args.branch=subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('utf-8').rstrip('\n')
+      print('autodetected branch: %s' % args.branch)
   if not args.repo.startswith('https://github.com/'):
       print('Error, only https://github.com/ repositories are allowed.')
       exit(2)
   (repo_owner, repo_name) = re.match(r'https://github\.com/([^/]+)/([^/.]+)', args.repo).groups()
 
   # POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
-  request_url = "https://api.github.com/repos/%s/%s/actions/workflows/%s/dispatches" % (repo_owner, repo_name, args.workflow)
-  print('POST url: %s' % request_url)
+  request_url = 'https://api.github.com/repos/%s/%s/actions/workflows/%s/dispatches' % (repo_owner, repo_name, args.workflow)
+  if args.verbose or args.dryrun:
+    print('request_url: %s' % request_url)
   json_params = {}
   for param in args.param:
       json_params[param[0]] = param[1]
-  json_text = '{"ref":%s,"inputs":%s}' % (json.dumps(args.commit), json.dumps(json_params))
-  print(json_text)
-  subprocess.run([args.curl, '-X', 'POST',
-                  '-H', 'Accept: application/vnd.github.v3+json',
-                  '-H', 'Authorization: token %s' % args.token,
-                  request_url, '-d', json_text])
-  
+  json_text = '{"ref":%s,"inputs":%s}' % (json.dumps(args.branch), json.dumps(json_params))
+  if args.verbose or args.dryrun:
+    print('request_body: %s' % json_text)
+  if not args.dryrun:
+    print('Sending request to GitHub API...')
+    run_output = subprocess.check_output([args.curl,
+                                          '-s', '-o', '-', '-w', '\nHTTP status %{http_code}\n',
+                                          '-X', 'POST',
+                                          '-H', 'Accept: application/vnd.github.v3+json',
+                                          '-H', 'Authorization: token %s' % args.token,
+                                          request_url, '-d', json_text]
+                                        + ([] if not args.verbose else ['-v'])).decode('utf-8').rstrip('\n')
+    if not re.search('HTTP status 2[0-9][0-9]$', run_output):
+      print(run_output)
+      print('Failure.')
+      return(-1)
+    else:
+      print('Success!')
+
 
 def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='Query matrix and config parameters used in Github workflows.')
+  parser.add_argument('-d', '--dryrun', action='store_true', help='Just print the URL and JSON and exit.')
   parser.add_argument('-w', '--workflow', required=True, help='Workflow name to run, e.g. "integration_test"')
   parser.add_argument('-t', '--token', required=True, help='GitHub access token')
-  parser.add_argument('-c', '--commit', help='Commit ID to trigger workflow on, default is current HEAD')
+  parser.add_argument('-b', '--branch', help='Branch name to trigger workflow on, default is current branch')
   parser.add_argument('-r', '--repo', help='GitHub repo to trigger workflow on, default is current repo')
   parser.add_argument('-C', '--curl', default='curl', help='Curl command to use for making request')
+  parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose mode')
   parser.add_argument('-p', '--param', default=[], nargs=2, action='append',
                       help='Add a parameter to the workflow run: -p <input> <value>')
   args = parser.parse_args()

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -106,7 +106,7 @@ def main():
     # Couldn't get a run ID, use a generic URL.
     workflow_url = 'https://github.com/%s/%s/actions/workflows/%s?query=event:workflow_dispatch+branch:%s' % (
       repo_owner, repo_name, args.workflow, args.branch)
-  print('%sStarted %s: %s' % ('::warning ::' if args.in_github_action else '',
+  print('%sStarted workflow %s: %s' % ('::warning ::' if args.in_github_action else '',
                               args.workflow, workflow_url))
 
 

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -33,7 +33,6 @@ import json
 import os
 import re
 import subprocess
-import urllib.parse
 
 def main():
   args = parse_cmdline_args()
@@ -74,7 +73,7 @@ def main():
     else:
       print('Success! Find the workflow run here:')
       print('https://github.com/%s/%s/actions/workflows/%s?query=event:workflow_dispatch+branch:%s' %
-            (repo_owner, repo_name, args.workflow, urllib.parse.quote(args.branch)))
+            (repo_owner, repo_name, args.workflow, args.branch))
 
 
 def parse_cmdline_args():

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -74,7 +74,11 @@ def main():
   if not re.search('HTTP status 2[0-9][0-9]$', run_output):
     if not args.verbose:
       print(run_output)
-    print('Failure.')
+    # Super quick and dirty way to get the message text since the appended status code means that
+    # the contents are not valid JSON.
+    error_message = re.search(r'"message": "([^"]+)"', run_output).group(1)
+    print('%sFailed to trigger workflow %s: %s' % (
+      '::error ::' if args.in_github_action else '', args.workflow, error_message))
     return(-1)
 
   print('Success!')

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -40,7 +40,7 @@ def main():
       args.repo=subprocess.check_output(['git', 'config', '--get', 'remote.origin.url']).decode('utf-8').rstrip("\n").lower()
       print('autodetect repo: %s' % args.repo)
   if args.commit is None:
-      args.commit=subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').rstrip("\n").lower()
+      args.commit=subprocess.check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).decode('utf-8').rstrip("\n").lower()
       print('autodetect commit: %s' % args.commit)
   if not args.repo.startswith('https://github.com/'):
       print('Error, only https://github.com/ repositories are allowed.')

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+
+# Copyright 2021 Google
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Trigger a GitHub workflow_dispatch workflow using the GitHub REST API.
+
+This script allows you to easily trigger a workflow on GitHub using an access
+token. It uses the GitHub REST API documented here:
+https://docs.github.com/en/rest/reference/actions#create-a-workflow-dispatch-event
+
+Usage:
+python trigger_workflow.py -w workflow_name -t github_token [-c commit_id]
+       [-r git_repo_url] [-p <input1> <value1> -p <input2> <value2> ...]'
+       [-C curl_command]
+
+If -r is unspecified, uses the current repo.
+If -c is unspecified, uses the current HEAD.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+
+def main():
+  args = parse_cmdline_args()
+  if args.repo is None:
+      args.repo=subprocess.check_output(['git', 'config', '--get', 'remote.origin.url']).decode('utf-8').rstrip("\n").lower()
+      print('autodetect repo: %s' % args.repo)
+  if args.commit is None:
+      args.commit=subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('utf-8').rstrip("\n").lower()
+      print('autodetect commit: %s' % args.commit)
+  if not args.repo.startswith('https://github.com/'):
+      print('Error, only https://github.com/ repositories are allowed.')
+      exit(2)
+  (repo_owner, repo_name) = re.match(r'https://github\.com/([^/]+)/([^/.]+)', args.repo).groups()
+
+  # POST /repos/{owner}/{repo}/actions/workflows/{workflow_id}/dispatches
+  request_url = "https://api.github.com/repos/%s/%s/actions/workflows/%s/dispatches" % (repo_owner, repo_name, args.workflow)
+  print('POST url: %s' % request_url)
+  json_params = {}
+  for param in args.param:
+      json_params[param[0]] = param[1]
+  json_text = '{ "ref": %s, "inputs": "%s" }' % (json.dumps(args.commit), json.dumps(json_params))
+  print(json_text)
+  subprocess.run([args.curl, '-X', 'POST', '-H', 'Accept: application/vnd.github.v3+json',
+                  request_url, '-d', json_text])
+  
+
+def parse_cmdline_args():
+  parser = argparse.ArgumentParser(description='Query matrix and config parameters used in Github workflows.')
+  parser.add_argument('-w', '--workflow', required=True, help='Workflow name to run, e.g. "integration_test"')
+  parser.add_argument('-t', '--token', required=True, help='GitHub access token')
+  parser.add_argument('-c', '--commit', help='Commit ID to trigger workflow on, default is current HEAD')
+  parser.add_argument('-r', '--repo', help='GitHub repo to trigger workflow on, default is current repo')
+  parser.add_argument('-C', '--curl', default='curl', help='Curl command to use for making request')
+  parser.add_argument('-p', '--param', default=[], nargs=2, action='append',
+                      help='Add a parameter to the workflow run: -p <input> <value>')
+  args = parser.parse_args()
+  return args
+
+
+if __name__ == '__main__':
+  main()
+
+

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -82,7 +82,7 @@ def main():
     return(-1)
 
   print('Success!')
-  time.sleep(5)  # Give a few seconds for the job to become queued.
+  time.sleep(args.sleep)  # Give a few seconds for the job to become queued.
   # Unfortunately, the GitHub REST API doesn't return the new workflow's run ID.
   # Query the list of workflows to find the one we just added.
   request_url = 'https://api.github.com/repos/%s/%s/actions/workflows/%s/runs?event=workflow_dispatch&branch=%s' % (repo_owner, repo_name, args.workflow, args.branch)
@@ -118,16 +118,20 @@ def main():
 
 def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='Query matrix and config parameters used in Github workflows.')
-  parser.add_argument('-d', '--dryrun', action='store_true', help='Just print the URL and JSON and exit.')
   parser.add_argument('-w', '--workflow', required=True, help='Workflow filename to run, e.g. "integration_tests.yml"')
   parser.add_argument('-t', '--token', required=True, help='GitHub access token')
   parser.add_argument('-b', '--branch', help='Branch name to trigger workflow on, default is current branch')
-  parser.add_argument('-r', '--repo', help='GitHub repo to trigger workflow on, default is current repo')
-  parser.add_argument('-C', '--curl', default='curl', help='Curl command to use for making request')
+  parser.add_argument('-r', '--repo', metavar='URL', help='GitHub repo to trigger workflow on, default is current repo')
+  parser.add_argument('-p', '--param', default=[], nargs=2, action='append', metavar=('NAME', 'VALUE'),
+                      help='Pass an input parameter to the workflow run. Can be used multiple times.')
+  parser.add_argument('-d', '--dryrun', action='store_true', help='Just print the URL and JSON and exit.')
   parser.add_argument('-v', '--verbose', action='store_true', help='Enable verbose mode')
+  parser.add_argument('-C', '--curl', default='curl', metavar='COMMAND', help='Curl command to use for making request')
   parser.add_argument('-A', '--in_github_action', action='store_true', help='Enable special logging for GitHub actions')
-  parser.add_argument('-p', '--param', default=[], nargs=2, action='append',
-                      help='Add a parameter to the workflow run: -p <input> <value>')
+  parser.add_argument('-s', '--sleep', type=int, default=5, metavar='SECONDS',
+                      help='How long to sleep before querying for the run ID, default 5')
+  parser.add_argument('-s', '--sleep', type=int, default=5, metavar='SECONDS',
+                      help='How long to sleep before querying for the run ID, default 5')
   args = parser.parse_args()
   return args
 

--- a/scripts/gha/trigger_workflow.py
+++ b/scripts/gha/trigger_workflow.py
@@ -34,6 +34,7 @@ import os
 import re
 import subprocess
 import time
+import urllib.parse
 
 def main():
   args = parse_cmdline_args()
@@ -107,10 +108,12 @@ def main():
     workflow_url = 'https://github.com/firebase/firebase-cpp-sdk/actions/runs/%s' % (run_id)
   else:
     # Couldn't get a run ID, use a generic URL.
-    workflow_url = 'https://github.com/%s/%s/actions/workflows/%s?query=event:workflow_dispatch+branch:%s' % (
-      repo_owner, repo_name, args.workflow, args.branch)
+    workflow_url = 'https://github.com/%s/%s/actions/workflows/%s?query=%s+%s' % (
+      repo_owner, repo_name, args.workflow,
+      urllib.parse.quote('event:workflow_dispatch', safe=''),
+      urllib.parse.quote('branch:'+args.branch, safe=''))
   print('%sStarted workflow %s: %s' % ('::warning ::' if args.in_github_action else '',
-                              args.workflow, workflow_url))
+                                       args.workflow, workflow_url))
 
 
 def parse_cmdline_args():


### PR DESCRIPTION
This change updates the integration_tests workflow so that it can download a packaged SDK from GHA and build the integration tests against it, instead of against the SDK source.

With that change, we no longer need to duplicate the integration test code in the C++ packaging workflow.

Instead, the C++ packaging workflow directly invokes the integration_tests workflow at the end via the GitHub REST API.

(Note that because you cannot invoke another workflow with the same GITHUB_TOKEN that your workflow is already using due to a limitation in GitHub actions, the packaging workflow fetches a new GitHub App token to use for the request.)