### PR TITLE
Improve integration test results reporting.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -472,6 +472,15 @@ jobs:
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
       - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install python deps
+        run: |
+          python scripts/gha/install_prereqs_desktop.py
+
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -525,6 +534,15 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@v2
+      - name: Setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+
+      - name: Install python deps
+        run: |
+          python scripts/gha/install_prereqs_desktop.py
+
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -396,6 +396,7 @@ jobs:
         shell: bash
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         run: |
+          ls -lR test_results
           mv test_results/test-results-*/test-results-*.txt test_results || true
           echo -n "::set-output name=table::"
           python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -397,7 +397,6 @@ jobs:
         shell: bash
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         run: |
-        run: |
           mv test_results/test-results-*/test-results-*.txt test_results || true
           echo 'SUMMARY_TABLE<<EOF' >> $GITHUB_ENV
           python scripts/gha/summarize_test_results.py --dir test_results --markdown >> $GITHUB_ENV

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -362,7 +362,7 @@ jobs:
 
       - name: upload results summary artifact
         uses: actions/upload-artifact@v2.2.2
-        if: !cancelled()
+        if: ${{ !cancelled() }}
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
           path: ta/summary.log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -359,15 +359,16 @@ jobs:
         if: matrix.target_platform != 'Desktop' && !cancelled()
         run: |
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir ta --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
+      - name: Prepare results summary artifact
+        if: !cancelled()
+        run: |
           cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
-
-      - name: upload results summary artifact
+      - name: Upload results summary artifact
         uses: actions/upload-artifact@v2.2.2
         if: ${{ !cancelled() }}
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
           path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
-
       ### The below allow us to set the failure label and comment early, when the first failure
       ### in the matrix occurs. It'll be cleaned up in a subsequent job.
       - name: add failure label
@@ -470,6 +471,7 @@ jobs:
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
+      - uses: actions/checkout@v2
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -518,10 +520,11 @@ jobs:
 
   summarize_results:
     name: "summarize results"
-    needs: [tests]
+    needs: [add_failure_label, tests]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
+      - uses: actions/checkout@v2
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -359,13 +359,14 @@ jobs:
         if: matrix.target_platform != 'Desktop' && !cancelled()
         run: |
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir ta --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
+          cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
 
       - name: upload results summary artifact
         uses: actions/upload-artifact@v2.2.2
         if: ${{ !cancelled() }}
         with:
-          name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
-          path: ta/summary.log
+          name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
+          path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
 
       ### The below allow us to set the failure label and comment early, when the first failure
       ### in the matrix occurs. It'll be cleaned up in a subsequent job.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -220,8 +220,6 @@ jobs:
             ssl_variant: boringssl
           - target_platform: Android
             ssl_variant: boringssl
-          - os: windows-latest
-            target_platform: Android
 
     steps:
       - uses: actions/checkout@v2
@@ -364,6 +362,7 @@ jobs:
 
       - name: upload results summary artifact
         uses: actions/upload-artifact@v2.2.2
+        if: !cancelled()
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
           path: ta/summary.log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -538,11 +538,9 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: '3.7'
-
       - name: Install python deps
         run: |
           python scripts/gha/install_prereqs_desktop.py
-
       - name: download artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -551,3 +549,10 @@ jobs:
         run: |
           mv test_results/test-results-*/test-results-*.txt test_results || true
           python scripts/gha/summarize_test_results.py --dir test_results --github_log
+      - uses: geekyeggo/delete-artifact@1-glob-support
+        # Delete all of the test result artifacts.
+        with:
+          name: |
+            test-results-*
+          failOnError: false
+          useGlob: true

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -360,7 +360,7 @@ jobs:
         run: |
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir ta --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Prepare results summary artifact
-        if: !cancelled()
+        if: ${{ !cancelled() }}
         run: |
           cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
       - name: Upload results summary artifact

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -397,11 +397,11 @@ jobs:
         shell: bash
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         run: |
-          ls -lR test_results
+        run: |
           mv test_results/test-results-*/test-results-*.txt test_results || true
