### PR TITLE
Firestore: Migrate hard assertions to common infrastructure too

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -34,6 +34,8 @@ set(common_SRCS
     src/common/firestore.cc
     src/common/futures.cc
     src/common/futures.h
+    src/common/hard_assert_common.cc
+    src/common/hard_assert_common.h
     src/common/listener_registration.cc
     src/common/macros.h
     src/common/main_for_testing_build.cc
@@ -185,7 +187,6 @@ set(main_SRCS
     src/ios/field_value_ios.h
     src/ios/firestore_ios.cc
     src/ios/firestore_ios.h
-    src/ios/hard_assert_ios.h
     src/ios/listener_ios.h
     src/ios/listener_registration_ios.cc
     src/ios/listener_registration_ios.h

--- a/firestore/src/common/hard_assert_common.cc
+++ b/firestore/src/common/hard_assert_common.cc
@@ -1,0 +1,33 @@
+#include "firestore/src/common/hard_assert_common.h"
+
+#include "firestore/src/common/exception_common.h"
+
+namespace firebase {
+namespace firestore {
+namespace util {
+namespace internal {
+
+#if defined(__ANDROID__)
+
+void FailAssertion(const char* file, const char* func, const int line,
+                   const std::string& message) {
+  Throw(ExceptionType::AssertionFailure, file, func, line, message);
+}
+
+void FailAssertion(const char* file, const char* func, const int line,
+                   const std::string& message, const char* condition) {
+  std::string failure;
+  if (message.empty()) {
+    failure = condition;
+  } else {
+    failure = message + " (expected " + condition + ")";
+  }
+  Throw(ExceptionType::AssertionFailure, file, func, line, failure);
+}
+
+#endif  // defined(__ANDROID__)
+
+}  // namespace internal
+}  // namespace util
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/src/common/hard_assert_common.h
+++ b/firestore/src/common/hard_assert_common.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Google
+ * Copyright 2019 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,24 +14,23 @@
  * limitations under the License.
  */
 
-#ifndef FIREBASE_FIRESTORE_CLIENT_CPP_SRC_IOS_HARD_ASSERT_IOS_H_
-#define FIREBASE_FIRESTORE_CLIENT_CPP_SRC_IOS_HARD_ASSERT_IOS_H_
+#ifndef FIREBASE_FIRESTORE_CLIENT_CPP_SRC_COMMON_HARD_ASSERT_COMMON_H_
+#define FIREBASE_FIRESTORE_CLIENT_CPP_SRC_COMMON_HARD_ASSERT_COMMON_H_
+
+// TODO(b/163140650): Remove this/unify with the iOS implementation.
+// On Android we still support customers building with STLPort, which precludes
+// use of Abseil here.
 
 #include <string>
 #include <utility>
 
-#include "absl/base/optimization.h"
-#include "Firestore/core/src/util/exception.h"
+#include "firestore/src/common/macros.h"
 
-// TODO(b/147444199): delete this file and use the one that comes from the
-// GitHub repo. This file provides simplified versions of `HARD_ASSERT`,
-// `HARD_FAIL`, and `ThrowInvalidArgument` that don't support string formatting.
+#if !defined(__ANDROID__)
+#include "Firestore/core/src/util/hard_assert.h"
+#endif  // !defined(__ANDROID__)
 
-#if defined(_MSC_VER)
-#define FIRESTORE_FUNCTION_NAME __FUNCSIG__
-#else
-#define FIRESTORE_FUNCTION_NAME __PRETTY_FUNCTION__
-#endif
+#if defined(__ANDROID__)
 
 /**
  * Invokes the internal Fail function below with all the required contextual
@@ -42,22 +41,24 @@
  */
 #define INVOKE_INTERNAL_FAIL(...)                     \
   firebase::firestore::util::internal::FailAssertion( \
-      __FILE__, FIRESTORE_FUNCTION_NAME, __LINE__, __VA_ARGS__)
+      __FILE__, __PRETTY_FUNCTION__, __LINE__, __VA_ARGS__)
+
+#endif  // !defined(__ANDROID__)
 
 /**
  * Fails the current function if the given condition is false.
  *
  * Unlike assert(3) or NSAssert, this macro is never compiled out.
  *
+ * Note: this version of `HARD_ASSERT` is deliberately simplified to avoid
+ * using `util::StringFormat`.
+ *
  * @param condition The condition to test.
  * @param message (optional) A message to print.
  */
-
-// Note: this version of `HARD_ASSERT` is deliberately dumbed down to avoid
-// using `util::StringFormat`.
-#define HARD_ASSERT_IOS(condition, ...)           \
+#define SIMPLE_HARD_ASSERT(condition, ...)        \
   do {                                            \
-    if (!ABSL_PREDICT_TRUE(condition)) {          \
+    if (!FIRESTORE_PREDICT_TRUE(condition)) {     \
       std::string _message{__VA_ARGS__};          \
       INVOKE_INTERNAL_FAIL(_message, #condition); \
     }                                             \
@@ -70,18 +71,13 @@
  *
  * @param message (optional) A message to print.
  */
-#define HARD_FAIL_IOS(...)             \
+#define SIMPLE_HARD_FAIL(...)          \
   do {                                 \
     std::string _failure{__VA_ARGS__}; \
     INVOKE_INTERNAL_FAIL(_failure);    \
   } while (0)
 
-/**
- * Indicates an area of the code that cannot be reached (except possibly due to
- * undefined behaviour or other similar badness). The only reasonable thing to
- * do in these cases is to immediately abort.
- */
-#define UNREACHABLE() abort()
+#if defined(__ANDROID__)
 
 /**
  * Returns the given `ptr` if it is non-null; otherwise, results in a failed
@@ -96,7 +92,7 @@
  * @param ptr The pointer to check and return. Can be a smart pointer.
  */
 #define NOT_NULL(ptr)                                                      \
-  (static_cast<void>(ABSL_PREDICT_FALSE((ptr) == nullptr)                  \
+  (static_cast<void>(FIRESTORE_PREDICT_FALSE((ptr) == nullptr)             \
                          ? INVOKE_INTERNAL_FAIL("Expected non-null " #ptr) \
                          : static_cast<void>(0)),                          \
    (ptr))  // NOLINT(whitespace/indent)
@@ -107,17 +103,22 @@ namespace util {
 namespace internal {
 
 // A no-return helper function. To raise an assertion, use Macro instead.
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file, const char* func,
-                                           int line,
-                                           const std::string& message);
+// These symbols are in the util::internal namespace to match their iOS
+// equivalents.
+FIRESTORE_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
+                                                const char* func, int line,
+                                                const std::string& message);
 
-ABSL_ATTRIBUTE_NORETURN void FailAssertion(const char* file, const char* func,
-                                           int line, const std::string& message,
-                                           const char* condition);
+FIRESTORE_ATTRIBUTE_NORETURN void FailAssertion(const char* file,
+                                                const char* func, int line,
+                                                const std::string& message,
+                                                const char* condition);
 
 }  // namespace internal
 }  // namespace util
 }  // namespace firestore
 }  // namespace firebase
 
-#endif  // FIREBASE_FIRESTORE_CLIENT_CPP_SRC_IOS_HARD_ASSERT_IOS_H_
+#endif  // defined(__ANDROID__)
+
+#endif  // FIREBASE_FIRESTORE_CLIENT_CPP_SRC_COMMON_HARD_ASSERT_COMMON_H_

--- a/firestore/src/ios/credentials_provider_desktop.cc
+++ b/firestore/src/ios/credentials_provider_desktop.cc
@@ -6,7 +6,7 @@
 #include "app/src/function_registry.h"
 #include "app/src/reference_counted_future_impl.h"
 #include "firestore/src/common/futures.h"
-#include "firestore/src/ios/hard_assert_ios.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/util/status.h"
 
@@ -79,8 +79,9 @@ StatusOr<Token> ConvertToken(const Future<std::string>& future, App& app) {
 void OnToken(const Future<std::string>& future_token, App& app,
              int token_generation, const TokenListener& listener,
              int expected_generation) {
-  HARD_ASSERT_IOS(future_token.status() == FutureStatus::kFutureStatusComplete,
-                  "Expected to receive a completed future");
+  SIMPLE_HARD_ASSERT(
+      future_token.status() == FutureStatus::kFutureStatusComplete,
+      "Expected to receive a completed future");
 
   if (expected_generation != token_generation) {
     // Cancel the request since the user may have changed while the request was
@@ -109,14 +110,14 @@ void FirebaseCppCredentialsProvider::SetCredentialChangeListener(
     std::lock_guard<std::recursive_mutex> lock(contents_->mutex);
 
     if (!listener) {
-      HARD_ASSERT_IOS(change_listener_,
-                      "Change listener removed without being set!");
+      SIMPLE_HARD_ASSERT(change_listener_,
+                         "Change listener removed without being set!");
       change_listener_ = {};
       RemoveAuthStateListener();
       return;
     }
 
-    HARD_ASSERT_IOS(!change_listener_, "Set change listener twice!");
+    SIMPLE_HARD_ASSERT(!change_listener_, "Set change listener twice!");
     change_listener_ = std::move(listener);
     change_listener_(GetCurrentUser(contents_->app));
   }
@@ -177,8 +178,8 @@ void FirebaseCppCredentialsProvider::OnAuthStateChanged(void* context) {
 // Private member functions
 
 void FirebaseCppCredentialsProvider::RequestToken(TokenListener listener) {
-  HARD_ASSERT_IOS(IsSignedIn(),
-                  "Cannot get token when there is no signed-in user");
+  SIMPLE_HARD_ASSERT(IsSignedIn(),
+                     "Cannot get token when there is no signed-in user");
 
   // Take note of the current value of `token_generation` so that this request
   // can fail if there is a token change while the request is outstanding.

--- a/firestore/src/ios/document_change_ios.cc
+++ b/firestore/src/ios/document_change_ios.cc
@@ -2,10 +2,10 @@
 
 #include <utility>
 
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/ios/converter_ios.h"
 #include "firestore/src/ios/document_snapshot_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "firestore/src/ios/util_ios.h"
 
 namespace firebase {

--- a/firestore/src/ios/document_snapshot_ios.cc
+++ b/firestore/src/ios/document_snapshot_ios.cc
@@ -60,8 +60,8 @@ MapFieldValue DocumentSnapshotInternal::GetData(
   const Map& map =
       maybe_object ? maybe_object.value().GetInternalValue() : Map{};
   FieldValue result = ConvertObject(map, stb);
-  HARD_ASSERT_IOS(result.type() == FieldValue::Type::kMap,
-                  "Expected snapshot data to parse to a map");
+  SIMPLE_HARD_ASSERT(result.type() == FieldValue::Type::kMap,
+                     "Expected snapshot data to parse to a map");
   return result.map_value();
 }
 
@@ -143,14 +143,14 @@ FieldValue DocumentSnapshotInternal::ConvertScalar(
       // HARD_FAIL("Unexpected kind of FieldValue: '%s'", scalar.type());
       auto message = std::string("Unexpected kind of FieldValue: '") +
                      std::to_string(static_cast<int>(scalar.type())) + "'";
-      HARD_FAIL_IOS(message.c_str());
+      SIMPLE_HARD_FAIL(message);
     }
   }
 }
 
 FieldValue DocumentSnapshotInternal::ConvertReference(
     const model::FieldValue::Reference& reference) const {
-  HARD_ASSERT_IOS(
+  SIMPLE_HARD_ASSERT(
       reference.database_id() == firestore_internal()->database_id(),
       "Converted reference is from another database");
 

--- a/firestore/src/ios/field_value_ios.cc
+++ b/firestore/src/ios/field_value_ios.cc
@@ -2,10 +2,10 @@
 
 #include <utility>
 
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/include/firebase/firestore/map_field_value.h"
 #include "firestore/src/ios/converter_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "Firestore/core/src/nanopb/byte_string.h"
 
 namespace firebase {
@@ -57,72 +57,72 @@ FieldValueInternal::FieldValueInternal(MapFieldValue value)
 // Accessors
 
 bool FieldValueInternal::boolean_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kBoolean);
+  SIMPLE_HARD_ASSERT(type_ == Type::kBoolean);
   return absl::get<model::FieldValue>(value_).boolean_value();
 }
 
 int64_t FieldValueInternal::integer_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kInteger);
+  SIMPLE_HARD_ASSERT(type_ == Type::kInteger);
   return absl::get<model::FieldValue>(value_).integer_value();
 }
 
 double FieldValueInternal::double_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kDouble);
+  SIMPLE_HARD_ASSERT(type_ == Type::kDouble);
   return absl::get<model::FieldValue>(value_).double_value();
 }
 
 Timestamp FieldValueInternal::timestamp_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kTimestamp);
+  SIMPLE_HARD_ASSERT(type_ == Type::kTimestamp);
   return absl::get<model::FieldValue>(value_).timestamp_value();
 }
 
 std::string FieldValueInternal::string_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kString);
+  SIMPLE_HARD_ASSERT(type_ == Type::kString);
   return absl::get<model::FieldValue>(value_).string_value();
 }
 
 const uint8_t* FieldValueInternal::blob_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kBlob);
+  SIMPLE_HARD_ASSERT(type_ == Type::kBlob);
   return absl::get<model::FieldValue>(value_).blob_value().data();
 }
 
 size_t FieldValueInternal::blob_size() const {
-  HARD_ASSERT_IOS(type_ == Type::kBlob);
+  SIMPLE_HARD_ASSERT(type_ == Type::kBlob);
   return absl::get<model::FieldValue>(value_).blob_value().size();
 }
 
 DocumentReference FieldValueInternal::reference_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kReference);
