### PR TITLE
Trigger integration tests by setting a "tests-requested" label.

### DIFF
--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -14,9 +14,9 @@ jobs:
     # This check fails if integration tests are queued, in progress, or failed.
     runs-on: ubuntu-latest
     steps:
-    - uses: danielchabr/pr-labels-checker@v3.0
+    - uses: docker://agilepathway/pull-request-label-checker:latest
       # Uncomment the below line if you want this check to only be on the main branch.
       # if: github.base_ref == 'main'
       with:
-        hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
-        githubToken: ${{ github.token }}
+        none_of: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
+        repo_token: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -12,7 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0
-      if: github.base_ref == 'main'
+      # Uncomment the below line if you want this check to only be on the main branch.
+      # if: github.base_ref == 'main'
       with:
         hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }}"
         githubToken: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,7 +1,7 @@
 name: Check PR Labels
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
 
 jobs:
   check_labels:

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0
-      if: github.base_ref == "main"
+      if: github.base_ref == 'main'
       with:
         hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }}"
         githubToken: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -8,7 +8,7 @@ jobs:
   check_labels:
     runs-on: ubuntu-latest
     steps:
-    - uses: danielchabr/pr-labels-checker@v3
+    - uses: danielchabr/pr-labels-checker@v3.0
       if: github.base_ref == 'main'
       with:
         hasNone: 'tests: failed, tests: in-progress'

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -8,7 +8,7 @@ env:
   statusLabelFailed: "tests: failed"
 
 jobs:
-  check_labels:
+  check_integration_test_success:
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -11,6 +11,7 @@ env:
 
 jobs:
   check_integration_test_labels:
+    # This check fails if integration tests are queued, in progress, or failed.
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -1,0 +1,13 @@
+name: Check PR Labels
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
+        with:
+          github-token: '${{ secrets.GITHUB_TOKEN }}'
+          invalid-labels: 'tests: failed, tests: in-progress'

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -15,8 +15,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: docker://agilepathway/pull-request-label-checker:latest
-      # Uncomment the below line if you want this check to only be on the main branch.
-      # if: github.base_ref == 'main'
       with:
         none_of: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
         repo_token: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -2,12 +2,14 @@ name: Check PR Labels
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
+    
 
 jobs:
   check_labels:
     runs-on: ubuntu-latest
     steps:
-      - uses: jesusvasquez333/verify-pr-label-action@v1.4.0
-        with:
-          github-token: '${{ secrets.GITHUB_TOKEN }}'
-          invalid-labels: 'tests: failed, tests: in-progress'
+    - uses: danielchabr/pr-labels-checker@v3
+      if: github.base_ref == 'main'
+      with:
+        hasNone: 'tests: failed, tests: in-progress'
+        githubToken: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -2,7 +2,7 @@ name: Check PR Labels
 on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
-    
+
 env:
   triggerLabelFull: "tests-requested: full"
   triggerLabelQuick: "tests-requested: quick"

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -3,13 +3,16 @@ on:
   pull_request:
     types: [opened, reopened, synchronize, labeled, unlabeled]
     
+env:
+  statusLabelInProgress: "tests: in-progress"
+  statusLabelFailed: "tests: failed"
 
 jobs:
   check_labels:
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0
-      if: github.base_ref == 'main'
+      if: github.base_ref == "main"
       with:
-        hasNone: 'tests: failed, tests: in-progress'
+        hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }}"
         githubToken: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -4,6 +4,8 @@ on:
     types: [opened, reopened, synchronize, labeled, unlabeled]
     
 env:
+  triggerLabelFull: "tests-requested: full"
+  triggerLabelQuick: "tests-requested: quick"
   statusLabelInProgress: "tests: in-progress"
   statusLabelFailed: "tests: failed"
 
@@ -15,5 +17,5 @@ jobs:
       # Uncomment the below line if you want this check to only be on the main branch.
       # if: github.base_ref == 'main'
       with:
-        hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }}"
+        hasNone: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
         githubToken: ${{ github.token }}

--- a/.github/workflows/check-labels.yml
+++ b/.github/workflows/check-labels.yml
@@ -8,7 +8,7 @@ env:
   statusLabelFailed: "tests: failed"
 
 jobs:
-  check_integration_test_success:
+  check_integration_test_labels:
     runs-on: ubuntu-latest
     steps:
     - uses: danielchabr/pr-labels-checker@v3.0

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -360,6 +360,8 @@ jobs:
         run: |
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
 
+      ### The below allow us to set the failure label and comment early, when the first failure
+      ### in the matrix occurs. It'll be cleaned up in a subsequent job.
       - name: add failure label
         # We can do mark a failure as soon as any one test fails.
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
@@ -380,7 +382,7 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
           message: |
-            ### ❌&nbsp; Integration test FAILED
+            ### ❌&nbsp; Integration test FAILED (but still ⏳&nbsp; in progress)
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
@@ -419,6 +421,35 @@ jobs:
         with:
           message: |
             ### ✅&nbsp; Integration test succeeded!
