### PR TITLE
Switch to a Firestore commit that fixes a Windows build error.

### DIFF
--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -18,7 +18,7 @@ if(TARGET firestore)
   return()
 endif()
 
-set(version CocoaPods-7.10.0)
+set(version 9bae3613d885fb8cc7d74c612c90f821a0e1981f)
 ExternalProject_Add(
   firestore
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -324,7 +324,12 @@ set(FIREBASE_FIRESTORE_CPP_DEFINES -DINTERNAL_EXPERIMENTAL=1)
 if (WIN32 AND NOT ANDROID AND NOT IOS)
   # On Windows, gRPC gives a compiler error in firebase_metadata_provider_desktop.cc
   # unless _WIN32_WINNT is defined to this value (0x0600, Windows Vista).
+  # Also set -DNOMINMAX for both Firestore and Firestore Core.
   set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600 -DNOMINMAX)
+  target_compile_definitions(firestore_core
+    PRIVATE
+      -DNOMINMAX
+  )
 endif()
 
 target_compile_definitions(firebase_firestore

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -292,8 +292,11 @@ def main(argv):
 
     # Extract test failures, which follow "TESTAPPS EXPERIENCED ERRORS:"
     m = re.search(r'^TEST SUMMARY(.*)TESTAPPS (EXPERIENCED ERRORS|FAILED):\n(([^\n]*\n)+)', log_text, re.MULTILINE | re.DOTALL)
-    if m and ((SIMULATOR in platform and not "(ON SIMULATOR)" in m.group(1)) or
-        (HARDWARE in platform and not "(ON HARDWARE)" in m.group(1))):
+    # If the log reports "(ON SIMULATOR)" or "(ON HARDWARE)", make sure it matches the platform.
+    if m and "(ON " in m.group(1) and (
+        (SIMULATOR in platform and not "(ON SIMULATOR)" in m.group(1)) or
+        (HARDWARE in platform and not "(ON HARDWARE)" in m.group(1))
+      ):
       m = None  # don't process this if it's for the wrong hardware target
     if m:
       for test_failure_line in m.group(3).strip("\n").split("\n"):

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -205,7 +205,9 @@ def print_log(log_results):
 def print_github_log(log_results):
   """Print a text log, but replace newlines with %0A and add
   the GitHub ::error text."""
-  output_lines = [LOG_HEADER, ""] + print_log(log_results)
+  output_lines = [LOG_HEADER,
+                  "".ljust(len(LOG_HEADER), "—"),
+                  ""] + print_log(log_results)
   # "%0A" produces a newline in GitHub workflow logs.
   return ["::error ::%s" % "%0A".join(output_lines)]
 


### PR DESCRIPTION
This fixes a Windows build error in Firestore's core library.
Also fix log summarization (as a minor change) on Android.