+  SIMPLE_HARD_ASSERT(type_ == Type::kReference);
   return absl::get<DocumentReference>(value_);
 }
 
 GeoPoint FieldValueInternal::geo_point_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kGeoPoint);
+  SIMPLE_HARD_ASSERT(type_ == Type::kGeoPoint);
   return absl::get<model::FieldValue>(value_).geo_point_value();
 }
 
 std::vector<FieldValue> FieldValueInternal::array_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kArray);
+  SIMPLE_HARD_ASSERT(type_ == Type::kArray);
   return absl::get<ArrayT>(value_);
 }
 
 MapFieldValue FieldValueInternal::map_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kMap);
+  SIMPLE_HARD_ASSERT(type_ == Type::kMap);
   return absl::get<MapT>(value_);
 }
 
 std::vector<FieldValue> FieldValueInternal::array_transform_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kArrayUnion || type_ == Type::kArrayRemove);
+  SIMPLE_HARD_ASSERT(type_ == Type::kArrayUnion || type_ == Type::kArrayRemove);
   return absl::get<ArrayT>(value_);
 }
 
 std::int64_t FieldValueInternal::integer_increment_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kIncrementInteger);
+  SIMPLE_HARD_ASSERT(type_ == Type::kIncrementInteger);
   return absl::get<model::FieldValue>(value_).integer_value();
 }
 
 double FieldValueInternal::double_increment_value() const {
-  HARD_ASSERT_IOS(type_ == Type::kIncrementDouble);
+  SIMPLE_HARD_ASSERT(type_ == Type::kIncrementDouble);
   return absl::get<model::FieldValue>(value_).double_value();
 }
 