+            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
+            Last updated: ${{ steps.get-time.outputs.time }}
+            **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
+
+  add_failure_label:
+    name: "add-failure-label"
+    needs: [check_trigger, tests]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && failure() }}
+    steps:
+      - name: add failure label
+        uses: buildsville/add-remove-label@v1
+        with:
+          token: ${{ github.token }}
+          label: "${{ env.statusLabelFailed }}"
+          type: add
+      - name: get current time for status comment
+        id: get-time
+        shell: bash
+        run: |
+          echo -n "::set-output name=time::"
+          TZ=America/Los_Angeles date
+      - name: add failure status comment
+        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        with:
+          message: |
+            ### ❌&nbsp; Integration test FAILED
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -352,8 +352,8 @@ jobs:
             exit 1
           fi
 
-  remove_inprogress_label:
-    name: "finish_job_remove_inprogress_label"
+  remove_in_progress_label:
+    name: "remove-in-progress-label"
     needs: [tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && always() }}
@@ -367,7 +367,7 @@ jobs:
           type: remove
 
   add_success_label:
-    name: "finish_job_add_success_label"
+    name: "add-success-label"
     needs: [tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -173,7 +173,7 @@ jobs:
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
       - name: Set auto-diff option if specified.
-        if: needs.check_trigger.outputs.requested_tests == "auto"
+        if: needs.check_trigger.outputs.requested_tests == 'auto'
         run: |
           echo "Autodetecting which tests to run."
           echo "AUTO_DIFF_PARAM=--auto_diff ${{github.event.pull_request.base.sha}}" >> $GITHUB_ENV

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -328,7 +328,7 @@ jobs:
 
       - name: add failure label
         # We can do this as soon as a test fails.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -181,9 +181,9 @@ jobs:
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
-          echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM}
-          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" ${AUTO_DIFF_PARAM}
-          echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM}
+          echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})"
+          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" ${AUTO_DIFF_PARAM})"
+          echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             echo "::warning ::Downloading SDK package from previous run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
           submodules: false
       - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == "full"
+        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == 'full'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -122,7 +122,12 @@ jobs:
         token: ${{secrets.GITHUB_TOKEN}}
         label: "${{ env.statusLabelFailed }}"
         type: remove
-
+    - name: add in-progress comment
+      uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+      with:
+        message: "[Integration test in progress.](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+        GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+        COMMENT_IDENTIFIER: "integration-test-status-comment"
 
   # To feed input into the job matrix, we first need to convert to a JSON
   # list. Then we can use fromJson to define the field in the matrix for the tests job.
@@ -339,9 +344,16 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{github.token}}
           label: "${{ env.statusLabelFailed }}"
           type: add
+      - name: add failure comment
+        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        with:
+          message: "[Integration test failed!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_IDENTIFIER: "integration-test-status-comment"
 
       - name: Summarize build and test results
         if: ${{ !cancelled() }}
@@ -385,3 +397,9 @@ jobs:
           token: ${{github.token}}
           label: "${{ env.statusLabelSucceeded }}"
           type: add
+      - name: add success comment
+        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        with:
+          message: "[Integration test succeeded!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -122,10 +122,10 @@ jobs:
         token: ${{secrets.GITHUB_TOKEN}}
         label: "${{ env.statusLabelFailed }}"
         type: remove
