### PR TITLE
Fix NPE in android_abis.gradle if ANDROID_NDK_HOME is not set

### DIFF
--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -24,8 +24,9 @@ android {
       // Default list of ABIs available in up-to-date NDK.
       abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
 
-      if (System.getenv("ANDROID_NDK_HOME").contains("r16b") ||
-          System.getenv("ANDROID_NDK_HOME").contains("r11c")) {
+      if (System.getenv("ANDROID_NDK_HOME") != null && (
+              System.getenv("ANDROID_NDK_HOME").contains("r16b") ||
+              System.getenv("ANDROID_NDK_HOME").contains("r11c"))) {
         // Deprecated ABIs are added to the list when building using older NDKs only.
         // Rather than an exhaustive list, we only support r11c and r16b.
         abiFilters.add("armeabi")

--- a/android_build_files/android_abis.gradle
+++ b/android_build_files/android_abis.gradle
@@ -25,8 +25,8 @@ android {
       abiFilters "x86", "armeabi-v7a", "arm64-v8a", "x86_64"
 
       if (System.getenv("ANDROID_NDK_HOME") != null && (
-              System.getenv("ANDROID_NDK_HOME").contains("r16b") ||
-              System.getenv("ANDROID_NDK_HOME").contains("r11c"))) {
+          System.getenv("ANDROID_NDK_HOME").contains("r16b") ||
+          System.getenv("ANDROID_NDK_HOME").contains("r11c"))) {
         // Deprecated ABIs are added to the list when building using older NDKs only.
         // Rather than an exhaustive list, we only support r11c and r16b.
         abiFilters.add("armeabi")


### PR DESCRIPTION
This fixes the following cryptic build error if the "ANDROID_NDK_HOME" environment variable is not set:

```
java.lang.NullPointerException: Cannot invoke method contains() on null object
```