### PR TITLE
Feature/update vcpkg dependency

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,6 +3,7 @@ name: Desktop Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
+  push:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -3,7 +3,6 @@ name: Desktop Builds
 on:
   pull_request:
     types: [opened, reopened, synchronize]
-  push:
 
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir


### PR DESCRIPTION
Updating vcpkg submodule to the latest version.
We found issues in our Github CI where vcpkg was trying to locate some files that no longer exist in the ftp server. It makes sense to move to the latest version as we have not done that for a while.
I ran the integration_tests, cpp_packaging and desktop workflows and didn't see anything break except some flaky unit tests erroring out. 