-    - name: add in-progress comment
+    - name: add in progress comment
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
-        message: "[Integration test in progress.](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+        message: "[Integration test in progress.](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
         GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -351,7 +351,7 @@ jobs:
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
-          message: "[Integration test failed!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+          message: "[Integration test failed!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -400,6 +400,6 @@ jobs:
       - name: add success comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
-          message: "[Integration test succeeded!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})")
+          message: "[Integration test succeeded!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -188,6 +188,8 @@ jobs:
     name: ${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
     needs: [prepare_matrix, check_trigger]
     runs-on: ${{ matrix.os }}
+    # Skip this if there is an empty matrix (which can happen if "auto" was set above).
+    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != ''
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -189,7 +189,7 @@ jobs:
     needs: [prepare_matrix, check_trigger]
     runs-on: ${{ matrix.os }}
     # Skip this if there is an empty matrix (which can happen if "auto" was set above).
-    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != ''
+    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -358,11 +358,19 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
     steps:
+      # Use a different token to remove the "in-progress" label,
+      # to allow the removal to trigger the "Check Labels" workflow.
+      - name: Generate token for GitHub API
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
       - name: remove in progress label
         if: ${{ !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{steps.generate-token.outputs.token}}
           label: "${{ env.statusLabelInProgress }}"
           type: remove
 
@@ -375,6 +383,6 @@ jobs:
       - name: add success label
         uses: buildsville/add-remove-label@v1
         with:
-          token: ${{secrets.GITHUB_TOKEN}}
+          token: ${{github.token}}
           label: "${{ env.statusLabelSucceeded }}"
           type: add

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -146,9 +146,9 @@ jobs:
           if [[ "${{ needs.check_trigger.outputs.requested_tests }}" == "quick" ]]; then
             echo "Quick tests requested."
             # Autodetect which APIs, platforms, and OSes to test based on what's changed in this PR.
-            echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" --auto_diff ${{github.event.pull_request.base.ref}})"
-            echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --auto_diff ${{github.event.pull_request.base.ref}})"
-            echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" --auto_diff ${{github.event.pull_request.base.ref}})"
+            echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" --auto_diff ${{github.event.pull_request.base.sha}})"
+            echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --auto_diff ${{github.event.pull_request.base.sha}})"
+            echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" --auto_diff ${{github.event.pull_request.base.sha}})"
           else
             echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" )"
             echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -91,7 +91,7 @@ jobs:
         if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelFull }}" ]]; then
           echo "::set-output name=requested_tests::full"
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
-          echo "::set-output name=requested_tests::quick"
+          echo "::set-output name=requested_tests::auto"
         fi
     - name: add in-progress label
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
@@ -143,8 +143,8 @@ jobs:
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
-          if [[ "${{ needs.check_trigger.outputs.requested_tests }}" == "quick" ]]; then
-            echo "Quick tests requested."
+          if [[ "${{ needs.check_trigger.outputs.requested_tests }}" == "auto" ]]; then
+            echo "Autodetecting which tests to run."
             # Autodetect which APIs, platforms, and OSes to test based on what's changed in this PR.
             echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" --auto_diff ${{github.event.pull_request.base.sha}})"
             echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --auto_diff ${{github.event.pull_request.base.sha}})"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -190,7 +190,7 @@ jobs:
     needs: [prepare_matrix, check_trigger]
     runs-on: ${{ matrix.os }}
     # Skip this if there is an empty matrix (which can happen if "auto" was set above).
-    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != ''
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -126,8 +126,8 @@ jobs:
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
-          Integration test: [in progress](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-          Requested by @#{{github.actor}} on commit ${{github.sha}}
+          Integration test: *[in progress](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})*
+          Requested by @${{github.actor}} on commit ${{github.sha}}
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -355,7 +355,7 @@ jobs:
         with:
           message: |
             Integration test: **[failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-            Requested by @#{{github.actor}} on commit ${{github.sha}}
+            Requested by @${{github.actor}} on commit ${{github.sha}}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -406,6 +406,6 @@ jobs:
         with:
           message: |
             Integration test: **[succeeded](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-            Requested by @#{{github.actor}} on commit ${{github.sha}}
+            Requested by @${{github.actor}} on commit ${{github.sha}}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -382,7 +382,7 @@ jobs:
 
   remove_in_progress_label:
     name: "remove-in-progress-label"
-    needs: [tests]
+    needs: [check_trigger, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
     steps:
@@ -403,7 +403,7 @@ jobs:
 
   add_success_label:
     name: "add-success-label"
-    needs: [tests]
+    needs: [check_trigger, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -52,18 +52,25 @@ env:
 
 jobs:
   check_trigger:
+    ### This job only runs when the workflow was triggered by a PR getting labeled.
+    ### It checks whether the label is a test-request trigger (cancelling
+    ### the workflow if not), and then sets the in-progress label. It sets
+    ### outputs to control the test matrix (full or quick) and to tell
+    ### subsequent steps to update the labels as well.
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request' && github.event.action == 'labeled'
     outputs:
       should_update_labels: ${{ steps.set_outputs.outputs.should_update_labels }}
       requested_tests: ${{ steps.set_outputs.outputs.requested_tests }}
     steps:
+    ### If the label isn't one of the test-request triggers, cancel the workflow.
     - name: cancel workflow if label is irrelevant
       if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: andymckay/cancel-action@0.2
     - name: wait for above cancellation if label is irrelevant
       if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       run: sleep 300
+    ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: styfle/cancel-workflow-action@0.8.0
@@ -73,12 +80,12 @@ jobs:
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
-        token: ${{secrets.GITHUB_TOKEN}}
+        token: ${{ github.token }}
         label: "${{ github.event.label.name }}"
         type: remove
+    ### Fail the workflow if the user does not have admin access to run the tests.
     - name: check if user has permission to trigger tests
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
-      # This step will cause the workflow to fail if the user does not have access.
       uses: lannonbr/repo-permission-check-action@2.0.0
       with:
         permission: "admin"
@@ -93,11 +100,12 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
+    ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
-        token: ${{secrets.GITHUB_TOKEN}}
+        token: ${{ github.token }}
         label: "${{ env.statusLabelInProgress }}"
         type: add
     - name: remove previous success label

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -138,7 +138,7 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     needs: check_trigger
-    if: ${{ !cancelled() && !failure() }}
+    if: ${{ !cancelled() && !failure() }}  # Run even if check_trigger was skipped.
     outputs:
       matrix_platform: ${{ steps.export-result.outputs.matrix_platform }}
       matrix_os: ${{ steps.export-result.outputs.matrix_os }}
@@ -190,7 +190,8 @@ jobs:
     needs: [prepare_matrix, check_trigger]
     runs-on: ${{ matrix.os }}
     # Skip this if there is an empty matrix (which can happen if "auto" was set above).
-    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != ''
+    # But check cancelled() && !failure() so it runs even if check_trigger was skipped.
+    if: needs.prepare_matrix.outputs.matrix_platform != '[]' && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,15 +69,15 @@ jobs:
       uses: andymckay/cancel-action@0.2
     - name: wait for above cancellation if label is irrelevant
       if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) }}
-      run: sleep 300
+      run: |
+        sleep 300
+        exit 1  # fail out if the cancellation above somehow failed.
     ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}
     - name: remove triggering label
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
         token: ${{ github.token }}
