### PR TITLE
Added a new test suite for SyncPoints

### DIFF
--- a/database/src/desktop/core/child_event_registration.cc
+++ b/database/src/desktop/core/child_event_registration.cc
@@ -35,11 +35,6 @@ bool ChildEventRegistration::RespondsTo(EventType event_type) {
 
 Event ChildEventRegistration::GenerateEvent(const Change& change,
                                             const QuerySpec& query_spec) {
-  // return Event(change.event_type, this,
-  //              DataSnapshotInternal(database_,
-  //                                   query_spec.path.GetChild(change.child_key),
-  //                                   change.indexed_variant.variant()),
-  //              change.prev_name);
   return Event(
       change.event_type, this,
       DataSnapshotInternal(database_, change.indexed_variant.variant(),

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -534,25 +534,6 @@ void Repo::PostEvents(const std::vector<Event>& events) {
   }
 }
 
-static std::map<Path, Variant> VariantToPathMap(const Variant& data) {
-  std::map<Path, Variant> path_map;
-  if (data.is_map()) {
-    for (const auto& key_value : data.map()) {
-      Variant key_string_variant;
-      const char* key;
-      if (key_value.first.is_string()) {
-        key = key_value.first.string_value();
-      } else {
-        key_string_variant = key_value.first.AsString();
-        key = key_string_variant.string_value();
-      }
-      const Variant& value = key_value.second;
-      path_map.insert(std::make_pair(Path(key), value));
-    }
-  }
-  return path_map;
-}
-
 void Repo::OnConnect() {
   SAFE_REFERENCE_RETURN_VOID_IF_INVALID(ThisRefLock, lock, safe_this_);
 

--- a/database/src/desktop/core/value_event_registration.cc
+++ b/database/src/desktop/core/value_event_registration.cc
@@ -30,10 +30,6 @@ bool ValueEventRegistration::RespondsTo(EventType event_type) {
 
 Event ValueEventRegistration::GenerateEvent(const Change& change,
                                             const QuerySpec& query_spec) {
-  // return Event(kEventTypeValue, this,
-  //              DataSnapshotInternal(database_,
-  //                                   query_spec.path.GetChild(change.child_key),
-  //                                   change.indexed_variant.variant()));
   return Event(
       kEventTypeValue, this,
       DataSnapshotInternal(database_, change.indexed_variant.variant(),

--- a/database/src/desktop/data_snapshot_desktop.cc
+++ b/database/src/desktop/data_snapshot_desktop.cc
@@ -123,7 +123,7 @@ Variant DataSnapshotInternal::GetValue() const {
   return result;
 }
 
-Variant DataSnapshotInternal::GetPriority() {
+Variant DataSnapshotInternal::GetPriority() const {
   return GetVariantPriority(data_);
 }
 

--- a/database/src/desktop/data_snapshot_desktop.h
+++ b/database/src/desktop/data_snapshot_desktop.h
@@ -81,7 +81,7 @@ class DataSnapshotInternal {
   Variant GetValue() const;
 
   // Get the priority of the data contained in this snapshot.
-  Variant GetPriority();
+  Variant GetPriority() const;
 
   // Obtain a DatabaseReference to the source location for this snapshot.
   //

--- a/database/src/desktop/database_reference_desktop.cc
+++ b/database/src/desktop/database_reference_desktop.cc
@@ -13,15 +13,17 @@
 // limitations under the License.
 
 #include "database/src/desktop/database_reference_desktop.h"
+
 #include <stdio.h>
+
 #include <sstream>
+
 #include "app/rest/util.h"
 #include "app/src/variant_util.h"
 #include "database/src/common/database_reference.h"
 #include "database/src/desktop/database_desktop.h"
 #include "database/src/desktop/disconnection_desktop.h"
 #include "database/src/desktop/util_desktop.h"
-
 #include "flatbuffers/util.h"
 
 namespace firebase {
@@ -37,15 +39,19 @@ const char kVirtualChildKeyPriority[] = ".priority";
 DatabaseReferenceInternal::DatabaseReferenceInternal(DatabaseInternal* database,
                                                      const Path& path)
     : QueryInternal(database, QuerySpec(path)) {
-  database_->future_manager().AllocFutureApi(&future_api_id_,
-                                             kDatabaseReferenceFnCount);
+  if (database_) {
+    database_->future_manager().AllocFutureApi(&future_api_id_,
+                                               kDatabaseReferenceFnCount);
+  }
 }
 
 DatabaseReferenceInternal::DatabaseReferenceInternal(
     const DatabaseReferenceInternal& internal)
     : QueryInternal(internal) {
-  database_->future_manager().AllocFutureApi(&future_api_id_,
-                                             kDatabaseReferenceFnCount);
+  if (database_) {
+    database_->future_manager().AllocFutureApi(&future_api_id_,
+                                               kDatabaseReferenceFnCount);
+  }
 }
 
 DatabaseReferenceInternal& DatabaseReferenceInternal::operator=(
@@ -57,22 +63,26 @@ DatabaseReferenceInternal& DatabaseReferenceInternal::operator=(
 #if defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 DatabaseReferenceInternal::DatabaseReferenceInternal(
     DatabaseReferenceInternal&& internal) {
-  database_->future_manager().MoveFutureApi(&internal.future_api_id_,
-                                            &future_api_id_);
+  if (database_) {
+    database_->future_manager().MoveFutureApi(&internal.future_api_id_,
+                                              &future_api_id_);
+  }
   QueryInternal::operator=(std::move(internal));
 }
 
 DatabaseReferenceInternal& DatabaseReferenceInternal::operator=(
     DatabaseReferenceInternal&& internal) {
-  database_->future_manager().MoveFutureApi(&internal.future_api_id_,
-                                            &future_api_id_);
+  if (database_) {
+    database_->future_manager().MoveFutureApi(&internal.future_api_id_,
+                                              &future_api_id_);
+  }
   QueryInternal::operator=(std::move(internal));
   return *this;
 }
 #endif  // defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 
 Database* DatabaseReferenceInternal::GetDatabase() const {
-  return Database::GetInstance(database_->GetApp());
+  return database_ ? Database::GetInstance(database_->GetApp()) : nullptr;
 }
 
 std::string DatabaseReferenceInternal::GetUrl() const {

--- a/database/src/desktop/persistence/persistence_manager.cc
+++ b/database/src/desktop/persistence/persistence_manager.cc
@@ -206,10 +206,8 @@ void PersistenceManager::DoPruneCheckAfterServerUpdate() {
           tracked_query_manager_->PruneOldQueries(*cache_policy_);
       PruneForestRef prune_forest_ref(&prune_forest);
       if (prune_forest_ref.PrunesAnything()) {
-        std::cout << __LINE__ << std::endl;
         storage_engine_->PruneCache(Path(), prune_forest_ref);
       } else {
-        std::cout << __LINE__ << std::endl;
         can_prune = false;
       }
       cache_size = storage_engine_->ServerCacheEstimatedSizeInBytes();

--- a/database/src/desktop/util_desktop.cc
+++ b/database/src/desktop/util_desktop.cc
@@ -1229,6 +1229,23 @@ std::vector<std::string> split_string(const std::string& s, const char delimiter
   return split_parts;
 }
 
+std::map<Path, Variant> VariantToPathMap(const Variant& data) {
+  std::map<Path, Variant> path_map;
+  if (data.is_map()) {
+    for (const auto& key_value : data.map()) {
+      const char* key;
+      if (key_value.first.is_string()) {
+        key = key_value.first.string_value();
+      } else {
+        key = key_value.first.AsString().string_value();
+      }
+      const Variant& value = key_value.second;
+      path_map.insert(std::make_pair(Path(key), value));
+    }
+  }
+  return path_map;
+}
+
 }  // namespace internal
 }  // namespace database
 }  // namespace firebase

--- a/database/src/desktop/util_desktop.cc
+++ b/database/src/desktop/util_desktop.cc
@@ -990,7 +990,7 @@ const std::string& GetHash(const Variant& data, std::string* output) {
 }
 
 bool IsValidPriority(const Variant& variant) {
-  return variant.is_numeric() || variant.is_string();
+  return variant.is_null() || variant.is_numeric() || variant.is_string();
 }
 
 std::pair<Variant, Variant> MakePost(const QueryParams& params,
@@ -1022,11 +1022,13 @@ std::pair<Variant, Variant> MakePost(const QueryParams& params,
 }
 
 bool HasStart(const QueryParams& params) {
-  return !params.start_at_value.is_null() || !params.equal_to_value.is_null();
+  return !params.start_at_value.is_null() || !params.equal_to_value.is_null() ||
+         GetStartName(params) != QueryParamsComparator::kMinKey;
 }
 
 bool HasEnd(const QueryParams& params) {
-  return !params.end_at_value.is_null() || !params.equal_to_value.is_null();
+  return !params.end_at_value.is_null() || !params.equal_to_value.is_null() ||
+         GetEndName(params) != QueryParamsComparator::kMaxKey;
 }
 
 std::string GetStartName(const QueryParams& params) {

--- a/database/src/desktop/util_desktop.h
+++ b/database/src/desktop/util_desktop.h
@@ -357,6 +357,9 @@ std::string GetAppDataPath(const char* app_name, bool should_create = true);
 // delimiter. Returns of vector of constituent parts
 std::vector<std::string> split_string(const std::string& s,
                                       const char delimiter='/');
+
+std::map<Path, Variant> VariantToPathMap(const Variant& data);
+
 }  // namespace internal
 }  // namespace database
 }  // namespace firebase

--- a/database/tests/CMakeLists.txt
+++ b/database/tests/CMakeLists.txt
@@ -225,6 +225,38 @@ firebase_cpp_cc_test(
     firebase_testing
 )
 
+set(SYNC_POINT_SPEC_SCHEMA "${CMAKE_CURRENT_LIST_DIR}/desktop/core/sync_point_spec.fbs")
+set(SYNC_POINT_SPEC_JSON "${CMAKE_CURRENT_LIST_DIR}/desktop/core/sync_point_spec.json")
+
+flatbuffers_generate_headers(
+  TARGET firebase_sync_point_spec
+  SCHEMAS ${SYNC_POINT_SPEC_SCHEMA}
+  INCLUDE_PREFIX "database/src/desktop/core"
+)
+
+flatbuffers_generate_binary_files(
+  TARGET firebase_sync_point_spec_data
+  SCHEMA ${SYNC_POINT_SPEC_SCHEMA}
+  JSON_FILES ${SYNC_POINT_SPEC_JSON}
+  OUTPUT_DIR "${PROJECT_BINARY_DIR}/database/tests"
+)
+
+firebase_cpp_cc_test(
+  firebase_rtdb_desktop_core_sync_point_spec_test
+  SOURCES
+    desktop/core/sync_point_spec_test.cc
+    desktop/test/mock_listen_provider.h
+    desktop/test/mock_listener.h
+    desktop/test/mock_persistence_manager.h
+    desktop/test/mock_persistence_storage_engine.h
+    desktop/test/mock_tracked_query_manager.h
+    desktop/test/mock_write_tree.h
+  DEPENDS
+    firebase_database
+    firebase_sync_point_spec
+    firebase_sync_point_spec_data
+    firebase_testing
+)
 firebase_cpp_cc_test(
   firebase_rtdb_desktop_core_sync_tree_test
   SOURCES

--- a/database/tests/desktop/core/sync_point_spec.fbs
+++ b/database/tests/desktop/core/sync_point_spec.fbs
@@ -1,0 +1,102 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This schema uses some non-idiomatic style for field names because it's
+// designed to parse an existing JSON file used by the Android and iOS
+// implementations of Realtime Database.
+
+namespace firebase.database.internal.test_data;
+
+// Order of these enum values matters. It must match the order of the EventType
+// enum in `database/src/desktop/view/event_type.h`
+enum EventType : uint8 {
+  child_removed,
+  child_added,
+  child_moved,
+  child_changed,
+  value,
+}
+
+enum StepType : uint8 {
+  ackUserWrite,
+  listen,
+  serverMerge,
+  serverUpdate,
+  set,
+  suppressWarning,
+  unlisten,
+  update,
+}
+
+table Event {
+  path: string;
+  type: EventType;
+  name: string;
+  prevName: string;
+  data: [uint8] (flexbuffer);
+}
+
+table Bound {
+  index: [uint8] (flexbuffer);
+  name: string;
+}
+
+table QueryParams {
+  tag: int32;
+  limitToFirst: int32;
+  limitToLast: int32;
+  orderByKey: bool;
+  orderByPriority: bool;
+  startAt: Bound;
+  endAt: Bound;
+  equalTo: Bound;
+  orderBy: string;
+}
+
+table Step {
+  // A comment that may be printed during the test, describing what the action 
+  // that the current step is performing. 
+  comment: string;
+
+  type: StepType;
+  path: string;
+  tag: int64;
+  params: QueryParams;
+  data: [uint8] (flexbuffer);
+  events: [Event];
+
+  visible: bool = true;
+  callbackId: int32;
+  writeId: int32;
+  revert: bool;
+}
+
+table TestCase {
+  // A comment that may be printed during the test, describing what the what is
+  // being tested.
+  comment: string;
+
+  // The name of the test.
+  name: string;
+
+  // The series of steps in this test, including what actions to take and what
+  // events are expected to be raised at each step.
+  steps: [Step];
+}
+
+table TestSuite {
+  test_cases: [TestCase];
+}
+
+root_type TestSuite;

--- a/database/tests/desktop/core/sync_point_spec.json
+++ b/database/tests/desktop/core/sync_point_spec.json
@@ -1,0 +1,8205 @@
+{
+  "test_cases": [
+    {
+      "name": "Default listen handles a parent set",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Now do a set at the parent. Expect only the 'a' child to get events",
+          "type": "set",
+          "path": "",
+          "data": {
+            "a": 1,
+            "b": 2
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": 1
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Default listen handles a set at the same level",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Do a set at the same level. Expect the full value to raise events",
+          "type": "set",
+          "path": "a",
+          "data": {
+            "foo": "bar",
+            "yes": true
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "yes",
+              "prevName": "foo",
+              "data": true
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "foo": "bar",
+                "yes": true
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "A query can get a complete cache then a merge",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 3,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "a",
+          "data": {
+            "a": 1,
+            "b": 2,
+            "d": 4
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "b",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "a": 1,
+                "b": 2,
+                "d": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "tag": 1,
+          "path": "a",
+          "data": {
+            "a": 5,
+            "c": 3
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "d",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "a",
+              "prevName": null,
+              "data": 5
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "a": 5,
+                "b": 2,
+                "c": 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server merge on listener with complete children",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 1,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "a/b",
+          "data": {"c": 3, "d": 4},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": 3, "d": 4}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": 3, "d": 4}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Empty set doesn't prevent server updates",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo" : "bar"
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "empty-path",
+          "data": null,
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": { "foo": "new-bar" },
+          "events": [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "foo",
+              "prevName": null,
+              "data": "new-bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo" : "new-bar"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Deep merge on listener with complete children",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "a/x/y/z",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/x/y/z",
+          "data": null,
+          "events": [
+            {
+              "path": "a/x/y/z",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "a/x/y/z",
+          "data": {"c": 3, "d": 4},
+          "comment": "No events for the top-level listener, since it's not a complete child",
+          "events": [
+            {
+              "path": "a/x/y/z",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a/x/y/z",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a/x/y/z",
+              "type": "value",
+              "data": {"c": 3, "d": 4}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update child listener twice",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 1,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b/c",
+          "data": "foo",
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": "foo"
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": "foo"}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": "foo"}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update child of default listen that already has a complete cache",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Fill the listen's cache so we can test a child set with an existing cache",
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {
+            "b": 2,
+            "c": 3
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": 2,
+                "c": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Now do a set at a child, expect the child event and a value event",
+          "type": "set",
+          "path": "a/b",
+          "data": 4,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": 4,
+                "c": 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update child of default listen that has no cache",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Now do a set at a child, expect the child event only",
+          "type": "set",
+          "path": "a/b",
+          "data": 4,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 4
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update (via set) the child of a co-located default listener and query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "startAt": {"index": null, "name": "b"},
+            "endAt": {"index": null, "name": "g"}
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Fill the cache. Since the default listener is there, no tag needed",
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {
+            "a": 1,
+            "c": 3,
+            "d": 4
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "a",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "c": 3, "d": 4}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"c": 3, "d": 4}
+            }
+          ]
+        },
+        {
+          "comment": "Cache is primed. Now do the child set",
+          "type": "set",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "b":2, "c": 3, "d": 4}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b":2, "c": 3, "d": 4}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update (via set) the child of a query with a full cache",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "startAt": {"index": null, "name": "b"},
+            "endAt": {"index": null, "name": "g"}
+          },
+          "events": []
+        },
+        {
+          "comment": "Fill the cache first",
+          "type": "serverUpdate",
+          "path": "a",
+          "tag": 1,
+          "data": {
+            "c": 3,
+            "d": 4
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"c": 3, "d": 4}
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2, "c": 3, "d": 4}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update (via set) a child below an empty query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "startAt": {"name": "b", "index": null},
+            "endAt": {"name": "g", "index": null}
+          },
+          "events": []
+        },
+        {
+          "comment": "Set a single child, outside the window",
+          "type": "set",
+          "path": "a/h",
+          "data": 8,
+          "events": []
+        },
+        {
+          "comment": "Now set a single child inside the window",
+          "type": "set",
+          "path": "a/e",
+          "data": 5,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "e",
+              "prevName": null,
+              "data": 5
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update descendant of default listener with full cache",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Fill the cache",
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {
+            "b": {
+              "d": 4
+            },
+            "e": 5
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "d": 4
+              }
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "e",
+              "prevName": "b",
+              "data": 5
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": {
+                  "d": 4
+                },
+                "e": 5
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Now do a set at a/b/c, expect child event + new value event",
+          "type": "set",
+          "path": "a/b/c",
+          "data": 3,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "c": 3,
+                "d": 4
+              }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": {
+                  "c": 3,
+                  "d": 4
+                },
+                "e": 5
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Descendant set below an empty default listener is ignored",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Now do a set at a/b/c, expect no events",
+          "type": "set",
+          "path": "a/b/c",
+          "data": 3,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Update of a child. This can happen if a child listener is added and removed",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert set with only child caches",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 3,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 3
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Can revert a duplicate child set",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 3,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 3
+            }
+          ]
+        },
+        {
+          "comment": "This set duplicates the data in the previous one, so no events expected",
+          "type": "set",
+          "path": "a/b",
+          "data": 3,
+          "events": []
+        },
+        {
+          "comment": "Clearing the second set should have no effect, as the underlying set still exists",
+          "type": "ackUserWrite",
+          "writeId": 1,
+          "revert": true,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Can revert a child set and see the underlying data",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 3,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 3
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 4,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 4
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 3,
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 4
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": []
+        },
+        {
+          "comment": "Clearing the second set should make the underlying set visible again, as it is now confirmed",
+          "type": "ackUserWrite",
+          "writeId": 1,
+          "revert": true,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 3
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert child set with no server data",
+      "steps": [
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": {"d": 4, "e": 5},
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {"d": 4, "e": 5}
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/c",
+          "data": {"z": 26},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": {"z": 26}
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "b",
+              "data": {"d": 4, "e": 5}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert deep set with no server data",
+      "steps": [
+        {
+          "type": "set",
+          "path": "a/b/c",
+          "data": {"d": 4, "e": 5},
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "a/x/y",
+          "data": {"z": 26},
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Revert set covered by non-visible transaction",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "comment": "Initial server value is X.",
+          "type": "serverUpdate",
+          "path": "",
+          "data": "X",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "X"
+            }
+          ]
+        },
+        {
+          "comment": "Set to Y.",
+          "type": "set",
+          "path": "",
+          "data": "Y",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "Y"
+            }
+          ]
+        },
+        {
+          "comment": "Overwrite with a non-visible 'transaction'.",
+          "type": "set",
+          "path": "",
+          "data": "Z",
+          "visible": false,
+          "events": []
+        },
+        {
+          "comment": "Revert set to Y (e.g. security failed), so we should see it go back to Y.",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "X"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Clear parent shadowing server values set with server children",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a",
+          "data": {"b": 28, "c": 3},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 28
+            }
+          ]
+        },
+        {
+          "comment": "This listen should get a complete event snap, as well as complete server children",
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 28
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 28, "c": 3}
+            }
+          ]
+        },
+        {
+          "comment": "Do a serverUpdate with a conflicting value for b, simulates a server value. It's still shadowed though",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 29,
+          "events": []
+        },
+        {
+          "comment": "Clearing the set should result in updated values for b",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 29
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 29
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 29, "c": 3}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Clear child shadowing server values set with server children",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 28,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 28
+            }
+          ]
+        },
+        {
+          "comment": "This listen should get an event child snap, as well as a complete server child: b",
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 28
+            }
+          ]
+        },
+        {
+          "comment": "Do a serverUpdate with a conflicting value for b, simulates a server value. It's still shadowed though",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 29,
+          "events": []
+        },
+        {
+          "comment": "Clearing the set should result in no events. We don't yet have the server data at the parent",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 29
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 29
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Unrelated merge doesn't shadow server updates",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a",
+          "data": {"b": 2, "c": 3},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2, "c": 3}
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/d",
+          "data": 4,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": 4
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2, "c": 3, "d": 4}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Can set alongside a remote merge",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2}
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "a",
+          "data": {"b": 28, "c": 3},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2, "c": 3}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "setPriority on a location with no cache",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "a/.priority",
+          "data": "foo",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": "bar",
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": { ".priority": "foo", ".value": "bar" }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "deep update deletes child from limit window and pulls in new child",
+      "steps": [
+        {
+          "type": "set",
+          "path": "a",
+          "data": {
+            "a": {"aa": 2, "aaa": 3},
+            "b": {"bb": 2, "bbb": 3},
+            "c": {"cc": 2, "ccc": 3}
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "limitToLast": 2
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {"bb": 2, "bbb": 3}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": {"cc": 2, "ccc": 3}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": {"bb": 2, "bbb": 3},
+                "c": {"cc": 2, "ccc": 3}
+              }
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a/b",
+          "data": {
+            "bb": null,
+            "bbb": null
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "b",
+              "data": {"bb": 2, "bbb": 3}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {"aa": 2, "aaa": 3}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "a": {"aa": 2, "aaa": 3},
+                "c": {"cc": 2, "ccc": 3}
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "deep set deletes child from limit window and pulls in new child",
+      "steps": [
+        {
+          "type": "set",
+          "path": "a",
+          "data": {
+            "a": {"aa": 2},
+            "b": {"bb": 2},
+            "c": {"cc": 2}
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "tag": 1,
+            "limitToLast": 2
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {"bb": 2}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": {"cc": 2}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": {"bb": 2},
+                "c": {"cc": 2}
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b/bb",
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "b",
+              "data": {"bb": 2}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {"aa": 2}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "a": {"aa": 2},
+                "c": {"cc": 2}
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Edge case in newChildForChange_",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/d",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a/b/c",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/d",
+          "data": 4,
+          "events": [
+            {
+              "type": "value",
+              "path": "a/d",
+              "data": 4
+            },
+            {
+              "type": "child_added",
+              "path": "a",
+              "name": "d",
+              "prevName": null,
+              "data": 4
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b/c",
+          "data": 3,
+          "events": [
+            {
+              "path": "a/b/c",
+              "type": "value",
+              "data": 3
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert set in query window",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "limitToLast": 1,
+            "tag": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "tag": 1,
+          "data": {"b": 2},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2}
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/c",
+          "data": 3,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "b",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"c": 3}
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "revert": true,
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "c",
+              "data": 3
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 2}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Handles a server value moving a child out of a query window",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {"b": {"c": {"value": 3}, "d": {"value": 4}}},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": {"value": 3}, "d": {"value": 4}}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": {"c": {"value": 3}, "d": {"value": 4}}}
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1,
+            "orderBy": "value"
+          },
+          "path": "a/b",
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": {"value": 4}
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"d": {"value": 4}}
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b/d/value",
+          "data": 5,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_moved",
+              "name": "d",
+              "prevName": null,
+              "data": {"value": 5}
+            },
+            {
+              "path": "a/b",
+              "type": "child_changed",
+              "name": "d",
+              "prevName": null,
+              "data": {"value": 5}
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"d": {"value": 5}}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": {"value": 3}, "d": {"value": 5}}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": {"c": {"value": 3}, "d": {"value": 5}}}
+            }
+          ]
+        },
+        {
+          "comment": "The query is shadowed, so only one data update arrives. We're simulating a server value, so it's different than what was set",
+          "type": "serverUpdate",
+          "path": "a/b/d/value",
+          "data": 2,
+          "events": []
+        },
+        {
+          "comment": "Now that we're acking the write, we should see the effect of the change",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_removed",
+              "name": "d",
+              "data": {"value": 5}
+            },
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": {"value": 3}
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": {"value": 3}}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": {"value": 3}, "d": {"value": 2}}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": {"c": {"value": 3}, "d": {"value": 2}}}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Update of indexed child works",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {"b": {"c": {"value": 3}, "d": {"value": 4}}},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": {"value": 3}, "d": {"value": 4}}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": {"c": {"value": 3}, "d": {"value": 4}}}
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1,
+            "orderBy": "value"
+          },
+          "path": "a/b",
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": {"value": 4}
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"d": {"value": 4}}
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a/b/c",
+          "data": {"value": 5},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_removed",
+              "name": "d",
+              "data": {"value": 4}
+            },
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": {"value": 5}
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": {"value": 5}}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {"c": {"value": 5}, "d": {"value": 4}}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": {"c": {"value": 5}, "d": {"value": 4}}}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Merge applied to empty limit",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "params": {
+            "limitToLast": 1,
+            "tag": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "tag": 1,
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a",
+          "data": {"b": 1},
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"b": 1}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Limit is refilled from server data after merge",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a/b",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {"a": 1, "b": {"c": 3, "d": 4}},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": 4
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"d": 4}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": {"c": 3, "d": 4}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "b": {"c": 3, "d": 4}}
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a/b",
+          "data": {"d": null},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_removed",
+              "name": "d",
+              "data": 4
+            },
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": 3}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": "a",
+              "data": {"c": 3}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "b": {"c": 3}}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Handle repeated listen with merge as first update",
+      "steps": [
+        {
+          "comment": "Assume that we just unlistened on this path, and before the unlisten arrives, a merge was sent by the server",
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "This happens when a merge arriving from the server while the 2nd listen is in flight",
+          "type": "serverMerge",
+          "path": "a",
+          "data": {"c": 3},
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Limit is refilled from server data after set",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a/b",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": {"a": 1, "b": {"c": 3, "d": 4}},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": 4
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"d": 4}
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": {"c": 3, "d": 4}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "b": {"c": 3, "d": 4}}
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/b/d",
+          "data": null,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_removed",
+              "name": "d",
+              "data": 4
+            },
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {"c": 3}
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": "a",
+              "data": {"c": 3}
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"a": 1, "b": {"c": 3}}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "query on weird path.",
+      "comment": "We used to use '|' as a separator, which broke with paths containing |",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo|!@%^&*()_<>?+={}blah",
+          "params": {
+            "tag": 1,
+            "limitToLast": 5
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo|!@%^&*()_<>?+={}blah",
+          "tag": 1,
+          "data": { "a": "a" },
+          "events": [
+            {
+              "path": "foo|!@%^&*()_<>?+={}blah",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": "a"
+            },
+            {
+              "path": "foo|!@%^&*()_<>?+={}blah",
+              "type": "value",
+              "data": { "a": "a" }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "runs, round2",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "foo",
+          "data": "baz",
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": "baz"
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "foo/new",
+          "data": "bar",
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "new",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": { "new" : "bar"}
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": "baz",
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": { "new" : "bar"},
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 1,
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": { "new" : true, "other" : "bar"},
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "other",
+              "prevName": "new",
+              "data": "bar"
+            },
+            {
+              "path": "foo",
+              "type": "child_changed",
+              "name": "new",
+              "prevName": null,
+              "data": true
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": { "new": true, "other": "bar"}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "handles nested listens",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo/bar",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "foo": {
+              "a": 1,
+              "b": 2,
+              "bar": {
+                "c": true,
+                "d": false
+              }
+            },
+            "baz": false
+          },
+          "events": [
+            {
+              "path": "foo/bar",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": true
+            },
+            {
+              "path": "foo/bar",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": false
+            },
+            {
+              "path": "foo/bar",
+              "type": "value",
+              "data": {"c": true, "d": false}
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "bar",
+              "prevName": "b",
+              "data": {"c": true, "d": false}
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "a": 1,
+                "b": 2,
+                "bar": {
+                  "c": true,
+                  "d": false
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "foo": {
+              "a": 1,
+              "b": 2,
+              "bar": {
+                "c": false,
+                "d": false,
+                "e": true
+              },
+              "f": 3
+            },
+            "baz": false
+          },
+          "events": [
+            {
+              "path": "foo/bar",
+              "type": "child_added",
+              "name": "e",
+              "prevName": "d",
+              "data": true
+            },
+            {
+              "path": "foo/bar",
+              "type": "child_changed",
+              "name": "c",
+              "prevName": null,
+              "data": false
+            },
+            {
+              "path": "foo/bar",
+              "type": "value",
+              "data": {
+                "c": false,
+                "d": false,
+                "e": true
+              }
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "f",
+              "prevName": "bar",
+              "data": 3
+            },
+            {
+              "path": "foo",
+              "type": "child_changed",
+              "name": "bar",
+              "prevName": "b",
+              "data": {
+                "c": false,
+                "d": false,
+                "e": true
+              }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "a": 1,
+                "b": 2,
+                "bar": {
+                  "c": false,
+                  "d": false,
+                  "e": true
+                },
+                "f": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Duplicate set, no events raised",
+          "type": "set",
+          "path": "",
+          "data": {
+            "foo": {
+              "a": 1,
+              "b": 2,
+              "bar": {
+                "c": false,
+                "d": false,
+                "e": true
+              },
+              "f": 3
+            },
+            "baz": false
+          },
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Handles a set below a listen",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "foo",
+          "data": 1,
+          "comment": "We only expect a child_added, since it does not completely fill the view",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "does non-default queries",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "foo": {
+              "a": 1,
+              "b": 2
+            }
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "b": 2
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Now have the server send the same data to the query. No events result because there is no change",
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "foo",
+          "data": {
+            "b": 2
+          },
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "handles a co-located default listener and query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "foo",
+          "data": { "a": 1, "b": 2},
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": { "a": 1, "b": 2}
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {"b": 2}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Default and non-default listener at same location with server update",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": {"a": 1, "b": 2},
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "data": 1,
+              "prevName": null
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "data": 2,
+              "prevName": "a"
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {"a": 1, "b": 2}
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "data": 2,
+              "prevName": null
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {"b": 2}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Add a parent listener to a complete child listener, expect child event",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": 1,
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Add listens to a set, expect correct events, including a child event",
+      "steps": [
+        {
+          "type": "set",
+          "path": "foo",
+          "data": {"bar": 1, "baz": 2},
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo/bar",
+          "events": [
+            {
+              "path": "foo/bar",
+              "type": "value",
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": {"bar": 1, "baz": 2}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "ServerUpdate to a child listener raises child events at parent",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": 1,
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "ServerUpdate to a child listener raises child events at parent query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": 1,
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Multiple complete children are handled properly",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo/a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo/b",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo/a",
+          "data": 1,
+          "events": [
+            {
+              "path": "foo/a",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "foo/b",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Write leaf node, overwrite at parent node",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/aa",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "a/aa",
+          "data": 1,
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "aa",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a",
+          "data": {
+            "aa": 2
+          },
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "aa",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "aa": 2
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Confirm complete children from the server",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/aa",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/aa",
+          "data": 1,
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "aa",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "comment": "At some point in the future, we might consider sending a hash here to avoid duplicate data",
+          "data": {"aa": 1},
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"aa": 1}
+            }
+          ]
+        },
+        {
+          "comment": "Now, delete the same child and make sure we get the right events",
+          "type": "serverUpdate",
+          "path": "a/aa",
+          "data": null,
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": null
+            },
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "aa",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": null
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Write leaf, overwrite from parent",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/aa",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a/bb",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "First set is at leaf. Expect only a child_added for the parent, nothing for the sibling",
+          "type": "set",
+          "path": "a/aa",
+          "data": 1,
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "aa",
+              "prevName": null,
+              "data": 1
+            }
+          ]
+        },
+        {
+          "comment": "Now set at the parent. Expect value events for everyone",
+          "type": "set",
+          "path": "a",
+          "data": {"aa": 2},
+          "events": [
+            {
+              "path": "a/aa",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "a/bb",
+              "type": "value",
+              "data": null
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "aa",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {"aa": 2}
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Basic update test",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "b",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "comment": "Initial data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": 1,
+            "b": 2,
+            "c": 3
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": 1
+            },
+            {
+              "path": "b",
+              "type": "value",
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": 1,
+                "b": 2,
+                "c": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Now update two children. Not b, there should be no events at b",
+          "type": "update",
+          "path": "",
+          "data": {
+            "a": true,
+            "c": false
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": true
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "a",
+              "prevName": null,
+              "data": true
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "c",
+              "prevName": "b",
+              "data": false
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": true,
+                "b": 2,
+                "c": false
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "No double value events for user ack",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToLast": 1,
+            "endAt": {"index": null, "name": "d"}
+          },
+          "events": []
+        },
+        {
+          "comment": "user sets data",
+          "type": "set",
+          "path": "foo",
+          "data": {
+            "a": 1,
+            "b": 2,
+            "c": 3
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": { "c": 3 }
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            }
+          ]
+        },
+        {
+          "comment": "server acks data, but local overwrite causes no events to fire",
+          "type": "serverUpdate",
+          "path": "foo",
+          "tag": 1,
+          "data": null,
+          "events": []
+        },
+        {
+          "comment": "server sends data with merge",
+          "type": "serverMerge",
+          "path": "foo",
+          "tag": 1,
+          "data": {
+            "c": 3
+          },
+          "events": [ ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "foo/d",
+          "data": 4,
+          "events": [
+            {
+              "path": "foo",
+              "type": "value",
+              "data": { "d": 4 }
+            },
+            {
+              "path": "foo",
+              "type": "child_removed",
+              "name": "c",
+              "prevName": null,
+              "data": 3
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": 4
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "foo",
+          "tag": 1,
+          "data": {
+            "d": 4
+          },
+          "events": [ ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 1,
+          "revert": false,
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "Basic key index sanity check",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderByKey": true,
+            "startAt": { "index": "aa" },
+            "endAt": { "index": "e" }
+          },
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "a": { ".priority": 10, ".value": "a" },
+            "b": { ".priority": 5, ".value": "b" },
+            "c": { ".priority": 20, ".value": "c" },
+            "d": { ".priority": 7, ".value": "d" },
+            "e": { ".priority": 30, ".value": "e" },
+            "f": { ".priority": 8, ".value": "f" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {".priority": 5, ".value": "b"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": {".priority": 20, ".value": "c"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": {".priority": 7, ".value": "d"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "e",
+              "prevName": "d",
+              "data": {".priority": 30, ".value": "e"}
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { ".priority": 5, ".value": "b" },
+                "c": { ".priority": 20, ".value": "c" },
+                "d": { ".priority": 7, ".value": "d" },
+                "e": { ".priority": 30, ".value": "e" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Add a new item outside of range and make sure we get events.",
+          "type": "set",
+          "path": "a",
+          "data": "hello!",
+          "events": [ ]
+        },
+        {
+          "comment": "Add a new item within range and ensure we get ld_added.",
+          "type": "set",
+          "path": "bass",
+          "data": 3.14,
+          "events":
+          [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "bass",
+              "prevName": "b",
+              "data": 3.14
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { ".priority": 5, ".value": "b" },
+                "bass": 3.14,
+                "c": { ".priority": 20, ".value": "c" },
+                "d": { ".priority": 7, ".value": "d" },
+                "e": { ".priority": 30, ".value": "e" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Modify an item and ensure we get child_changed.",
+          "type": "set",
+          "path": "b",
+          "data": 42,
+          "events":
+          [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 42
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": 42,
+                "bass": 3.14,
+                "c": { ".priority": 20, ".value": "c" },
+                "d": { ".priority": 7, ".value": "d" },
+                "e": { ".priority": 30, ".value": "e" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Collect correct subviews to listen on",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "callbackId": 1,
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "callbackId": 1,
+          "path": "/a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "callbackId": 1,
+          "path": "/a/b",
+          "events": []
+        },
+        {
+          "comment": "should not cause /a/b to be listened upon",
+          "type": "unlisten",
+          "callbackId": 1,
+          "path": "",
+          "events": []
+        },
+        {
+          "comment": "should now cause /a/b to be listened upon",
+          "type": "unlisten",
+          "callbackId": 1,
+          "path": "/a",
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "Limit to first one on ordered query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "vanished",
+            "limitToFirst": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "triceratops": {"vanished": -66000000},
+            "stegosaurus": {"vanished": -155000000},
+            "pterodactyl": {"vanished": -75000000}
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "stegosaurus",
+              "prevName": null,
+              "data": {"vanished": -155000000}
+            },
+            {
+              "path": "",
+              "type": "value",
+              "name": "",
+              "prevName": null,
+              "data": {"stegosaurus": {"vanished": -155000000}}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Limit to last one on ordered query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "vanished",
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "triceratops": {"vanished": -66000000},
+            "stegosaurus": {"vanished": -155000000},
+            "pterodactyl": {"vanished": -75000000}
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "triceratops",
+              "prevName": null,
+              "data": {"vanished": -66000000}
+            },
+            {
+              "path": "",
+              "type": "value",
+              "name": "",
+              "prevName": null,
+              "data": {"triceratops": {"vanished": -66000000}}
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Update indexed value on existing child from limited query",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "age",
+            "limitToLast": 4
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "4": { "age": 41, "highscore": 400, "name": "old mama"},
+            "5": { "age": 18, "highscore": 1200, "name": "young mama"},
+            "6": { "age": 20, "highscore": 1003, "name": "micheal blub"},
+            "7": { "age": 30, "highscore": 10000, "name": "no. 7"}
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "4",
+              "prevName": "7",
+              "data": { "age": 41, "highscore": 400, "name": "old mama"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "5",
+              "prevName": null,
+              "data": { "age": 18, "highscore": 1200, "name": "young mama"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "6",
+              "prevName": "5",
+              "data": { "age": 20, "highscore": 1003, "name": "micheal blub"}
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "7",
+              "prevName": "6",
+              "data": { "age": 30, "highscore": 10000, "name": "no. 7"}
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "4": { "age": 41, "highscore": 400, "name": "old mama"},
+                "5": { "age": 18, "highscore": 1200, "name": "young mama"},
+                "6": { "age": 20, "highscore": 1003, "name": "micheal blub"},
+                "7": { "age": 30, "highscore": 10000, "name": "no. 7"}
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update the order by value, should cause a new value event",
+          "type": "serverUpdate",
+          "path": "4/age",
+          "tag": 1,
+          "data": 25,
+          "events": [
+            {
+              "path": "",
+              "type": "child_moved",
+              "name": "4",
+              "prevName": "6",
+              "data": { "age": 25, "highscore": 400, "name": "old mama"}
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "4",
+              "prevName": "6",
+              "data": { "age": 25, "highscore": 400, "name": "old mama"}
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "4": { "age": 25, "highscore": 400, "name": "old mama"},
+                "5": { "age": 18, "highscore": 1200, "name": "young mama"},
+                "6": { "age": 20, "highscore": 1003, "name": "micheal blub"},
+                "7": { "age": 30, "highscore": 10000, "name": "no. 7"}
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Can create startAt, endAt, equalTo queries with bool",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "boolKey",
+            "startAt": {"index": true}
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 2,
+            "orderBy": "boolKey",
+            "endAt": {"index": true}
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 3,
+            "orderBy": "boolKey",
+            "equalTo": {"index": true}
+          },
+          "events": []
+        },
+        {
+          "type": "suppressWarning",
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "Query with existing server snap",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "age"
+          },
+          "events": []
+        },
+        {
+          "comment": "untagged update, since index doesn't exist",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": { "age": 10, "score": 100, "bar": "baz" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": { "age": 10, "score": 100, "bar": "baz" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": { "age": 10, "score": 100, "bar": "baz" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "new listen should use existing data and index correctly",
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 2,
+            "orderBy": "score"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": { "age": 10, "score": 100, "bar": "baz" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": { "age": 10, "score": 100, "bar": "baz" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Server data is not purged for non-server-indexed queries",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "highscore",
+            "limitToLast": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "server has no index, so it sends down everything",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "highscore": 100, "value": "a" },
+            "b": { "highscore": 200, "value": "b" },
+            "c": { "highscore": 0, "value": "c" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "highscore": 100, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "highscore": 200, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "highscore": 100, "value": "a" },
+                "b": { "highscore": 200, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update of highscore leads to only a partial update",
+          "type": "serverUpdate",
+          "path": "c/highscore",
+          "data": 300,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "prevName": null,
+              "data": { "highscore": 100, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "highscore": 300, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "highscore": 200, "value": "b" },
+                "c": { "highscore": 300, "value": "c" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Limit with custom orderBy is refilled with correct item",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "age",
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "age": 4 },
+            "b": { "age": 3 },
+            "c": { "age": 2 },
+            "d": { "age": 1 }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "age": 4 }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "age": 4 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "delete 'a' and make sure 'b' comes into view.",
+          "type": "set",
+          "path": "a",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "age": 4 }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": { "age": 3 }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "age": 3 }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "startAt/endAt dominates limit",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 2 },
+            "limitToFirst": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "server has no index, so it sends down everything",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 1000, "value": "b" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to fill limit and beyond",
+          "type": "serverMerge",
+          "path": "",
+          "data": {
+            "b": { "index": 1, "value": "b" },
+            "c": { "index": 2, "value": "c" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 1, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 1, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to move entry out of window",
+          "type": "serverUpdate",
+          "path": "a/index",
+          "data": 1000,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 2, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "index": 1, "value": "b" },
+                "c": { "index": 2, "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to move all but one entry out of window",
+          "type": "serverUpdate",
+          "path": "b/index",
+          "data": 1000,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "b",
+              "data": { "index": 1, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "c": { "index": 2, "value": "c" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Update to single child that moves out of window",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends all data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 2, "value": "b" },
+            "c": { "index": 3, "value": "c" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to move child out of query",
+          "type": "serverUpdate",
+          "path": "a/index",
+          "data": -1,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to move child out of query",
+          "type": "serverUpdate",
+          "path": "b/index",
+          "data": -1,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "b",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "c": { "index": 3, "value": "c" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Limited query doesn't pull in out of range child",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends all data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 2, "value": "b" },
+            "c": { "index": 1000, "value": "c" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server to move child out of query",
+          "type": "serverUpdate",
+          "path": "a/index",
+          "data": -1,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "index": 2, "value": "b" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Merge for location with default and limited listener",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "comment": "complete update",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 2, "value": "b" },
+            "c": { "index": 3, "value": "c" },
+            "d": { "index": 4, "value": "d" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "c",
+              "data": { "index": 4, "value": "d" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" },
+                "d": { "index": 4, "value": "d" }
+              }
+            }
+          ]
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "limitToFirst": 2
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "update from server pulls in other node",
+          "type": "serverMerge",
+          "path": "",
+          "data": {
+            "a": null,
+            "d": null
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "d",
+              "data": { "index": 4, "value": "d" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" }
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "User merge pulls in correct values",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 3
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends all data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 2, "value": "b" },
+            "c": { "index": 3, "value": "c" },
+            "d": { "index": 1000, "value": "d" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user merge pulls in existing value",
+          "type": "update",
+          "path": "d",
+          "data": { "index": 2 },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "c",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "b",
+              "data": { "index": 2, "value": "d" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" },
+                "d": { "index": 2, "value": "d" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "User deep set pulls in correct values",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 3
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends all data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 2, "value": "b" },
+            "c": { "index": 3, "value": "c" },
+            "d": { "index": 1000, "value": "d" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 2, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" },
+                "c": { "index": 3, "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user deep set pulls in existing value",
+          "type": "set",
+          "path": "d/index",
+          "data": 2,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "c",
+              "data": { "index": 3, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "d",
+              "prevName": "b",
+              "data": { "index": 2, "value": "d" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 2, "value": "b" },
+                "d": { "index": 2, "value": "d" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Queries with equalTo(null) work",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": null },
+            "endAt": { "index": null }
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends all data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "value": "a" },
+            "b": { "value": "b" },
+            "c": { "value": "c", "index": 1 }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "value": "a" },
+                "b": { "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "server updates existing value (bringing c into query)",
+          "type": "serverUpdate",
+          "path": "c/index",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "value": "a" },
+                "b": { "value": "b" },
+                "c": { "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "server updates existing value (sending c out of query)",
+          "type": "serverUpdate",
+          "path": "c/index",
+          "data": 1,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "c",
+              "data": { "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "value": "a" },
+                "b": { "value": "b" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Reverted writes update query",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends only query data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 5, "value": "b" },
+            "d": { "index": 6, "value": "d" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 5, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 5, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user adds new value should update query",
+          "type": "set",
+          "path": "",
+          "data": {
+            "c": { "index": 2, "value": "c" },
+            "a": { "index": 1, "value": "a" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "b",
+              "data": { "index": 5, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "a",
+              "data": { "index": 2, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "c": { "index": 2, "value": "c" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "write is reverted should revert query to old state",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "c",
+              "data": { "index": 2, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 5, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 5, "value": "b" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Deep set for non-local data doesn't raise events",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "startAt": { "index": 1 },
+            "endAt": { "index": 10 },
+            "limitToFirst": 2
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends only query data",
+          "type": "serverUpdate",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "a": { "index": 1, "value": "a" },
+            "b": { "index": 5, "value": "b" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "index": 1, "value": "a" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "index": 5, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "b": { "index": 5, "value": "b" }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user updates a value for node outside of query, should trigger no events",
+          "type": "set",
+          "path": "c/index",
+          "data": 1,
+          "events": [ ]
+        },
+        {
+          "comment": "update from server now contains complete data",
+          "type": "serverMerge",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "c": { "index": 1, "value": "c" }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "b",
+              "data": { "index": 5, "value": "b" }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "a",
+              "data": { "index": 1, "value": "c" }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": { "index": 1, "value": "a" },
+                "c": { "index": 1, "value": "c" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "User update with new children triggers events",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "orderBy": "value",
+            "tag": 1
+          },
+          "events": []
+        },
+        {
+          "comment": "update from server sends query data",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "value": 5 },
+            "c": { "value": 3 }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": null,
+              "data": { "value": 3 }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": "c",
+              "data": { "value": 5 }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "c": { "value": 3 },
+                "a": { "value": 5 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user adds new children through an update",
+          "type": "update",
+          "path": "",
+          "data": {
+            "b": { "value": 4 },
+            "d": { "value": 2 }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "d",
+              "prevName": null,
+              "data": { "value": 2 }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "c",
+              "data": { "value": 4 }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "d": { "value": 2 },
+                "c": { "value": 3 },
+                "b": { "value": 4 },
+                "a": { "value": 5 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "server send new server",
+          "type": "serverMerge",
+          "path": "",
+          "data": {
+            "b": { "value": 4 },
+            "d": { "value": 2 }
+          },
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": [ ]
+        }
+      ]
+    },
+    {
+      "name": "User write with deep user overwrite",
+      "steps":
+      [
+        {
+          "type": "listen",
+          "path": "/foo",
+          "params": {
+            "orderBy": "value",
+            "tag": 1
+          },
+          "events": []
+        },
+        {
+          "comment": "user sets initial data",
+          "type": "set",
+          "path": "/foo",
+          "data": {
+            "a": { "value": 1 },
+            "b": { "value": 5 },
+            "c": { "value": 10 }
+          },
+          "events": [
+            {
+              "path": "/foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": { "value": 1 }
+            },
+            {
+              "path": "/foo",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": { "value": 5 }
+            },
+            {
+              "path": "/foo",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": { "value": 10 }
+            },
+            {
+              "path": "/foo",
+              "type": "value",
+              "data": {
+                "a": { "value": 1 },
+                "b": { "value": 5 },
+                "c": { "value": 10 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user quickly overwrites value",
+          "type": "set",
+          "path": "/foo/c/value",
+          "data": 3,
+          "events": [
+            {
+              "path": "/foo",
+              "type": "child_moved",
+              "name": "c",
+              "prevName": "a",
+              "data": { "value": 3 }
+            },
+            {
+              "path": "/foo",
+              "type": "child_changed",
+              "name": "c",
+              "prevName": "a",
+              "data": { "value": 3 }
+            },
+            {
+              "path": "/foo",
+              "type": "value",
+              "data": {
+                "a": { "value": 1 },
+                "c": { "value": 3 },
+                "b": { "value": 5 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "server sends complete but outdated data",
+          "type": "serverUpdate",
+          "path": "/foo",
+          "data": {
+            "a": { "value": 1 },
+            "b": { "value": 5 },
+            "c": { "value": 10 }
+          },
+          "events": [ ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [ ]
+        },
+        {
+          "comment": "server sends update",
+          "type": "serverUpdate",
+          "path": "/foo/c/value",
+          "data": 3,
+          "events": [ ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 1,
+          "events": [ ]
+        }
+      ]
+    },
+
+    {
+      "name": "Deep server merge",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": {
+              "bar1" : { "a": "baz1", "b": "qux1" },
+              "bar2" : { "a": "baz2", "b": "qux2" }
+            }
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "bar1",
+              "prevName": null,
+              "data": { "a": "baz1", "b": "qux1" }
+            },
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "bar2",
+              "prevName": "bar1",
+              "data": { "a": "baz2", "b": "qux2" }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "bar1" : { "a": "baz1", "b": "qux1" },
+                "bar2" : { "a": "baz2", "b": "qux2" }
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "foo",
+          "data": {
+            "bar1/a": "newbaz1",
+            "bar2/b": "newqux2"
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_changed",
+              "name": "bar1",
+              "prevName": null,
+              "data": { "a": "newbaz1", "b": "qux1" }
+            },
+            {
+              "path": "foo",
+              "type": "child_changed",
+              "name": "bar2",
+              "prevName": "bar1",
+              "data": { "a": "baz2", "b": "newqux2" }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "bar1" : { "a": "newbaz1", "b": "qux1" },
+                "bar2" : { "a": "baz2", "b": "newqux2" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server updates priority",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "a/foo",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "data": { "foo": "bar" },
+          "events": [
+            {
+              "path": "a/foo",
+              "type": "value",
+              "data": "bar"
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": { "foo": "bar" }
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/foo/.priority",
+          "data": "qux",
+          "events": [
+            {
+              "path": "a/foo",
+              "type": "value",
+              "data": { ".value": "bar", ".priority": "qux" }
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "foo",
+              "prevName": null,
+              "data": { ".value": "bar", ".priority": "qux" }
+            },
+            {
+              "path": "a",
+              "type": "child_moved",
+              "name": "foo",
+              "prevName": null,
+              "data": { ".value": "bar", ".priority": "qux" }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "foo": { ".value": "bar", ".priority": "qux" }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert underlying full overwrite",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "key-a": "val-a",
+            "key-b": "val-b"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-a",
+              "prevName": null,
+              "data": "val-a"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-b",
+              "prevName": "key-a",
+              "data": "val-b"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-a": "val-a",
+                "key-b": "val-b"
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "key-c": "val-c",
+            "key-d": "val-d"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-a",
+              "data": "val-a"
+            },
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-b",
+              "data": "val-b"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-c",
+              "prevName": null,
+              "data": "val-c"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-d",
+              "prevName": "key-c",
+              "data": "val-d"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-c": "val-c",
+                "key-d": "val-d"
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "key-e": "val-e",
+            "key-f": "val-f"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-c",
+              "data": "val-c"
+            },
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-d",
+              "data": "val-d"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-e",
+              "prevName": null,
+              "data": "val-e"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-f",
+              "prevName": "key-e",
+              "data": "val-f"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-e": "val-e",
+                "key-f": "val-f"
+              }
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [ ]
+        }
+      ]
+    },
+
+    {
+      "name": "User child overwrite for non-existent server node",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "foo",
+          "data": { "bar": "qux" },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": { "bar": "qux" }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert user overwrite of child on leaf node",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": "foo",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "foo"
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "key",
+          "data": "value",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key",
+              "prevName": null,
+              "data": "value"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": { "key": "value" }
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key",
+              "prevName": null,
+              "data": "value"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": "foo"
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server overwrite with deep user delete",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "key-1": "value-1"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": "value-1"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": "value-1"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User deletes non-existent key, which shouldn't trigger events",
+          "type": "set",
+          "path": "key-2/non-key",
+          "data": null,
+          "events": []
+        },
+        {
+          "comment": "Server updates node with deep user delete",
+          "type": "serverUpdate",
+          "path": "key-2",
+          "data": {
+            "deep-key": "deep-value"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-2",
+              "prevName": "key-1",
+              "data": {
+                "deep-key": "deep-value"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": "value-1",
+                "key-2": {
+                  "deep-key": "deep-value"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "User overwrites leaf node with priority",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            ".value": "value",
+            ".priority": "prio"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".value": "value",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Overwrite leaf with children node",
+          "type": "set",
+          "path": "foo",
+          "data": "bar",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "foo": "bar"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "User overwrites inherit priority values from leaf nodes",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            ".value": "value",
+            ".priority": "prio"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".value": "value",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user updates the node",
+          "type": "set",
+          "path": "foo",
+          "data": "foo-value",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "foo-value"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "foo": "foo-value"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "The server updates the data for the set",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            ".value": "value",
+            ".priority": "prio"
+          },
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        },
+        {
+          "comment": "Add another update, should not have old priority",
+          "type": "set",
+          "path": "bar",
+          "data": "bar-value",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "bar",
+              "prevName": null,
+              "data": "bar-value"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "foo": "foo-value",
+                "bar": "bar-value"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "User update on user set leaf node with priority after server update",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            ".value": "value",
+            ".priority": "prio"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".value": "value",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user overwrite shadows server data",
+          "type": "serverMerge",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": [ ]
+        },
+        {
+          "comment": "user updates the node",
+          "type": "update",
+          "path": "deep/deeper",
+          "data": {
+              "0-key": null,
+              "key": "value"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "deep",
+              "prevName": null,
+              "data": { "deeper": { "key": "value" } }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "deep": { "deeper": { "key": "value" } }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server deep delete on leaf node",
+      "comment": "This is a contrived example, as the server will probably not send null updates to leaf nodes",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": "foo",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "foo"
+            }
+          ]
+        },
+        {
+          "comment": "this should trigger no events",
+          "type": "serverUpdate",
+          "path": "deep/child",
+          "data": null,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "User sets root priority",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar"
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": ".priority",
+          "data": "prio",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "foo": "bar"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "User updates priority on empty root",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "comment": "Priority on empty root should not trigger events",
+          "type": "set",
+          "path": ".priority",
+          "data": "prio",
+          "events": []
+        },
+        {
+          "comment": "This should a value event without priority",
+          "type": "serverUpdate",
+          "path": "",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "comment": "This should now have the user priority",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "foo": "bar"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Revert set at root with priority",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User overwrites root",
+          "type": "set",
+          "path": "",
+          "data": {
+            "baz": "qux",
+            ".priority": "prio"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "baz",
+              "prevName": null,
+              "data": "qux"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".priority": "prio",
+                "baz": "qux"
+              }
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "baz",
+              "prevName": null,
+              "data": "qux"
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server updates priority after user sets priority",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": { ".value": "foo", ".priority": "prio" },
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": { ".value": "foo", ".priority": "prio" }
+            }
+          ]
+        },
+        {
+          "comment": "User overwrites priority",
+          "type": "set",
+          "path": ".priority",
+          "data": "prio-2",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": { ".value": "foo", ".priority": "prio-2" }
+            }
+          ]
+        },
+        {
+          "comment": "this should not trigger any events since a user write is shadowing",
+          "type": "serverUpdate",
+          "path": ".priority",
+          "data": null,
+          "events": [ ]
+        }
+      ]
+    },
+
+    {
+      "name": "User updates priority twice, first is reverted",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": { "foo": "bar" },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": { "foo": "bar" }
+            }
+          ]
+        },
+        {
+          "comment": "User overwrites priority first time",
+          "type": "set",
+          "path": ".priority",
+          "data": "prio-1",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar",
+                ".priority": "prio-1"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User overwrites priority second time",
+          "type": "set",
+          "path": ".priority",
+          "data": "prio-2",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar",
+                ".priority": "prio-2"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "revert should not trigger event",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": true,
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "foo",
+          "data": "new-bar",
+          "events": [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "foo",
+              "prevName": null,
+              "data": "new-bar"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "new-bar",
+                ".priority": "prio-2"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Server acks root priority set after user deletes root node",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": "foo",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": "foo"
+            }
+          ]
+        },
+        {
+          "comment": "User overwrites root priority",
+          "type": "set",
+          "path": ".priority",
+          "data": "prio",
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                ".value": "foo",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User deletes root node",
+          "type": "set",
+          "path": "",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": ".priority",
+          "data": "prio",
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "A delete in a merge doesn't push out nodes",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 3,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "key-1": 1,
+            "key-3": 3,
+            "key-4": 4
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-3",
+              "prevName": "key-1",
+              "data": 3
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-4",
+              "prevName": "key-3",
+              "data": 4
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": 1,
+                "key-3": 3,
+                "key-4": 4
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Since key-3 is deleted, key-5 should still remain in the query",
+          "type": "serverMerge",
+          "path": "",
+          "data": {
+            "key-3": null,
+            "key-2": 2
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-3",
+              "data": 3
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-2",
+              "prevName": "key-1",
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": 1,
+                "key-2": 2,
+                "key-4": 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "A tagged query fires events eventually",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "limitToLast": 2
+          },
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "",
+          "data": {
+            "key-1": 1,
+            "key-2": 2,
+            "key-3": 3
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-2",
+              "prevName": null,
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-3",
+              "prevName": "key-2",
+              "data": 3
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-2": 2,
+                "key-3": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server updates tagged data, should filter key-1 node",
+          "type": "serverUpdate",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "key-2": 2,
+            "key-3": 3
+          },
+          "events": []
+        },
+        {
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        },
+        {
+          "comment": "User deletes element, only child removed event is fired, since data is not available",
+          "type": "set",
+          "path": "key-2",
+          "data": null,
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-2",
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-3": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server updates tagged data, should filter key-1 node",
+          "type": "serverMerge",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "key-1": 1,
+            "key-2": null
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "value",
+              "name": "",
+              "data": {
+                "key-1": 1,
+                "key-3": 3
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "A server update that leaves user sets unchanged is not ignored",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "key-1": 1,
+            "key-2": 2
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": 1
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-2",
+              "prevName": "key-1",
+              "data": 2
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": 1,
+                "key-2": 2
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user adds a new node",
+          "type": "set",
+          "path": "key-3",
+          "data": 3,
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-3",
+              "prevName": "key-2",
+              "data": 3
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": 1,
+                "key-2": 2,
+                "key-3": 3
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server adds new children with full overwrite",
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "key-1": 1,
+            "key-2": 2,
+            "key-4": 4
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-4",
+              "prevName": "key-3",
+              "data": 4
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": 1,
+                "key-2": 2,
+                "key-3": 3,
+                "key-4": 4
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "User write outside of limit is ignored for tagged queries",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 2,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "key-1": {
+              "index": 1,
+              "other-key": "foo"
+            },
+            "key-4": {
+              "index": 4,
+              "other-key": "bar"
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-4",
+              "prevName": "key-1",
+              "data": {
+                "index": 4,
+                "other-key": "bar"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "foo"
+                },
+                "key-4": {
+                  "index": 4,
+                  "other-key": "bar"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "user updates index of child outside, which should bring it in view eventually, but not before the server sends the complete node",
+          "type": "set",
+          "path": "key-2/index",
+          "data": 2,
+          "events": []
+        },
+        {
+          "comment": "In the meantime the server adds another node",
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "key-1": {
+              "index": 1,
+              "other-key": "new-foo"
+            },
+            "key-3": {
+              "index": 3,
+              "other-key": "baz"
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-4",
+              "data": {
+                "index": 4,
+                "other-key": "bar"
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-3",
+              "prevName": "key-1",
+              "data": {
+                "index": 3,
+                "other-key": "baz"
+              }
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "new-foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "new-foo"
+                },
+                "key-3": {
+                  "index": 3,
+                  "other-key": "baz"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server now incorperates user update",
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "key-2",
+          "data": {
+            "index": 2,
+            "other-key": "qux"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "key-3",
+              "data": {
+                "index": 3,
+                "other-key": "baz"
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-2",
+              "prevName": "key-1",
+              "data": {
+                "index": 2,
+                "other-key": "qux"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "new-foo"
+                },
+                "key-2": {
+                  "index": 2,
+                  "other-key": "qux"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Ack for merge doesn't raise value event for later listen",
+      "steps": [
+        {
+          "type": "update",
+          "path": "",
+          "data": {
+            "foo": "bar"
+          },
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "",
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": "bar"
+            }
+          ]
+        },
+        {
+          "type": "ackUserWrite",
+          "comment": "This acks a merge, so we can't raise a value event yet",
+          "writeId": 0,
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "foo": "bar",
+            "qux": "quux"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "qux",
+              "prevName": "foo",
+              "data": "quux"
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "foo": "bar",
+                "qux": "quux"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Clear parent shadowing server values merge with server children",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 2,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 2
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "a",
+          "data": {"b": 28, "c": 3},
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 28
+            }
+          ]
+        },
+        {
+          "comment": "This listen should get a complete event snap, as well as complete server children",
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": 28
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": 3
+            }
+          ]
+        },
+        {
+          "comment": "Do a serverUpdate with a conflicting value for b, simulates a server value. It's still shadowed though",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": 29,
+          "events": []
+        },
+        {
+          "comment": "Clearing the set should result in updated values for b",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": 29
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": 29
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Priorities don't make me sick",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "set",
+          "path": "a/foo",
+          "data": {
+            "bar": "baz",
+            ".priority": "prio"
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "foo",
+              "prevName": null,
+              "data": {
+                "bar": "baz",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "a/foo/bar",
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "foo",
+              "data": {
+                "bar": "baz",
+                ".priority": "prio"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "this caused vomitting in the past...",
+          "type": "set",
+          "path": "a/foo/bar",
+          "data": null,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Merge that moves child from window to boundary does not cause child to be readded",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": [],
+          "params": {
+            "tag": 1,
+            "limitToFirst": 2,
+            "startAt": {"index": 1},
+            "orderBy": "index"
+          }
+        },
+        {
+          "type": "serverUpdate",
+          "path": "a",
+          "tag": 1,
+          "data": {
+            "2-a": {
+              "index": 10
+            },
+            "1-b": {
+              "index": 20
+            }
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "2-a",
+              "prevName": null,
+              "data": {
+                "index": 10
+              }
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "1-b",
+              "prevName": "2-a",
+              "data": {
+                "index": 20
+              }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "2-a": { "index": 10 },
+                "1-b": { "index": 20 }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "2-a will be the 'next' child after the old '1-b' which will be updated first, but it shouldn't be added because it will actually be out of the window...",
+          "type": "update",
+          "path": "a",
+          "data": {
+            "1-b": { "index": 0 },
+            "2-a": { "index": 30 },
+            "3-c": { "index": 5 },
+            "4-d": { "index": 6 }
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "2-a",
+              "data": { "index": 10 }
+            },
+            {
+              "path": "a",
+              "type": "child_removed",
+              "name": "1-b",
+              "data": { "index": 20 }
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "3-c",
+              "prevName": null,
+              "data": { "index": 5 }
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "4-d",
+              "prevName": "3-c",
+              "data": { "index": 6 }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "3-c": { "index": 5 },
+                "4-d": { "index": 6 }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Deep merge ack is handled correctly.",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "comment": "Initial server data.",
+          "type": "serverUpdate",
+          "path": "a",
+          "data": null,
+          "events": [
+            {
+              "path": "a",
+              "type": "value",
+              "data": null
+            }
+          ]
+        },
+        {
+          "comment": "Do deep merge.",
+          "type": "update",
+          "path": "a/b",
+          "data": {
+            "c": 42,
+            "d": "hi"
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "c": 42,
+                "d": "hi"
+              }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "b": {
+                  "c": 42,
+                  "d": "hi"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server update for our deep merge.",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": {
+            "c": 42,
+            "d": "hi"
+          },
+          "events": []
+        },
+        {
+          "comment": "ack deep merge.",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Deep merge ack (on incomplete data, and with server values)",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a/b",
+          "events": []
+        },
+        {
+          "comment": "Initial server data.",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": {
+            "c": "original-server-value"
+          },
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_added",
+              "name": "c",
+              "data": "original-server-value",
+              "prevName": null
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {
+                "c": "original-server-value"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Do deep merge.",
+          "type": "update",
+          "path": "a/b",
+          "data": {
+            "c": "user-merge-value"
+          },
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_changed",
+              "name": "c",
+              "data": "user-merge-value",
+              "prevName": null
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {
+                "c": "user-merge-value"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Listen on a (which won't have complete data).",
+          "type": "listen",
+          "path": "a",
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "c": "user-merge-value"
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server update for our deep merge, but change data (simulate server value).",
+          "type": "serverUpdate",
+          "path": "a/b",
+          "data": {
+            "c": "user-merge-value-after-server-resolution"
+          },
+          "events": []
+        },
+        {
+          "comment": "ack deep merge.",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "events": [
+            {
+              "path": "a/b",
+              "type": "child_changed",
+              "name": "c",
+              "data": "user-merge-value-after-server-resolution",
+              "prevName": null
+            },
+            {
+              "path": "a/b",
+              "type": "value",
+              "data": {
+                "c": "user-merge-value-after-server-resolution"
+              }
+            },
+            {
+              "path": "a",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "c": "user-merge-value-after-server-resolution"
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Limit query handles deep server merge for out-of-view item.",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 1
+          },
+          "events": []
+        },
+        {
+          "comment": "Initial server data.",
+          "type": "serverUpdate",
+          "path": "foo",
+          "tag": 1,
+          "data": {
+            "a": {
+              "val": "a-val",
+              ".priority": "a-pri"
+            }
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "val": "a-val",
+                ".priority": "a-pri"
+              }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "a": {
+                  "val": "a-val",
+                  ".priority": "a-pri"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server merge for out-of-view child 'b' (perhaps for another listener).  Shouldn't trigger events since we don't have complete data.",
+          "type": "serverMerge",
+          "path": "foo/b",
+          "data": {
+            "val": "b-val"
+          },
+          "events": [ ]
+        }
+      ]
+    },
+
+    {
+      "name": "Limit query handles deep user merge for out-of-view item.",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 1
+          },
+          "events": []
+        },
+        {
+          "comment": "Initial server data.",
+          "type": "serverUpdate",
+          "path": "foo",
+          "tag": 1,
+          "data": {
+            "a": {
+              "val": "a-val",
+              ".priority": "a-pri"
+            }
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "val": "a-val",
+                ".priority": "a-pri"
+              }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "a": {
+                  "val": "a-val",
+                  ".priority": "a-pri"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User merge for out-of-view child 'b'.  Shouldn't trigger events since we don't have complete data.",
+          "type": "update",
+          "path": "foo/b",
+          "data": {
+            "val": "b-val"
+          },
+          "events": [ ]
+        }
+      ]
+    },
+
+    {
+      "name": "Limit query handles deep user merge for out-of-view item followed by server update.",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "foo",
+          "params": {
+            "tag": 1,
+            "limitToFirst": 1
+          },
+          "events": []
+        },
+        {
+          "comment": "Initial server data.",
+          "type": "serverUpdate",
+          "path": "foo",
+          "tag": 1,
+          "data": {
+            "a": {
+              "val": "a-val",
+              ".priority": "a-pri"
+            }
+          },
+          "events": [
+            {
+              "path": "foo",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "val": "a-val",
+                ".priority": "a-pri"
+              }
+            },
+            {
+              "path": "foo",
+              "type": "value",
+              "data": {
+                "a": {
+                  "val": "a-val",
+                  ".priority": "a-pri"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "User merge for out-of-view child 'b'.  Shouldn't trigger events since we don't have complete data.",
+          "type": "update",
+          "path": "foo/b",
+          "data": {
+            "val": "b-val-new"
+          },
+          "events": [ ]
+        },
+        {
+          "comment": "Server update for 'b', bringing it into view.",
+          "type": "serverUpdate",
+          "path": "foo/b",
+          "data": {
+            "val": "b-val-old",
+            "val2": "b-val2"
+          },
+          "events": [
+            {
+              "type": "child_removed",
+              "path": "foo",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "val": "a-val",
+                ".priority": "a-pri"
+              }
+            },
+            {
+              "type": "child_added",
+              "path": "foo",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "val": "b-val-new",
+                "val2": "b-val2"
+              }
+            },
+            {
+              "type": "value",
+              "path": "foo",
+              "data": {
+                "b": {
+                  "val": "b-val-new",
+                  "val2": "b-val2"
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+
+    {
+      "name": "Unrelated, untagged update is not cached in tagged listen",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "limitToFirst": 1,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "key-1": {
+              "index": 1,
+              "other-key": "foo"
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "server sends update for key-2 which should not be cached or marked complete",
+          "type": "serverUpdate",
+          "path": "key-2",
+          "data": {
+            "index": 2,
+            "other-key": "bar"
+          },
+          "events": []
+        },
+        {
+          "comment": "Now an update for key-1 comes in, marking query as filtered",
+          "type": "serverMerge",
+          "tag": 1,
+          "path": "key-1",
+          "data": {
+            "other-key": "new-foo"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "new-foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "new-foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Server now updates node out of view, should not mark view unfiltered",
+          "type": "serverUpdate",
+          "path": "key-3",
+          "data": { "index": 3, "other-key": "qux" },
+          "events": []
+        },
+        {
+          "comment": "Server now updates node out of view, should not raise any events",
+          "type": "serverMerge",
+          "path": "key-2",
+          "data": { "index": 0 },
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Unrelated, acked set is not cached in tagged listen",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "limitToFirst": 1,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "key-1": {
+              "index": 1,
+              "other-key": "foo"
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "set",
+          "path": "key-1/other-key",
+          "data": "new-foo",
+          "events": [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "new-foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "new-foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverUpdate",
+          "path": "key-1/other-key",
+          "tag": 1,
+          "data": "new-foo",
+          "events": []
+        },
+        {
+          "comment": "The ack should not mark key-2 complete in tagged listen",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        },
+        {
+          "comment": "Server now updates node out of view, should not raise any events",
+          "type": "serverMerge",
+          "path": "key-2",
+          "data": { "index": 0 },
+          "events": []
+        }
+      ]
+    },
+
+    {
+      "name": "Unrelated, acked update is not cached in tagged listen",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "index",
+            "limitToFirst": 1,
+            "startAt": {"index": null}
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "tag": 1,
+          "path": "",
+          "data": {
+            "key-1": {
+              "index": 1,
+              "other-key": "foo"
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "key-1",
+          "data": {
+            "other-key": "new-foo"
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "key-1",
+              "prevName": null,
+              "data": {
+                "index": 1,
+                "other-key": "new-foo"
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "key-1": {
+                  "index": 1,
+                  "other-key": "new-foo"
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "key-1",
+          "tag": 1,
+          "data": {
+            "other-key": "new-foo"
+          },
+          "events": []
+        },
+        {
+          "comment": "The ack should not mark key-2 complete in tagged listen",
+          "type": "ackUserWrite",
+          "writeId": 0,
+          "revert": false,
+          "events": []
+        },
+        {
+          "comment": "Server now updates node out of view, should not raise any events",
+          "type": "serverMerge",
+          "path": "key-2",
+          "data": { "index": 0 },
+          "events": []
+        }
+      ]
+    },
+    {
+      "name": "Deep update raises immediate events only if has complete data",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "age",
+            "limitToLast": 1
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "a": {
+              "age": 4
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "age": 4
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": {
+                  "age": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "",
+          "data": {
+            "a/age": 0,
+            "e": {
+              "age": 4
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": {
+                "age": 4
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "e",
+              "prevName": null,
+              "data": {
+                "age": 4
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "e": {
+                  "age": 4
+                }
+              }
+            }
+          ]
+        },
+        {
+          "comment": "Now we don't have a full data for child /f, don't raise the event. The events for child /e are correct, although may be confusing for customers.",
+          "type": "update",
+          "path": "",
+          "data": {
+            "e/age": 0,
+            "f/age": 4
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_moved",
+              "name": "e",
+              "prevName": null,
+              "data": {
+                "age": 0
+              }
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "e",
+              "prevName": null,
+              "data": {
+                "age": 0
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "e": {
+                  "age": 0
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "f": {
+              "age": 4
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "e",
+              "data": {
+                "age": 0
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "f",
+              "prevName": null,
+              "data": {
+                "age": 4
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "f": {
+                  "age": 4
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Deep update returns minimum data required",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "",
+          "params": {
+            "tag": 1,
+            "orderBy": "idx",
+            "equalTo": { "index": true }
+          },
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "a": {
+              "name": "foo",
+              "idx": true
+            },
+            "b": {
+              "name": "bar",
+              "idx": true
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "a",
+              "prevName": null,
+              "data": {
+                "name": "foo",
+                "idx": true
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "b",
+              "prevName": "a",
+              "data": {
+                "name": "bar",
+                "idx": true
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "a": {
+                  "name": "foo",
+                  "idx": true
+                },
+                "b": {
+                  "name": "bar",
+                  "idx": true
+                }
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "",
+          "tag": 1,
+          "data": {
+            "a/idx": false,
+            "b/name": "blah",
+            "c": {
+              "name": "bar",
+              "idx": true
+            }
+          },
+          "events": [
+            {
+              "path": "",
+              "type": "child_removed",
+              "name": "a",
+              "data": {
+                "name": "foo",
+                "idx": true
+              }
+            },
+            {
+              "path": "",
+              "type": "child_changed",
+              "name": "b",
+              "prevName": null,
+              "data": {
+                "name": "blah",
+                "idx": true
+              }
+            },
+            {
+              "path": "",
+              "type": "child_added",
+              "name": "c",
+              "prevName": "b",
+              "data": {
+                "name": "bar",
+                "idx": true
+              }
+            },
+            {
+              "path": "",
+              "type": "value",
+              "data": {
+                "b": {
+                  "name": "blah",
+                  "idx": true
+                },
+                "c": {
+                  "name": "bar",
+                  "idx": true
+                }
+              }
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Deep update raises all events",
+      "steps": [
+        {
+          "type": "listen",
+          "path": "a",
+          "events": []
+        },
+        {
+          "type": "listen",
+          "path": "b",
+          "events": []
+        },
+        {
+          "type": "serverUpdate",
+          "path": "",
+          "data": {
+            "a": { "aa": 1, "ab": 2 },
+            "b": { "ba": 3, "bb": 4 }
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_added",
+              "prevName": null,
+              "name": "aa",
+              "data": 1
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "prevName": "aa",
+              "name": "ab",
+              "data": 2
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "aa": 1,
+                "ab": 2
+              }
+            },
+            {
+              "path": "b",
+              "type": "child_added",
+              "prevName": null,
+              "name": "ba",
+              "data": 3
+            },
+            {
+              "path": "b",
+              "type": "child_added",
+              "prevName": "ba",
+              "name": "bb",
+              "data": 4
+            },
+            {
+              "path": "b",
+              "type": "value",
+              "data": {
+                "ba": 3,
+                "bb": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "update",
+          "path": "",
+          "data": {
+            "a/aa": 0,
+            "b/ba": 0
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_changed",
+              "prevName": null,
+              "name": "aa",
+              "data": 0
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "aa": 0,
+                "ab": 2
+              }
+            },
+            {
+              "path": "b",
+              "type": "child_changed",
+              "prevName": null,
+              "name": "ba",
+              "data": 0
+            },
+            {
+              "path": "b",
+              "type": "value",
+              "data": {
+                "ba": 0,
+                "bb": 4
+              }
+            }
+          ]
+        },
+        {
+          "type": "serverMerge",
+          "path": "a",
+          "data": {
+            "ab/abc": 1,
+            "ac/acd": 2
+          },
+          "events": [
+            {
+              "path": "a",
+              "type": "child_changed",
+              "prevName": "aa",
+              "name": "ab",
+              "data": { "abc": 1 }
+            },
+            {
+              "path": "a",
+              "type": "child_added",
+              "prevName": "ab",
+              "name": "ac",
+              "data": { "acd": 2 }
+            },
+            {
+              "path": "a",
+              "type": "value",
+              "data": {
+                "aa": 0,
+                "ab": { "abc": 1 },
+                "ac": { "acd": 2 }
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/database/tests/desktop/core/sync_point_spec_test.cc
+++ b/database/tests/desktop/core/sync_point_spec_test.cc
@@ -1,0 +1,883 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <memory>
+#include <set>
+
+#include "app/src/include/firebase/variant.h"
+#include "app/src/logger.h"
+#include "app/src/path.h"
+#include "app/src/variant_util.h"
+#include "database/src/desktop/core/child_event_registration.h"
+#include "database/src/desktop/core/indexed_variant.h"
+#include "database/src/desktop/core/sync_point_spec_generated.h"
+#include "database/src/desktop/core/sync_tree.h"
+#include "database/src/desktop/core/value_event_registration.h"
+#include "database/src/desktop/data_snapshot_desktop.h"
+#include "database/src/desktop/database_reference_desktop.h"
+#include "database/src/desktop/persistence/noop_persistence_manager.h"
+#include "database/src/desktop/persistence/persistence_manager.h"
+#include "database/src/desktop/persistence/persistence_manager_interface.h"
+#include "database/src/desktop/persistence/persistence_storage_engine.h"
+#include "database/src/desktop/query_desktop.h"
+#include "database/src/desktop/util_desktop.h"
+#include "database/src/include/firebase/database/common.h"
+#include "flatbuffers/util.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using ::testing::Eq;
+using ::testing::Not;
+using ::testing::Pointwise;
+using ::testing::Test;
+using ::testing::UnorderedPointwise;
+
+namespace firebase {
+
+using util::FlexbufferToVariant;
+
+namespace database {
+namespace internal {
+
+// Compare all fields of Events except the event registration pointer.
+MATCHER(EventEq, "EventEq") {
+  const Event& event_a = std::get<0>(arg);
+  const Event& event_b = std::get<1>(arg);
+  if (event_a.snapshot.has_value() != event_b.snapshot.has_value()) {
+    return false;
+  } else if (event_a.snapshot.has_value()) {
+    const DataSnapshotInternal& snapshot_a = *event_a.snapshot;
+    const DataSnapshotInternal& snapshot_b = *event_b.snapshot;
+    if (snapshot_a.GetKeyString() != snapshot_b.GetKeyString() ||
+        snapshot_a.GetValue() != snapshot_b.GetValue() ||
+        snapshot_a.GetPriority() != snapshot_b.GetPriority()) {
+      return false;
+    }
+  }
+  return event_a.prev_name == event_b.prev_name && event_a.path == event_b.path;
+}
+
+namespace {
+
+class FakeListenProvider : public ListenProvider {
+ public:
+  FakeListenProvider(LoggerBase* logger) : logger_(logger), listens_() {}
+
+  ~FakeListenProvider() override {}
+
+  void StartListening(const QuerySpec& query_spec, const Tag& tag,
+                      const View* view) override {
+    const Path& path = query_spec.path;
+    logger_->LogDebug(
+        "Listening at %s for Tag %s", path.c_str(),
+        tag.has_value() ? std::to_string(*tag).c_str() : "<None>");
+    assert(listens_.count(query_spec) == 0);
+    listens_.insert(query_spec);
+  }
+
+  void StopListening(const QuerySpec& query_spec, const Tag& tag) override {
+    const Path& path = query_spec.path;
+    logger_->LogDebug(
+        "Stop listening at %s for Tag %s", path.c_str(),
+        tag.has_value() ? std::to_string(*tag).c_str() : "<None>");
+    assert(listens_.count(query_spec) > 0);
+    listens_.erase(query_spec);
+  }
+
+ private:
+  LoggerBase* logger_;
+  std::set<QuerySpec> listens_;
+};
+
+class SyncTreeTest : public Test {
+ public:
+  SyncTreeTest() {
+    const char* kTestDataFile = "sync_point_spec.bin";
+    flatbuffers::LoadFile(kTestDataFile, true, &buffer_);
+    test_suite_ = test_data::GetTestSuite(buffer_.data());
+  }
+
+  void SetUp() override {
+    sync_tree_ = new SyncTree(MakeUnique<WriteTree>(),
+                              MakeUnique<NoopPersistenceManager>(),
+                              MakeUnique<FakeListenProvider>(&logger_));
+  }
+
+  void TearDown() override { delete sync_tree_; }
+  void RunOne(const char* name);
+  void RunTest(const test_data::TestCase* test_spec, Path base_path);
+
+ protected:
+  std::string buffer_;
+  const test_data::TestSuite* test_suite_;
+
+  SystemLogger logger_;
+  SyncTree* sync_tree_;
+};
+
+class TestEventRegistration : public EventRegistration {
+ public:
+  TestEventRegistration(QuerySpec query_spec) : EventRegistration(query_spec) {}
+
+  bool RespondsTo(EventType event_type) override { return true; }
+
+  Event GenerateEvent(const Change& change,
+                      const QuerySpec& query_spec) override {
+    if (change.event_type == kEventTypeValue) {
+      return Event(kEventTypeValue, this,
+                   DataSnapshotInternal(
+                       nullptr, change.indexed_variant.variant(),
+                       QuerySpec(query_spec.path.GetChild(change.child_key),
+                                 change.indexed_variant.query_params())));
+    } else {
+      return Event(change.event_type, this,
+                   DataSnapshotInternal(
+                       nullptr, change.indexed_variant.variant(),
+                       QuerySpec(query_spec.path.GetChild(change.child_key),
+                                 change.indexed_variant.query_params())),
+                   change.prev_name);
+    }
+  }
+
+  void FireEvent(const Event& event) override {
+    EXPECT_TRUE(false) << "Can't raise test events!";
+  }
+
+  void FireCancelEvent(Error error) override {
+    EXPECT_TRUE(false) << "Can't raise test events!";
+  }
+
+  bool MatchesListener(const void* listener_ptr) const override {
+    EXPECT_TRUE(false) << "Can't raise test events!";
+    return static_cast<const void*>(this) == listener_ptr;
+  }
+};
+
+UniquePtr<QueryInternal> ParseQuery(
+    UniquePtr<QueryInternal> query,
+    const test_data::QueryParams* query_params) {
+  EXPECT_NE(query_params->tag(), 0) << "Non-default queries must have a tag";
+  if (query_params->orderBy()) {
+    query.reset(query->OrderByChild(query_params->orderBy()->c_str()));
+  } else if (query_params->orderByKey()) {
+    query.reset(query->OrderByKey());
+  } else if (query_params->orderByPriority()) {
+    query.reset(query->OrderByPriority());
+  }
+  if (query_params->startAt()) {
+    const test_data::Bound* bound = query_params->startAt();
+    const char* name = bound->name() ? bound->name()->c_str() : "";
+    Variant index =
+        bound->index()
+            ? util::FlexbufferToVariant(bound->index_flexbuffer_root())
+            : Variant::Null();
+    query.reset(query->StartAt(index, name));
+  }
+  if (query_params->endAt()) {
+    const test_data::Bound* bound = query_params->endAt();
+    const char* name = bound->name() ? bound->name()->c_str() : "";
+    Variant index =
+        bound->index()
+            ? util::FlexbufferToVariant(bound->index_flexbuffer_root())
+            : Variant::Null();
+    query.reset(query->EndAt(index, name));
+  }
+  if (query_params->equalTo()) {
+    const test_data::Bound* bound = query_params->equalTo();
+    const char* name = bound->name() ? bound->name()->c_str() : "";
+    Variant index =
+        bound->index()
+            ? util::FlexbufferToVariant(bound->index_flexbuffer_root())
+            : Variant::Null();
+    query.reset(query->EqualTo(index, name));
+  }
+  if (query_params->limitToFirst()) {
+    query.reset(query->LimitToFirst(query_params->limitToFirst()));
+  }
+  if (query_params->limitToLast()) {
+    query.reset(query->LimitToLast(query_params->limitToLast()));
+  }
+  return query;
+}
+
+Event ParseEvent(const test_data::Event* event_spec, Path path) {
+  EventType type = static_cast<EventType>(event_spec->type());
+
+  EXPECT_NE(event_spec->path(), nullptr);
+  path = path.GetChild(event_spec->path()->c_str());
+  if (event_spec->name() != nullptr) {
+    path = path.GetChild(event_spec->name()->c_str());
+  }
+  Variant data = event_spec->data()
+                     ? FlexbufferToVariant(event_spec->data_flexbuffer_root())
+                     : Variant::Null();
+  DataSnapshotInternal snapshot(nullptr, data, QuerySpec(path));
+
+  const char* prev_name =
+      event_spec->prevName() != nullptr ? event_spec->prevName()->c_str() : "";
+  return Event(type, nullptr, snapshot, prev_name);
+}
+
+void SyncTreeTest::RunTest(const test_data::TestCase* test_spec,
+                           Path base_path) {
+  logger_.LogInfo("Running \"%s\"", test_spec->name()->c_str());
+
+  int current_write_id = 0;
+
+  std::map<int, EventRegistration*> registrations;
+  for (const test_data::Step* spec : *test_spec->steps()) {
+    if (spec->comment()) {
+      logger_.LogInfo(" > %s", spec->comment()->c_str());
+    }
+    const char* path_str = spec->path() ? spec->path()->c_str() : "";
+    Path path = base_path.GetChild(path_str);
+    DatabaseReferenceInternal reference(nullptr, path);
+    std::vector<Event> expected;
+    for (const auto* event_spec : *spec->events()) {
+      expected.push_back(ParseEvent(event_spec, base_path));
+    }
+    switch (spec->type()) {
+      case test_data::StepType_listen: {
+        UniquePtr<QueryInternal> query(new QueryInternal(reference));
+        if (spec->params()) {
+          query = ParseQuery(std::move(query), spec->params());
+        }
+        EventRegistration* event_registration = nullptr;
+        int callback_id = spec->callbackId();
+        if (callback_id != 0 && registrations.count(callback_id) != 0) {
+          event_registration = registrations[callback_id];
+        } else {
+          event_registration = new TestEventRegistration(query->query_spec());
+          if (callback_id != 0) {
+            registrations[callback_id] = event_registration;
+          }
+        }
+        std::vector<Event> actual = sync_tree_->AddEventRegistration(
+            UniquePtr<EventRegistration>(event_registration));
+        EXPECT_THAT(actual, Pointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_unlisten: {
+        EventRegistration* event_registration = nullptr;
+        int callback_id = spec->callbackId();
+        EXPECT_TRUE(callback_id != 0 && registrations.count(callback_id) != 0);
+        event_registration = registrations[callback_id];
+        ASSERT_NE(event_registration, nullptr);
+        std::vector<Event> actual = sync_tree_->RemoveEventRegistration(
+            event_registration->query_spec(),
+            static_cast<void*>(event_registration), kErrorNone);
+        EXPECT_THAT(actual, Pointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_serverUpdate: {
+        Variant update = spec->data()
+                             ? FlexbufferToVariant(spec->data_flexbuffer_root())
+                             : Variant::Null();
+        std::vector<Event> actual;
+        if (spec->tag()) {
+          actual = sync_tree_->ApplyTaggedQueryOverwrite(path, update,
+                                                         Tag(spec->tag()));
+        } else {
+          actual = sync_tree_->ApplyServerOverwrite(path, update);
+        }
+        EXPECT_THAT(actual, UnorderedPointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_serverMerge: {
+        std::map<Path, Variant> merges =
+            VariantToPathMap(FlexbufferToVariant(spec->data_flexbuffer_root()));
+        std::vector<Event> actual;
+        if (spec->tag()) {
+          actual =
+              sync_tree_->ApplyTaggedQueryMerge(path, merges, Tag(spec->tag()));
+        } else {
+          actual = sync_tree_->ApplyServerMerge(path, merges);
+        }
+        EXPECT_THAT(actual, UnorderedPointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_set: {
+        Variant to_set = FlexbufferToVariant(spec->data_flexbuffer_root());
+        OverwriteVisibility visible =
+            spec->visible() ? kOverwriteVisible : kOverwriteInvisible;
+        // For now, assume anything visible should be persisted.
+        Persist persist = spec->visible() ? kPersist : kDoNotPersist;
+        std::vector<Event> actual = sync_tree_->ApplyUserOverwrite(
+            path, to_set, to_set, current_write_id++, visible, persist);
+        EXPECT_THAT(actual, UnorderedPointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_update: {
+        CompoundWrite merges = CompoundWrite::FromVariantMerge(
+            FlexbufferToVariant(spec->data_flexbuffer_root()));
+        std::vector<Event> actual = sync_tree_->ApplyUserMerge(
+            path, merges, merges, current_write_id++, kPersist);
+        EXPECT_THAT(actual, UnorderedPointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_ackUserWrite: {
+        int to_clear = static_cast<int>(spec->writeId());
+        AckStatus ack_status = spec->revert() ? kAckRevert : kAckConfirm;
+        std::vector<Event> actual = sync_tree_->AckUserWrite(
+            to_clear, ack_status, kPersist, /*server_time_offset=*/0);
+        EXPECT_THAT(actual, UnorderedPointwise(EventEq(), expected));
+        break;
+      }
+      case test_data::StepType_suppressWarning: {
+        // Do nothing. This is a hack so JS's Jasmine tests don't throw warnings
+        // for "expect no errors" tests.
+        break;
+      }
+      default: {
+        EXPECT_TRUE(false) << "Unknown spec: " << spec->type();
+      }
+    }
+  }
+}
+
+void SyncTreeTest::RunOne(const char* name) {
+  for (const auto* test_spec : *test_suite_->test_cases()) {
+    if (strcmp(name, test_spec->name()->c_str()) == 0) {
+      RunTest(test_spec, Path());
+
+      TearDown();
+      SetUp();
+
+      // Run again at a deeper path.
+      RunTest(test_spec, Path("foo/bar/baz"));
+      return;
+    }
+  }
+  EXPECT_TRUE(false) << "Didn't find test spec with name " << name;
+}
+
+TEST(EventEqTest, Matcher) {
+  TestEventRegistration event_registration((QuerySpec()));
+  TestEventRegistration another_event_registration((QuerySpec()));
+
+  QueryParams query_params;
+  QueryParams different_query_params;
+  different_query_params.start_at_value = 9999;
+
+  DataSnapshotInternal snapshot(nullptr, 1234, QuerySpec(query_params));
+  DataSnapshotInternal snapshot_with_different_query_params(
+      nullptr, 1234, QuerySpec(different_query_params));
+  DataSnapshotInternal snapshot_with_different_value(nullptr, 4321,
+                                                     QuerySpec(query_params));
+
+  // These events should all be considered equal, even if they differ in a few
+  // specific ways.
+  Event event(kEventTypeValue, &event_registration, snapshot, "previous");
+  Event same_event(kEventTypeValue, &event_registration, snapshot, "previous");
+  Event different_registration_event(
+      kEventTypeValue, &another_event_registration, snapshot, "previous");
+  Event different_query_params_event(kEventTypeValue, &event_registration,
+                                     snapshot, "previous");
+
+  // These events should not be considered equal, as they each differ in
+  // important, critical ways.
+  Event null_snapshot_event(kEventTypeValue, &event_registration, snapshot,
+                            "previous");
+  null_snapshot_event.snapshot = Optional<DataSnapshotInternal>();
+  Event different_snapshot_value_event(kEventTypeValue, &event_registration,
+                                       snapshot_with_different_value,
+                                       "previous");
+  Event different_prevname_event(kEventTypeValue, &event_registration, snapshot,
+                                 "next");
+
+  EXPECT_THAT(std::make_tuple(event, same_event), EventEq());
+  EXPECT_THAT(std::make_tuple(event, different_registration_event), EventEq());
+  EXPECT_THAT(std::make_tuple(event, different_query_params_event), EventEq());
+
+  EXPECT_THAT(std::make_tuple(event, null_snapshot_event), Not(EventEq()));
+  EXPECT_THAT(std::make_tuple(event, different_snapshot_value_event),
+              Not(EventEq()));
+  EXPECT_THAT(std::make_tuple(event, different_prevname_event), Not(EventEq()));
+}
+
+TEST_F(SyncTreeTest, DefaultListenHandlesParentSet) {
+  RunOne("Default listen handles a parent set");
+}
+
+TEST_F(SyncTreeTest, DefaultListenHandlesASetAtTheSameLevel) {
+  RunOne("Default listen handles a set at the same level");
+}
+
+TEST_F(SyncTreeTest, AQueryCanGetACompleteCacheThenAMerge) {
+  RunOne("A query can get a complete cache then a merge");
+}
+
+TEST_F(SyncTreeTest, ServerMergeOnListenerWithCompleteChildren) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Server merge on listener with complete children");
+}
+
+TEST_F(SyncTreeTest, DeepMergeOnListenerWithCompleteChildren) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Deep merge on listener with complete children");
+}
+
+TEST_F(SyncTreeTest, UpdateChildListenerTwice) {
+  RunOne("Update child listener twice");
+}
+
+TEST_F(SyncTreeTest, ChildOfDefaultListenThatAlreadyHasACompleteCache) {
+  RunOne("Update child of default listen that already has a complete cache");
+}
+
+TEST_F(SyncTreeTest, UpdateChildOfDefaultListenThatHasNoCache) {
+  RunOne("Update child of default listen that has no cache");
+}
+
+TEST_F(SyncTreeTest, UpdateTheChildOfACoLocatedDefaultListenerAndQuery) {
+  RunOne(
+      "Update (via set) the child of a co-located default listener and "
+      "query");
+}
+
+TEST_F(SyncTreeTest, UpdateTheChildOfAQueryWithAFullCache) {
+  RunOne("Update (via set) the child of a query with a full cache");
+}
+
+TEST_F(SyncTreeTest, UpdateAChildBelowAnEmptyQuery) {
+  RunOne("Update (via set) a child below an empty query");
+}
+
+TEST_F(SyncTreeTest, UpdateDescendantOfDefaultListenerWithFullCache) {
+  RunOne("Update descendant of default listener with full cache");
+}
+
+TEST_F(SyncTreeTest, DescendantSetBelowAnEmptyDefaultLIstenerIsIgnored) {
+  RunOne("Descendant set below an empty default listener is ignored");
+}
+
+TEST_F(SyncTreeTest, UpdateOfAChild) {
+  RunOne(
+      "Update of a child. This can happen if a child listener is added and "
+      "removed");
+}
+
+TEST_F(SyncTreeTest, RevertSetWithOnlyChildCaches) {
+  RunOne("Revert set with only child caches");
+}
+
+TEST_F(SyncTreeTest, CanRevertADuplicateChildSet) {
+  RunOne("Can revert a duplicate child set");
+}
+
+TEST_F(SyncTreeTest, CanRevertAChildSetAndSeeTheUnderlyingData) {
+  RunOne("Can revert a child set and see the underlying data");
+}
+
+TEST_F(SyncTreeTest, RevertChildSetWithNoServerData) {
+  RunOne("Revert child set with no server data");
+}
+
+TEST_F(SyncTreeTest, RevertDeepSetWithNoServerData) {
+  RunOne("Revert deep set with no server data");
+}
+
+TEST_F(SyncTreeTest, RevertSetCoveredByNonvisibleTransaction) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Revert set covered by non-visible transaction");
+}
+
+TEST_F(SyncTreeTest, ClearParentShadowingServerValuesSetWithServerChildren) {
+  RunOne("Clear parent shadowing server values set with server children");
+}
+
+TEST_F(SyncTreeTest, ClearChildShadowingServerValuesSetWithServerChildren) {
+  RunOne("Clear child shadowing server values set with server children");
+}
+
+TEST_F(SyncTreeTest, UnrelatedMergeDoesntShadowServerUpdates) {
+  RunOne("Unrelated merge doesn't shadow server updates");
+}
+
+TEST_F(SyncTreeTest, CanSetAlongsideARemoteMerge) {
+  RunOne("Can set alongside a remote merge");
+}
+
+TEST_F(SyncTreeTest, SetPriorityOnALocationWithNoCache) {
+  // GTEST_SKIP();
+  RunOne("setPriority on a location with no cache");
+}
+
+TEST_F(SyncTreeTest, DeepUpdateDeletesChildFromLimitWindowAndPullsInNewChild) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("deep update deletes child from limit window and pulls in new child");
+}
+
+TEST_F(SyncTreeTest, DeepSetDeletesChildFromLimitWindowAndPullsInNewChild) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("deep set deletes child from limit window and pulls in new child");
+}
+
+TEST_F(SyncTreeTest, EdgeCaseInNewChildForChange) {
+  RunOne("Edge case in newChildForChange_");
+}
+
+TEST_F(SyncTreeTest, RevertSetInQueryWindow) {
+  RunOne("Revert set in query window");
+}
+
+TEST_F(SyncTreeTest, HandlesAServerValueMovingAChildOutOfAQueryWindow) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Handles a server value moving a child out of a query window");
+}
+
+TEST_F(SyncTreeTest, UpdateOfIndexedChildWorks) {
+  RunOne("Update of indexed child works");
+}
+
+TEST_F(SyncTreeTest, MergeAppliedToEmptyLimit) {
+  RunOne("Merge applied to empty limit");
+}
+
+TEST_F(SyncTreeTest, LimitIsRefilledFromServerDataAfterMerge) {
+  RunOne("Limit is refilled from server data after merge");
+}
+
+TEST_F(SyncTreeTest, HandleRepeatedListenWithMergeAsFirstUpdate) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Handle repeated listen with merge as first update");
+}
+
+TEST_F(SyncTreeTest, LimitIsRefilledFromServerDataAfterSet) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Limit is refilled from server data after set");
+}
+
+TEST_F(SyncTreeTest, QueryOnWeirdPath) { RunOne("query on weird path."); }
+
+TEST_F(SyncTreeTest, RunsRound2) { RunOne("runs, round2"); }
+
+TEST_F(SyncTreeTest, HandlesNestedListens) { RunOne("handles nested listens"); }
+
+TEST_F(SyncTreeTest, HandlesASetBelowAListen) {
+  RunOne("Handles a set below a listen");
+}
+
+TEST_F(SyncTreeTest, DoesNonDefaultQueries) {
+  RunOne("does non-default queries");
+}
+
+TEST_F(SyncTreeTest, HandlesCoLocatedDefaultListenerAndQuery) {
+  RunOne("handles a co-located default listener and query");
+}
+
+TEST_F(SyncTreeTest,
+       DefaultAndNonDefaultListenerAtSameLocationWithServerUpdate) {
+  RunOne(
+      "Default and non-default listener at same location with server update");
+}
+
+TEST_F(SyncTreeTest,
+       AddAParentListenerToACompleteChildListenerExpectChildEvent) {
+  RunOne(
+      "Add a parent listener to a complete child listener, expect child "
+      "event");
+}
+
+TEST_F(SyncTreeTest, AddListensToASetExpectCorrectEventsIncludingAChildEvent) {
+  RunOne(
+      "Add listens to a set, expect correct events, including a child event");
+}
+
+TEST_F(SyncTreeTest, ServerUpdateToAChildListenerRaisesChildEventsAtParent) {
+  RunOne("ServerUpdate to a child listener raises child events at parent");
+}
+
+TEST_F(SyncTreeTest,
+       ServerUpdateToAChildListenerRaisesChildEventsAtParentQuery) {
+  RunOne(
+      "ServerUpdate to a child listener raises child events at parent query");
+}
+
+TEST_F(SyncTreeTest, MultipleCompleteChildrenAreHandleProperly) {
+  RunOne("Multiple complete children are handled properly");
+}
+
+TEST_F(SyncTreeTest, WriteLeafNodeOverwriteAtParentNode) {
+  RunOne("Write leaf node, overwrite at parent node");
+}
+
+TEST_F(SyncTreeTest, ConfirmCompleteChildrenFromTheServer) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Confirm complete children from the server");
+}
+
+TEST_F(SyncTreeTest, WriteLeafOverwriteFromParent) {
+  RunOne("Write leaf, overwrite from parent");
+}
+
+TEST_F(SyncTreeTest, BasicUpdateTest) { RunOne("Basic update test"); }
+
+TEST_F(SyncTreeTest, NoDoubleValueEventsForUserAck) {
+  RunOne("No double value events for user ack");
+}
+
+TEST_F(SyncTreeTest, BasicKeyIndexSanityCheck) {
+  RunOne("Basic key index sanity check");
+}
+
+TEST_F(SyncTreeTest, CollectCorrectSubviewsToListenOn) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Collect correct subviews to listen on");
+}
+
+TEST_F(SyncTreeTest, LimitToFirstOneOnOrderedQuery) {
+  RunOne("Limit to first one on ordered query");
+}
+
+TEST_F(SyncTreeTest, LimitToLastOneOnOrderedQuery) {
+  RunOne("Limit to last one on ordered query");
+}
+
+TEST_F(SyncTreeTest, UpdateIndexedValueOnExistingChildFromLimitedQuery) {
+  RunOne("Update indexed value on existing child from limited query");
+}
+
+TEST_F(SyncTreeTest, CanCreateStartAtEndAtEqualToQueriesWithBool) {
+  RunOne("Can create startAt, endAt, equalTo queries with bool");
+}
+
+TEST_F(SyncTreeTest, QueryForExistingServerSnap) {
+  RunOne("Query with existing server snap");
+}
+
+TEST_F(SyncTreeTest, ServerDataIsNotPurgedForNonServerIndexedQueries) {
+  RunOne("Server data is not purged for non-server-indexed queries");
+}
+
+TEST_F(SyncTreeTest, LimitWithCustomOrderByIsRefilledWithCorrectItem) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Limit with custom orderBy is refilled with correct item");
+}
+
+TEST_F(SyncTreeTest, StartAtEndAtDominatesLimit) {
+  RunOne("startAt/endAt dominates limit");
+}
+
+TEST_F(SyncTreeTest, UpdateToSingleChildThatMovesOutOfWindow) {
+  RunOne("Update to single child that moves out of window");
+}
+
+TEST_F(SyncTreeTest, LimitedQueryDoesntPullInOutOfRangeChild) {
+  RunOne("Limited query doesn't pull in out of range child");
+}
+
+TEST_F(SyncTreeTest, MergerForLocationWithDefaultAndLimitedListener) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Merge for location with default and limited listener");
+}
+
+TEST_F(SyncTreeTest, UserMergePullsInCorrectValues) {
+  RunOne("User merge pulls in correct values");
+}
+
+TEST_F(SyncTreeTest, UserDeepSetPullsInCorrectValues) {
+  RunOne("User deep set pulls in correct values");
+}
+
+TEST_F(SyncTreeTest, QueriesWithEqualToNullWork) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Queries with equalTo(null) work");
+}
+
+TEST_F(SyncTreeTest, RevertedWritesUpdateQuery) {
+  RunOne("Reverted writes update query");
+}
+
+TEST_F(SyncTreeTest, DeepSetForNonLocalDataDoesntRaiseEvents) {
+  RunOne("Deep set for non-local data doesn't raise events");
+}
+
+TEST_F(SyncTreeTest, UserUpdateWithNewChildrenTriggersEvents) {
+  RunOne("User update with new children triggers events");
+}
+
+TEST_F(SyncTreeTest, UserWriteWithDeepOverwrite) {
+  RunOne("User write with deep user overwrite");
+}
+
+TEST_F(SyncTreeTest, DeepServerMerge) { RunOne("Deep server merge"); }
+
+TEST_F(SyncTreeTest, ServerUpdatesPriority) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Server updates priority");
+}
+
+TEST_F(SyncTreeTest, RevertFullUnderlyingWrite) {
+  RunOne("Revert underlying full overwrite");
+}
+
+TEST_F(SyncTreeTest, UserChildOverwriteForNonexistentServerNode) {
+  RunOne("User child overwrite for non-existent server node");
+}
+
+TEST_F(SyncTreeTest, RevertUserOverwriteOfChildOnLeafNode) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Revert user overwrite of child on leaf node");
+}
+
+TEST_F(SyncTreeTest, ServerOverwriteWithDeepUserDelete) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Server overwrite with deep user delete");
+}
+
+TEST_F(SyncTreeTest, UserOverwritesLeafNodeWithPriority) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("User overwrites leaf node with priority");
+}
+
+TEST_F(SyncTreeTest, UserOverwritesInheritPriorityValuesFromLeafNodes) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("User overwrites inherit priority values from leaf nodes");
+}
+
+TEST_F(SyncTreeTest, UserUpdateOnUserSetLeafNodeWithPriorityAfterServerUpdate) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("User update on user set leaf node with priority after server update");
+}
+
+TEST_F(SyncTreeTest, ServerDeepDeleteOnLeafNode) {
+  RunOne("Server deep delete on leaf node");
+}
+
+TEST_F(SyncTreeTest, UserSetsRootPriority) {
+  RunOne("User sets root priority");
+}
+
+TEST_F(SyncTreeTest, UserUpdatesPriorityOnEmptyRoot) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("User updates priority on empty root");
+}
+
+TEST_F(SyncTreeTest, RevertSetAtRootWithPriority) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Revert set at root with priority");
+}
+
+TEST_F(SyncTreeTest, ServerUpdatesPriorityAfterUserSetsPriority) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Server updates priority after user sets priority");
+}
+
+TEST_F(SyncTreeTest, EmptySetDoesntPreventServerUpdates) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Empty set doesn't prevent server updates");
+}
+
+TEST_F(SyncTreeTest, UserUpdatesPriorityTwiceFirstIsReverted) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("User updates priority twice, first is reverted");
+}
+
+TEST_F(SyncTreeTest, ServerAcksRootPrioritySetAfterUserDeletesRootNode) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Server acks root priority set after user deletes root node");
+}
+
+TEST_F(SyncTreeTest, ADeleteInAMergeDoesntPushOutNodes) {
+  RunOne("A delete in a merge doesn't push out nodes");
+}
+
+TEST_F(SyncTreeTest, ATaggedQueryFiresEventsEventually) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("A tagged query fires events eventually");
+}
+
+TEST_F(SyncTreeTest, AServerUpdateThatLeavesUserSetsUnchangedIsNotIgnored) {
+  RunOne("A server update that leaves user sets unchanged is not ignored");
+}
+
+TEST_F(SyncTreeTest, UserWriteOutsideOfLimitIsIgnoredForTaggedQueries) {
+  RunOne("User write outside of limit is ignored for tagged queries");
+}
+
+TEST_F(SyncTreeTest, AckForMergeDoesntRaiseValueEventForLaterListen) {
+  RunOne("Ack for merge doesn't raise value event for later listen");
+}
+
+TEST_F(SyncTreeTest, ClearParentShadowingServerValuesMergeWithServerChildren) {
+  RunOne("Clear parent shadowing server values merge with server children");
+}
+
+TEST_F(SyncTreeTest, PrioritiesDontMakeMeSick) {
+  GTEST_SKIP();  // Fails assert.
+  RunOne("Priorities don't make me sick");
+}
+
+TEST_F(SyncTreeTest,
+       MergeThatMovesChildFromWindowToBoundaryDoesNotCauseChildToBeReadded) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne(
+      "Merge that moves child from window to boundary does not cause child "
+      "to be readded");
+}
+
+TEST_F(SyncTreeTest, DeepMergeAckIsHandledCorrectly) {
+  RunOne("Deep merge ack is handled correctly.");
+}
+
+TEST_F(SyncTreeTest, DeepMergeAckOnIncompleteDataAndWithServerValues) {
+  RunOne("Deep merge ack (on incomplete data, and with server values)");
+}
+
+TEST_F(SyncTreeTest, LimitQueryHandlesDeepServerMergeForOutOfViewItem) {
+  RunOne("Limit query handles deep server merge for out-of-view item.");
+}
+
+TEST_F(SyncTreeTest, LimitQueryHandlesDeepUserMergeForOutOfViewItem) {
+  RunOne("Limit query handles deep user merge for out-of-view item.");
+}
+
+TEST_F(SyncTreeTest,
+       LimitQueryHandlesDeepUserMergeForOutOfViewItemFollowedByServerUpdate) {
+  RunOne(
+      "Limit query handles deep user merge for out-of-view item followed by "
+      "server update.");
+}
+
+TEST_F(SyncTreeTest, UnrelatedUntaggedUpdateIsNotCachedInTaggedListen) {
+  RunOne("Unrelated, untagged update is not cached in tagged listen");
+}
+
+TEST_F(SyncTreeTest, UnrelatedAckedSetIsNotCachedInTaggedListen) {
+  RunOne("Unrelated, acked set is not cached in tagged listen");
+}
+
+TEST_F(SyncTreeTest, UnrelatedAckedUpdateIsNotCachedInTaggedListen) {
+  RunOne("Unrelated, acked update is not cached in tagged listen");
+}
+
+TEST_F(SyncTreeTest, DeepUpdateRaisesImmediateEventsOnlyIfHasCompleteData) {
+  GTEST_SKIP();  // Fails expectations.
+  RunOne("Deep update raises immediate events only if has complete data");
+}
+
+TEST_F(SyncTreeTest, DeepUpdateReturnsMinimumDataRequired) {
+  RunOne("Deep update returns minimum data required");
+}
+
+TEST_F(SyncTreeTest, DeepUpdateRaisesAllEvents) {
+  RunOne("Deep update raises all events");
+}
+
+}  // namespace
+}  // namespace internal
+}  // namespace database
+}  // namespace firebase


### PR DESCRIPTION
The new test suite is driven by the same master set of test cases that
drive SyncPoint tests on the iOS and Android implementation.

All tests are run twice, once at the root, and once again at a deeper
level, to ensure that the depth of the changes made does not matter.

Some tests currently fail. It's not clear if these are legitimate bugs
in the test suite, or if there are some bugs in the DB implementation.
For the time being, these tests are skipped using `GTEST_SKIP();` and
are annotated with whether they result in an assert being triggered or
just a failure due to unmet expectations. Fixes for these failing tests
will be made in follow-up PR's.