-          echo -n "::set-output name=table::"
-          python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
-
+          echo 'SUMMARY_TABLE<<EOF' >> $GITHUB_ENV
+          python scripts/gha/summarize_test_results.py --dir test_results --markdown >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
@@ -411,7 +411,7 @@ jobs:
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-            ${{ steps.get-summary.outputs.table }}
+            ${{ env.SUMMARY_TABLE }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 
@@ -478,12 +478,12 @@ jobs:
           # will download all artifacts. Sadly this is what we must do.
           path: test_results
       - name: get summary of test results
-        id: get-summary
         shell: bash
         run: |
           mv test_results/test-results-*/test-results-*.txt test_results || true
-          echo -n "::set-output name=table::"
-          python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
+          echo 'SUMMARY_TABLE<<EOF' >> $GITHUB_ENV
+          python scripts/gha/summarize_test_results.py --dir test_results --markdown >> $GITHUB_ENV
+          echo 'EOF' >> $GITHUB_ENV
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
@@ -492,7 +492,7 @@ jobs:
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
-            ${{ steps.get-summary.outputs.table }}
+            ${{ env.SUMMARY_TABLE }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -516,3 +516,17 @@ jobs:
           label: "${{ env.statusLabelInProgress }}"
           type: remove
 
+  summarize_results:
+    name: "summarize results"
+    needs: [tests]
+    runs-on: ubuntu-latest
+    if: ${{ !cancelled() }}
+    steps:
+      - name: download artifact
+        uses: actions/download-artifact@v2.0.8
+        with:
+          path: test_results
+      - name: Summarize results into GitHub log.
+        run: |
+          mv test_results/test-results-*/test-results-*.txt test_results || true
+          python scripts/gha/summarize_test_results.py --dir test_results --github_log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,6 +99,7 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
+        echo '${{ toJson(jobs[github.job]) }}'
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       uses: buildsville/add-remove-label@v1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,6 +99,7 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
+        echo ${{ toJson(github) }}          
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       uses: buildsville/add-remove-label@v1
@@ -366,7 +367,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
-          path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+          path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}-.txt
 
       ### The below allow us to set the failure label and comment early, when the first failure
       ### in the matrix occurs. It'll be cleaned up in a subsequent job.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -362,6 +362,12 @@ jobs:
         run: |
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir ta --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
 
+      - name: upload results summary artifact
+        uses: actions/upload-artifact@v2.2.2
+        with:
+          name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+          path: ta/summary.log
+
       ### The below allow us to set the failure label and comment early, when the first failure
       ### in the matrix occurs. It'll be cleaned up in a subsequent job.
       - name: add failure label
@@ -379,6 +385,22 @@ jobs:
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
+      - name: download artifact
+        uses: actions/download-artifact@v2.0.8
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        with:
+          # download-artifact doesn't support wildcards, but by default
+          # will download all artifacts. Sadly this is what we must do.
+          path: test_results
+      - name: get summary of test results
+        id: get-summary
+        shell: bash
+        if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
+        run: |
+          mv test_results/test-results-*/test-results-*.txt test_results
+          echo -n "::set-output name=table::"
+          python scripts/gha/summarize_test_results.py -d test_results --singleline
+
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
@@ -388,6 +410,7 @@ jobs:
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            ${{ steps.get-summary.outputs.table }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 
@@ -447,6 +470,19 @@ jobs:
         run: |
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
+      - name: download artifact
+        uses: actions/download-artifact@v2.0.8
+        with:
+          # download-artifact doesn't support wildcards, but by default
+          # will download all artifacts. Sadly this is what we must do.
+          path: test_results
+      - name: get summary of test results
+        id: get-summary
+        shell: bash
+        run: |
+          mv test_results/test-results-*/test-results-*.txt test_results
+          echo -n "::set-output name=table::"
+          python scripts/gha/summarize_test_results.py -d test_results --singleline
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:
@@ -455,6 +491,7 @@ jobs:
             Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
+            ${{ steps.get-summary.outputs.table }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -398,7 +398,7 @@ jobs:
         run: |
           mv test_results/test-results-*/test-results-*.txt test_results
           echo -n "::set-output name=table::"
-          python scripts/gha/summarize_test_results.py -d test_results --singleline
+          python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
 
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
@@ -481,7 +481,7 @@ jobs:
         run: |
           mv test_results/test-results-*/test-results-*.txt test_results
           echo -n "::set-output name=table::"
-          python scripts/gha/summarize_test_results.py -d test_results --singleline
+          python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
       - name: add failure status comment
         uses: phulsechinmay/rewritable-pr-comment@v0.2.1
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,7 +99,6 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
-        echo '${{ toJson(job) }}'
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       uses: buildsville/add-remove-label@v1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,7 +99,7 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
-        echo '${{ toJson(jobs[github.job]) }}'
+        echo '${{ toJson(job) }}'
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       uses: buildsville/add-remove-label@v1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -99,7 +99,6 @@ jobs:
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
         fi
-        echo ${{ toJson(github) }}          
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
       uses: buildsville/add-remove-label@v1

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -480,7 +480,7 @@ jobs:
         id: get-summary
         shell: bash
         run: |
-          mv test_results/test-results-*/test-results-*.txt test_results
+          mv test_results/test-results-*/test-results-*.txt test_results || true
           echo -n "::set-output name=table::"
           python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
       - name: add failure status comment

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -519,8 +519,8 @@ jobs:
           type: remove
 
   summarize_results:
-    name: "summarize results"
-    needs: [add_failure_label, tests]
+    name: "summarize-results"
+    needs: [add_failure_label, add_success_label, remove_in_progress_label, tests]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
@@ -529,7 +529,7 @@ jobs:
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
-      - name: Summarize results into GitHub log.
+      - name: Summarize results into GitHub log
         run: |
           mv test_results/test-results-*/test-results-*.txt test_results || true
           python scripts/gha/summarize_test_results.py --dir test_results --github_log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -366,7 +366,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
-          path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}-.txt
+          path: test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
 
       ### The below allow us to set the failure label and comment early, when the first failure
       ### in the matrix occurs. It'll be cleaned up in a subsequent job.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -396,7 +396,7 @@ jobs:
         shell: bash
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         run: |
-          mv test_results/test-results-*/test-results-*.txt test_results
+          mv test_results/test-results-*/test-results-*.txt test_results || true
           echo -n "::set-output name=table::"
           python scripts/gha/summarize_test_results.py --dir test_results --singleline --markdown
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -220,6 +220,8 @@ jobs:
             ssl_variant: boringssl
           - target_platform: Android
             ssl_variant: boringssl
+          - os: windows-latest
+            target_platform: Android
 
     steps:
       - uses: actions/checkout@v2

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -220,6 +220,7 @@ def main(argv):
       output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))
 
   if FLAGS.github_log:
+    # "%0A" produces a newline in GitHub workflow logs.
     print("::error ::%s%%0A%s%%0A%%0A%s" % (LOG_HEADER, "-".ljust(len(LOG_HEADER), "-"), "%0A".join(output_lines)))
   else:
     print("\n".join(output_lines))

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -153,6 +153,7 @@ def main(argv):
     # Certain spaces are replaced with HTML non-breaking spaces, to prevent
     # aggressive word-wrapping from messing up the formatting.
     space_char = "&nbsp;"
+    list_seperator = "<br/>"
   else:
     # For text formatting, see how wide the strings are so we can
     # justify the text table.
@@ -160,8 +161,9 @@ def main(argv):
     max_build_failures = len(BUILD_FAILURES_HEADER)
     max_test_failures = len(TEST_FAILURES_HEADER)
     for (platform, results) in log_results.items():
-      build_failures = ", ".join(sorted(log_results[platform]["build_failures"]))
-      test_failures = ", ".join(sorted(log_results[platform]["test_failures"]))
+      list_seperator = ", "
+      build_failures = list_seperator.join(sorted(log_results[platform]["build_failures"]))
+      test_failures = list_seperator.join(sorted(log_results[platform]["test_failures"]))
       max_platform = max(max_platform, len(platform))
       max_build_failures = max(max_build_failures, len(build_failures))
       max_test_failures = max(max_test_failures, len(test_failures))
@@ -181,8 +183,8 @@ def main(argv):
   for platform in sorted(log_results.keys()):
     if log_results[platform]["build_failures"] or log_results[platform]["test_failures"]:
       platform_str = re.sub(r'\b \b', space_char, platform.ljust(max_platform))
-      build_failures = ", ".join(sorted(log_results[platform]["build_failures"])).ljust(max_build_failures)
-      test_failures = ", ".join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
+      build_failures = list_seperator.join(sorted(log_results[platform]["build_failures"])).ljust(max_build_failures)
+      test_failures = list_seperator.join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
       if FLAGS.markdown:
         # If there are more than N failures, collapse the results.
         if FLAGS.list_max and len(log_results[platform]["build_failures"]) > FLAGS.list_max:
@@ -191,9 +193,6 @@ def main(argv):
         if FLAGS.list_max and len(log_results[platform]["test_failures"]) > FLAGS.list_max:
           test_failures = "<details><summary>_(%s items)_</summary>%s</details>" % (
             len(log_results[platform]["test_failures"]), test_failures)
-      else:
-        build_failures = ", ".join(sorted(log_results[platform]["build_failures"])).ljust(max_build_failures)
-        test_failures = ", ".join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
       output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))
 
   print("\n".join(output_lines))

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -52,6 +52,10 @@ flags.DEFINE_bool(
     "markdown", False,
     "Display a Markdown-formatted table.")
 
+flags.DEFINE_bool(
+    "github_log", False,
+    "Display a GitHub log formatted table.")
+
 flags.DEFINE_integer(
     "list_max", 5,
     "In Markdown mode, collapse lists larger than this size. 0 to disable.")
@@ -70,6 +74,8 @@ CAPITALIZATIONS = {
 PLATFORM_HEADER = "Platform"
 BUILD_FAILURES_HEADER = "Build failures"
 TEST_FAILURES_HEADER = "Test failures"
+
+LOG_HEADER = "INTEGRATION TEST FAILURES"
 
 def main(argv):
   if len(argv) > 1:
@@ -213,7 +219,10 @@ def main(argv):
             len(log_results[platform]["test_failures"]), test_failures)
       output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))
 
-  print("\n".join(output_lines))
+  if FLAGS.github_log:
+    print("::error ::%s%%0A%s%%0A%%0A%s" % (LOG_HEADER, "-".ljust(len(LOG_HEADER), "-"), "%0A".join(output_lines)))
+  else:
+    print("\n".join(output_lines))
 
 if __name__ == "__main__":
   flags.mark_flag_as_required("dir")

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -113,7 +113,7 @@ def main(argv):
       if m:
         log_results[platform]["attempted"].update(m.group(1).split(","))
       # Extract build failure lines, which follow "SOME FAILURES OCCURRED:"