@@ -85,14 +85,12 @@ jobs:
         type: remove
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: check if user has permission to trigger tests
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: lannonbr/repo-permission-check-action@2.0.0
       with:
         permission: "admin"
       env:
         GITHUB_TOKEN: ${{ github.token }}
     - id: set_outputs
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       run: |
         echo "::set-output name=should_update_labels::1"
         if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelFull }}" ]]; then
@@ -102,32 +100,35 @@ jobs:
         fi
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
         token: ${{ github.token }}
         label: "${{ env.statusLabelInProgress }}"
         type: add
     - name: remove previous success label
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
         token: ${{ github.token }}
         label: "${{ env.statusLabelSucceeded }}"
         type: remove
     - name: remove previous failure label
-      if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
         token: ${{ github.token }}
         label: "${{ env.statusLabelFailed }}"
         type: remove
+    - name: get current time for status comment
+      id: get-time
+      run: |
+        echo -n "::set-output name=time::"
+        TZ=America/Los_Angeles date
     - name: add in progress comment
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
           Integration test: *[in progress](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})*
           Requested by @${{github.actor}} on commit ${{github.sha}}
+          Last updated: ${{ steps.get-time.outputs.time }}
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -342,13 +343,19 @@ jobs:
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir testapps --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
 
       - name: add failure label
-        # We can do this as soon as a test fails.
+        # We can do mark a failure as soon as any one test fails.
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{ github.token }}
           label: "${{ env.statusLabelFailed }}"
           type: add
+      - name: get current time for status comment
+        id: get-time
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        run: |
+          echo -n "::set-output name=time::"
+          TZ=America/Los_Angeles date
       - name: add failure comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
