### PR TITLE
Fix Firestore 7.10.0 build in C++ SDK, and match NanoPB versions.

### DIFF
--- a/cmake/external/nanopb.cmake
+++ b/cmake/external/nanopb.cmake
@@ -18,12 +18,14 @@ if(TARGET nanopb OR NOT DOWNLOAD_NANOPB)
   return()
 endif()
 
+set(version 0.3.9.8)
+
 ExternalProject_Add(
   nanopb
 
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  URL https://github.com/nanopb/nanopb/archive/0.3.9.2.tar.gz
-  URL_HASH SHA256=b8dd5cb0d184d424ddfea13ddee3f7b0920354334cbb44df434d55e5f0086b12
+  URL https://github.com/nanopb/nanopb/archive/nanopb-${version}.tar.gz
+  URL_HASH SHA256=2047ff111ca408c9b3c06a6774b723c1b1c9e31dc2320c61ee3abce93359eb30
 
   PREFIX ${PROJECT_BINARY_DIR}
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -313,7 +313,7 @@ else()
   target_include_directories(firebase_firestore
     PUBLIC
       ${FIRESTORE_SOURCE_DIR}/Firestore/core/include
-      ${FIRESTORE_SOURCE_DIR}/Firestore/Protos/nanpob
+      ${FIRESTORE_SOURCE_DIR}/Firestore/Protos/nanopb
     PRIVATE
       ${FIRESTORE_SOURCE_DIR}
   )

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -299,6 +299,7 @@ if(IOS)
       # The Firestore core on iOS comes via the FirebaseFirestore CocoaPod, and
       # public headers should come from there.
       ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include
+      ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/Protos/nanopb
     PRIVATE
       # Additionally, the core C++ API is not declared publicly within the
       # FirebaseFirestore pod, so depend on headers available in the source
@@ -312,6 +313,7 @@ else()
   target_include_directories(firebase_firestore
     PUBLIC
       ${FIRESTORE_SOURCE_DIR}/Firestore/core/include
+      ${FIRESTORE_SOURCE_DIR}/Firestore/Protos/nanpob
     PRIVATE
       ${FIRESTORE_SOURCE_DIR}
   )


### PR DESCRIPTION
Add the new Firestore nanopb proto header path to the build.
Update NanoPB package to match Firestore version.
