### PR TITLE
Port cl/361876089: JniRunnable: Fix a deadlock when Detach() is called from Run()

### DIFF
--- a/firestore/src/android/jni_runnable_android.cc
+++ b/firestore/src/android/jni_runnable_android.cc
@@ -1,5 +1,6 @@
 #include "firestore/src/android/jni_runnable_android.h"
 
+#include "app/src/assert.h"
 #include "app/src/util_android.h"
 #include "firestore/src/jni/declaration.h"
 #include "firestore/src/jni/env.h"
@@ -30,9 +31,7 @@ Method<Task> kRunOnNewThread("runOnNewThread",
 Constructor<Object> kConstructor("(J)V");
 
 void NativeRun(JNIEnv* env, jobject java_object, jlong data) {
-  if (data == 0) {
-    return;
-  }
+  FIREBASE_ASSERT_MESSAGE(data != 0, "NativeRun() invoked with data==0");
   reinterpret_cast<JniRunnableBase*>(data)->Run();
 }
 

--- a/firestore/src/tests/android/jni_runnable_android_test.cc
+++ b/firestore/src/tests/android/jni_runnable_android_test.cc
@@ -1,5 +1,7 @@
 #include "firestore/src/android/jni_runnable_android.h"
 
+#include "app/memory/atomic.h"
+#include "app/src/mutex.h"
 #include "firestore/src/jni/declaration.h"
 #include "firestore/src/jni/object.h"
 #include "firestore/src/jni/ownership.h"
@@ -18,6 +20,7 @@ using jni::Global;
 using jni::Local;
 using jni::Method;
 using jni::Object;
+using jni::StaticField;
 using jni::StaticMethod;
 using jni::Task;
 using jni::Throwable;
@@ -27,6 +30,8 @@ Method<Object> kLooperGetThread("getThread", "()Ljava/lang/Thread;");
 Method<void> kRunnableRun("run", "()V");
 StaticMethod<Object> kCurrentThread("currentThread", "()Ljava/lang/Thread;");
 Method<jlong> kThreadGetId("getId", "()J");
+Method<Object> kThreadGetState("getState", "()Ljava/lang/Thread$State;");
+StaticField<Object> kThreadStateWaiting("WAITING", "Ljava/lang/Thread$State;");
 
 class JniRunnableTest : public FirestoreAndroidIntegrationTest {
  public:
@@ -34,7 +39,9 @@ class JniRunnableTest : public FirestoreAndroidIntegrationTest {
     FirestoreAndroidIntegrationTest::SetUp();
     loader().LoadClass("android/os/Looper", kGetMainLooper, kLooperGetThread);
     loader().LoadClass("java/lang/Runnable", kRunnableRun);
-    loader().LoadClass("java/lang/Thread", kCurrentThread, kThreadGetId);
+    loader().LoadClass("java/lang/Thread", kCurrentThread, kThreadGetId,
+                       kThreadGetState);
+    loader().LoadClass("java/lang/Thread$State", kThreadStateWaiting);
     ASSERT_TRUE(loader().ok());
   }
 };
@@ -54,6 +61,16 @@ jlong GetMainThreadId(Env& env) {
   Local<Object> main_looper = env.Call(kGetMainLooper);
   Local<Object> main_thread = env.Call(main_looper, kLooperGetThread);
   return env.Call(main_thread, kThreadGetId);
+}
+
+/**
+ * Returns whether or not the given thread is in the "waiting" state.
+ * See java.lang.Thread.State.WAITING.
+ */
+bool IsThreadWaiting(Env& env, Object& thread) {
+  Local<Object> actual_state = env.Call(thread, kThreadGetState);
+  Local<Object> expected_state = env.Get(kThreadStateWaiting);
+  return Object::Equals(env, expected_state, actual_state);
 }
 
 TEST_F(JniRunnableTest, JavaRunCallsCppRun) {
@@ -145,6 +162,27 @@ TEST_F(JniRunnableTest, DetachDetachesEvenIfAnExceptionIsPending) {
   EXPECT_TRUE(env.ok());
 }
 
+// Verify that b/181129657 does not regress; that is, calling `Detach()` from
+// `Run()` should not deadlock.
+TEST_F(JniRunnableTest, DetachCanBeCalledFromRun) {
+  Env env;
+  int run_count = 0;
+  auto runnable = MakeJniRunnable(env, [&run_count](JniRunnableBase& runnable) {
+    ++run_count;
+    Env env;
+    runnable.Detach(env);
+  });
+  Local<Object> java_runnable = runnable.GetJavaRunnable();
+
+  // Call `run()` twice to verify that the call to `Detach()` successfully
+  // detaches and the second `run()` invocation does not call C++ `Run()`.
+  env.Call(java_runnable, kRunnableRun);
+  env.Call(java_runnable, kRunnableRun);
+
+  EXPECT_TRUE(env.ok());
+  EXPECT_EQ(run_count, 1);
+}
+
 TEST_F(JniRunnableTest, DestructionCausesJavaRunToDoNothing) {
   Env env;
   bool invoked = false;
@@ -191,29 +229,21 @@ TEST_F(JniRunnableTest, RunOnMainThreadTaskFailsIfRunThrowsException) {
 }
 
 TEST_F(JniRunnableTest, RunOnMainThreadRunsSynchronouslyFromMainThread) {
-  class ChainedMainThreadJniRunnable : public JniRunnableBase {
-   public:
-    using JniRunnableBase::JniRunnableBase;
-
-    void Run() override {
-      Env env;
-      EXPECT_EQ(GetCurrentThreadId(env), GetMainThreadId(env));
-      if (is_nested_call_) {
-        return;
-      }
-      is_nested_call_ = true;
-      Local<Task> task = RunOnMainThread(env);
-      EXPECT_TRUE(task.IsComplete(env));
-      EXPECT_TRUE(task.IsSuccessful(env));
-      is_nested_call_ = false;
-    }
-
-   private:
-    bool is_nested_call_ = false;
-  };
-
   Env env;
-  ChainedMainThreadJniRunnable runnable(env);
+  bool is_recursive_call = false;
+  auto runnable =
+      MakeJniRunnable(env, [&is_recursive_call](JniRunnableBase& runnable) {
+        Env env;
+        EXPECT_EQ(GetCurrentThreadId(env), GetMainThreadId(env));
+        if (is_recursive_call) {
+          return;
+        }
+        is_recursive_call = true;
+        Local<Task> task = runnable.RunOnMainThread(env);
+        EXPECT_TRUE(task.IsComplete(env));
+        EXPECT_TRUE(task.IsSuccessful(env));
+        is_recursive_call = false;
+      });
 
   Local<Task> task = runnable.RunOnMainThread(env);
 
@@ -250,6 +280,54 @@ TEST_F(JniRunnableTest, RunOnNewThreadTaskFailsIfRunThrowsException) {
   Local<Throwable> thrown_exception = task.GetException(env);
   EXPECT_TRUE(thrown_exception);
   EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+}
+
+TEST_F(JniRunnableTest, DetachReturnsAfterLastRunOnAnotherThreadCompletes) {
+  Env env;
+  compat::Atomic<int32_t> run_count;
+  run_count.store(0);
+  Mutex detach_thread_mutex;
+  Global<Object> detach_thread;
+  auto runnable =
+      MakeJniRunnable(env, [&run_count, &detach_thread,
+                            &detach_thread_mutex](JniRunnableBase& runnable) {
+        Env env;
+        auto old_run_count = run_count.fetch_add(1);
+        if (old_run_count == 0) {
+          // Wait for another call of `Run()` by another thread to call
+          // `Detach()` and start waiting for this call to `Run()` to return.
+          while (env.ok()) {
+            MutexLock lock(detach_thread_mutex);
+            if (detach_thread && IsThreadWaiting(env, detach_thread)) {
+              break;
+            }
+          }
+          EXPECT_TRUE(env.ok()) << "IsThreadWaiting() failed with an exception";
+        } else if (old_run_count == 1) {
+          {
+            MutexLock lock(detach_thread_mutex);
+            detach_thread = env.Call(kCurrentThread);
+          }
+          runnable.Detach(env);
+          EXPECT_TRUE(env.ok()) << "Detach() failed with an exception";
+        } else {
+          EXPECT_TRUE(false) << "Lambda was invoked too many times";
+        }
+      });
+
+  // Wait for the first invocation of `Run()` to start.
+  Local<Task> task1 = runnable.RunOnNewThread(env);
+  while (true) {
+    if (run_count.load() > 0) {
+      break;
+    }
+  }
+
+  // Start the second invocation of `Run()`, which will call `Detach()`.
+  Local<Task> task2 = runnable.RunOnNewThread(env);
+
+  Await(env, task1);
+  Await(env, task2);
 }
 
 }  // namespace


### PR DESCRIPTION
This is a port of cl/361876089:

JniRunnable: Fix a deadlock when Detach() is called from Run().

The deadlock occurred because Detach() attempted to acquire a write lock on a ReentrantReadWriteLock, which waits for all read locks to first be released; however, the Run() invocation on the call stack holds one of these read locks and therefore the read lock count will never reach zero causing the acquisition of the write lock to block forever.

This fix replaces the ReentrantReadWriteLock with standard Java synchronization. This implementation has the limitation that concurrent invocations of `run()` will be serialized with the advantage of a simple implementation. A more complicated version that allows concurrent invocations of `run()` is in a previous commit in this PR and is also recorded at https://gist.github.com/dconeybe/2d95fbc75f88de58a49804df5c55157b for potential future use.