@@ -244,7 +244,7 @@ std::string Describe(Type type) {
       // HARD_FAIL("Unexpected type '%s'", type);
       auto message = std::string("Unexpected type '") +
                      std::to_string(static_cast<int>(type)) + "'";
-      HARD_FAIL_IOS(message.c_str());
+      SIMPLE_HARD_FAIL(message.c_str());
     }
   }
 }

--- a/firestore/src/ios/firestore_ios.cc
+++ b/firestore/src/ios/firestore_ios.cc
@@ -4,6 +4,7 @@
 
 #include "app/src/include/firebase/future.h"
 #include "app/src/reference_counted_future_impl.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/common/util.h"
 #include "firestore/src/include/firebase/firestore.h"
@@ -12,7 +13,6 @@
 #include "firestore/src/ios/create_firebase_metadata_provider.h"
 #include "firestore/src/ios/document_reference_ios.h"
 #include "firestore/src/ios/document_snapshot_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "firestore/src/ios/listener_ios.h"
 #include "absl/memory/memory.h"
 #include "absl/types/any.h"

--- a/firestore/src/ios/promise_factory_ios.h
+++ b/firestore/src/ios/promise_factory_ios.h
@@ -6,7 +6,7 @@
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/future.h"
 #include "app/src/reference_counted_future_impl.h"
