### PR TITLE
Firestore: Expand validation_test to cover other platforms

### DIFF
--- a/firestore/src/android/field_path_portable.cc
+++ b/firestore/src/android/field_path_portable.cc
@@ -90,6 +90,22 @@ std::vector<std::string> SplitOnDots(const std::string& input) {
   return result;
 }
 
+void ValidateSegments(const std::vector<std::string>& segments) {
+  if (segments.empty()) {
+    SimpleThrowInvalidArgument(
+        "Invalid field path. Provided names must not be empty.");
+  }
+
+  for (size_t i = 0; i < segments.size(); ++i) {
+    if (segments[i].empty()) {
+      std::ostringstream message;
+      message << "Invalid field name at index " << i
+              << ". Field names must not be empty.";
+      SimpleThrowInvalidArgument(message.str());
+    }
+  }
+}
+
 }  // anonymous namespace
 
 std::string FieldPathPortable::CanonicalString() const {
@@ -116,6 +132,12 @@ std::string FieldPathPortable::CanonicalString() const {
 
 bool FieldPathPortable::IsKeyFieldPath() const {
   return size() == 1 && segments_[0] == FieldPathPortable::kDocumentKeyPath;
+}
+
+FieldPathPortable FieldPathPortable::FromSegments(
+    std::vector<std::string> segments) {
+  ValidateSegments(segments);
+  return FieldPathPortable(Move(segments));
 }
 
 FieldPathPortable FieldPathPortable::FromDotSeparatedString(

--- a/firestore/src/android/field_path_portable.h
+++ b/firestore/src/android/field_path_portable.h
@@ -65,8 +65,16 @@ class FieldPathPortable {
     return segments_ >= rhs.segments_;
   }
 
-  // Creates and returns a new path from a dot-separated field-path string,
-  // where path segments are separated by a dot ".".
+  /**
+   * Creates and returns a new path from an explicitly pre-split list of
+   * segments.
+   */
+  static FieldPathPortable FromSegments(std::vector<std::string> segments);
+
+  /**
+   * Creates and returns a new path from a dot-separated field-path string,
+   * where path segments are separated by a dot ".".
+   */
   static FieldPathPortable FromDotSeparatedString(const std::string& path);
 
   static FieldPathPortable KeyFieldPath();

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -61,6 +61,8 @@ namespace {
 
 using jni::Constructor;
 using jni::Env;
+using jni::Global;
+using jni::HashMap;
 using jni::Loader;
 using jni::Local;
 using jni::Long;
@@ -170,15 +172,15 @@ class JavaFirestoreMap {
  private:
   // Ensures that the backing map is initialized.
   // Prerequisite: `mutex_` must be locked before calling this method.
-  jni::HashMap& GetMapLocked(Env& env) {
+  HashMap& GetMapLocked(Env& env) {
     if (!firestores_) {
-      firestores_ = jni::HashMap::Create(env);
+      firestores_ = HashMap::Create(env);
     }
     return firestores_;
   }
 
   Mutex mutex_;
-  jni::Global<jni::HashMap> firestores_;
+  Global<HashMap> firestores_;
 };
 
 // init_mutex protects all the globals below.
@@ -496,34 +498,34 @@ void FirestoreInternal::ClearListeners() {
   listener_registrations_.clear();
 }
 
-jni::Env FirestoreInternal::GetEnv() {
-  jni::Env env;
+Env FirestoreInternal::GetEnv() {
+  Env env;
   env.SetUnhandledExceptionHandler(GlobalUnhandledExceptionHandler, nullptr);
   return env;
 }
 
 CollectionReference FirestoreInternal::NewCollectionReference(
-    jni::Env& env, const jni::Object& reference) const {
+    Env& env, const jni::Object& reference) const {
   return MakePublic<CollectionReference>(env, mutable_this(), reference);
 }
 
 DocumentReference FirestoreInternal::NewDocumentReference(
-    jni::Env& env, const jni::Object& reference) const {
+    Env& env, const jni::Object& reference) const {
   return MakePublic<DocumentReference>(env, mutable_this(), reference);
 }
 
 DocumentSnapshot FirestoreInternal::NewDocumentSnapshot(
-    jni::Env& env, const jni::Object& snapshot) const {
+    Env& env, const jni::Object& snapshot) const {
   return MakePublic<DocumentSnapshot>(env, mutable_this(), snapshot);
 }
 
-Query FirestoreInternal::NewQuery(jni::Env& env,
+Query FirestoreInternal::NewQuery(Env& env,
                                   const jni::Object& query) const {
   return MakePublic<Query>(env, mutable_this(), query);
 }
 
 QuerySnapshot FirestoreInternal::NewQuerySnapshot(
-    jni::Env& env, const jni::Object& snapshot) const {
+    Env& env, const jni::Object& snapshot) const {
   return MakePublic<QuerySnapshot>(env, mutable_this(), snapshot);
 }
 

--- a/firestore/src/common/field_path.cc
+++ b/firestore/src/common/field_path.cc
@@ -24,6 +24,8 @@
 #include <unordered_set>
 #endif  // defined(_STLPORT_VERSION)
 
+#include "app/meta/move.h"
+
 #if defined(__ANDROID__) || defined(FIRESTORE_STUB_BUILD)
 #include "firestore/src/android/field_path_portable.h"
 #else
@@ -38,11 +40,11 @@ FieldPath::FieldPath() {}
 
 #if !defined(_STLPORT_VERSION)
 FieldPath::FieldPath(std::initializer_list<std::string> field_names)
-    : internal_(new FieldPathInternal{field_names}) {}
+    : internal_(InternalFromSegments(std::vector<std::string>(field_names))) {}
 #endif  // !defined(_STLPORT_VERSION)
 
 FieldPath::FieldPath(const std::vector<std::string>& field_names)
-    : internal_(new FieldPathInternal{std::vector<std::string>{field_names}}) {}
+    : internal_(InternalFromSegments(field_names)) {}
 
 FieldPath::FieldPath(const FieldPath& path)
     : internal_(new FieldPathInternal{*path.internal_}) {}
@@ -76,6 +78,12 @@ FieldPath& FieldPath::operator=(FieldPath&& path) noexcept {
 /* static */
 FieldPath FieldPath::DocumentId() {
   return FieldPath{new FieldPathInternal{FieldPathInternal::KeyFieldPath()}};
+}
+
+FieldPath::FieldPathInternal* FieldPath::InternalFromSegments(
+    std::vector<std::string> field_names) {
+  return new FieldPathInternal(
+      FieldPathInternal::FromSegments(Move(field_names)));
 }
 
 /* static */

--- a/firestore/src/include/firebase/firestore/field_path.h
+++ b/firestore/src/include/firebase/firestore/field_path.h
@@ -170,6 +170,9 @@ class FieldPath final {
 
   explicit FieldPath(FieldPathInternal* internal);
 
+  static FieldPathInternal* InternalFromSegments(
+      std::vector<std::string> field_names);
+
   static FieldPath FromDotSeparatedString(const std::string& path);
 
   FieldPathInternal* internal_ = nullptr;


### PR DESCRIPTION
Also fix transactions on Android to throw immediately when C++
exceptions are enabled. While this doesn't have much of an effect on
C++ users, this will make it possible for the Unity client to
synchronously throw in these cases, which is expected in C#.

Cloned from CL 355019084 by 'g4 patch'.
Original change by mcg@mcg:fig-export-firestore-change-286-4f589224b545:4324:citc on 2021/02/01 13:52:36.

PiperOrigin-RevId: 359824564