### PR TITLE
Deflake: Cache NDK Downloads

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -76,7 +76,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/android-ndk-r16b
-          key: android-ndk-${{ matrix.os }}
+          key: android-ndk-${{ matrix.os }}-r16b
 
       - name: Install prerequisites
         shell: bash

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -70,6 +70,13 @@ jobs:
       - name: Add msbuild to PATH
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
+      
+      - name: Cache NDK
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: android-ndk-${{ matrix.os }}
 
       - name: Install prerequisites
         shell: bash

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -228,6 +228,13 @@ jobs:
           path: sdk-src
           ref: ${{ github.event.inputs.commitIdToPackage }}
 
+      - name: Cache NDK
+        id: cache_ndk
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: android-ndk-${{ matrix.os }}
+
       - name: install prerequisites
         run: sdk-src/build_scripts/android/install_prereqs.sh
 

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -233,7 +233,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/android-ndk-r16b
-          key: android-ndk-${{ matrix.os }}
+          key: android-ndk-${{ matrix.os }}-r16b
 
       - name: install prerequisites
         run: sdk-src/build_scripts/android/install_prereqs.sh

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -129,7 +129,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: /tmp/android-ndk-r16b
-          key: android-ndk-${{ matrix.os }}
+          key: android-ndk-${{ matrix.os }}-r16b
       
       - name: Setup python
         uses: actions/setup-python@v2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -123,6 +123,14 @@ jobs:
           path: external/vcpkg/installed
           key: dev-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
 
+      - name: Cache NDK
+        id: cache_ndk
+        if: matrix.target_platform == 'Android'
+        uses: actions/cache@v2
+        with:
+          path: /tmp/android-ndk-r16b
+          key: android-ndk-${{ matrix.os }}
+      
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -61,26 +61,26 @@ fi
 if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.properties") ]]; then
     if [[ -d /tmp/android-ndk-r16b && \
 	      -n $(grep "Pkg\.Revision = 16\." "/tmp/android-ndk-r16b/source.properties") ]]; then
-	echo "Using NDK r16b in /tmp/android-ndk-r16b".
+	    echo "Using NDK r16b in /tmp/android-ndk-r16b".
     else
-       echo "NDK_ROOT environment variable is not set, or NDK version is incorrect."
+        echo "NDK_ROOT environment variable is not set, or NDK version is incorrect."
         echo "This build requires NDK r16b for STLPort compatibility, downloading..."
-	if [[ -z $(which curl) ]]; then
-	    echo "Error, could not run 'curl' to download NDK. Is it in your PATH?"
-	    exit 1
-	fi
-	set +e
-	# Retry up to 10 times because Curl has a tendency to timeout on
-	# Github runners.
-	for retry in {1..10} error; do
-	    if [[ $retry == "error" ]]; then exit 5; fi
-	    curl --http1.1 -LSs \
-		 "https://dl.google.com/android/repository/android-ndk-r16b-${platform}-x86_64.zip" \
-		 --output /tmp/android-ndk-r16b.zip && break
-	    sleep 300
-	done
-	set -e
-	(cd /tmp && unzip -q android-ndk-r16b.zip && rm -f android-ndk-r16b.zip)
-	echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
+	    if [[ -z $(which curl) ]]; then
+	        echo "Error, could not run 'curl' to download NDK. Is it in your PATH?"
+	        exit 1
+	    fi
+	    set +e
+	    # Retry up to 10 times because Curl has a tendency to timeout on
+	    # Github runners.
+	    for retry in {1..10} error; do
+	        if [[ $retry == "error" ]]; then exit 5; fi
+	        curl --http1.1 -LSs \
+		    "https://dl.google.com/android/repository/android-ndk-r16b-${platform}-x86_64.zip" \
+		    --output /tmp/android-ndk-r16b.zip && break
+	        sleep 300
+	    done
+	    set -e
+	    (cd /tmp && unzip -q android-ndk-r16b.zip && rm -f android-ndk-r16b.zip)
+	    echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
     fi
 fi


### PR DESCRIPTION
There have been many workflow runs which have failed to download the NDK. I'mt not sure if this is due to its size or if the GHA Vms have a bad connection, etc, but more often than not when theres a failed download, it's the NDK.

Adding steps to cache the NDK to the Integration, Packaging and Android workflows. The NDK cache is based on the host OS and is based on the path of the android/install_prereqs.py script.

Includes some indentation changes to the Android Prereqs script, but no logical changes.