### PR TITLE
Use Firebase/Crashlytics instead of Crashlytics.

### DIFF
--- a/ios_pod/Podfile
+++ b/ios_pod/Podfile
@@ -7,6 +7,7 @@ target 'GetPods' do
   pod 'Firebase/AdMob', '7.10.0'
   pod 'Firebase/Analytics', '7.10.0'
   pod 'Firebase/Auth', '7.10.0'
+  pod 'Firebase/Crashlytics', '7.10.0'
   pod 'Firebase/Database', '7.10.0'
   pod 'Firebase/DynamicLinks', '7.10.0'
   pod 'Firebase/Firestore', '7.10.0'
@@ -17,5 +18,4 @@ target 'GetPods' do
   pod 'Firebase/RemoteConfig', '7.10.0'
   pod 'Firebase/Storage', '7.10.0'
 
-  pod 'Crashlytics', '3.14.0'
 end


### PR DESCRIPTION
The previous version of Crashlytics (3.x) was missing some headers required for Unity builds.