### PR TITLE
Port cl/362275804: Fix build error in promise_android_test.cc

### DIFF
--- a/firestore/src/tests/android/promise_android_test.cc
+++ b/firestore/src/tests/android/promise_android_test.cc
@@ -39,7 +39,10 @@ namespace {
 
 class PromiseTest : public FirestoreAndroidIntegrationTest {
  public:
-  PromiseTest() : promises_(GetFirestoreInternal(TestFirestore())) {
+  PromiseTest() : promises_(GetFirestoreInternal(TestFirestore())) {}
+
+  void SetUp() override {
+    FirestoreAndroidIntegrationTest::SetUp();
     jni::Env env = GetEnv();
     cancellation_token_source_ = CancellationTokenSource::Create(env);
     task_completion_source_ = TaskCompletionSource::Create(


### PR DESCRIPTION
This is a port of cl/362275804. The changelist in google3 fixed some build logic that caused some tests to be excluded from continuous runs. That allowed `promise_android_test.cc` to get stale and fail to build. This PR fixes the build error in `promise_android_test.cc` that was discovered by the build fix. The build fix itself is not relevant for GitHub.