-      m = re.search(r'SOME FAILURES OCCURRED:\n(([\d+]:[^\n]*\n)+)', log_text, re.MULTILINE)
+      m = re.search(r'SOME FAILURES OCCURRED:\n(([\d]+:[^\n]*\n)+)', log_text, re.MULTILINE)
       if m:
         for build_failure_line in m.group(1).strip("\n").split("\n"):
           m2 = re.match(r'[\d]+: ([^,]+)', build_failure_line)

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -58,12 +58,13 @@ flags.DEFINE_integer(
 
 CAPITALIZATIONS = {
     "macos": "MacOS",
-    "ubuntu": "Ubuntu",
+    "ubuntu": "Linux",
     "windows": "Windows",
     "openssl": "(OpenSSL)",
     "boringssl": "(BoringSSL)",
     "ios": "iOS",
     "android": "Android",
+    "desktop": "Desktop",
 }
 
 PLATFORM_HEADER = "Platform"
@@ -90,17 +91,26 @@ def main(argv):
       # Split the matrix name into components.
       log_name = re.sub(r'[-_.]+', ' ', log_name).split()
       # Remove redundant components.
+      if "latest" in log_name: log_name.remove("latest")
       if "Android" in log_name or "iOS" in log_name:
           log_name.remove('openssl')
-      log_name.remove('latest')
       # Capitalize components in a nice way.
       log_name = [
           CAPITALIZATIONS[name.lower()]
           if name.lower() in CAPITALIZATIONS
           else name
           for name in log_name]
+      if FLAGS.markdown:
+        if "Android" in log_name or "iOS" in log_name:
+          # For Android and iOS, highlight the target OS.
+            log_name[0] = "(built on %s)" % log_name[0]
+            log_name[1] = "**%s**" % log_name[1]
+        else:
+          # For desktop, highlight the entire platform string.
+          log_name[0] = "%s**" % log_name[0]
+          log_name[1] = "**%s" % log_name[1]
       # Rejoin matrix name with spaces.
-      log_name = ' '.join(log_name)
+      log_name = ' '.join([log_name[1], log_name[0]]+log_name[2:])
       with open(log_file, "r") as log_reader:
           log_data[log_name] = log_reader.read()
 

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -141,9 +141,9 @@ def main(argv):
               any_failures = True
 
       # Extract test failures, which follow "TESTAPPS EXPERIENCED ERRORS:"
-      m = re.search(r'TESTAPPS EXPERIENCED ERRORS:\n(([^\n]*\n)+)', log_text, re.MULTILINE)
+      m = re.search(r'TESTAPPS (EXPERIENCED ERRORS|FAILED):\n(([^\n]*\n)+)', log_text, re.MULTILINE)
       if m:
-        for test_failure_line in m.group(1).strip("\n").split("\n"):
+        for test_failure_line in m.group(2).strip("\n").split("\n"):
           # Only get the lines showing paths.
           if "/firebase-cpp-sdk/" not in test_failure_line: continue
           test_filename = "";
@@ -151,6 +151,11 @@ def main(argv):
             test_filename = re.match(r'^(.*) log tail', test_failure_line).group(1)
           if "lacks logs" in test_failure_line:
             test_filename = re.match(r'^(.*) lacks logs', test_failure_line).group(1)
+          if "it-debug.apk" in test_failure_line:
+            test_filename = re.match(r'^(.*it-debug\.apk)', test_failure_line).group(1)
+          if "integration_test.ipa" in test_failure_line:
+            test_filename = re.match(r'^(.*integration_test\.ipa)', test_failure_line).group(1)
+
           if test_filename:
             m2 = re.search(r'/ta/(firebase)?([^/]+)/iti?/', test_filename, re.IGNORECASE)
             if not m2: m2 = re.search(r'/testapps/(firebase)?([^/]+)/integration_test', test_filename, re.IGNORECASE)

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -226,7 +226,8 @@ def main(argv):
 
   if FLAGS.github_log:
     # "%0A" produces a newline in GitHub workflow logs.
-    print("::error ::%s%%0A%s%%0A%%0A%s" % (LOG_HEADER, "-".ljust(len(LOG_HEADER), "-"), "%0A".join(output_lines)))
+    output_lines = [output_lines[1]] + output_lines + [output_lines[1]]
+    print("::error ::%s%%0A%%0A%s" % (LOG_HEADER, "%0A".join(output_lines).replace(" ", "&nbsp;")))
   else:
     print("\n".join(output_lines))
 

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -100,15 +100,15 @@ def main(argv):
           if name.lower() in CAPITALIZATIONS
           else name
           for name in log_name]
