### PR TITLE
Prevent absl_time_zone from using weak symbols on Windows.

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -325,6 +325,12 @@ if (WIN32 AND NOT ANDROID AND NOT IOS)
   # On Windows, gRPC gives a compiler error in firebase_metadata_provider_desktop.cc
   # unless _WIN32_WINNT is defined to this value (0x0600, Windows Vista).
   set(FIREBASE_FIRESTORE_CPP_DEFINES ${FIREBASE_FIRESTORE_CPP_DEFINES} -D_WIN32_WINNT=0x0600 -DNOMINMAX)
+  # Special handling for the absl time zone library, define _LIBCPP_VERSION on
+  # Windows to avoid the shenanigans they do with Windows mangled symbols to
+  # accomplish weak linking. See
+  # https://github.com/google/cctz/blob/master/src/zone_info_source.cc for a
+  # look at what we're up against.
+  target_compile_definitions(absl_time_zone "-D_LIBCPP_VERSION=99")
 endif()
 
 target_compile_definitions(firebase_firestore

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -331,7 +331,9 @@ if (WIN32 AND NOT ANDROID AND NOT IOS)
   # accomplish weak linking. See
   # https://github.com/google/cctz/blob/master/src/zone_info_source.cc for a
   # look at what we're up against.
-  target_compile_definitions(absl_time_zone "-D_LIBCPP_VERSION=99")
+  target_compile_definitions(absl_time_zone
+    PRIVATE
+    _LIBCPP_VERSION=99)
 endif()
 
 target_compile_definitions(firebase_firestore


### PR DESCRIPTION
On Windows, absl's time_internal library does some stuff to achieve having a weak symbol. This completely fails in our binary builds.

Our binary builds don't care about zone_info_source_factory being a weak symbol. This change makes absl time_info no longer broken on Windows.

(Also, don't bother setting NOMINMAX on firestore_core directly - it already has it set internally.)