@@ -356,6 +363,7 @@ jobs:
           message: |
             Integration test: **[failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
             Requested by @${{github.actor}} on commit ${{github.sha}}
+            Last updated: ${{ steps.get-time.outputs.time }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -401,11 +409,17 @@ jobs:
           token: ${{github.token}}
           label: "${{ env.statusLabelSucceeded }}"
           type: add
+      - name: get current time for status comment
+        id: get-time
+        run: |
+          echo -n "::set-output name=time::"
+          TZ=America/Los_Angeles date
       - name: add success comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
           message: |
             Integration test: **[succeeded](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
             Requested by @${{github.actor}} on commit ${{github.sha}}
+            Last updated: ${{ steps.get-time.outputs.time }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -344,9 +344,9 @@ jobs:
             exit 1
           fi
 
-  finish_job_remove_inprogress_label:
+  remove_inprogress_label:
     name: "finish_job_remove_inprogress_label"
-    needs: [prepare_matrix, check_trigger, tests]
+    needs: [tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && always() }}
     steps:
@@ -358,9 +358,9 @@ jobs:
           label: "${{ env.statusLabelInProgress }}"
           type: remove
 
-  finish_job_add_success_label:
+  add_success_label:
     name: "finish_job_add_success_label"
-    needs: [prepare_matrix, check_trigger, tests, finish_job_remove_inprogress_label]
+    needs: [tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -403,7 +403,7 @@ jobs:
 
   add_success_label:
     name: "add-success-label"
-    needs: [check_trigger, tests]
+    needs: [check_trigger, tests, remove_in_progress_label]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -127,7 +127,7 @@ jobs:
       with:
         message: |
           ### ⏳  Integration test in progress
-          Requested by @${{github.actor}} on commit ${{github.sha}}
+          Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
           Last updated: ${{ steps.get-time.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
@@ -363,7 +363,7 @@ jobs:
         with:
           message: |
             ### ❌  Integration test FAILED
-            Requested by @${{github.actor}} on commit ${{github.sha}}
+            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
@@ -421,7 +421,7 @@ jobs:
         with:
           message: |
             ### ✅  Integration test succeeded! 
-            Requested by @${{github.actor}} on commit ${{github.sha}}
+            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -136,7 +136,7 @@ jobs:
           fetch-depth: 0
           submodules: false
       - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
+        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == "full"
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -357,6 +357,14 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           label: "${{ env.statusLabelInProgress }}"
           type: remove
+      - name: add failure label
+        # We can do this as soon as a test fails.
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() }}
+        uses: buildsville/add-remove-label@v1
+        with:
+          token: ${{secrets.GITHUB_TOKEN}}
+          label: "${{ env.statusLabelFailed }}"
+          type: add
       - name: add success label
         # Must wait for all tests to finish before marking successful.
         if: ${{ needs.check_trigger.outputs.should_update_labels && success() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -349,6 +349,7 @@ jobs:
     name: "finish_job"
     needs: [prepare_matrix, check_trigger, tests]
     runs-on: ubuntu-latest
+    if: ${{ always() }}
     steps:
       - name: remove in progress label
         if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -356,7 +356,7 @@ jobs:
     name: "remove-in-progress-label"
     needs: [tests]
     runs-on: ubuntu-latest
-    if: ${{ needs.check_trigger.outputs.should_update_labels && always() }}
+    if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
     steps:
       - name: remove in progress label
         if: ${{ !cancelled() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -138,6 +138,7 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     needs: check_trigger
+    if: !cancelled() && !failure()
     outputs:
       matrix_platform: ${{ steps.export-result.outputs.matrix_platform }}
       matrix_os: ${{ steps.export-result.outputs.matrix_os }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -49,6 +49,7 @@ env:
   statusLabelInProgress: "tests: in-progress"
   statusLabelFailed: "tests: failed"
   statusLabelSucceeded: "tests: succeeded"
+  statusCommentIdentifier: "integration-test-status-comment"
 
 jobs:
   check_trigger:
@@ -117,13 +118,27 @@ jobs:
         token: ${{ github.token }}
         label: "${{ env.statusLabelFailed }}"
         type: remove
+    - name: find old status comment, if any
+      uses: peter-evans/find-comment@v1
+      id: find-comment
+      with:
+        issue-number: ${{github.event.number}}
+        body-includes: ${{ env.statusCommentIdentifier }}
+        token: ${{github.token}}
+    - name: delete old status comment
+      if: ${{ steps.find-comment.outputs.comment-id != 0 }}
+      uses: jungwinter/comment@v1
+      with:
+        type: delete
+        comment_id: ${{ steps.find-comment.outputs.comment-id }}
+        token: ${{ github.token }}
     - name: get current time for status comment
       id: get-time
       shell: bash
       run: |
         echo -n "::set-output name=time::"
         TZ=America/Los_Angeles date
-    - name: add in progress comment
+    - name: add in progress status comment
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
@@ -132,7 +147,7 @@ jobs:
           Last updated: ${{ steps.get-time.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
-        COMMENT_IDENTIFIER: "integration-test-status-comment"
+        COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 
   # To feed input into the job matrix, we first need to convert to a JSON
   # list. Then we can use fromJson to define the field in the matrix for the tests job.
@@ -359,7 +374,7 @@ jobs:
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
-      - name: add failure comment
+      - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
@@ -369,7 +384,7 @@ jobs:
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
-          COMMENT_IDENTIFIER: "integration-test-status-comment"
+          COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 
       - name: Summarize build and test results
         if: ${{ !cancelled() }}
@@ -398,7 +413,7 @@ jobs:
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
-      - name: add success comment
+      - name: add success status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
           message: |
@@ -407,7 +422,7 @@ jobs:
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
-          COMMENT_IDENTIFIER: "integration-test-status-comment"
+          COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 
   remove_in_progress_label:
     name: "remove-in-progress-label"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -126,7 +126,7 @@ jobs:
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
-          ### ⏳  Integration test in progress
+          ### ⏳&nbsp; Integration test in progress...
           Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
           Last updated: ${{ steps.get-time.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
@@ -364,7 +364,7 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
           message: |
-            ### ❌  Integration test FAILED
+            ### ❌&nbsp; Integration test FAILED
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
@@ -380,8 +380,36 @@ jobs:
             exit 1
           fi
 
-  remove_in_progress_label:
-    name: "remove-in-progress-label"
+  add_success_label:
+    name: "add-success-label"
+    needs: [check_trigger, tests]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
+    steps:
+      - name: add success label
+        uses: buildsville/add-remove-label@v1
+        with:
+          token: ${{github.token}}
+          label: "${{ env.statusLabelSucceeded }}"
+          type: add
+      - name: get current time for status comment
+        id: get-time
+        run: |
+          echo -n "::set-output name=time::"
+          TZ=America/Los_Angeles date
+      - name: add success comment
+        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        with:
+          message: |
+            ### ✅&nbsp; Integration test succeeded!
+            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
+            Last updated: ${{ steps.get-time.outputs.time }}
+            **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+          GITHUB_TOKEN: ${{ github.token }}
+          COMMENT_IDENTIFIER: "integration-test-status-comment"
+
+  remove_in_progress_label_failure:
+    name: "remove-in-progress-label-failure"
     needs: [check_trigger, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
@@ -401,30 +429,3 @@ jobs:
           label: "${{ env.statusLabelInProgress }}"
           type: remove
 
-  add_success_label:
-    name: "add-success-label"
-    needs: [check_trigger, tests, remove_in_progress_label]
-    runs-on: ubuntu-latest
-    if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
-    steps:
-      - name: add success label
-        uses: buildsville/add-remove-label@v1
-        with:
-          token: ${{github.token}}
-          label: "${{ env.statusLabelSucceeded }}"
-          type: add
-      - name: get current time for status comment
-        id: get-time
-        run: |
-          echo -n "::set-output name=time::"
-          TZ=America/Los_Angeles date
-      - name: add success comment
-        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
-        with:
-          message: |
-            ### ✅  Integration test succeeded! 
-            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
-            Last updated: ${{ steps.get-time.outputs.time }}
-            **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-          GITHUB_TOKEN: ${{ github.token }}
-          COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -138,7 +138,7 @@ jobs:
   prepare_matrix:
     runs-on: ubuntu-latest
     needs: check_trigger
-    if: !cancelled() && !failure()
+    if: ${{ !cancelled() && !failure() }}
     outputs:
       matrix_platform: ${{ steps.export-result.outputs.matrix_platform }}
       matrix_os: ${{ steps.export-result.outputs.matrix_os }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,21 +112,21 @@ jobs:
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
-        token: ${{secrets.GITHUB_TOKEN}}
+        token: ${{ github.token }}
         label: "${{ env.statusLabelSucceeded }}"
         type: remove
     - name: remove previous failure label
       if: ${{ startsWith(github.event.label.name, env.triggerLabelPrefix) }}
       uses: buildsville/add-remove-label@v1
       with:
-        token: ${{secrets.GITHUB_TOKEN}}
+        token: ${{ github.token }}
         label: "${{ env.statusLabelFailed }}"
         type: remove
     - name: add in progress comment
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: "[Integration test in progress.](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
-        GITHUB_TOKEN: ${{ secrets.ACTION_TOKEN }}
+        GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
   # To feed input into the job matrix, we first need to convert to a JSON
@@ -344,7 +344,7 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
-          token: ${{github.token}}
+          token: ${{ github.token }}
           label: "${{ env.statusLabelFailed }}"
           type: add
       - name: add failure comment

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -344,29 +344,27 @@ jobs:
             exit 1
           fi
 
-
-  finish_job:
-    name: "finish_job"
+  finish_job_remove_inprogress_label:
+    name: "finish_job_remove_inprogress_label"
     needs: [prepare_matrix, check_trigger, tests]
     runs-on: ubuntu-latest
-    if: ${{ always() }}
+    if: ${{ needs.check_trigger.outputs.should_update_labels && always() }}
     steps:
       - name: remove in progress label
-        if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
+        if: ${{ !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           label: "${{ env.statusLabelInProgress }}"
           type: remove
-      - name: add failure label
-        if: ${{ needs.check_trigger.outputs.should_update_labels && (failure() || needs.prepare_matrix.status == 'failure') && !cancelled() }}
-        uses: buildsville/add-remove-label@v1
-        with:
-          token: ${{secrets.GITHUB_TOKEN}}
-          label: "${{ env.statusLabelFailed }}"
-          type: add
+
+  finish_job_add_success_label:
+    name: "finish_job_add_success_label"
+    needs: [prepare_matrix, check_trigger, tests, finish_job_remove_inprogress_label]
+    runs-on: ubuntu-latest
+    if: ${{ needs.check_trigger.outputs.should_update_labels }}
+    steps:
       - name: add success label
-        if: ${{ needs.check_trigger.outputs.should_update_labels && (success() && needs.tests.status != 'failure') && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -360,7 +360,7 @@ jobs:
           type: remove
       - name: add failure label
         # We can do this as soon as a test fails.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -368,7 +368,7 @@ jobs:
           type: add
       - name: add success label
         # Must wait for all tests to finish before marking successful.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && success() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && success() && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -359,15 +359,14 @@ jobs:
           label: "${{ env.statusLabelInProgress }}"
           type: remove
       - name: add failure label
-        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && needs.prepare_matrix.status == 'failure' && !cancelled() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && (failure() || needs.prepare_matrix.status == 'failure') && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           label: "${{ env.statusLabelFailed }}"
           type: add
       - name: add success label
-        # Must wait for all tests to finish before marking successful.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && success() && needs.tests.status == 'success' && !cancelled() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && (success() && needs.tests.status != 'failure') && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -405,7 +405,7 @@ jobs:
     name: "add-success-label"
     needs: [check_trigger, tests, remove_in_progress_label]
     runs-on: ubuntu-latest
-    if: ${{ needs.check_trigger.outputs.should_update_labels }}
+    if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
     steps:
       - name: add success label
         uses: buildsville/add-remove-label@v1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -359,8 +359,7 @@ jobs:
           label: "${{ env.statusLabelInProgress }}"
           type: remove
       - name: add failure label
-        # We can do this as soon as a test fails.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && needs.prepare_matrix.status == 'failure' && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}
@@ -368,7 +367,7 @@ jobs:
           type: add
       - name: add success label
         # Must wait for all tests to finish before marking successful.
-        if: ${{ needs.check_trigger.outputs.should_update_labels && success() && !cancelled() }}
+        if: ${{ needs.check_trigger.outputs.should_update_labels && success() && needs.tests.status == 'success' && !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -119,6 +119,7 @@ jobs:
         type: remove
     - name: get current time for status comment
       id: get-time
+      shell: bash
       run: |
         echo -n "::set-output name=time::"
         TZ=America/Los_Angeles date
@@ -358,6 +359,7 @@ jobs:
       - name: get current time for status comment
         id: get-time
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        shell: bash
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
@@ -396,6 +398,7 @@ jobs:
           type: add
       - name: get current time for status comment
         id: get-time
+        shell: bash
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -367,7 +367,6 @@ jobs:
           app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
           private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
       - name: remove in progress label
-        if: ${{ !cancelled() }}
         uses: buildsville/add-remove-label@v1
         with:
           token: ${{steps.generate-token.outputs.token}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -408,8 +408,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
-  remove_in_progress_label_failure:
-    name: "remove-in-progress-label-failure"
+  remove_in_progress_label:
+    name: "remove-in-progress-label"
     needs: [check_trigger, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -125,7 +125,9 @@ jobs:
     - name: add in progress comment
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
-        message: "[Integration test in progress.](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
+        message: |
+          Integration test: [in progress](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+          Requested by @#{{github.actor}} on commit ${{github.sha}}
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -351,7 +353,9 @@ jobs:
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
-          message: "[Integration test failed!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
+          message: |
+            Integration test: **[failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            Requested by @#{{github.actor}} on commit ${{github.sha}}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -400,6 +404,8 @@ jobs:
       - name: add success comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
-          message: "[Integration test succeeded!](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})"
+          message: |
+            Integration test: **[succeeded](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            Requested by @#{{github.actor}} on commit ${{github.sha}}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -152,27 +152,23 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
-          fetch-depth: 0
           submodules: false
       - name: Use expanded matrix
         if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == 'full'
         run: |
           echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
+      - name: Set auto-diff option if specified.
+        if: needs.check_trigger.outputs.requested_tests == "auto"
+        run: |
+          echo "Autodetecting which tests to run."
+          echo "AUTO_DIFF_PARAM=--auto_diff ${{github.event.pull_request.base.sha}}" >> $GITHUB_ENV
 
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
-          if [[ "${{ needs.check_trigger.outputs.requested_tests }}" == "auto" ]]; then
-            echo "Autodetecting which tests to run."
-            # Autodetect which APIs, platforms, and OSes to test based on what's changed in this PR.
-            echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" --auto_diff ${{github.event.pull_request.base.sha}})"
-            echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --auto_diff ${{github.event.pull_request.base.sha}})"
-            echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" --auto_diff ${{github.event.pull_request.base.sha}})"
-          else
-            echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" )"
-            echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" )"
-            echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" )"
-          fi
+          echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM}
+          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" ${AUTO_DIFF_PARAM}
+          echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM}
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
             echo "::warning ::Downloading SDK package from previous run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -126,7 +126,7 @@ jobs:
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
-          \#\#\# ⏳  Integration test in progress
+          ### ⏳  Integration test in progress
           Requested by @${{github.actor}} on commit ${{github.sha}}
           Last updated: ${{ steps.get-time.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
@@ -362,7 +362,7 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
           message: |
-            \#\#\# ❌  Integration test FAILED
+            ### ❌  Integration test FAILED
             Requested by @${{github.actor}} on commit ${{github.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
@@ -420,7 +420,7 @@ jobs:
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
           message: |
-            \#\#\# ✅  Integration test succeeded! 
+            ### ✅  Integration test succeeded! 
             Requested by @${{github.actor}} on commit ${{github.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -126,9 +126,10 @@ jobs:
       uses: phulsechinmay/rewritable-pr-comment@v0.2.1
       with:
         message: |
-          Integration test: *[in progress](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})*
+          \#\#\# ⏳  Integration test in progress
           Requested by @${{github.actor}} on commit ${{github.sha}}
           Last updated: ${{ steps.get-time.outputs.time }}
+          **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -361,9 +362,10 @@ jobs:
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
           message: |
-            Integration test: **[failed](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            \#\#\# ❌  Integration test FAILED
             Requested by @${{github.actor}} on commit ${{github.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
+            **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"
 
@@ -418,8 +420,9 @@ jobs:
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
           message: |
-            Integration test: **[succeeded](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            \#\#\# ✅  Integration test succeeded! 
             Requested by @${{github.actor}} on commit ${{github.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
+            **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: "integration-test-status-comment"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -167,6 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: false
       - name: Use expanded matrix
         if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == 'full'

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-// Touch this file to run a subset of tests.
-
 #import "FIRAdditionalUserInfo.h"
 #import "FIRAuthDataResult.h"
 #import "FIRAuthErrors.h"

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -191,7 +191,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
   Remove entries from the list based on what we observe in the
   source tree, relative to the given base branch."""
   file_list = set(subprocess.check_output(['git', 'diff', '--name-only', auto_diff]).decode('utf-8').rstrip('\n').split('\n'))
-  
+
   if parm_key == 'apis':
     custom_triggers = {
       # Ones set to None are ignored.
@@ -202,9 +202,8 @@ def filter_values_on_diff(parm_key, value, auto_diff):
     }
     requested_api_list = set(value.split(','))
     filtered_api_list = set()
-    
+
     for path in file_list:
-      print(path)
       topdir = path.split(os.path.sep)[0]
       if topdir in custom_triggers:
         if not custom_triggers[topdir]: continue  # Skip ones set to None.
@@ -231,7 +230,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
     for path in file_list:
       matched = False
       if (re.search(r'^external/', path) or
-          re.search(r'^release_build_files/', path) or 
+          re.search(r'^release_build_files/', path) or
           re.search(r'readme', path, re.IGNORECASE)):
         matched = True
       if "Android" in requested_platform_list and (
@@ -260,7 +259,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
     return sorted(filtered_platform_list)
   else:
     return value
-  
+
 
 def main():
   args = parse_cmdline_args()

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -193,10 +193,13 @@ def filter_values_on_diff(parm_key, value, auto_diff):
   file_list = set(subprocess.check_output(['git', 'diff', '--name-only', auto_diff]).decode('utf-8').rstrip('\n').split('\n'))
   if parm_key == 'apis':
     custom_triggers = {
-      # Ones set to None are ignored.
+      # Special handling for several top-level directories.
+      # Any top-level directories set to None are completely ignored.
       "external": None,
       "release_build_files": None,
-      # Ones set to a list of APIs will trigger those APIs.
+      # Top-level directories listed below trigger additional APIs being tested.
+      # For example, if auth is touched by a PR, we also need to test functions,
+      # database, firestore, and storage.
       "auth": "auth,functions,database,firestore,storage",
     }
     requested_api_list = set(value.split(','))

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -249,7 +249,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
         matched = True
       if "Desktop" in requested_platform_list and (
           re.search(r'desktop', path)):
-        filtered_platform_list.add("iOS")
+        filtered_platform_list.add("Desktop")
         matched = True
       if not matched:
         # If the file didn't match any of these, trigger all requested platforms.

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -191,7 +191,6 @@ def filter_values_on_diff(parm_key, value, auto_diff):
   Remove entries from the list based on what we observe in the
   source tree, relative to the given base branch."""
   file_list = set(subprocess.check_output(['git', 'diff', '--name-only', auto_diff]).decode('utf-8').rstrip('\n').split('\n'))
-
   if parm_key == 'apis':
     custom_triggers = {
       # Ones set to None are ignored.
@@ -204,6 +203,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
     filtered_api_list = set()
 
     for path in file_list:
+      if len(path) == 0: continue
       topdir = path.split(os.path.sep)[0]
       if topdir in custom_triggers:
         if not custom_triggers[topdir]: continue  # Skip ones set to None.
@@ -228,6 +228,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
     requested_platform_list = set(value)
     filtered_platform_list = set()
     for path in file_list:
+      if len(path) == 0: continue
       matched = False
       if (re.search(r'^external/', path) or
           re.search(r'^release_build_files/', path) or

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -59,6 +59,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 
 # Note that desktop is used for fallback,
 # if there is no direct match for a key.

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -216,7 +216,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
         # Abort this whole process and just return the original api list.
         sys.stderr.write("Defaulting to all APIs: %s\n" % value)
         return value
-    sys.stderr.write("Automatically selected APIs: %s\n" % ','.join(sorted(filtered_api_list)))
+    sys.stderr.write("::warning::Autodetected APIs: %s\n" % ','.join(sorted(filtered_api_list)))
     return ','.join(sorted(filtered_api_list))
   elif parm_key == 'platform':
     # Quick and dirty check:
@@ -255,7 +255,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
         # If the file didn't match any of these, trigger all requested platforms.
         sys.stderr.write("Defaulting to all platforms: %s\n" % ','.join(sorted(requested_platform_list)))
         return sorted(requested_platform_list)
-    sys.stderr.write("Automatically selected platforms: %s\n" % ','.join(sorted(filtered_platform_list)))
+    sys.stderr.write("::warning::Autodetected platforms: %s\n" % ','.join(sorted(filtered_platform_list)))
     return sorted(filtered_platform_list)
   else:
     return value


### PR DESCRIPTION
This PR adds some label-based triggers for integration tests, which allow the integration tests to be requested on a PR by setting the "tests-requested" label.

There are two modes for requesting tests, "quick" and "full":

"quick" tries to be clever and figure out a subset of APIs (and even platforms) to test. This heuristic is really simple right now (it just looks at directory names and, for platform, filenames) and if there is *any* ambiguity it will just run the normal suite of tests.

"full" just runs all the tests. Currently this is set to use an expanded test matrix, though this could be changed in the future.

The test workflow handles updating the labels and posting/updating a comment with the status of the integration tests as they run. All of the jobs that mess with labels and comments are skipped if the workflow wasn't run from the PR label.

(See #337—which won't be merged—for an example of "quick" mode in action, autodetecting to just run a subset of tests.)