### PR TITLE
Deflake: Cache NDK download

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -1,6 +1,9 @@
 name: Android Builds
 
 on:
+  push:
+    branches:
+      feature/ddb-ndk-cache
   pull_request:
     types: [opened, reopened, synchronize]
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -3,54 +3,22 @@ name: Android Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  workflow_dispatch:
-    inputs:
-      use_expanded_matrix:
-        description: 'Use an expanded matrix?'
-        default: '0'
-        required: true
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir
 
 jobs:
-  prepare_matrix:
-    runs-on: ubuntu-latest
-    outputs:
-      matrix_os: ${{ steps.export-result.outputs.matrix_os }}
-      matrix_architecture: ${{ steps.export-result.outputs.matrix_architecture }}
-      matrix_python_version: ${{ steps.export-result.outputs.matrix_python_version }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          submodules: false
-      - name: Use expanded matrix
-        if: github.event.inputs.use_expanded_matrix == '1'
-        run: |
-          echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
-      - id: export-result
-        run: |
-          echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w android -k os ${EXPANDED_MATRIX_PARAM} )"
-          echo "::set-output name=matrix_architecture::$( python scripts/gha/print_matrix_configuration.py -w android -k architecture ${EXPANDED_MATRIX_PARAM} )"
-          echo "::set-output name=matrix_python_version::$( python scripts/gha/print_matrix_configuration.py -w android -k python_version ${EXPANDED_MATRIX_PARAM} )"
-
   build:
-    name: android-${{ matrix.os }}-${{ matrix.architecture }}-${{ matrix.python_version }}
+    name: android-${{ matrix.os }}-${{ matrix.build_type }}-${{ matrix.architecture }}-${{ matrix.python_version }}
     runs-on: ${{ matrix.os }}
-    needs: prepare_matrix
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
-        architecture: ${{ fromJson(needs.prepare_matrix.outputs.matrix_architecture) }}
-        python_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_python_version) }}
-    steps:
-      - name: Check expanded matrix config
-        if: github.event.inputs.expanded_matrix == '1'
-        run: |
-          echo "Enabling expanded build and test matrix."
-          echo "USE_EXPANDED_MATRIX=1" >> $GITHUB_ENV
+        # Windows temporarily removed while broken
+        os: [ubuntu-latest, macos-latest]
+        architecture: ["x64"]
 
+    steps:
       - uses: actions/checkout@v2
         with:
           submodules: true
@@ -64,7 +32,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v2
         with:
-          python-version: ${{ matrix.python_version }}
+          python-version: 3.7
           architecture: ${{ matrix.architecture }}
 
       - name: Add msbuild to PATH
@@ -82,6 +50,13 @@ jobs:
         with:
           path: ccache_dir
           key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
+      
+      - name: Cache NDK
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: anndroid-ndk-${{ matrix.os }}
 
       - name: Build SDK
         shell: bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -42,6 +42,13 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
 
+      - name: Cache NDK
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: anndroid-ndk-${{ matrix.os }}
+
       - name: Install prerequisites
         shell: bash
         run: |
@@ -54,12 +61,6 @@ jobs:
           path: ccache_dir
           key: dev-test-ccache-${{ env.MATRIX_UNIQUE_NAME }}
       
-      - name: Cache NDK
-        id: cache_ndk
-        uses: actions/cache@v2
-        with:
-          path: /tmp/android-ndk-r16b
-          key: anndroid-ndk-${{ matrix.os }}
 
       - name: Build SDK
         shell: bash

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -228,6 +228,13 @@ jobs:
           path: sdk-src
           ref: ${{ github.event.inputs.commitIdToPackage }}
 
+      - name: Cache NDK
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: anndroid-ndk-${{ matrix.os }}
+
       - name: install prerequisites
         run: sdk-src/build_scripts/android/install_prereqs.sh
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -115,6 +115,14 @@ jobs:
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
 
+      - name: Cache NDK
+        if: matrix.target_platform == 'Android'
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: anndroid-ndk-${{ matrix.os }}
+
       - name: Cache vcpkg C++ dependencies
         if: matrix.target_platform == 'Desktop'
         id: cache_vcpkg

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -61,26 +61,26 @@ fi
 if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.properties") ]]; then
     if [[ -d /tmp/android-ndk-r16b && \
 	      -n $(grep "Pkg\.Revision = 16\." "/tmp/android-ndk-r16b/source.properties") ]]; then
-	echo "Using NDK r16b in /tmp/android-ndk-r16b".
+	    echo "Using NDK r16b in /tmp/android-ndk-r16b".
     else
-       echo "NDK_ROOT environment variable is not set, or NDK version is incorrect."
+        echo "NDK_ROOT environment variable is not set, or NDK version is incorrect."
         echo "This build requires NDK r16b for STLPort compatibility, downloading..."
-	if [[ -z $(which curl) ]]; then
-	    echo "Error, could not run 'curl' to download NDK. Is it in your PATH?"
-	    exit 1
-	fi
-	set +e
-	# Retry up to 10 times because Curl has a tendency to timeout on
-	# Github runners.
-	for retry in {1..10} error; do
-	    if [[ $retry == "error" ]]; then exit 5; fi
-	    curl --http1.1 -LSs \
-		 "https://dl.google.com/android/repository/android-ndk-r16b-${platform}-x86_64.zip" \
-		 --output /tmp/android-ndk-r16b.zip && break
-	    sleep 300
-	done
-	set -e
-	(cd /tmp && unzip -q android-ndk-r16b.zip && rm -f android-ndk-r16b.zip)
-	echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
+	    if [[ -z $(which curl) ]]; then
+	        echo "Error, could not run 'curl' to download NDK. Is it in your PATH?"
+	        exit 1
+	    fi
+	    set +e
+	    # Retry up to 10 times because Curl has a tendency to timeout on
+	    # Github runners.
+	    for retry in {1..10} error; do
+	        if [[ $retry == "error" ]]; then exit 5; fi
+	        curl --http1.1 -LSs \
+		    "https://dl.google.com/android/repository/android-ndk-r16b-${platform}-x86_64.zip" \
+		    --output /tmp/android-ndk-r16b.zip && break
+	        sleep 300
+	    done
+	    set -e
+	    (cd /tmp && unzip -q android-ndk-r16b.zip && rm -f android-ndk-r16b.zip)
+	    echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
     fi
 fi


### PR DESCRIPTION
There have been many workflow runs which have failed to download the NDK.   I'mt not sure if this is due to its size or if the GHA Vms have a bad connection, etc, but more often than not when theres a failed download, it's the NDK.

Adding steps to cache the NDK to the Integration, Packaging and Android workflows. The NDK cache is based on the host OS and is based on the path of the android/install_prereqs.py script.