-#include "firestore/src/ios/hard_assert_ios.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/ios/promise_ios.h"
 
 namespace firebase {

--- a/firestore/src/ios/promise_ios.h
+++ b/firestore/src/ios/promise_ios.h
@@ -7,7 +7,7 @@
 #include "app/src/cleanup_notifier.h"
 #include "app/src/include/firebase/future.h"
 #include "app/src/reference_counted_future_impl.h"
-#include "firestore/src/ios/hard_assert_ios.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "absl/meta/type_traits.h"
 #include "firebase/firestore/firestore_errors.h"
 #include "Firestore/core/src/util/status.h"
@@ -124,7 +124,7 @@ class Promise {
   }
 
   void SetError(const util::Status& status) {
-    HARD_ASSERT_IOS(
+    SIMPLE_HARD_ASSERT(
         !status.ok(),
         "To fulfill a promise with 'ok' status, use Promise::SetValue.");
     if (IsCleanedUp()) {

--- a/firestore/src/ios/query_ios.cc
+++ b/firestore/src/ios/query_ios.cc
@@ -4,11 +4,11 @@
 
 #include "app/src/assert.h"
 #include "firestore/src/common/exception_common.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/include/firebase/firestore.h"
 #include "firestore/src/ios/converter_ios.h"
 #include "firestore/src/ios/document_snapshot_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "firestore/src/ios/listener_ios.h"
 #include "firestore/src/ios/promise_ios.h"
 #include "firestore/src/ios/set_options_ios.h"

--- a/firestore/src/ios/source_ios.h
+++ b/firestore/src/ios/source_ios.h
@@ -1,8 +1,8 @@
 #ifndef FIREBASE_FIRESTORE_CLIENT_CPP_SRC_IOS_SOURCE_IOS_H_
 #define FIREBASE_FIRESTORE_CLIENT_CPP_SRC_IOS_SOURCE_IOS_H_
 
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/include/firebase/firestore/source.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "Firestore/core/src/api/source.h"
 
 namespace firebase {

--- a/firestore/src/ios/transaction_ios.cc
+++ b/firestore/src/ios/transaction_ios.cc
@@ -3,10 +3,10 @@
 #include <future>  // NOLINT(build/c++11)
 #include <utility>
 
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/ios/converter_ios.h"
 #include "firestore/src/ios/document_reference_ios.h"
 #include "firestore/src/ios/field_value_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "firestore/src/ios/set_options_ios.h"
 #include "firestore/src/ios/util_ios.h"
 #include "absl/types/optional.h"
@@ -37,7 +37,7 @@ const model::DocumentKey& GetKey(const DocumentReference& document) {
 DocumentSnapshot ConvertToSingleSnapshot(
     const std::shared_ptr<api::Firestore>& firestore, model::DocumentKey key,
     const std::vector<MaybeDocument>& documents) {
-  HARD_ASSERT_IOS(
+  SIMPLE_HARD_ASSERT(
       documents.size() == 1,
       "Expected core::Transaction::Lookup() to return a single document");
 
@@ -66,7 +66,7 @@ DocumentSnapshot ConvertToSingleSnapshot(
                        "core::Transaction::Lookup() returned unexpected "
                        "document type: '") +
                    std::to_string(static_cast<int>(doc.type())) + "'";
-    HARD_FAIL_IOS(message.c_str());
+    SIMPLE_HARD_FAIL(message);
   }
 }
 

--- a/firestore/src/ios/user_data_converter_ios.cc
+++ b/firestore/src/ios/user_data_converter_ios.cc
@@ -4,10 +4,10 @@
 #include <string>
 
 #include "firestore/src/common/exception_common.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/ios/converter_ios.h"
 #include "firestore/src/ios/field_value_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "firestore/src/ios/set_options_ios.h"
 #include "absl/memory/memory.h"
 #include "Firestore/core/src/core/user_data.h"
@@ -45,7 +45,7 @@ void ParseDelete(ParseContext&& context) {
   }
 
   if (context.data_source() == UserDataSource::Update) {
-    HARD_ASSERT_IOS(
+    SIMPLE_HARD_ASSERT(
         !context.path()->empty(),
         "FieldValue.Delete() at the top level should have already been "
         "handled.");
@@ -95,7 +95,7 @@ void ParseArrayTransform(Type type, const model::FieldValue::Array& elements,
         auto message = std::string("Unexpected type '") +
                        std::to_string(static_cast<int>(type)) +
                        "' given to ParseArrayTransform";
-        HARD_FAIL_IOS(message.c_str());
+        SIMPLE_HARD_FAIL(message);
       }
     }
   }();
@@ -119,7 +119,7 @@ void ParseNumericIncrement(const FieldValue& value, ParseContext&& context) {
       break;
 
     default:
-      HARD_FAIL_IOS("A non-increment value given to ParseNumericIncrement");
+      SIMPLE_HARD_FAIL("A non-increment value given to ParseNumericIncrement");
   }
 
   context.AddToFieldTransforms(*context.path(),
@@ -230,9 +230,9 @@ model::FieldValue UserDataConverter::ParseQueryValue(const FieldValue& input,
 
   absl::optional<model::FieldValue> parsed =
       ParseData(input, accumulator.RootContext());
-  HARD_ASSERT_IOS(parsed, "Parsed data should not be nullopt.");
-  HARD_ASSERT_IOS(accumulator.field_transforms().empty(),
-                  "Field transforms should have been disallowed.");
+  SIMPLE_HARD_ASSERT(parsed, "Parsed data should not be nullopt.");
+  SIMPLE_HARD_ASSERT(accumulator.field_transforms().empty(),
+                     "Field transforms should have been disallowed.");
   return parsed.value();
 }
 
@@ -365,7 +365,7 @@ void UserDataConverter::ParseSentinel(const FieldValue& value,
       // HARD_FAIL("Unknown FieldValue type: '%s'", Describe(value.type()));
       auto message = std::string("Unknown FieldValue type: '") +
                      Describe(value.type()) + "'";
-      HARD_FAIL_IOS(message.c_str());
+      SIMPLE_HARD_FAIL(message);
   }
 }
 
@@ -429,7 +429,7 @@ model::FieldValue UserDataConverter::ParseScalar(const FieldValue& value,
       return model::FieldValue::FromGeoPoint(value.geo_point_value());
 
     default:
-      HARD_FAIL_IOS("A non-scalar field value given to ParseScalar");
+      SIMPLE_HARD_FAIL("A non-scalar field value given to ParseScalar");
   }
 }
 
@@ -457,7 +457,7 @@ model::FieldValue::Array UserDataConverter::ParseArrayTransformElements(
       auto message =
           std::string("Failed to properly parse array transform element: ") +
           Describe(element.type());
-      HARD_FAIL_IOS(message.c_str());
+      SIMPLE_HARD_FAIL(message);
     }
 
     result.push_back(std::move(parsed_element).value());

--- a/firestore/src/tests/util/integration_test_util.cc
+++ b/firestore/src/tests/util/integration_test_util.cc
@@ -3,9 +3,9 @@
 
 #include "devtools/build/runtime/get_runfiles_dir.h"
 #include "app/src/include/firebase/app.h"
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/include/firebase/firestore.h"
 #include "firestore/src/ios/firestore_ios.h"
-#include "firestore/src/ios/hard_assert_ios.h"
 #include "absl/memory/memory.h"
 #include "Firestore/core/src/auth/empty_credentials_provider.h"
 
@@ -36,8 +36,8 @@ App* GetApp(const char* name) {
     return App::Create();
   } else {
     App* default_app = App::GetInstance();
-    HARD_ASSERT_IOS(default_app,
-                    "Cannot create a named app before the default app");
+    SIMPLE_HARD_ASSERT(default_app,
+                       "Cannot create a named app before the default app");
     return App::Create(default_app->options(), name);
   }
 }


### PR DESCRIPTION
Cloned from CL 357750787 by 'g4 patch'.
Original change by mcg@mcg:fig-export-firestore-92888e3fee62:4342:citc on 2021/02/16 10:30:15.

PiperOrigin-RevId: 360506827