-      if FLAGS.markdown:
-        if "Android" in log_name or "iOS" in log_name:
-          # For Android and iOS, highlight the target OS.
-            log_name[0] = "(built on %s)" % log_name[0]
-            log_name[1] = "**%s**" % log_name[1]
-        else:
-          # For desktop, highlight the entire platform string.
-          log_name[0] = "%s**" % log_name[0]
-          log_name[1] = "**%s" % log_name[1]
+      if "Android" in log_name or "iOS" in log_name:
+        # For Android and iOS, highlight the target OS.
+        log_name[0] = "(built on %s)" % log_name[0]
+        if FLAGS.markdown:
+          log_name[1] = "**%s**" % log_name[1]
+      elif FLAGS.markdown:
+        # For desktop, highlight the entire platform string.
+        log_name[0] = "%s**" % log_name[0]
+        log_name[1] = "**%s" % log_name[1]
       # Rejoin matrix name with spaces.
       log_name = ' '.join([log_name[1], log_name[0]]+log_name[2:])
       with open(log_file, "r") as log_reader:

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -1,0 +1,169 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Summarize integration test results.
+
+USAGE:
+
+python summarize_test_results.py -d <directory>
+
+Example output:
+
+| Platform                | Build failures | Test failures   |
+| ----------------------- | -------------- | --------------- |
+| MacOS iOS               |                | auth, firestore |
+| Windows Desktop OpenSSL | analytics      | database        |
+"""
+
+from absl import app
+from absl import flags
+from absl import logging
+import glob
+import re
+import os
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_string(
+    "dir", None,
+    "Directory containing test results.",
+    short_name="d")
+
+flags.DEFINE_string(
+    "pattern", "test-results-*.txt",
+    "File pattern (glob) for test results.")
+
+flags.DEFINE_bool(
+    "full", False,
+    "Print a full table, including successful tests.")
+
+flags.DEFINE_bool(
+    "singleline", False,
+    "Output a single line, with \n for newlines.")
+
+CAPITALIZATIONS = {
+    "macos": "MacOS",
+    "ubuntu": "Ubuntu",
+    "windows": "Windows",
+    "openssl": "OpenSSL",
+    "boringssl": "BoringSSL",
+    "ios": "iOS",
+    "android": "Android",
+}
+
+PLATFORM_HEADER = "Platform"
+BUILD_FAILURES_HEADER = "Build failures"
+TEST_FAILURES_HEADER = "Test failures"
+
+def main(argv):
+  if len(argv) > 1:
+      raise app.UsageError("Too many command-line arguments.")
+
+  log_files = glob.glob(os.path.join(FLAGS.dir, FLAGS.pattern))
+
+  # Replace the "*" in the file glob with a regex capture group,
+  # so we can report the test name.
+  log_name_re = re.escape(
+      os.path.join(FLAGS.dir,FLAGS.pattern)).replace("\\*", "(.*)")
+
+  log_data = {}
+
+  for log_file in log_files:
+      # Extract the matrix name for this log.
+      log_name = re.search(log_name_re, log_file).groups(1)[0]
+      # Split the matrix name into components.
+      log_name = re.sub(r'[-_.]+', ' ', log_name).split()
+      # Remove redundant components.
+      if "Android" in log_name or "iOS" in log_name:
+          log_name.remove('openssl')
+      log_name.remove('latest')
+      # Capitalize components in a nice way.
+      log_name = [
+          CAPITALIZATIONS[name.lower()]
+          if name.lower() in CAPITALIZATIONS
+          else name.capitalize()
+          for name in log_name]
+      # Rejoin matrix name with spaces.
+      log_name = ' '.join(log_name)
+      with open(log_file, "r") as log_reader:
+          log_data[log_name] = log_reader.read()
+
+  log_results = {}
+  # Go through each log and extract out the build and test failures.
+  for (platform, log_text) in log_data.items():
+      log_results[platform] = { "build_failures": set(), "test_failures": set() }
+      # Extract build failure lines, which follow "SOME FAILURES OCCURRED:"
+      m = re.search(r'SOME FAILURES OCCURRED:\n(([\d+]:[^\n]*\n)+)', log_text, re.MULTILINE)
+      if m:
+        for build_failure_line in m.group(1).strip("\n").split("\n"):
+          m2 = re.match(r'[\d]+: ([^,]+)', build_failure_line)
+          if m2:
+            product_name = m2.group(1).lower()
+            if product_name:
+              log_results[platform]["build_failures"].add(product_name)
+      # Extract test failures, which follow "TESTAPPS EXPERIENCED ERRORS:"
+      m = re.search(r'TESTAPPS EXPERIENCED ERRORS:\n(([^\n]*\n)+)', log_text, re.MULTILINE)
+      if m:
+        for test_failure_line in m.group(1).strip("\n").split("\n"):
+          # Only get the lines showing paths.
+          if "/firebase-cpp-sdk/" not in test_failure_line: continue
+          test_filename = "";
+          if "log tail" in test_failure_line:
+            test_filename = re.match(r'^(.*) log tail', test_failure_line).group(1)
+          if "lacks logs" in test_failure_line:
+            test_filename = re.match(r'^(.*) lacks logs', test_failure_line).group(1)
+          if test_filename:
+            m2 = re.search(r'/ta/(firebase)?([^/]+)/iti?/', test_filename, re.IGNORECASE)
+            if not m2: m2 = re.search(r'/testapps/(firebase)?([^/]+)/integration_test', test_filename, re.IGNORECASE)
+            if m2:
+              product_name = m2.group(2).lower()
+              if product_name:
+                log_results[platform]["test_failures"].add(product_name)
+          
+
+  
+  # For text formatting, see how wide the strings are.
+  max_platform = len(PLATFORM_HEADER)
+  max_build_failures = len(BUILD_FAILURES_HEADER)
+  max_test_failures = len(TEST_FAILURES_HEADER)
+  for (platform, results) in log_results.items():
+    build_failures = ", ".join(sorted(log_results[platform]["build_failures"]))
+    test_failures = ", ".join(sorted(log_results[platform]["test_failures"]))
+    max_platform = max(max_platform, len(platform))
+    max_build_failures = max(max_build_failures, len(build_failures))
+    max_test_failures = max(max_test_failures, len(test_failures))
+
+  output_lines = list()
+  output_lines.append("| %s | %s | %s |" % (
+    PLATFORM_HEADER.ljust(max_platform),
+    BUILD_FAILURES_HEADER.ljust(max_build_failures),
+    TEST_FAILURES_HEADER.ljust(max_test_failures)))
+  output_lines.append("|-%s-|-%s-|-%s-|" % (
+    "".ljust(max_platform, "-"),
+    "".ljust(max_build_failures, "-"),
+    "".ljust(max_test_failures, "-")))
+
+  for platform in sorted(log_results.keys()):
+    if log_results[platform]["build_failures"] or log_results[platform]["test_failures"]:
+      platform_str = platform.ljust(max_platform)
+      build_failures = ", ".join(sorted(log_results[platform]["build_failures"])).ljust(max_build_failures)
+      test_failures = ", ".join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
+      output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))
+
+  output_delim = "\\n" if FLAGS.singleline else "\n"
+  print(output_delim.join(output_lines))
+
+if __name__ == "__main__":
+  flags.mark_flag_as_required("dir")
+  app.run(main)

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -49,10 +49,6 @@ flags.DEFINE_bool(
     "Print a full table, including successful tests.")
 
 flags.DEFINE_bool(
-    "singleline", False,
-    "Output a single line, with \n for newlines.")
-
-flags.DEFINE_bool(
     "markdown", False,
     "Display a Markdown-formatted table.")
 
@@ -200,8 +196,7 @@ def main(argv):
         test_failures = ", ".join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
       output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))
 
-  output_delim = "\\n" if FLAGS.singleline else "\n"
-  print(output_delim.join(output_lines))
+  print("\n".join(output_lines))
 
 if __name__ == "__main__":
   flags.mark_flag_as_required("dir")

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -52,6 +52,10 @@ flags.DEFINE_bool(
     "singleline", False,
     "Output a single line, with \n for newlines.")
 
+flags.DEFINE_bool(
+    "markdown", False,
+    "Display a Markdown-formatted table.")
+
 CAPITALIZATIONS = {
     "macos": "MacOS",
     "ubuntu": "Ubuntu",
@@ -92,7 +96,7 @@ def main(argv):
       log_name = [
           CAPITALIZATIONS[name.lower()]
           if name.lower() in CAPITALIZATIONS
-          else name.capitalize()
+          else name
           for name in log_name]
       # Rejoin matrix name with spaces.
       log_name = ' '.join(log_name)
@@ -144,11 +148,12 @@ def main(argv):
     max_build_failures = max(max_build_failures, len(build_failures))
     max_test_failures = max(max_test_failures, len(test_failures))
 
+  space_char = "&nbsp;" if FLAGS.markdown else " ";
   output_lines = list()
   output_lines.append("| %s | %s | %s |" % (
-    PLATFORM_HEADER.ljust(max_platform),
-    BUILD_FAILURES_HEADER.ljust(max_build_failures),
-    TEST_FAILURES_HEADER.ljust(max_test_failures)))
+    re.sub(r'\b \b', space_char, PLATFORM_HEADER.ljust(max_platform)),
+    re.sub(r'\b \b', space_char,BUILD_FAILURES_HEADER.ljust(max_build_failures)),
+    re.sub(r'\b \b', space_char,TEST_FAILURES_HEADER.ljust(max_test_failures))))
   output_lines.append("|-%s-|-%s-|-%s-|" % (
     "".ljust(max_platform, "-"),
     "".ljust(max_build_failures, "-"),
@@ -156,7 +161,7 @@ def main(argv):
 
   for platform in sorted(log_results.keys()):
     if log_results[platform]["build_failures"] or log_results[platform]["test_failures"]:
-      platform_str = platform.ljust(max_platform)
+      platform_str = re.sub(r'\b \b', space_char, platform.ljust(max_platform))
       build_failures = ", ".join(sorted(log_results[platform]["build_failures"])).ljust(max_build_failures)
       test_failures = ", ".join(sorted(log_results[platform]["test_failures"])).ljust(max_test_failures)
       output_lines.append("| %s | %s | %s |" % (platform_str, build_failures, test_failures))


### PR DESCRIPTION
Each test phase now uploads its results summary as a temporary artifact. A new summarize script looks at those artifacts and prints out a table and/or a github log entry at the end of the test run, if any builds or tests failed.