### PR TITLE
Applied clang-tidy modernize fixups

### DIFF
--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -133,10 +133,10 @@ FutureCallbackData* CreateFutureCallbackData(FutureData* future_data,
 
 // Non-inline implementation of the Listeners' virtual destructors, to prevent
 // their vtables from being emitted in each translation unit.
-BannerView::Listener::~Listener() {}
-InterstitialAd::Listener::~Listener() {}
-NativeExpressAdView::Listener::~Listener() {}
-rewarded_video::Listener::~Listener() {}
+BannerView::Listener::~Listener() = default;
+InterstitialAd::Listener::~Listener() = default;
+NativeExpressAdView::Listener::~Listener() = default;
+rewarded_video::Listener::~Listener() = default;
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -16,8 +16,7 @@
 
 #include "admob/src/common/admob_common.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <vector>
 
 #include "admob/src/include/firebase/admob.h"

--- a/admob/src/common/admob_common.h
+++ b/admob/src/common/admob_common.h
@@ -17,8 +17,7 @@
 #ifndef FIREBASE_ADMOB_CLIENT_CPP_SRC_COMMON_ADMOB_COMMON_H_
 #define FIREBASE_ADMOB_CLIENT_CPP_SRC_COMMON_ADMOB_COMMON_H_
 
-#include <stdarg.h>
-
+#include <cstdarg>
 #include <vector>
 
 #include "app/src/cleanup_notifier.h"

--- a/admob/src/include/firebase/admob/rewarded_video.h
+++ b/admob/src/include/firebase/admob/rewarded_video.h
@@ -148,9 +148,9 @@ class Listener {
 class PollableRewardListener : public Listener {
  public:
   PollableRewardListener();
-  ~PollableRewardListener();
-  void OnRewarded(RewardItem reward);
-  void OnPresentationStateChanged(PresentationState state);
+  ~PollableRewardListener() override;
+  void OnRewarded(RewardItem reward) override;
+  void OnPresentationStateChanged(PresentationState state) override;
 
   /// Pop the oldest queued reward, and copy its data into the provided
   /// RewardItem. If no reward is available, the struct is unchanged.

--- a/admob/src/stub/banner_view_internal_stub.h
+++ b/admob/src/stub/banner_view_internal_stub.h
@@ -31,7 +31,7 @@ class BannerViewInternalStub : public BannerViewInternal {
   explicit BannerViewInternalStub(BannerView* base)
       : BannerViewInternal(base) {}
 
-  ~BannerViewInternalStub() override {}
+  ~BannerViewInternalStub() override = default;
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id,
                           AdSize size) override {

--- a/admob/src/stub/interstitial_ad_internal_stub.h
+++ b/admob/src/stub/interstitial_ad_internal_stub.h
@@ -31,7 +31,7 @@ class InterstitialAdInternalStub : public InterstitialAdInternal {
   explicit InterstitialAdInternalStub(InterstitialAd* base)
       : InterstitialAdInternal(base) {}
 
-  ~InterstitialAdInternalStub() override {}
+  ~InterstitialAdInternalStub() override = default;
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id) override {
     return CreateAndCompleteFutureStub(kInterstitialAdFnInitialize);

--- a/admob/src/stub/native_express_ad_view_internal_stub.h
+++ b/admob/src/stub/native_express_ad_view_internal_stub.h
@@ -31,7 +31,7 @@ class NativeExpressAdViewInternalStub : public NativeExpressAdViewInternal {
   explicit NativeExpressAdViewInternalStub(NativeExpressAdView* base)
       : NativeExpressAdViewInternal(base) {}
 
-  ~NativeExpressAdViewInternalStub() override {}
+  ~NativeExpressAdViewInternalStub() override = default;
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id,
                           AdSize size) override {

--- a/analytics/src/analytics_common.cc
+++ b/analytics/src/analytics_common.cc
@@ -16,7 +16,7 @@
 
 #include "analytics/src/analytics_common.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "analytics/src/include/firebase/analytics.h"
 #include "app/src/cleanup_notifier.h"

--- a/analytics/src/analytics_common.h
+++ b/analytics/src/analytics_common.h
@@ -29,7 +29,7 @@ enum AnalyticsFn { kAnalyticsFnGetAnalyticsInstanceId, kAnalyticsFnCount };
 class FutureData {
  public:
   FutureData() : api_(kAnalyticsFnCount) {}
-  ~FutureData() {}
+  ~FutureData() = default;
 
   ReferenceCountedFutureImpl* api() { return &api_; }
 

--- a/app/instance_id/instance_id_desktop_impl.cc
+++ b/app/instance_id/instance_id_desktop_impl.cc
@@ -14,9 +14,8 @@
 
 #include "app/instance_id/instance_id_desktop_impl.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 
 #include "app/instance_id/iid_data_generated.h"
 #include "app/rest/transport_curl.h"

--- a/app/instance_id/instance_id_desktop_impl.h
+++ b/app/instance_id/instance_id_desktop_impl.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <map>
 #include <string>
+#include <utility>
 
 #include "app/memory/unique_ptr.h"
 #include "app/src/callback.h"
@@ -139,11 +140,11 @@ class InstanceIdDesktopImpl {
   class FetchServerTokenCallback : public callback::Callback {
    public:
     FetchServerTokenCallback(InstanceIdDesktopImpl* iid,
-                             const std::string& scope,
+                             std::string  scope,
                              SafeFutureHandle<std::string> future_handle)
         : iid_(iid),
-          scope_(scope),
-          future_handle_(future_handle),
+          scope_(std::move(scope)),
+          future_handle_(std::move(future_handle)),
           retry_delay_time_(0) {}
 
     void Run() override;

--- a/app/instance_id/instance_id_desktop_impl.h
+++ b/app/instance_id/instance_id_desktop_impl.h
@@ -139,8 +139,7 @@ class InstanceIdDesktopImpl {
   // Fetches a token with expodential backoff using the scheduler.
   class FetchServerTokenCallback : public callback::Callback {
    public:
-    FetchServerTokenCallback(InstanceIdDesktopImpl* iid,
-                             std::string  scope,
+    FetchServerTokenCallback(InstanceIdDesktopImpl* iid, std::string scope,
                              SafeFutureHandle<std::string> future_handle)
         : iid_(iid),
           scope_(std::move(scope)),

--- a/app/memory/shared_ptr.h
+++ b/app/memory/shared_ptr.h
@@ -35,7 +35,7 @@ namespace internal {
 // Used to implement SharedPtr.
 class ControlBlock {
  public:
-  ControlBlock() : ref_count_(1) {}
+  ControlBlock() : ref_count_(1) = default;
 
   // Increase the reference count by one.
   // Returns the newly updated reference count.

--- a/app/rest/controller_interface.cc
+++ b/app/rest/controller_interface.cc
@@ -19,7 +19,7 @@
 namespace firebase {
 namespace rest {
 
-Controller::~Controller() {}
+Controller::~Controller() = default;
 
 }  // namespace rest
 }  // namespace firebase

--- a/app/rest/gzipheader.cc
+++ b/app/rest/gzipheader.cc
@@ -17,9 +17,8 @@
 
 #include "app/rest/gzipheader.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 
 #include "app/src/assert.h"
 #include "app/src/util.h"

--- a/app/rest/gzipheader.h
+++ b/app/rest/gzipheader.h
@@ -35,7 +35,7 @@ namespace firebase {
 class GZipHeader {
  public:
   GZipHeader() { Reset(); }
-  ~GZipHeader() {}
+  ~GZipHeader() = default;
 
   // Wipe the slate clean and start from scratch.
   void Reset() {

--- a/app/rest/gzipheader.h
+++ b/app/rest/gzipheader.h
@@ -28,7 +28,7 @@
 // you've read from a file or socket.
 //
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace firebase {
 

--- a/app/rest/request.cc
+++ b/app/rest/request.cc
@@ -31,7 +31,7 @@ Request::Request(const char* post_fields_buffer, size_t post_fields_buffer_size)
   InitializeBuffer(post_fields_buffer, post_fields_buffer_size);
 }
 
-Request::~Request() {}
+Request::~Request() = default;
 
 void Request::set_post_fields(const char* data, size_t size) {
   std::string* post_fields = &options_.post_fields;

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -21,10 +21,9 @@
 #ifndef _FILE_OFFSET_BITS
 #define _FILE_OFFSET_BITS 64
 #endif  // _FILE_OFFSET_BITS
-#include <stdio.h>
-
 #include <cassert>
 #include <cstddef>
+#include <cstdio>
 
 // Map to POSIX compliant fseek on Windows.
 #if FIREBASE_PLATFORM_WINDOWS

--- a/app/rest/request_file.h
+++ b/app/rest/request_file.h
@@ -17,9 +17,8 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_REST_REQUEST_FILE_H_
 #define FIREBASE_APP_CLIENT_CPP_REST_REQUEST_FILE_H_
 
-#include <stdio.h>
-
 #include <cstddef>
+#include <cstdio>
 
 #include "app/rest/request.h"
 

--- a/app/rest/response.h
+++ b/app/rest/response.h
@@ -34,7 +34,7 @@ namespace rest {
 class Response : public Transfer {
  public:
   Response();
-  ~Response() override {}
+  ~Response() override = default;
 
   // Note: remove if support for Visual Studio <2015 is no longer needed.
   // Prior to version 2015, Visual Studio didn't support implicitly

--- a/app/rest/response.h
+++ b/app/rest/response.h
@@ -34,7 +34,7 @@ namespace rest {
 class Response : public Transfer {
  public:
   Response();
-  virtual ~Response() {}
+  ~Response() override {}
 
   // Note: remove if support for Visual Studio <2015 is no longer needed.
   // Prior to version 2015, Visual Studio didn't support implicitly

--- a/app/rest/transfer_interface.h
+++ b/app/rest/transfer_interface.h
@@ -22,7 +22,7 @@ namespace rest {
 
 class Transfer {
  public:
-  virtual ~Transfer() {}
+  virtual ~Transfer() = default;
 
   // Mark the transfer completed.
   virtual void MarkCompleted() = 0;

--- a/app/rest/transport_curl.cc
+++ b/app/rest/transport_curl.cc
@@ -647,10 +647,9 @@ int CurlThread::CancelRequest(TransportCurl* transport_curl, Response* response,
   }
   // Make sure the transfer is currently running.
   bool transferring = false;
-  for (auto & it : transport_by_response_) {
+  for (auto& it : transport_by_response_) {
     BackgroundTransportCurl* transport = it.second;
-    if (it.first == response &&
-        transport->transport_curl() == transport_curl &&
+    if (it.first == response && transport->transport_curl() == transport_curl &&
         transport->curl() == curl) {
       transferring = true;
     }
@@ -700,7 +699,7 @@ BackgroundTransportCurl* CurlThread::RemoveTransfer(Response* response) {
 
 void CurlThread::CancelAllTransfers() {
   MutexLock lock(mutex_);
-  for (auto & it : transport_by_response_) {
+  for (auto& it : transport_by_response_) {
     BackgroundTransportCurl* transport = it.second;
     CancelRequest(transport->transport_curl(), transport->response(),
                   transport->curl());
@@ -826,7 +825,7 @@ void CurlThread::ProcessRequests() {
     // Update controllers with transfer status.
     {
       MutexLock lock(mutex_);
-      for (auto & it : transport_by_response_) {
+      for (auto& it : transport_by_response_) {
         BackgroundTransportCurl* transport = it.second;
         ControllerCurl* controller = transport->controller();
         if (!controller) continue;

--- a/app/rest/transport_curl.cc
+++ b/app/rest/transport_curl.cc
@@ -647,10 +647,9 @@ int CurlThread::CancelRequest(TransportCurl* transport_curl, Response* response,
   }
   // Make sure the transfer is currently running.
   bool transferring = false;
-  for (auto it = transport_by_response_.begin();
-       it != transport_by_response_.end(); ++it) {
-    BackgroundTransportCurl* transport = it->second;
-    if (it->first == response &&
+  for (auto & it : transport_by_response_) {
+    BackgroundTransportCurl* transport = it.second;
+    if (it.first == response &&
         transport->transport_curl() == transport_curl &&
         transport->curl() == curl) {
       transferring = true;
@@ -701,9 +700,8 @@ BackgroundTransportCurl* CurlThread::RemoveTransfer(Response* response) {
 
 void CurlThread::CancelAllTransfers() {
   MutexLock lock(mutex_);
-  for (auto it = transport_by_response_.begin();
-       it != transport_by_response_.end(); ++it) {
-    BackgroundTransportCurl* transport = it->second;
+  for (auto & it : transport_by_response_) {
+    BackgroundTransportCurl* transport = it.second;
     CancelRequest(transport->transport_curl(), transport->response(),
                   transport->curl());
   }
@@ -828,9 +826,8 @@ void CurlThread::ProcessRequests() {
     // Update controllers with transfer status.
     {
       MutexLock lock(mutex_);
-      for (auto it = transport_by_response_.begin();
-           it != transport_by_response_.end(); ++it) {
-        BackgroundTransportCurl* transport = it->second;
+      for (auto & it : transport_by_response_) {
+        BackgroundTransportCurl* transport = it.second;
         ControllerCurl* controller = transport->controller();
         if (!controller) continue;
         // Update transfer status.

--- a/app/rest/transport_interface.cc
+++ b/app/rest/transport_interface.cc
@@ -24,7 +24,7 @@
 namespace firebase {
 namespace rest {
 
-Transport::~Transport() {}
+Transport::~Transport() = default;
 
 }  // namespace rest
 }  // namespace firebase

--- a/app/rest/transport_interface.h
+++ b/app/rest/transport_interface.h
@@ -30,7 +30,7 @@ namespace rest {
 
 class Transport {
  public:
-  Transport() {}
+  Transport() = default;
   virtual ~Transport();
 
   // Perform a HTTP request and put result in response and return a Controller

--- a/app/rest/util.h
+++ b/app/rest/util.h
@@ -86,7 +86,7 @@ std::string DecodeUrl(const std::string& path);
 // flexbuffers.
 class JsonData {
  public:
-  virtual ~JsonData() {}
+  virtual ~JsonData() = default;
 
   virtual bool Parse(const char* json_txt);
   Variant root() { return root_; }

--- a/app/rest/www_form_url_encoded.cc
+++ b/app/rest/www_form_url_encoded.cc
@@ -49,8 +49,9 @@ std::vector<WwwFormUrlEncoded::Item> WwwFormUrlEncoded::Parse(
     if (end_of_field != current_field) {
       const char* separator = std::find(current_field, end_of_field, '=');
       if (separator != end_of_field) {
-        form_data.emplace_back(util::DecodeUrl(std::string(current_field, separator)),
-                 util::DecodeUrl(std::string(separator + 1, end_of_field)));
+        form_data.emplace_back(
+            util::DecodeUrl(std::string(current_field, separator)),
+            util::DecodeUrl(std::string(separator + 1, end_of_field)));
       }
     }
     current_field = end_of_field + 1;

--- a/app/rest/www_form_url_encoded.cc
+++ b/app/rest/www_form_url_encoded.cc
@@ -49,9 +49,8 @@ std::vector<WwwFormUrlEncoded::Item> WwwFormUrlEncoded::Parse(
     if (end_of_field != current_field) {
       const char* separator = std::find(current_field, end_of_field, '=');
       if (separator != end_of_field) {
-        form_data.push_back(
-            Item(util::DecodeUrl(std::string(current_field, separator)),
-                 util::DecodeUrl(std::string(separator + 1, end_of_field))));
+        form_data.emplace_back(util::DecodeUrl(std::string(current_field, separator)),
+                 util::DecodeUrl(std::string(separator + 1, end_of_field)));
       }
     }
     current_field = end_of_field + 1;

--- a/app/rest/www_form_url_encoded.cc
+++ b/app/rest/www_form_url_encoded.cc
@@ -16,9 +16,8 @@
 
 #include "app/rest/www_form_url_encoded.h"
 
-#include <string.h>
-
 #include <algorithm>
+#include <cstring>
 #include <string>
 #include <vector>
 

--- a/app/rest/www_form_url_encoded.h
+++ b/app/rest/www_form_url_encoded.h
@@ -30,7 +30,7 @@ class WwwFormUrlEncoded {
  public:
   // Form item.
   struct Item {
-    Item() {}
+    Item() = default;
     Item(const std::string& key_, const std::string& value_)
         : key(key_), value(value_) {}
 

--- a/app/rest/www_form_url_encoded.h
+++ b/app/rest/www_form_url_encoded.h
@@ -18,6 +18,7 @@
 #define FIREBASE_APP_CLIENT_CPP_REST_WWW_FORM_URL_ENCODED_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace firebase {
@@ -31,8 +32,8 @@ class WwwFormUrlEncoded {
   // Form item.
   struct Item {
     Item() = default;
-    Item(const std::string& key_, const std::string& value_)
-        : key(key_), value(value_) {}
+    Item(std::string key_, std::string value_)
+        : key(std::move(key_)), value(std::move(value_)) {}
 
     std::string key;
     std::string value;

--- a/app/rest/zlibwrapper.cc
+++ b/app/rest/zlibwrapper.cc
@@ -264,9 +264,9 @@ int ZLib::CompressInit(Bytef* dest, uLongf* destLen, const Bytef* source,
 
   // First use or previous state was not reusable with current settings.
   if (!comp_init_) {
-    comp_stream_.zalloc = (alloc_func)0;
-    comp_stream_.zfree = (free_func)0;
-    comp_stream_.opaque = (voidpf)0;
+    comp_stream_.zalloc = (alloc_func)nullptr;
+    comp_stream_.zfree = (free_func)nullptr;
+    comp_stream_.opaque = (voidpf)nullptr;
     err = DeflateInit();
     if (err != Z_OK) return err;
     comp_init_ = true;
@@ -487,9 +487,9 @@ int ZLib::UncompressInit(Bytef* dest, uLongf* destLen, const Bytef* source,
 
   // First use or previous state was not reusable with current settings.
   if (!uncomp_init_) {
-    uncomp_stream_.zalloc = (alloc_func)0;
-    uncomp_stream_.zfree = (free_func)0;
-    uncomp_stream_.opaque = (voidpf)0;
+    uncomp_stream_.zalloc = (alloc_func)nullptr;
+    uncomp_stream_.zfree = (free_func)nullptr;
+    uncomp_stream_.opaque = (voidpf)nullptr;
     err = InflateInit();
     if (err != Z_OK) return err;
     uncomp_init_ = true;

--- a/app/rest/zlibwrapper.cc
+++ b/app/rest/zlibwrapper.cc
@@ -16,10 +16,9 @@
 
 #include "app/rest/zlibwrapper.h"
 
-#include <assert.h>
-#include <stdio.h>
-
 #include <algorithm>
+#include <cassert>
+#include <cstdio>
 #include <memory>
 #include <string>
 

--- a/app/rest/zlibwrapper.cc
+++ b/app/rest/zlibwrapper.cc
@@ -264,9 +264,9 @@ int ZLib::CompressInit(Bytef* dest, uLongf* destLen, const Bytef* source,
 
   // First use or previous state was not reusable with current settings.
   if (!comp_init_) {
-    comp_stream_.zalloc = (alloc_func)nullptr;
-    comp_stream_.zfree = (free_func)nullptr;
-    comp_stream_.opaque = (voidpf)nullptr;
+    comp_stream_.zalloc = (alloc_func) nullptr;
+    comp_stream_.zfree = (free_func) nullptr;
+    comp_stream_.opaque = (voidpf) nullptr;
     err = DeflateInit();
     if (err != Z_OK) return err;
     comp_init_ = true;
@@ -487,9 +487,9 @@ int ZLib::UncompressInit(Bytef* dest, uLongf* destLen, const Bytef* source,
 
   // First use or previous state was not reusable with current settings.
   if (!uncomp_init_) {
-    uncomp_stream_.zalloc = (alloc_func)nullptr;
-    uncomp_stream_.zfree = (free_func)nullptr;
-    uncomp_stream_.opaque = (voidpf)nullptr;
+    uncomp_stream_.zalloc = (alloc_func) nullptr;
+    uncomp_stream_.zfree = (free_func) nullptr;
+    uncomp_stream_.opaque = (voidpf) nullptr;
     err = InflateInit();
     if (err != Z_OK) return err;
     uncomp_init_ = true;

--- a/app/src/app_common.cc
+++ b/app/src/app_common.cc
@@ -185,7 +185,7 @@ struct AppData {
 // Tracks library registrations.
 class LibraryRegistry {
  private:
-  LibraryRegistry() {}
+  LibraryRegistry() = default;
 
  public:
   // Register a library, returns true if the library version changed.

--- a/app/src/app_common.cc
+++ b/app/src/app_common.cc
@@ -16,9 +16,8 @@
 
 #include "app/src/app_common.h"
 
-#include <assert.h>
-#include <string.h>
-
+#include <cassert>
+#include <cstring>
 #include <map>
 #include <string>
 #include <utility>  // Used to detect STL variant.

--- a/app/src/app_common.cc
+++ b/app/src/app_common.cc
@@ -452,8 +452,8 @@ void GetOuterMostSdkAndVersion(std::string* sdk, std::string* version) {
       FIREBASE_CPP_USER_AGENT_PREFIX,
   };
   LibraryRegistry* registry = LibraryRegistry::Initialize();
-  for (size_t i = 0; i < FIREBASE_ARRAYSIZE(kLibraryVersions); ++i) {
-    std::string library(kLibraryVersions[i]);
+  for (auto& kLibraryVersion : kLibraryVersions) {
+    std::string library(kLibraryVersion);
     std::string library_version = registry->GetLibraryVersion(library);
     if (!library_version.empty()) {
       *sdk = library;

--- a/app/src/app_common.h
+++ b/app/src/app_common.h
@@ -17,8 +17,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_APP_COMMON_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_APP_COMMON_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <map>
 #include <string>
 

--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -14,8 +14,7 @@
  * limitations under the License.
  */
 
-#include <string.h>
-
+#include <cstring>
 #include <fstream>
 
 #include "app/src/app_common.h"

--- a/app/src/app_identifier.cc
+++ b/app/src/app_identifier.cc
@@ -16,8 +16,7 @@
 
 #include "app/src/app_identifier.h"
 
-#include <string.h>
-
+#include <cstring>
 #include <string>
 
 #include "app/src/include/firebase/app.h"

--- a/app/src/app_options.cc
+++ b/app/src/app_options.cc
@@ -14,9 +14,8 @@
  * limitations under the License.
  */
 
-#include <string.h>
-
 #include <cstdint>
+#include <cstring>
 #include <string>
 
 #include "app/google_services_generated.h"
@@ -158,7 +157,7 @@ AppOptions* AppOptions::LoadFromJsonConfig(const char* config,  // NOLINT
       // We explicitly ignore the value of GA tracking ID and Messaging Sender
       // ID as we don't support analytics on desktop at the moment.
   };
-  for (auto & validate_option : options_to_validate) {
+  for (auto& validate_option : options_to_validate) {
     if (strlen(validate_option.option_value) == 0) {
       LogWarning("%s not set in the Firebase config.",
                  validate_option.option_name);

--- a/app/src/app_options.cc
+++ b/app/src/app_options.cc
@@ -158,8 +158,7 @@ AppOptions* AppOptions::LoadFromJsonConfig(const char* config,  // NOLINT
       // We explicitly ignore the value of GA tracking ID and Messaging Sender
       // ID as we don't support analytics on desktop at the moment.
   };
-  for (size_t i = 0; i < FIREBASE_ARRAYSIZE(options_to_validate); ++i) {
-    const auto& validate_option = options_to_validate[i];
+  for (auto & validate_option : options_to_validate) {
     if (strlen(validate_option.option_value) == 0) {
       LogWarning("%s not set in the Firebase config.",
                  validate_option.option_name);

--- a/app/src/callback.cc
+++ b/app/src/callback.cc
@@ -35,8 +35,8 @@ class CallbackEntry;
 
 class CallbackQueue : public std::list<SharedPtr<CallbackEntry>> {
  public:
-  CallbackQueue() {}
-  ~CallbackQueue() {}
+  CallbackQueue() = default;
+  ~CallbackQueue() = default;
 
   // Get the mutex that controls access to this queue.
   Mutex* mutex() { return &mutex_; }
@@ -108,7 +108,7 @@ class CallbackEntry {
 // Dispatches a queue of callbacks.
 class CallbackDispatcher {
  public:
-  CallbackDispatcher() {}
+  CallbackDispatcher() = default;
 
   ~CallbackDispatcher() {
     MutexLock lock(*queue_.mutex());

--- a/app/src/callback.h
+++ b/app/src/callback.h
@@ -35,6 +35,7 @@
 /// to the threads created to handle them internally.
 
 #include <string>
+#include <utility>
 
 namespace FIREBASE_NAMESPACE {
 namespace callback {
@@ -282,8 +283,8 @@ class CallbackMoveValue1 : public Callback {
 /// Callback implementation that wraps std::function
 class CallbackStdFunction : public Callback {
  public:
-  explicit CallbackStdFunction(const std::function<void()>& func)
-      : func_(func) {}
+  explicit CallbackStdFunction(std::function<void()>  func)
+      : func_(std::move(func)) {}
   ~CallbackStdFunction() override = default;
   void Run() override { func_(); }
 

--- a/app/src/callback.h
+++ b/app/src/callback.h
@@ -83,7 +83,7 @@ class CallbackArg<const char*> {
 /// need to guarantee that any string conversion happens on the C# thread.
 class Callback {
  public:
-  virtual ~Callback() {}
+  virtual ~Callback() = default;
   /// Function to execute from the proper context.
   virtual void Run() = 0;
 
@@ -101,7 +101,7 @@ class CallbackVoid : public Callback {
   typedef void (*UserCallback)();
 
   CallbackVoid(UserCallback user_callback) : user_callback_(user_callback) {}
-  ~CallbackVoid() override {}
+  ~CallbackVoid() override = default;
   void Run() override { user_callback_(); }
 
  private:
@@ -116,7 +116,7 @@ class Callback1 : public Callback {
 
   Callback1(const T& data, UserCallback user_callback)
       : data_(data), user_callback_(user_callback) {}
-  ~Callback1() override {}
+  ~Callback1() override = default;
   void Run() override { user_callback_(&data_); }
 
  private:
@@ -133,7 +133,7 @@ class CallbackValue1 : public Callback {
 
   CallbackValue1(const T data, UserCallback user_callback)
       : data_(data), user_callback_(user_callback) {}
-  ~CallbackValue1() override {}
+  ~CallbackValue1() override = default;
   void Run() override { user_callback_(data_); }
 
  private:
@@ -150,7 +150,7 @@ class CallbackValue2 : public Callback {
 
   CallbackValue2(const T1 data1, const T2 data2, UserCallback user_callback)
       : data1_(data1), data2_(data2), user_callback_(user_callback) {}
-  ~CallbackValue2() override {}
+  ~CallbackValue2() override = default;
   void Run() override { user_callback_(data1_, data2_); }
 
  private:
@@ -166,7 +166,7 @@ class CallbackString : public Callback {
 
   CallbackString(const char* data, UserCallback user_callback)
       : data_(SafeString(data)), user_callback_(user_callback) {}
-  ~CallbackString() override {}
+  ~CallbackString() override = default;
   void Run() override { user_callback_(data_.c_str()); }
 
  private:
@@ -183,7 +183,7 @@ class CallbackValue1String1 : public Callback {
   CallbackValue1String1(const T data, const char* str,
                         UserCallback user_callback)
       : data_(data), str_(SafeString(str)), user_callback_(user_callback) {}
-  ~CallbackValue1String1() override {}
+  ~CallbackValue1String1() override = default;
   void Run() override { user_callback_(data_, str_.c_str()); }
 
  private:
@@ -204,7 +204,7 @@ class CallbackString2Value1 : public Callback {
         str2_(SafeString(str2)),
         data_(data),
         user_callback_(user_callback) {}
-  ~CallbackString2Value1() override {}
+  ~CallbackString2Value1() override = default;
   void Run() override { user_callback_(str1_.c_str(), str2_.c_str(), data_); }
 
  private:
@@ -226,7 +226,7 @@ class CallbackValue2String1 : public Callback {
         data2_(data2),
         str_(SafeString(str)),
         user_callback_(user_callback) {}
-  ~CallbackValue2String1() override {}
+  ~CallbackValue2String1() override = default;
   void Run() override { user_callback_(data1_, data2_, str_.c_str()); }
 
  private:
@@ -249,7 +249,7 @@ class CallbackValue3String1 : public Callback {
         data3_(data3),
         str_(SafeString(str)),
         user_callback_(user_callback) {}
-  ~CallbackValue3String1() override {}
+  ~CallbackValue3String1() override = default;
   void Run() override { user_callback_(data1_, data2_, data3_, str_.c_str()); }
 
  private:
@@ -270,7 +270,7 @@ class CallbackMoveValue1 : public Callback {
 
   CallbackMoveValue1(T data, UserCallback user_callback)
       : data_(Move(data)), user_callback_(user_callback) {}
-  ~CallbackMoveValue1() override {}
+  ~CallbackMoveValue1() override = default;
   void Run() override { user_callback_(&data_); }
 
  private:
@@ -284,7 +284,7 @@ class CallbackStdFunction : public Callback {
  public:
   explicit CallbackStdFunction(const std::function<void()>& func)
       : func_(func) {}
-  ~CallbackStdFunction() override {}
+  ~CallbackStdFunction() override = default;
   void Run() override { func_(); }
 
  private:
@@ -330,7 +330,7 @@ class CallbackVariadic : public Callback {
 
   explicit CallbackVariadic(UserCallback user_callback, ArgTypes... args)
       : user_callback_(user_callback), args_(CallbackArg<ArgTypes>(args)...) {}
-  ~CallbackVariadic() override {}
+  ~CallbackVariadic() override = default;
   void Run() override {
     // Get the number of args and generate an IntegerSequence from them.
     RunInternal(typename GenerateSequence<sizeof...(ArgTypes)>::Type());

--- a/app/src/cleanup_notifier.cc
+++ b/app/src/cleanup_notifier.cc
@@ -16,9 +16,8 @@
 
 #include "app/src/cleanup_notifier.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 
 #if !defined(FIREBASE_NAMESPACE)
 #define FIREBASE_NAMESPACE firebase

--- a/app/src/function_registry.cc
+++ b/app/src/function_registry.cc
@@ -16,7 +16,7 @@
 
 #include "app/src/function_registry.h"
 
-#include <assert.h>
+#include <cassert>
 
 #if !defined(FIREBASE_NAMESPACE)
 #define FIREBASE_NAMESPACE firebase

--- a/app/src/future_manager.cc
+++ b/app/src/future_manager.cc
@@ -22,7 +22,7 @@
 
 namespace FIREBASE_NAMESPACE {
 
-FutureManager::FutureManager() {}
+FutureManager::FutureManager() = default;
 
 FutureManager::~FutureManager() {
   MutexLock lock(future_api_mutex_);

--- a/app/src/future_manager.h
+++ b/app/src/future_manager.h
@@ -63,10 +63,10 @@ class FutureManager {
 
  private:
   // Disallow copying and moving.
-  FutureManager(const FutureManager& rhs);
-  FutureManager& operator=(const FutureManager& rhs);
-  FutureManager(FutureManager&& rhs);
-  FutureManager& operator=(FutureManager&& rhs);
+  FutureManager(const FutureManager& rhs) = delete;
+  FutureManager& operator=(const FutureManager& rhs) = delete;
+  FutureManager(FutureManager&& rhs) = delete;
+  FutureManager& operator=(FutureManager&& rhs) = delete;
 
   // Insert a ReferenceCountedFutureImpl into the API list, owned by the given
   // object. If any previous ReferenceCountedFutureImpl was owned by the object,

--- a/app/src/include/firebase/app.h
+++ b/app/src/include/firebase/app.h
@@ -122,7 +122,7 @@ class AppOptions {
   /// @see FirebaseApp.Create().
   /// @endif
   /// </SWIG>
-  AppOptions() {}
+  AppOptions() = default;
 
   /// Set the Firebase app ID used to uniquely identify an instance of an app.
   ///

--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -17,9 +17,8 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_INCLUDE_FIREBASE_FUTURE_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_INCLUDE_FIREBASE_FUTURE_H_
 
-#include <stddef.h>
-#include <stdint.h>
-
+#include <cstddef>
+#include <cstdint>
 #include <utility>
 
 #include "firebase/internal/common.h"

--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -406,7 +406,7 @@ class Future : public FutureBase {
                                           void* user_data);
 
   /// Construct a future.
-  Future() {}
+  Future() = default;
 
   /// @cond FIREBASE_APP_INTERNAL
 

--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -149,7 +149,7 @@ class FutureBase {
   ///
   /// @param api API class used to provide the future implementation.
   /// @param handle Handle to the future.
-  FutureBase(detail::FutureApiInterface* api, const FutureHandle& handle);
+  FutureBase(detail::FutureApiInterface* api, FutureHandle  handle);
 
   /// @endcond
 

--- a/app/src/include/firebase/internal/future_impl.h
+++ b/app/src/include/firebase/internal/future_impl.h
@@ -196,8 +196,8 @@ inline FutureBase::CompletionCallbackHandle Future<ResultType>::AddOnCompletion(
 inline FutureBase::FutureBase() : api_(NULL), handle_(0) {}  // NOLINT
 
 inline FutureBase::FutureBase(detail::FutureApiInterface* api,
-                              const FutureHandle& handle)
-    : api_(api), handle_(handle) {
+                              FutureHandle  handle)
+    : api_(api), handle_(std::move(handle)) {
   api_->ReferenceFuture(handle_);
   // Once the FutureBase has reference, we don't need extra handle reference.
   handle_.Detach();

--- a/app/src/include/firebase/variant.h
+++ b/app/src/include/firebase/variant.h
@@ -17,8 +17,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_INCLUDE_FIREBASE_VARIANT_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_INCLUDE_FIREBASE_VARIANT_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <cstring>
 #include <map>
 #include <string>

--- a/app/src/intrusive_list.h
+++ b/app/src/intrusive_list.h
@@ -209,8 +209,8 @@ class intrusive_list_node {
 
 #if !defined(_MSC_VER)
   // Disallow copying.
-  intrusive_list_node(const intrusive_list_node&);
-  intrusive_list_node& operator=(const intrusive_list_node&);
+  intrusive_list_node(const intrusive_list_node&) = delete;
+  intrusive_list_node& operator=(const intrusive_list_node&) = delete;
 #endif  // !defined(_MSC_VER)
 };
 

--- a/app/src/invites/cached_receiver.cc
+++ b/app/src/invites/cached_receiver.cc
@@ -16,7 +16,7 @@
 
 #include "app/src/invites/cached_receiver.h"
 
-#include <assert.h>
+#include <cassert>
 
 namespace firebase {
 namespace invites {

--- a/app/src/invites/cached_receiver.h
+++ b/app/src/invites/cached_receiver.h
@@ -32,7 +32,7 @@ namespace internal {
 class CachedReceiver : public ReceiverInterface {
  public:
   CachedReceiver();
-  virtual ~CachedReceiver();
+  ~CachedReceiver() override;
 
   // Callback called when an invite is received. If an error occurred,
   // result_code should be non-zero. Otherwise, either invitation_id should be

--- a/app/src/invites/invites_receiver_internal.cc
+++ b/app/src/invites/invites_receiver_internal.cc
@@ -116,9 +116,8 @@ void InvitesReceiverInternal::ReceivedInviteCallback(
       "error=%s",
       invitation_id.c_str(), deep_link_url.c_str(),
       static_cast<int>(match_strength), result_code, error_message.c_str());
-  for (auto it = receiver_implementations_.begin();
-       it != receiver_implementations_.end(); ++it) {
-    (*it)->ReceivedInviteCallback(invitation_id, deep_link_url, match_strength,
+  for (auto & receiver_implementation : receiver_implementations_) {
+    receiver_implementation->ReceivedInviteCallback(invitation_id, deep_link_url, match_strength,
                                   result_code, error_message);
   }
 }

--- a/app/src/invites/invites_receiver_internal.cc
+++ b/app/src/invites/invites_receiver_internal.cc
@@ -16,9 +16,8 @@
 
 #include "app/src/invites/invites_receiver_internal.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 
 #include "app/src/include/firebase/app.h"
 #include "app/src/include/firebase/future.h"
@@ -116,9 +115,10 @@ void InvitesReceiverInternal::ReceivedInviteCallback(
       "error=%s",
       invitation_id.c_str(), deep_link_url.c_str(),
       static_cast<int>(match_strength), result_code, error_message.c_str());
-  for (auto & receiver_implementation : receiver_implementations_) {
-    receiver_implementation->ReceivedInviteCallback(invitation_id, deep_link_url, match_strength,
-                                  result_code, error_message);
+  for (auto& receiver_implementation : receiver_implementations_) {
+    receiver_implementation->ReceivedInviteCallback(
+        invitation_id, deep_link_url, match_strength, result_code,
+        error_message);
   }
 }
 

--- a/app/src/invites/invites_receiver_internal.h
+++ b/app/src/invites/invites_receiver_internal.h
@@ -118,7 +118,7 @@ class InvitesReceiverInternal : public SenderReceiverInterface {
   }
 
   // Virtual destructor is required.
-  ~InvitesReceiverInternal() override {}
+  ~InvitesReceiverInternal() override = default;
 
   // Whether this object was successfully initialized by the constructor.
   bool initialized() const { return app_ != nullptr; }

--- a/app/src/invites/invites_receiver_internal.h
+++ b/app/src/invites/invites_receiver_internal.h
@@ -118,7 +118,7 @@ class InvitesReceiverInternal : public SenderReceiverInterface {
   }
 
   // Virtual destructor is required.
-  virtual ~InvitesReceiverInternal() {}
+  ~InvitesReceiverInternal() override {}
 
   // Whether this object was successfully initialized by the constructor.
   bool initialized() const { return app_ != nullptr; }

--- a/app/src/invites/receiver_interface.h
+++ b/app/src/invites/receiver_interface.h
@@ -49,7 +49,7 @@ enum InternalLinkMatchStrength {
 
 class ReceiverInterface {
  public:
-  virtual ~ReceiverInterface() {}
+  virtual ~ReceiverInterface() = default;
 
   // Callback called when an invite is received. If an error occurred,
   // result_code should be non-zero. Otherwise, either invitation_id should be

--- a/app/src/invites/sender_receiver_interface.h
+++ b/app/src/invites/sender_receiver_interface.h
@@ -33,8 +33,8 @@ namespace internal {
 // is completely separate from the invite sending logic.
 class SenderReceiverInterface : public ReceiverInterface {
  public:
-  SenderReceiverInterface() {}
-  ~SenderReceiverInterface() override {}
+  SenderReceiverInterface() = default;
+  ~SenderReceiverInterface() override = default;
 
   // Called when an invite has been sent.
   virtual void SentInviteCallback(

--- a/app/src/invites/sender_receiver_interface.h
+++ b/app/src/invites/sender_receiver_interface.h
@@ -34,7 +34,7 @@ namespace internal {
 class SenderReceiverInterface : public ReceiverInterface {
  public:
   SenderReceiverInterface() {}
-  virtual ~SenderReceiverInterface() {}
+  ~SenderReceiverInterface() override {}
 
   // Called when an invite has been sent.
   virtual void SentInviteCallback(

--- a/app/src/invites/stub/invites_receiver_internal_stub.cc
+++ b/app/src/invites/stub/invites_receiver_internal_stub.cc
@@ -20,7 +20,7 @@ namespace firebase {
 namespace invites {
 namespace internal {
 
-InvitesReceiverInternalStub::~InvitesReceiverInternalStub() {}
+InvitesReceiverInternalStub::~InvitesReceiverInternalStub() = default;
 
 bool InvitesReceiverInternalStub::PerformFetch() { return true; }
 

--- a/app/src/log.cc
+++ b/app/src/log.cc
@@ -16,9 +16,8 @@
 
 #include "app/src/log.h"
 
-#include <stdarg.h>
-#include <stdio.h>
-
+#include <cstdarg>
+#include <cstdio>
 #include <cstdlib>
 
 #include "app/src/assert.h"

--- a/app/src/log.h
+++ b/app/src/log.h
@@ -17,7 +17,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_LOG_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_LOG_H_
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #include "app/src/include/firebase/internal/common.h"
 #include "app/src/include/firebase/log.h"

--- a/app/src/log_stdio.cc
+++ b/app/src/log_stdio.cc
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-#include <assert.h>
-#include <stdarg.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
 
 #include "app/src/include/firebase/internal/common.h"
 #include "app/src/include/firebase/internal/platform.h"

--- a/app/src/logger.cc
+++ b/app/src/logger.cc
@@ -18,7 +18,7 @@
 
 namespace FIREBASE_NAMESPACE {
 
-LoggerBase::~LoggerBase() {}
+LoggerBase::~LoggerBase() = default;
 
 void LoggerBase::LogDebug(const char* format, ...) const {
   va_list list;
@@ -74,7 +74,7 @@ void LoggerBase::FilterLogMessageV(LogLevel log_level, const char* format,
   }
 }
 
-SystemLogger::~SystemLogger() {}
+SystemLogger::~SystemLogger() = default;
 
 void SystemLogger::SetLogLevel(LogLevel log_level) {
   ::FIREBASE_NAMESPACE::SetLogLevel(log_level);
@@ -89,7 +89,7 @@ void SystemLogger::LogMessageImplV(LogLevel log_level, const char* format,
   ::FIREBASE_NAMESPACE::LogMessageWithCallbackV(log_level, format, args);
 }
 
-Logger::~Logger() {}
+Logger::~Logger() = default;
 
 void Logger::SetLogLevel(LogLevel log_level) { log_level_ = log_level; }
 

--- a/app/src/logger.h
+++ b/app/src/logger.h
@@ -15,7 +15,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_LOGGER_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_LOGGER_H_
 
-#include <stdarg.h>
+#include <cstdarg>
 
 #include "app/src/include/firebase/log.h"
 #include "app/src/log.h"

--- a/app/src/mutex.h
+++ b/app/src/mutex.h
@@ -157,7 +157,7 @@ class MutexLock {
  private:
   // Copy is disallowed.
   MutexLock(const MutexLock& rhs);  // NOLINT
-  MutexLock& operator=(const MutexLock& rhs);
+  MutexLock& operator=(const MutexLock& rhs) = delete;
 
   Mutex* mutex_;
 };

--- a/app/src/mutex.h
+++ b/app/src/mutex.h
@@ -16,7 +16,7 @@
 
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_MUTEX_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_MUTEX_H_
-#include <errno.h>
+#include <cerrno>
 
 #include "app/src/include/firebase/internal/platform.h"
 

--- a/app/src/path.cc
+++ b/app/src/path.cc
@@ -39,7 +39,7 @@ static std::vector<std::string> Split(const std::string& str,
       return strchr(delims, c) != nullptr;
     });
     if (start != finish) {
-      result.push_back(std::string(start, finish));
+      result.emplace_back(start, finish);
     }
   }
   return result;

--- a/app/src/reference_counted_future_impl.cc
+++ b/app/src/reference_counted_future_impl.cc
@@ -19,6 +19,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string>
+#include <utility>
 
 #include "app/src/assert.h"
 #include "app/src/include/firebase/future.h"
@@ -69,9 +70,8 @@ namespace {
 // This class manages the link between the two.
 class FutureProxyManager {
  public:
-  FutureProxyManager(ReferenceCountedFutureImpl* api,
-                     const FutureHandle& subject)
-      : api_(api), subject_(subject) {}
+  FutureProxyManager(ReferenceCountedFutureImpl* api, FutureHandle subject)
+      : api_(api), subject_(std::move(subject)) {}
 
   ~FutureProxyManager() {
     MutexLock lock(mutex_);
@@ -92,8 +92,8 @@ class FutureProxyManager {
   }
 
   struct UnregisterData {
-    UnregisterData(FutureProxyManager* proxy, const FutureHandle& handle)
-        : proxy(proxy), handle(handle) {}
+    UnregisterData(FutureProxyManager* proxy, FutureHandle handle)
+        : proxy(proxy), handle(std::move(handle)) {}
     FutureProxyManager* proxy;
     FutureHandle handle;
   };

--- a/app/src/reference_counted_future_impl.cc
+++ b/app/src/reference_counted_future_impl.cc
@@ -334,8 +334,8 @@ const char ReferenceCountedFutureImpl::kErrorMessageFutureIsNoLongerValid[] =
 
 ReferenceCountedFutureImpl::~ReferenceCountedFutureImpl() {
   // All futures should be released before we destroy ourselves.
-  for (size_t i = 0; i < last_results_.size(); ++i) {
-    last_results_[i].Release();
+  for (auto& last_result : last_results_) {
+    last_result.Release();
   }
 
   // Invalidate any externally-held futures.
@@ -708,9 +708,9 @@ ReferenceCountedFutureImpl::AddCompletionCallbackLambda(
 bool ReferenceCountedFutureImpl::IsSafeToDelete() const {
   MutexLock lock(mutex_);
   // Check if any Futures we have are still pending.
-  for (auto i = backings_.begin(); i != backings_.end(); ++i) {
+  for (auto backing : backings_) {
     // If any Future is still pending, not safe to delete.
-    if (i->second->status == kFutureStatusPending) return false;
+    if (backing.second->status == kFutureStatusPending) return false;
   }
 
   if (is_running_callback_) {
@@ -730,12 +730,12 @@ bool ReferenceCountedFutureImpl::IsReferencedExternally() const {
 
   int total_references = 0;
   int internal_references = 0;
-  for (auto i = backings_.begin(); i != backings_.end(); ++i) {
+  for (auto backing : backings_) {
     // Count the total number of references to all valid Futures.
-    total_references += i->second->reference_count;
+    total_references += backing.second->reference_count;
   }
-  for (int i = 0; i < last_results_.size(); i++) {
-    if (last_results_[i].status() != kFutureStatusInvalid) {
+  for (const auto& last_result : last_results_) {
+    if (last_result.status() != kFutureStatusInvalid) {
       // If the status is not invalid, this entry is using up a reference.
       // Count up the internal references.
       internal_references++;

--- a/app/src/reference_counted_future_impl.cc
+++ b/app/src/reference_counted_future_impl.cc
@@ -325,7 +325,7 @@ namespace detail {
 
 // Non-inline implementation of FutureApiInterface's virtual destructor
 // to prevent its vtable being emitted in each translation unit.
-FutureApiInterface::~FutureApiInterface() {}
+FutureApiInterface::~FutureApiInterface() = default;
 
 }  // namespace detail
 

--- a/app/src/reference_counted_future_impl.h
+++ b/app/src/reference_counted_future_impl.h
@@ -19,6 +19,7 @@
 
 #include <functional>
 #include <map>
+#include <utility>
 #include <vector>
 
 #include "app/src/cleanup_notifier.h"
@@ -63,8 +64,8 @@ template <typename T>
 class SafeFutureHandle {
  public:
   inline SafeFutureHandle() : handle_(kInvalidFutureHandle) {}
-  inline explicit SafeFutureHandle(const FutureHandle& handle)
-      : handle_(handle) {}
+  inline explicit SafeFutureHandle(FutureHandle  handle)
+      : handle_(std::move(handle)) {}
   inline const FutureHandle& get() const { return handle_; }
   // See FutureHandle::Detach.
   void Detach() { handle_.Detach(); }

--- a/app/src/scheduler.h
+++ b/app/src/scheduler.h
@@ -65,7 +65,7 @@ struct RequestStatusBlock {
 // is not thread-safe.
 class RequestHandle {
  public:
-  RequestHandle() : status_() {}
+  RequestHandle() : status_() = default;
   explicit RequestHandle(const SharedPtr<RequestStatusBlock>& status)
       : status_(status) {}
 

--- a/app/src/secure/user_secure_data_handle.h
+++ b/app/src/secure/user_secure_data_handle.h
@@ -40,7 +40,7 @@ enum UserSecureFutureResult {
 
 template <typename T>
 struct UserSecureDataHandle {
-  UserSecureDataHandle(std::string  appName, std::string  userData,
+  UserSecureDataHandle(std::string appName, std::string userData,
                        ReferenceCountedFutureImpl* futureApi,
                        const SafeFutureHandle<T>& futureHandle)
       : app_name(std::move(appName)),

--- a/app/src/secure/user_secure_data_handle.h
+++ b/app/src/secure/user_secure_data_handle.h
@@ -16,6 +16,7 @@
 #define FIREBASE_APP_CLIENT_CPP_SRC_SECURE_USER_SECURE_DATA_HANDLE_H_
 
 #include <string>
+#include <utility>
 
 #include "app/src/include/firebase/future.h"
 #include "app/src/reference_counted_future_impl.h"
@@ -39,11 +40,11 @@ enum UserSecureFutureResult {
 
 template <typename T>
 struct UserSecureDataHandle {
-  UserSecureDataHandle(const std::string& appName, const std::string& userData,
+  UserSecureDataHandle(std::string  appName, std::string  userData,
                        ReferenceCountedFutureImpl* futureApi,
                        const SafeFutureHandle<T>& futureHandle)
-      : app_name(appName),
-        user_data(userData),
+      : app_name(std::move(appName)),
+        user_data(std::move(userData)),
         future_api(futureApi),
         future_handle(futureHandle) {}
 

--- a/app/src/secure/user_secure_linux_internal.cc
+++ b/app/src/secure/user_secure_linux_internal.cc
@@ -51,7 +51,7 @@ UserSecureLinuxInternal::UserSecureLinuxInternal(const char* domain,
   storage_schema_ = BuildSchema(key_namespace_.c_str());
 }
 
-UserSecureLinuxInternal::~UserSecureLinuxInternal() {}
+UserSecureLinuxInternal::~UserSecureLinuxInternal() = default;
 
 std::string UserSecureLinuxInternal::LoadUserData(const std::string& app_name) {
   std::string empty_str("");

--- a/app/src/secure/user_secure_manager.cc
+++ b/app/src/secure/user_secure_manager.cc
@@ -279,7 +279,7 @@ void UserSecureManager::BinaryToAscii(const std::string& original,
 }
 
 void UserSecureManager::CancelScheduledTasks() {
-  for (auto & operation_handle : operation_handles_) {
+  for (auto& operation_handle : operation_handles_) {
     operation_handle.second.Cancel();
   }
   operation_handles_.clear();

--- a/app/src/secure/user_secure_manager.cc
+++ b/app/src/secure/user_secure_manager.cc
@@ -279,9 +279,8 @@ void UserSecureManager::BinaryToAscii(const std::string& original,
 }
 
 void UserSecureManager::CancelScheduledTasks() {
-  for (auto it = operation_handles_.begin(); it != operation_handles_.end();
-       ++it) {
-    it->second.Cancel();
+  for (auto & operation_handle : operation_handles_) {
+    operation_handle.second.Cancel();
   }
   operation_handles_.clear();
 }

--- a/app/src/semaphore.h
+++ b/app/src/semaphore.h
@@ -17,7 +17,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_SEMAPHORE_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_SEMAPHORE_H_
 
-#include <errno.h>
+#include <cerrno>
 
 #include "app/src/include/firebase/internal/platform.h"
 #include "app/src/time.h"
@@ -29,8 +29,8 @@
 #include <fcntl.h>
 #include <semaphore.h>
 #include <sys/stat.h>
-#include <time.h>
 
+#include <ctime>
 #include <string>
 #endif  // FIREBASE_PLATFORM_WINDOWS
 

--- a/app/src/thread_cpp11.cc
+++ b/app/src/thread_cpp11.cc
@@ -24,9 +24,9 @@
 
 namespace FIREBASE_NAMESPACE {
 
-Thread::Thread() {}
+Thread::Thread() = default;
 
-Thread::~Thread() {}
+Thread::~Thread() = default;
 
 #ifdef FIREBASE_USE_EXPLICIT_DEFAULT_METHODS
 Thread::Thread(Thread&& other) = default;

--- a/app/src/time.h
+++ b/app/src/time.h
@@ -25,8 +25,9 @@
 #include <windows.h>
 #else  // !FIREBASE_PLATFORM_WINDOWS
 #include <sys/time.h>
-#include <time.h>
 #include <unistd.h>
+
+#include <ctime>
 #endif  // FIREBASE_PLATFORM_WINDOWS
 
 #if FIREBASE_PLATFORM_OSX || FIREBASE_PLATFORM_IOS

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -16,8 +16,7 @@
 
 #include "app/src/include/firebase/util.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <map>
 #include <string>
 #include <vector>

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -210,7 +210,7 @@ class AppCallback {
 class StaticFutureData {
  public:
   explicit StaticFutureData(int num_functions) : api_(num_functions) {}
-  ~StaticFutureData() {}
+  ~StaticFutureData() = default;
 
   ReferenceCountedFutureImpl* api() { return &api_; }
 

--- a/app/src/uuid.h
+++ b/app/src/uuid.h
@@ -17,7 +17,7 @@
 #ifndef FIREBASE_APP_CLIENT_CPP_SRC_UUID_H_
 #define FIREBASE_APP_CLIENT_CPP_SRC_UUID_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 namespace firebase {
 namespace internal {

--- a/app/src/variant.cc
+++ b/app/src/variant.cc
@@ -16,9 +16,8 @@
 
 #include "app/src/include/firebase/variant.h"
 
-#include <limits.h>
-#include <stdlib.h>
-
+#include <climits>
+#include <cstdlib>
 #include <iomanip>
 #include <sstream>
 

--- a/app/src/variant_util.cc
+++ b/app/src/variant_util.cc
@@ -313,7 +313,7 @@ bool VariantToFlexbuffer(const Variant& variant, flexbuffers::Builder* fbb) {
 bool VariantMapToFlexbuffer(const std::map<Variant, Variant>& map,
                             flexbuffers::Builder* fbb) {
   auto start = fbb->StartMap();
-  for (const auto & iter : map) {
+  for (const auto& iter : map) {
     // Flexbuffers only supports string keys, return false if the key is not a
     // type that can be coerced to a string.
     if (iter.first.is_null() || !iter.first.is_fundamental_type()) {
@@ -337,7 +337,7 @@ bool VariantMapToFlexbuffer(const std::map<Variant, Variant>& map,
 bool VariantVectorToFlexbuffer(const std::vector<Variant>& vector,
                                flexbuffers::Builder* fbb) {
   auto start = fbb->StartVector();
-  for (const auto & iter : vector) {
+  for (const auto& iter : vector) {
     if (!VariantToFlexbuffer(iter, fbb)) {
       fbb->EndVector(start, false, false);
       return false;

--- a/app/src/variant_util.cc
+++ b/app/src/variant_util.cc
@@ -313,19 +313,19 @@ bool VariantToFlexbuffer(const Variant& variant, flexbuffers::Builder* fbb) {
 bool VariantMapToFlexbuffer(const std::map<Variant, Variant>& map,
                             flexbuffers::Builder* fbb) {
   auto start = fbb->StartMap();
-  for (auto iter = map.begin(); iter != map.end(); ++iter) {
+  for (const auto & iter : map) {
     // Flexbuffers only supports string keys, return false if the key is not a
     // type that can be coerced to a string.
-    if (iter->first.is_null() || !iter->first.is_fundamental_type()) {
+    if (iter.first.is_null() || !iter.first.is_fundamental_type()) {
       LogError(
           "Variants of non-fundamental types may not be used as map keys.");
       fbb->EndMap(start);
       return false;
     }
     // Add key.
-    fbb->Key(iter->first.AsString().string_value());
+    fbb->Key(iter.first.AsString().string_value());
     // Add value.
-    if (!VariantToFlexbuffer(iter->second, fbb)) {
+    if (!VariantToFlexbuffer(iter.second, fbb)) {
       fbb->EndMap(start);
       return false;
     }
@@ -337,8 +337,8 @@ bool VariantMapToFlexbuffer(const std::map<Variant, Variant>& map,
 bool VariantVectorToFlexbuffer(const std::vector<Variant>& vector,
                                flexbuffers::Builder* fbb) {
   auto start = fbb->StartVector();
-  for (auto iter = vector.begin(); iter != vector.end(); ++iter) {
-    if (!VariantToFlexbuffer(*iter, fbb)) {
+  for (const auto & iter : vector) {
+    if (!VariantToFlexbuffer(iter, fbb)) {
       fbb->EndVector(start, false, false);
       return false;
     }

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -16,11 +16,10 @@
 
 #include "auth/src/include/firebase/auth.h"
 
-#include <assert.h>
-#include <stdio.h>
-
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <map>
 #include <string>
 

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -52,9 +52,9 @@ void CleanupCredentialFutureImpl() {
 }
 
 void ClearUserInfos(AuthData* auth_data) {
-  for (size_t i = 0; i < auth_data->user_infos.size(); ++i) {
-    delete auth_data->user_infos[i];
-    auth_data->user_infos[i] = nullptr;
+  for (auto & user_info : auth_data->user_infos) {
+    delete user_info;
+    user_info = nullptr;
   }
   auth_data->user_infos.clear();
 }

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -52,7 +52,7 @@ void CleanupCredentialFutureImpl() {
 }
 
 void ClearUserInfos(AuthData* auth_data) {
-  for (auto & user_info : auth_data->user_infos) {
+  for (auto& user_info : auth_data->user_infos) {
     delete user_info;
     user_info = nullptr;
   }

--- a/auth/src/desktop/auth_credential.cc
+++ b/auth/src/desktop/auth_credential.cc
@@ -17,6 +17,6 @@
 namespace firebase {
 namespace auth {
 
-AuthCredential::~AuthCredential() {}
+AuthCredential::~AuthCredential() = default;
 }  // namespace auth
 }  // namespace firebase

--- a/auth/src/desktop/auth_credential.h
+++ b/auth/src/desktop/auth_credential.h
@@ -33,7 +33,7 @@ class AuthCredential {
   // This is an abstract class. Concrete instances should be created via factory
   // method getCredential() in each authentication provider class e.g.
   // FacebookAuthProvider::getCredential().
-  AuthCredential() {}
+  AuthCredential() = default;
 };
 
 }  // namespace auth

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -96,7 +96,7 @@ void DestroyFunctionRegistryListener(AuthData* auth_data);
 
 IdTokenRefreshListener::IdTokenRefreshListener() : token_timestamp_(0) {}
 
-IdTokenRefreshListener::~IdTokenRefreshListener() {}
+IdTokenRefreshListener::~IdTokenRefreshListener() = default;
 
 void IdTokenRefreshListener::OnIdTokenChanged(Auth* auth) {
   // Note:  Make sure to always make future_impl.mutex the innermost lock,
@@ -505,7 +505,7 @@ void Auth::SignOut() {
 class CurrentUserBlockListener : public firebase::auth::AuthStateListener {
  public:
   explicit CurrentUserBlockListener() : semaphore_(0) {}
-  ~CurrentUserBlockListener() override {}
+  ~CurrentUserBlockListener() override = default;
 
   void OnAuthStateChanged(Auth* auth) override { semaphore_.Post(); }
 

--- a/auth/src/desktop/auth_desktop.h
+++ b/auth/src/desktop/auth_desktop.h
@@ -36,7 +36,7 @@ namespace auth {
 class IdTokenRefreshListener : public IdTokenListener {
  public:
   IdTokenRefreshListener();
-  ~IdTokenRefreshListener();
+  ~IdTokenRefreshListener() override;
 
   void OnIdTokenChanged(Auth* auth) override;
   std::string GetCurrentToken();

--- a/auth/src/desktop/auth_desktop.h
+++ b/auth/src/desktop/auth_desktop.h
@@ -139,7 +139,7 @@ class FunctionRegistryAuthStateListener : public AuthStateListener {
 
 // The desktop-specific Auth implementation.
 struct AuthImpl {
-  AuthImpl() {}
+  AuthImpl() = default;
 
   // The application's API key.
   std::string api_key;

--- a/auth/src/desktop/auth_providers/email_auth_credential.h
+++ b/auth/src/desktop/auth_providers/email_auth_credential.h
@@ -37,7 +37,7 @@ class EmailAuthCredential : public AuthCredential {
   std::string GetPassword() const { return password_; }
 
  private:
-  EmailAuthCredential(std::string  email, std::string  password)
+  EmailAuthCredential(std::string email, std::string password)
       : email_(std::move(email)), password_(std::move(password)) {}
 
   const std::string email_;

--- a/auth/src/desktop/auth_providers/email_auth_credential.h
+++ b/auth/src/desktop/auth_providers/email_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_EMAIL_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_EMAIL_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/auth_credential.h"
 
@@ -35,8 +37,8 @@ class EmailAuthCredential : public AuthCredential {
   std::string GetPassword() const { return password_; }
 
  private:
-  EmailAuthCredential(const std::string& email, const std::string& password)
-      : email_(email), password_(password) {}
+  EmailAuthCredential(std::string  email, std::string  password)
+      : email_(std::move(email)), password_(std::move(password)) {}
 
   const std::string email_;
   const std::string password_;

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -37,8 +39,8 @@ class FacebookAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit FacebookAuthCredential(const std::string& access_token)
-      : access_token_(access_token) {}
+  explicit FacebookAuthCredential(std::string  access_token)
+      : access_token_(std::move(access_token)) {}
 
   const std::string access_token_;
 

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -39,7 +39,7 @@ class FacebookAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit FacebookAuthCredential(std::string  access_token)
+  explicit FacebookAuthCredential(std::string access_token)
       : access_token_(std::move(access_token)) {}
 
   const std::string access_token_;

--- a/auth/src/desktop/auth_providers/federated_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/federated_auth_provider.cc
@@ -24,7 +24,7 @@ namespace auth {
 
 #ifdef INTERNAL_EXPERIMENTAL
 
-FederatedOAuthProvider::FederatedOAuthProvider() {}
+FederatedOAuthProvider::FederatedOAuthProvider() = default;
 
 FederatedOAuthProvider::FederatedOAuthProvider(
     const FederatedOAuthProviderData& provider_data) {

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -39,7 +39,7 @@ class GitHubAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit GitHubAuthCredential(std::string  token) : token_(std::move(token)) {}
+  explicit GitHubAuthCredential(std::string token) : token_(std::move(token)) {}
 
   const std::string token_;
 

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -37,7 +39,7 @@ class GitHubAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit GitHubAuthCredential(const std::string& token) : token_(token) {}
+  explicit GitHubAuthCredential(std::string  token) : token_(std::move(token)) {}
 
   const std::string token_;
 

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -42,9 +44,9 @@ class GoogleAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  GoogleAuthCredential(const std::string& id_token,
-                       const std::string& access_token)
-      : id_token_(id_token), access_token_(access_token) {}
+  GoogleAuthCredential(std::string  id_token,
+                       std::string  access_token)
+      : id_token_(std::move(id_token)), access_token_(std::move(access_token)) {}
 
   const std::string id_token_;
   const std::string access_token_;

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -44,9 +44,9 @@ class GoogleAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  GoogleAuthCredential(std::string  id_token,
-                       std::string  access_token)
-      : id_token_(std::move(id_token)), access_token_(std::move(access_token)) {}
+  GoogleAuthCredential(std::string id_token, std::string access_token)
+      : id_token_(std::move(id_token)),
+        access_token_(std::move(access_token)) {}
 
   const std::string id_token_;
   const std::string access_token_;

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -46,8 +46,8 @@ class OAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  OAuthCredential(std::string  provider_id, std::string  id_token,
-                  std::string  raw_nonce, std::string  access_token)
+  OAuthCredential(std::string provider_id, std::string id_token,
+                  std::string raw_nonce, std::string access_token)
       : provider_id_(std::move(provider_id)),
         id_token_(std::move(id_token)),
         raw_nonce_(std::move(raw_nonce)),

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -44,12 +46,12 @@ class OAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  OAuthCredential(const std::string& provider_id, const std::string& id_token,
-                  const std::string& raw_nonce, const std::string& access_token)
-      : provider_id_(provider_id),
-        id_token_(id_token),
-        raw_nonce_(raw_nonce),
-        access_token_(access_token) {}
+  OAuthCredential(std::string  provider_id, std::string  id_token,
+                  std::string  raw_nonce, std::string  access_token)
+      : provider_id_(std::move(provider_id)),
+        id_token_(std::move(id_token)),
+        raw_nonce_(std::move(raw_nonce)),
+        access_token_(std::move(access_token)) {}
 
   const std::string provider_id_;
   const std::string id_token_;

--- a/auth/src/desktop/auth_providers/phone_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/phone_auth_provider.cc
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "app/src/assert.h"
 #include "auth/src/data.h"

--- a/auth/src/desktop/auth_providers/phone_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/phone_auth_provider.cc
@@ -32,7 +32,7 @@ static const char* kMockVerificationId = "mock verification id";
 PhoneAuthProvider::ForceResendingToken::ForceResendingToken()
     : data_(nullptr) {}
 
-PhoneAuthProvider::ForceResendingToken::~ForceResendingToken() {}
+PhoneAuthProvider::ForceResendingToken::~ForceResendingToken() = default;
 
 PhoneAuthProvider::ForceResendingToken::ForceResendingToken(
     const ForceResendingToken& rhs)
@@ -55,10 +55,10 @@ bool PhoneAuthProvider::ForceResendingToken::operator!=(
 }
 
 PhoneAuthProvider::Listener::Listener() : data_(nullptr) {}
-PhoneAuthProvider::Listener::~Listener() {}
+PhoneAuthProvider::Listener::~Listener() = default;
 
 PhoneAuthProvider::PhoneAuthProvider() : data_(nullptr) {}
-PhoneAuthProvider::~PhoneAuthProvider() {}
+PhoneAuthProvider::~PhoneAuthProvider() = default;
 
 void PhoneAuthProvider::VerifyPhoneNumber(
     const char* /*phone_number*/, uint32_t /*auto_verify_time_out_ms*/,

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -37,8 +39,8 @@ class PlayGamesAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit PlayGamesAuthCredential(const std::string& server_auth_code)
-      : server_auth_code_(server_auth_code) {}
+  explicit PlayGamesAuthCredential(std::string  server_auth_code)
+      : server_auth_code_(std::move(server_auth_code)) {}
 
   const std::string server_auth_code_;
 

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -39,7 +39,7 @@ class PlayGamesAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  explicit PlayGamesAuthCredential(std::string  server_auth_code)
+  explicit PlayGamesAuthCredential(std::string server_auth_code)
       : server_auth_code_(std::move(server_auth_code)) {}
 
   const std::string server_auth_code_;

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -39,7 +39,7 @@ class TwitterAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  TwitterAuthCredential(std::string  token, std::string  secret)
+  TwitterAuthCredential(std::string token, std::string secret)
       : token_(std::move(token)), secret_(std::move(secret)) {}
 
   const std::string token_;

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 
+#include <utility>
+
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
@@ -37,8 +39,8 @@ class TwitterAuthCredential : public IdentityProviderCredential {
   }
 
  private:
-  TwitterAuthCredential(const std::string& token, const std::string& secret)
-      : token_(token), secret_(secret) {}
+  TwitterAuthCredential(std::string  token, std::string  secret)
+      : token_(std::move(token)), secret_(std::move(secret)) {}
 
   const std::string token_;
   const std::string secret_;

--- a/auth/src/desktop/provider_user_info.h
+++ b/auth/src/desktop/provider_user_info.h
@@ -27,7 +27,7 @@ namespace auth {
 
 // Simple storage for user info properties, but conforming to UserInfoInterface.
 struct UserInfoInterfaceImpl : public UserInfoInterface {
-  explicit UserInfoInterfaceImpl(UserInfoImpl  set_impl)
+  explicit UserInfoInterfaceImpl(UserInfoImpl set_impl)
       : impl(std::move(set_impl)) {}
 
   std::string uid() const override { return impl.uid; }

--- a/auth/src/desktop/provider_user_info.h
+++ b/auth/src/desktop/provider_user_info.h
@@ -16,6 +16,7 @@
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_DESKTOP_PROVIDER_USER_INFO_H_
 
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "auth/src/desktop/user_desktop.h"
@@ -26,8 +27,8 @@ namespace auth {
 
 // Simple storage for user info properties, but conforming to UserInfoInterface.
 struct UserInfoInterfaceImpl : public UserInfoInterface {
-  explicit UserInfoInterfaceImpl(const UserInfoImpl& set_impl)
-      : impl(set_impl) {}
+  explicit UserInfoInterfaceImpl(UserInfoImpl  set_impl)
+      : impl(std::move(set_impl)) {}
 
   std::string uid() const override { return impl.uid; }
   std::string email() const override { return impl.email; }

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -14,7 +14,7 @@
 
 #include "auth/src/desktop/rpcs/auth_request.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "app/src/app_common.h"
 #include "app/src/include/firebase/app.h"

--- a/auth/src/desktop/rpcs/auth_response.h
+++ b/auth/src/desktop/rpcs/auth_response.h
@@ -30,7 +30,7 @@ namespace auth {
 class AuthResponse
     : public firebase::rest::ResponseJson<fbs::Response, fbs::ResponseT> {
  public:
-  AuthResponse() : ResponseJson(response_resource_data) {}
+  AuthResponse() : ResponseJson(response_resource_data) = default;
 
   // Visual Studio 2013 and below don't generate implicitly-defined move
   // constructors.

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -66,7 +66,7 @@ namespace {
 class GetTokenResult {
  public:
   explicit GetTokenResult(const AuthError error) : error_(error) {}
-  explicit GetTokenResult(std::string  token)
+  explicit GetTokenResult(std::string token)
       : error_(kAuthErrorNone), token_(std::move(token)) {}
 
   bool IsValid() const { return error_ == kAuthErrorNone; }

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <memory>
+#include <utility>
 
 #include "app/rest/transport_builder.h"
 #include "app/rest/util.h"
@@ -65,8 +66,8 @@ namespace {
 class GetTokenResult {
  public:
   explicit GetTokenResult(const AuthError error) : error_(error) {}
-  explicit GetTokenResult(const std::string& token)
-      : error_(kAuthErrorNone), token_(token) {}
+  explicit GetTokenResult(std::string  token)
+      : error_(kAuthErrorNone), token_(std::move(token)) {}
 
   bool IsValid() const { return error_ == kAuthErrorNone; }
   AuthError error() const { return error_; }

--- a/auth/src/desktop/user_desktop.h
+++ b/auth/src/desktop/user_desktop.h
@@ -99,7 +99,7 @@ struct UserData : public UserInfoImpl {
 class UserDataPersist : public firebase::auth::AuthStateListener {
  public:
   UserDataPersist(const char* app_id);
-  ~UserDataPersist() override {}
+  ~UserDataPersist() override = default;
 
   // Overloaded constructor to set the internal instance.
   explicit UserDataPersist(

--- a/auth/src/desktop/user_desktop.h
+++ b/auth/src/desktop/user_desktop.h
@@ -99,7 +99,7 @@ struct UserData : public UserInfoImpl {
 class UserDataPersist : public firebase::auth::AuthStateListener {
  public:
   UserDataPersist(const char* app_id);
-  ~UserDataPersist() {}
+  ~UserDataPersist() override {}
 
   // Overloaded constructor to set the internal instance.
   explicit UserDataPersist(

--- a/auth/src/desktop/user_view.h
+++ b/auth/src/desktop/user_view.h
@@ -103,7 +103,7 @@ class UserView {
   };
 
   // Construct a user view from an existing set of user data.
-  explicit UserView(const UserData& user_data) : user_data_(user_data) {}
+  explicit UserView(UserData  user_data) : user_data_(std::move(user_data)) {}
 
   // Exposed for testing.
   const UserData& user_data() const { return user_data_; }

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -715,7 +715,7 @@ class FederatedAuthProvider {
   template <class T>
   class Handler {
    public:
-    virtual ~Handler() {}
+    virtual ~Handler() = default;
 
     /// @brief Application sign-in handler.
     ///
@@ -831,8 +831,8 @@ class FederatedAuthProvider {
 #endif  // not SWIG
 #endif  // INTERNAL_EXPERIMENTAL
 
-  FederatedAuthProvider() {}
-  virtual ~FederatedAuthProvider() {}
+  FederatedAuthProvider() = default;
+  virtual ~FederatedAuthProvider() = default;
 
  private:
   friend class ::firebase::auth::Auth;

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -17,12 +17,11 @@
 #ifndef FIREBASE_AUTH_CLIENT_CPP_SRC_INCLUDE_FIREBASE_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_CLIENT_CPP_SRC_INCLUDE_FIREBASE_AUTH_CREDENTIAL_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <string>
 
-#include "firebase/internal/common.h"
 #include "firebase/auth/types.h"
+#include "firebase/internal/common.h"
 
 namespace firebase {
 

--- a/auth/src/include/firebase/auth/types.h
+++ b/auth/src/include/firebase/auth/types.h
@@ -433,7 +433,7 @@ struct FederatedProviderData {
 /// @brief Contains information to identify an OAuth povider.
 struct FederatedOAuthProviderData : FederatedProviderData {
   /// Initailizes an empty provider data structure.
-  FederatedOAuthProviderData() {}
+  FederatedOAuthProviderData() = default;
 
   /// Initializes the provider data structure with a provider id.
   explicit FederatedOAuthProviderData(const std::string& provider) {

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -143,7 +143,7 @@ struct UserMetadata {
 
 /// @brief Result of operations that can affect authentication state.
 struct SignInResult {
-  SignInResult() : user(NULL) {}
+  SignInResult() : user(nullptr) {}
 
   /// The currently signed-in @ref User, or NULL if there isn't any (i.e. the
   /// user is signed out).
@@ -169,7 +169,7 @@ class User : public UserInfoInterface {
   /// For fields you want to reset, pass "".
   struct UserProfile {
     /// Construct a UserProfile with no display name or photo URL.
-    UserProfile() : display_name(NULL), photo_url(NULL) {}
+    UserProfile() : display_name(nullptr), photo_url(nullptr) {}
 
     /// User display name.
     const char* display_name;

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -178,7 +178,7 @@ class User : public UserInfoInterface {
     const char* photo_url;
   };
 
-  ~User();
+  ~User() override;
 
   /// The Java Web Token (JWT) that can be used to identify the user to
   /// the backend.
@@ -424,7 +424,7 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string uid() const;
+  std::string uid() const override;
 
   /// Gets email associated with the user, if any.
   /// <SWIG>
@@ -434,7 +434,7 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string email() const;
+  std::string email() const override;
 
   /// Gets the display name associated with the user, if any.
   /// <SWIG>
@@ -444,7 +444,7 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string display_name() const;
+  std::string display_name() const override;
 
   /// Gets the photo url associated with the user, if any.
   /// <SWIG>
@@ -454,7 +454,7 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string photo_url() const;
+  std::string photo_url() const override;
 
   /// Gets the provider ID for the user (For example, "Facebook").
   /// <SWIG>
@@ -464,10 +464,10 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string provider_id() const;
+  std::string provider_id() const override;
 
   /// Gets the phone number for the user, in E.164 format.
-  virtual std::string phone_number() const;
+  std::string phone_number() const override;
 
  private:
   /// @cond FIREBASE_APP_INTERNAL

--- a/auth/src/user.cc
+++ b/auth/src/user.cc
@@ -54,7 +54,7 @@ Future<std::string> User::GetTokenThreadSafe(bool force_refresh) {
 
 // Non-inline implementation of UserInfoInterface's virtual destructor
 // to prevent its vtable being emitted in each translation unit.
-UserInfoInterface::~UserInfoInterface() {}
+UserInfoInterface::~UserInfoInterface() = default;
 
 }  // namespace auth
 }  // namespace firebase

--- a/database/src/common/database.cc
+++ b/database/src/common/database.cc
@@ -14,8 +14,7 @@
 
 #include "database/src/include/firebase/database.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <map>
 #include <string>
 

--- a/database/src/common/listener.cc
+++ b/database/src/common/listener.cc
@@ -19,9 +19,9 @@
 namespace firebase {
 namespace database {
 
-ValueListener::~ValueListener() {}
+ValueListener::~ValueListener() = default;
 
-ChildListener::~ChildListener() {}
+ChildListener::~ChildListener() = default;
 
 }  // namespace database
 }  // namespace firebase

--- a/database/src/common/query_spec.h
+++ b/database/src/common/query_spec.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_COMMON_QUERY_SPEC_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_COMMON_QUERY_SPEC_H_
 
+#include <utility>
+
 #include "app/src/include/firebase/variant.h"
 #include "app/src/path.h"
 
@@ -107,10 +109,10 @@ struct QueryParams {
 // remove a listener from a different (but matching) Query to the original.
 struct QuerySpec {
   QuerySpec() : path(), params() {}
-  explicit QuerySpec(const Path& _path) : path(_path), params() {}
-  explicit QuerySpec(const QueryParams& _params) : path(), params(_params) {}
-  QuerySpec(const Path& _path, const QueryParams& _params)
-      : path(_path), params(_params) {}
+  explicit QuerySpec(Path  _path) : path(std::move(_path)), params() {}
+  explicit QuerySpec(QueryParams  _params) : path(), params(std::move(_params)) {}
+  QuerySpec(Path  _path, QueryParams  _params)
+      : path(std::move(_path)), params(std::move(_params)) {}
 
   // Compare two QuerySpecs, which are considered the same if all fields are the
   // same.

--- a/database/src/common/query_spec.h
+++ b/database/src/common/query_spec.h
@@ -109,9 +109,10 @@ struct QueryParams {
 // remove a listener from a different (but matching) Query to the original.
 struct QuerySpec {
   QuerySpec() : path(), params() {}
-  explicit QuerySpec(Path  _path) : path(std::move(_path)), params() {}
-  explicit QuerySpec(QueryParams  _params) : path(), params(std::move(_params)) {}
-  QuerySpec(Path  _path, QueryParams  _params)
+  explicit QuerySpec(Path _path) : path(std::move(_path)), params() {}
+  explicit QuerySpec(QueryParams _params)
+      : path(), params(std::move(_params)) {}
+  QuerySpec(Path _path, QueryParams _params)
       : path(std::move(_path)), params(std::move(_params)) {}
 
   // Compare two QuerySpecs, which are considered the same if all fields are the

--- a/database/src/desktop/connection/connection.h
+++ b/database/src/desktop/connection/connection.h
@@ -215,7 +215,7 @@ class Connection : public WebSocketClientEventHandler {
 // All the function here will be triggered only from scheduler thread.
 class ConnectionEventHandler {
  public:
-  virtual ~ConnectionEventHandler() {}
+  virtual ~ConnectionEventHandler() = default;
 
   // Triggered when a handshake message or a reset message is received from
   // server  Those messages contain the information of the cache host.

--- a/database/src/desktop/connection/host_info.cc
+++ b/database/src/desktop/connection/host_info.cc
@@ -14,9 +14,8 @@
 
 #include "database/src/desktop/connection/host_info.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 #include <sstream>
 #include <string>
 

--- a/database/src/desktop/connection/host_info.cc
+++ b/database/src/desktop/connection/host_info.cc
@@ -56,16 +56,9 @@ HostInfo::HostInfo(const char* host, const char* ns, bool secure)
 
 HostInfo::HostInfo(const HostInfo& other) { *this = other; }
 
-HostInfo::~HostInfo() {}
+HostInfo::~HostInfo() = default;
 
-HostInfo& HostInfo::operator=(const HostInfo& other) {
-  host_ = other.host_;
-  namespace_ = other.namespace_;
-  secure_ = other.secure_;
-  user_agent_ = other.user_agent_;
-  web_socket_user_agent_ = other.web_socket_user_agent_;
-  return *this;
-}
+HostInfo& HostInfo::operator=(const HostInfo& other) = default;
 
 std::string HostInfo::GetConnectionUrl(const char* last_session_id) const {
   std::stringstream ss;

--- a/database/src/desktop/connection/host_info.h
+++ b/database/src/desktop/connection/host_info.h
@@ -33,7 +33,7 @@ namespace connection {
 // server hostname may look like "s-usc1c-nss-123.firebaseio.com"
 class HostInfo {
  public:
-  explicit HostInfo() {}
+  explicit HostInfo() = default;
 
   // Constructor to pass in hostname, namespace and whether this is for a
   // secured connection

--- a/database/src/desktop/connection/persistent_connection.h
+++ b/database/src/desktop/connection/persistent_connection.h
@@ -20,6 +20,7 @@
 #include <queue>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "app/memory/atomic.h"
@@ -237,11 +238,11 @@ class PersistentConnection : public ConnectionEventHandler {
 
   // Capture the outstanding or ongoing listen requests.
   struct OutstandingListen {
-    explicit OutstandingListen(const QuerySpec& query_spec, const Tag& tag,
+    explicit OutstandingListen(QuerySpec query_spec, Tag tag,
                                ResponsePtr response, uint64_t outstanding_id)
-        : query_spec(query_spec),
-          tag(tag),
-          response(response),
+        : query_spec(std::move(query_spec)),
+          tag(std::move(tag)),
+          response(std::move(response)),
           outstanding_id(outstanding_id) {}
 
     // Path and query params for the listen request.
@@ -263,9 +264,12 @@ class PersistentConnection : public ConnectionEventHandler {
   // Capture the outstanding OnDisconnect requests when the connection is not
   // established yet.
   struct OutstandingOnDisconnect {
-    explicit OutstandingOnDisconnect(const char* action, const Path& path,
-                                     const Variant& data, ResponsePtr response)
-        : action(action), path(path), data(data), response(Move(response)) {}
+    explicit OutstandingOnDisconnect(const char* action, Path path,
+                                     Variant data, ResponsePtr response)
+        : action(action),
+          path(std::move(path)),
+          data(std::move(data)),
+          response(Move(response)) {}
 
     // Action of the request such as PUT, MERGE and CANCEL
     std::string action;
@@ -284,9 +288,12 @@ class PersistentConnection : public ConnectionEventHandler {
   // Capture the outstanding Put requests when the connection is not
   // established yet.
   struct OutstandingPut {
-    explicit OutstandingPut(const char* action, const Variant& data,
+    explicit OutstandingPut(const char* action, Variant data,
                             ResponsePtr response)
-        : action(action), data(data), response(Move(response)), sent(false) {}
+        : action(action),
+          data(std::move(data)),
+          response(Move(response)),
+          sent(false) {}
 
     // Action of the request such as PUT, MERGE and CANCEL
     std::string action;

--- a/database/src/desktop/connection/persistent_connection.h
+++ b/database/src/desktop/connection/persistent_connection.h
@@ -70,7 +70,7 @@ class Response {
     // TODO(b/77552340): Replace the implementation of Response with
     // std::function
   }
-  virtual ~Response() {}
+  virtual ~Response() = default;
 
   // Check if there is any error in response
   bool HasError() const { return error_code_ != kErrorNone; }
@@ -550,7 +550,7 @@ class PersistentConnection : public ConnectionEventHandler {
 
 class PersistentConnectionEventHandler {
  public:
-  virtual ~PersistentConnectionEventHandler() {}
+  virtual ~PersistentConnectionEventHandler() = default;
 
   virtual void OnConnect() = 0;
 

--- a/database/src/desktop/connection/persistent_connection.h
+++ b/database/src/desktop/connection/persistent_connection.h
@@ -104,7 +104,7 @@ class PersistentConnection : public ConnectionEventHandler {
                                 PersistentConnectionEventHandler* event_handler,
                                 scheduler::Scheduler* scheduler,
                                 Logger* logger);
-  ~PersistentConnection();
+  ~PersistentConnection() override;
 
   // PersistentConnection is neither copyable nor movable.
   PersistentConnection(const PersistentConnection&) = delete;

--- a/database/src/desktop/connection/web_socket_client_impl.cc
+++ b/database/src/desktop/connection/web_socket_client_impl.cc
@@ -30,7 +30,7 @@ namespace internal {
 namespace connection {
 
 WebSocketClientImpl::WebSocketClientImpl(
-    std::string  uri, std::string  user_agent, Logger* logger,
+    std::string uri, std::string user_agent, Logger* logger,
     scheduler::Scheduler* scheduler,
     WebSocketClientEventHandler* handler /*=nullptr*/)
     : uri_(std::move(uri)),

--- a/database/src/desktop/connection/web_socket_client_impl.cc
+++ b/database/src/desktop/connection/web_socket_client_impl.cc
@@ -15,6 +15,7 @@
 #include "database/src/desktop/connection/web_socket_client_impl.h"
 
 #include <cassert>
+#include <utility>
 
 #include "app/src/app_common.h"
 #include "app/src/assert.h"
@@ -29,10 +30,10 @@ namespace internal {
 namespace connection {
 
 WebSocketClientImpl::WebSocketClientImpl(
-    const std::string& uri, const std::string& user_agent, Logger* logger,
+    std::string  uri, std::string  user_agent, Logger* logger,
     scheduler::Scheduler* scheduler,
     WebSocketClientEventHandler* handler /*=nullptr*/)
-    : uri_(uri),
+    : uri_(std::move(uri)),
       handler_(handler),
       thread_(nullptr),
       hub_(),
@@ -42,7 +43,7 @@ WebSocketClientImpl::WebSocketClientImpl(
       callback_queue_mutex_(Mutex::kModeNonRecursive),
       is_destructing_(0),
       websocket_(nullptr),
-      user_agent_(user_agent),
+      user_agent_(std::move(user_agent)),
       logger_(logger),
       scheduler_(scheduler),
       safe_this_(this) {

--- a/database/src/desktop/connection/web_socket_client_impl.h
+++ b/database/src/desktop/connection/web_socket_client_impl.h
@@ -17,6 +17,7 @@
 
 #include <queue>
 #include <string>
+#include <utility>
 
 #include "app/memory/atomic.h"
 #include "app/memory/unique_ptr.h"
@@ -35,7 +36,7 @@ namespace connection {
 
 class WebSocketClientImpl : public WebSocketClientInterface {
  public:
-  WebSocketClientImpl(const std::string& uri, const std::string& user_agent,
+  WebSocketClientImpl(std::string  uri, std::string  user_agent,
                       Logger* logger, scheduler::Scheduler* scheduler,
                       WebSocketClientEventHandler* handler = nullptr);
   ~WebSocketClientImpl() override;
@@ -117,8 +118,8 @@ class WebSocketClientImpl : public WebSocketClientInterface {
   // the client, int_value and string_value stored in this data structure.
   struct CallbackData {
     explicit CallbackData(Callback c, WebSocketClientImpl* ws_client, int i,
-                          const std::string& str)
-        : callback(c), client(ws_client), int_value(i), string_value(str) {}
+                          std::string  str)
+        : callback(c), client(ws_client), int_value(i), string_value(std::move(str)) {}
 
     Callback callback;
 

--- a/database/src/desktop/connection/web_socket_client_impl.h
+++ b/database/src/desktop/connection/web_socket_client_impl.h
@@ -36,8 +36,8 @@ namespace connection {
 
 class WebSocketClientImpl : public WebSocketClientInterface {
  public:
-  WebSocketClientImpl(std::string  uri, std::string  user_agent,
-                      Logger* logger, scheduler::Scheduler* scheduler,
+  WebSocketClientImpl(std::string uri, std::string user_agent, Logger* logger,
+                      scheduler::Scheduler* scheduler,
                       WebSocketClientEventHandler* handler = nullptr);
   ~WebSocketClientImpl() override;
 
@@ -118,8 +118,11 @@ class WebSocketClientImpl : public WebSocketClientInterface {
   // the client, int_value and string_value stored in this data structure.
   struct CallbackData {
     explicit CallbackData(Callback c, WebSocketClientImpl* ws_client, int i,
-                          std::string  str)
-        : callback(c), client(ws_client), int_value(i), string_value(std::move(str)) {}
+                          std::string str)
+        : callback(c),
+          client(ws_client),
+          int_value(i),
+          string_value(std::move(str)) {}
 
     Callback callback;
 

--- a/database/src/desktop/connection/web_socket_client_interface.h
+++ b/database/src/desktop/connection/web_socket_client_interface.h
@@ -27,7 +27,7 @@ namespace connection {
 // platform.
 class WebSocketClientInterface {
  public:
-  virtual ~WebSocketClientInterface() {}
+  virtual ~WebSocketClientInterface() = default;
 
   // Request to connect to websocket server
   virtual void Connect(int timeout_ms) = 0;
@@ -54,7 +54,7 @@ class WebSocketClientErrorData {
 
 class WebSocketClientEventHandler {
  public:
-  virtual ~WebSocketClientEventHandler() {}
+  virtual ~WebSocketClientEventHandler() = default;
 
   // Called when the connection is established
   virtual void OnOpen() = 0;

--- a/database/src/desktop/core/cache_policy.cc
+++ b/database/src/desktop/core/cache_policy.cc
@@ -28,12 +28,12 @@ const uint64_t kMaxNumberOfPrunableQueriesToKeep = 1000;
 // 20% at a time until we're below our max.
 const double kPercentOfQueriesToPruneAtOnce = 0.2;
 
-CachePolicy::~CachePolicy() {}
+CachePolicy::~CachePolicy() = default;
 
 LRUCachePolicy::LRUCachePolicy(uint64_t max_size_bytes)
     : max_size_bytes_(max_size_bytes) {}
 
-LRUCachePolicy::~LRUCachePolicy() {}
+LRUCachePolicy::~LRUCachePolicy() = default;
 
 bool LRUCachePolicy::ShouldPrune(uint64_t current_size_bytes,
                                  uint64_t count_of_prunable_queries) const {

--- a/database/src/desktop/core/child_event_registration.cc
+++ b/database/src/desktop/core/child_event_registration.cc
@@ -24,7 +24,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-ChildEventRegistration::~ChildEventRegistration() {}
+ChildEventRegistration::~ChildEventRegistration() = default;
 
 bool ChildEventRegistration::RespondsTo(EventType event_type) {
   return event_type == kEventTypeChildRemoved ||

--- a/database/src/desktop/core/compound_write.cc
+++ b/database/src/desktop/core/compound_write.cc
@@ -196,7 +196,7 @@ std::vector<std::pair<Variant, Variant>> CompoundWrite::GetCompleteChildren()
     const Variant* value = GetVariantValue(&write_tree_.value().value());
     if (value->is_map()) {
       for (auto& entry : value->map()) {
-        children.push_back(entry);
+        children.emplace_back(entry);
       }
     }
   } else {
@@ -204,7 +204,7 @@ std::vector<std::pair<Variant, Variant>> CompoundWrite::GetCompleteChildren()
       const std::string& key = entry.first;
       const Tree<Variant>& subtree = entry.second;
       if (subtree.value().has_value()) {
-        children.push_back(std::make_pair(key, subtree.value().value()));
+        children.emplace_back(key, subtree.value().value());
       }
     }
   }

--- a/database/src/desktop/core/compound_write.h
+++ b/database/src/desktop/core/compound_write.h
@@ -33,7 +33,7 @@ namespace internal {
 // existing path will modify that existing write to reflect the write added.
 class CompoundWrite {
  public:
-  CompoundWrite() : write_tree_() {}
+  CompoundWrite() : write_tree_() = default;
 
   // Create a compound write from a tree of variants, where each variant in the
   // tree represents a write at that location.

--- a/database/src/desktop/core/event_registration.cc
+++ b/database/src/desktop/core/event_registration.cc
@@ -18,7 +18,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-EventRegistration::~EventRegistration() {}
+EventRegistration::~EventRegistration() = default;
 
 void EventRegistration::SafelyFireEvent(const Event& event) {
   // Ensure that the listener has not already been removed.

--- a/database/src/desktop/core/event_registration.h
+++ b/database/src/desktop/core/event_registration.h
@@ -36,7 +36,7 @@ struct Event;
 // can be used to fire the event later.
 class EventRegistration {
  public:
-  explicit EventRegistration(QuerySpec  query_spec)
+  explicit EventRegistration(QuerySpec query_spec)
       : status_(kActive), query_spec_(std::move(query_spec)) {}
 
   virtual ~EventRegistration();

--- a/database/src/desktop/core/event_registration.h
+++ b/database/src/desktop/core/event_registration.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_CORE_EVENT_REGISTRATION_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_CORE_EVENT_REGISTRATION_H_
 
+#include <utility>
+
 #include "app/src/path.h"
 #include "database/src/common/query_spec.h"
 #include "database/src/desktop/view/change.h"
@@ -34,8 +36,8 @@ struct Event;
 // can be used to fire the event later.
 class EventRegistration {
  public:
-  explicit EventRegistration(const QuerySpec& query_spec)
-      : status_(kActive), query_spec_(query_spec) {}
+  explicit EventRegistration(QuerySpec  query_spec)
+      : status_(kActive), query_spec_(std::move(query_spec)) {}
 
   virtual ~EventRegistration();
 

--- a/database/src/desktop/core/indexed_variant.cc
+++ b/database/src/desktop/core/indexed_variant.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <utility>
 
 #include "app/src/assert.h"
 #include "app/src/include/firebase/variant.h"
@@ -32,17 +33,17 @@ IndexedVariant::IndexedVariant()
   EnsureIndexed();
 }
 
-IndexedVariant::IndexedVariant(const Variant& variant)
-    : variant_(variant),
+IndexedVariant::IndexedVariant(Variant  variant)
+    : variant_(std::move(variant)),
       query_params_(),
       index_(QueryParamsLesser(&query_params_)) {
   EnsureIndexed();
 }
 
-IndexedVariant::IndexedVariant(const Variant& variant,
-                               const QueryParams& query_params)
-    : variant_(variant),
-      query_params_(query_params),
+IndexedVariant::IndexedVariant(Variant  variant,
+                               QueryParams  query_params)
+    : variant_(std::move(variant)),
+      query_params_(std::move(query_params)),
       index_(QueryParamsLesser(&query_params_)) {
   EnsureIndexed();
 }

--- a/database/src/desktop/core/indexed_variant.cc
+++ b/database/src/desktop/core/indexed_variant.cc
@@ -33,15 +33,14 @@ IndexedVariant::IndexedVariant()
   EnsureIndexed();
 }
 
-IndexedVariant::IndexedVariant(Variant  variant)
+IndexedVariant::IndexedVariant(Variant variant)
     : variant_(std::move(variant)),
       query_params_(),
       index_(QueryParamsLesser(&query_params_)) {
   EnsureIndexed();
 }
 
-IndexedVariant::IndexedVariant(Variant  variant,
-                               QueryParams  query_params)
+IndexedVariant::IndexedVariant(Variant variant, QueryParams query_params)
     : variant_(std::move(variant)),
       query_params_(std::move(query_params)),
       index_(QueryParamsLesser(&query_params_)) {

--- a/database/src/desktop/core/indexed_variant.h
+++ b/database/src/desktop/core/indexed_variant.h
@@ -36,8 +36,8 @@ class IndexedVariant {
       Index;
 
   IndexedVariant();
-  IndexedVariant(Variant  variant);
-  IndexedVariant(Variant  variant, QueryParams  query_params);
+  IndexedVariant(Variant variant);
+  IndexedVariant(Variant variant, QueryParams query_params);
 
   IndexedVariant(const IndexedVariant& other);
   IndexedVariant& operator=(const IndexedVariant& other);

--- a/database/src/desktop/core/indexed_variant.h
+++ b/database/src/desktop/core/indexed_variant.h
@@ -36,8 +36,8 @@ class IndexedVariant {
       Index;
 
   IndexedVariant();
-  IndexedVariant(const Variant& variant);
-  IndexedVariant(const Variant& variant, const QueryParams& query_params);
+  IndexedVariant(Variant  variant);
+  IndexedVariant(Variant  variant, QueryParams  query_params);
 
   IndexedVariant(const IndexedVariant& other);
   IndexedVariant& operator=(const IndexedVariant& other);

--- a/database/src/desktop/core/info_listen_provider.h
+++ b/database/src/desktop/core/info_listen_provider.h
@@ -30,7 +30,7 @@ class InfoListenProvider : public ListenProvider {
   InfoListenProvider(Repo* repo, Variant* info_data)
       : repo_(repo), info_data_(info_data), sync_tree_(nullptr) {}
 
-  ~InfoListenProvider() override {}
+  ~InfoListenProvider() override = default;
 
   void set_sync_tree(SyncTree* sync_tree) { sync_tree_ = sync_tree; }
 

--- a/database/src/desktop/core/keep_synced_event_registration.cc
+++ b/database/src/desktop/core/keep_synced_event_registration.cc
@@ -22,7 +22,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-KeepSyncedEventRegistration::~KeepSyncedEventRegistration() {}
+KeepSyncedEventRegistration::~KeepSyncedEventRegistration() = default;
 
 bool KeepSyncedEventRegistration::RespondsTo(EventType event_type) {
   (void)event_type;

--- a/database/src/desktop/core/keep_synced_event_registration.h
+++ b/database/src/desktop/core/keep_synced_event_registration.h
@@ -39,7 +39,7 @@ class KeepSyncedEventRegistration : public EventRegistration {
                                        const QuerySpec& query_spec)
       : EventRegistration(query_spec), sync_tree_(sync_tree) {}
 
-  virtual ~KeepSyncedEventRegistration();
+  ~KeepSyncedEventRegistration() override;
 
   // KeepSyncedEventRegistrations never respond to any events of any type.
   bool RespondsTo(EventType event_type) override;

--- a/database/src/desktop/core/listen_provider.cc
+++ b/database/src/desktop/core/listen_provider.cc
@@ -18,7 +18,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-ListenProvider::~ListenProvider() {}
+ListenProvider::~ListenProvider() = default;
 
 }  // namespace internal
 }  // namespace database

--- a/database/src/desktop/core/operation.h
+++ b/database/src/desktop/core/operation.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_CORE_OPERATION_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_CORE_OPERATION_H_
 
+#include <utility>
+
 #include "app/src/assert.h"
 #include "app/src/optional.h"
 #include "app/src/path.h"
@@ -80,14 +82,14 @@ struct Operation {
         affected_tree(),
         revert() {}
 
-  Operation(Type _type, const OperationSource& _source, const Path& _path,
-            const Variant& _snapshot, const CompoundWrite& _children,
+  Operation(Type _type, OperationSource  _source, Path  _path,
+            Variant  _snapshot, CompoundWrite  _children,
             const Tree<bool>& _affected_tree, AckStatus status)
       : type(_type),
-        source(_source),
-        path(_path),
-        snapshot(_snapshot),
-        children(_children),
+        source(std::move(_source)),
+        path(std::move(_path)),
+        snapshot(std::move(_snapshot)),
+        children(std::move(_children)),
         affected_tree(_affected_tree),
         revert(status == kAckRevert) {}
 

--- a/database/src/desktop/core/operation.h
+++ b/database/src/desktop/core/operation.h
@@ -82,9 +82,9 @@ struct Operation {
         affected_tree(),
         revert() {}
 
-  Operation(Type _type, OperationSource  _source, Path  _path,
-            Variant  _snapshot, CompoundWrite  _children,
-            const Tree<bool>& _affected_tree, AckStatus status)
+  Operation(Type _type, OperationSource _source, Path _path, Variant _snapshot,
+            CompoundWrite _children, const Tree<bool>& _affected_tree,
+            AckStatus status)
       : type(_type),
         source(std::move(_source)),
         path(std::move(_path)),

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -804,8 +804,7 @@ void Repo::AbortTransactionsAtNode(Tree<std::vector<TransactionDataPtr>>* node,
                                       "Unknown transaction abort reason");
           // If it was cancelled, it was already removed from the sync tree
         }
-        futures_to_complete.push_back(
-            FutureToComplete(transaction, abort_error));
+        futures_to_complete.emplace_back(transaction, abort_error);
       }
     }
 
@@ -926,8 +925,8 @@ void Repo::HandleTransactionResponse(const connection::ResponsePtr& ptr) {
                                                kAckConfirm, kDoNotPersist,
                                                server_time_offset_);
 
-      futures_to_complete.push_back(FutureToComplete(
-          transaction, transaction->current_output_snapshot_resolved));
+      futures_to_complete.emplace_back(
+          transaction, transaction->current_output_snapshot_resolved);
     }
 
     // Now remove the completed transactions.
@@ -1081,8 +1080,8 @@ void Repo::RerunTransactionQueue(const std::vector<TransactionDataPtr>& queue,
           new DatabaseReferenceInternal(database_, path);
       DatabaseReference ref(database_ref_impl);
 
-      futures_to_complete.push_back(FutureToComplete(
-          transaction, abort_reason, transaction->current_input_snapshot));
+      futures_to_complete.emplace_back(transaction, abort_reason,
+                                       transaction->current_input_snapshot);
 
       // Removing a callback can trigger pruning which can muck with
       // merged_data/visible_data (as it prunes data). So defer removing the

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -621,7 +621,7 @@ void Repo::SetKeepSynchronized(const QuerySpec& query_spec,
 
 class NoopListener : public ValueListener {
  public:
-  ~NoopListener() override {}
+  ~NoopListener() override = default;
   void OnValueChanged(const DataSnapshot& snapshot) override { (void)snapshot; }
   void OnCancelled(const Error& error, const char* error_message) override {
     (void)error;

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -621,9 +621,9 @@ void Repo::SetKeepSynchronized(const QuerySpec& query_spec,
 
 class NoopListener : public ValueListener {
  public:
-  virtual ~NoopListener() {}
-  void OnValueChanged(const DataSnapshot& snapshot) { (void)snapshot; }
-  void OnCancelled(const Error& error, const char* error_message) {
+  ~NoopListener() override {}
+  void OnValueChanged(const DataSnapshot& snapshot) override { (void)snapshot; }
+  void OnCancelled(const Error& error, const char* error_message) override {
     (void)error;
     (void)error_message;
   }

--- a/database/src/desktop/core/sparse_snapshot_tree.h
+++ b/database/src/desktop/core/sparse_snapshot_tree.h
@@ -25,7 +25,7 @@ namespace internal {
 
 class SparseSnapshotTree {
  public:
-  SparseSnapshotTree() : value_(), children_() {}
+  SparseSnapshotTree() : value_(), children_() = default;
 
   void Remember(const Path& path, const Variant& data);
 

--- a/database/src/desktop/core/sync_tree.h
+++ b/database/src/desktop/core/sync_tree.h
@@ -53,7 +53,7 @@ class SyncTree {
         next_query_tag_(1L),
         listen_provider_(std::move(listen_provider)) {}
 
-  virtual ~SyncTree() {}
+  virtual ~SyncTree() = default;
 
   // Returns true if the SyncTree does not contain any SyncPoints.
   virtual bool IsEmpty();

--- a/database/src/desktop/core/tracked_query_manager.cc
+++ b/database/src/desktop/core/tracked_query_manager.cc
@@ -40,7 +40,7 @@ bool operator!=(const TrackedQuery& lhs, const TrackedQuery& rhs) {
   return !(lhs == rhs);
 }
 
-TrackedQueryManagerInterface::~TrackedQueryManagerInterface() {}
+TrackedQueryManagerInterface::~TrackedQueryManagerInterface() = default;
 
 // Returns true if the given TrackedQueryMap has a complete default query.
 static bool HasDefaultCompletePredicate(
@@ -97,7 +97,7 @@ TrackedQueryManager::TrackedQueryManager(
   }
 }
 
-TrackedQueryManager::~TrackedQueryManager() {}
+TrackedQueryManager::~TrackedQueryManager() = default;
 
 const TrackedQuery* TrackedQueryManager::FindTrackedQuery(
     const QuerySpec& query_spec) const {

--- a/database/src/desktop/core/tracked_query_manager.h
+++ b/database/src/desktop/core/tracked_query_manager.h
@@ -47,9 +47,8 @@ struct TrackedQuery {
         complete(false),
         active(false) {}
 
-  TrackedQuery(QueryId _query_id, QuerySpec  _query_spec,
-               uint64_t _last_use, CompletionStatus _complete,
-               ActivityStatus _active)
+  TrackedQuery(QueryId _query_id, QuerySpec _query_spec, uint64_t _last_use,
+               CompletionStatus _complete, ActivityStatus _active)
       : query_id(_query_id),
         query_spec(std::move(_query_spec)),
         last_use(_last_use),

--- a/database/src/desktop/core/tracked_query_manager.h
+++ b/database/src/desktop/core/tracked_query_manager.h
@@ -18,6 +18,7 @@
 #include <cstdint>
 #include <map>
 #include <set>
+#include <utility>
 
 #include "app/src/logger.h"
 #include "app/src/optional.h"
@@ -46,11 +47,11 @@ struct TrackedQuery {
         complete(false),
         active(false) {}
 
-  TrackedQuery(QueryId _query_id, const QuerySpec& _query_spec,
+  TrackedQuery(QueryId _query_id, QuerySpec  _query_spec,
                uint64_t _last_use, CompletionStatus _complete,
                ActivityStatus _active)
       : query_id(_query_id),
-        query_spec(_query_spec),
+        query_spec(std::move(_query_spec)),
         last_use(_last_use),
         complete(_complete == kComplete),
         active(_active == kActive) {}

--- a/database/src/desktop/core/tree.h
+++ b/database/src/desktop/core/tree.h
@@ -83,7 +83,7 @@ class Tree {
   explicit Tree(Optional<Value>&& maybe_value)
       : key_(), value_(std::move(maybe_value)), children_(), parent_(nullptr) {}
 
-  ~Tree() {}
+  ~Tree() = default;
 
   // Return the key of this node in the tree. Root elements will not have a key.
   const std::string& key() const { return key_; }

--- a/database/src/desktop/core/value_event_registration.cc
+++ b/database/src/desktop/core/value_event_registration.cc
@@ -22,7 +22,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-ValueEventRegistration::~ValueEventRegistration() {}
+ValueEventRegistration::~ValueEventRegistration() = default;
 
 bool ValueEventRegistration::RespondsTo(EventType event_type) {
   return event_type == kEventTypeValue;

--- a/database/src/desktop/core/web_socket_listen_provider.cc
+++ b/database/src/desktop/core/web_socket_listen_provider.cc
@@ -14,6 +14,8 @@
 
 #include "database/src/desktop/core/web_socket_listen_provider.h"
 
+#include <utility>
+
 #include "database/src/common/query_spec.h"
 #include "database/src/desktop/connection/persistent_connection.h"
 #include "database/src/desktop/core/listen_provider.h"
@@ -30,14 +32,14 @@ using connection::ResponsePtr;
 class WebSocketListenResponse : public connection::Response {
  public:
   WebSocketListenResponse(const Response::ResponseCallback& callback,
-                          const Repo::ThisRef& repo_ref, SyncTree* sync_tree,
-                          const QuerySpec& query_spec, const Tag& tag,
+                          Repo::ThisRef  repo_ref, SyncTree* sync_tree,
+                          QuerySpec  query_spec, Tag  tag,
                           const View* view, Logger* logger)
       : connection::Response(callback),
-        repo_ref_(repo_ref),
+        repo_ref_(std::move(repo_ref)),
         sync_tree_(sync_tree),
-        query_spec_(query_spec),
-        tag_(tag),
+        query_spec_(std::move(query_spec)),
+        tag_(std::move(tag)),
         view_(view),
         logger_(logger) {}
 

--- a/database/src/desktop/core/web_socket_listen_provider.cc
+++ b/database/src/desktop/core/web_socket_listen_provider.cc
@@ -32,9 +32,9 @@ using connection::ResponsePtr;
 class WebSocketListenResponse : public connection::Response {
  public:
   WebSocketListenResponse(const Response::ResponseCallback& callback,
-                          Repo::ThisRef  repo_ref, SyncTree* sync_tree,
-                          QuerySpec  query_spec, Tag  tag,
-                          const View* view, Logger* logger)
+                          Repo::ThisRef repo_ref, SyncTree* sync_tree,
+                          QuerySpec query_spec, Tag tag, const View* view,
+                          Logger* logger)
       : connection::Response(callback),
         repo_ref_(std::move(repo_ref)),
         sync_tree_(sync_tree),

--- a/database/src/desktop/core/web_socket_listen_provider.h
+++ b/database/src/desktop/core/web_socket_listen_provider.h
@@ -35,7 +35,7 @@ class WebSocketListenProvider : public ListenProvider {
         connection_(connection),
         logger_(logger) {}
 
-  ~WebSocketListenProvider() override {}
+  ~WebSocketListenProvider() override = default;
 
   void set_sync_tree(SyncTree* sync_tree) { sync_tree_ = sync_tree; }
 

--- a/database/src/desktop/core/write_tree.cc
+++ b/database/src/desktop/core/write_tree.cc
@@ -15,6 +15,7 @@
 #include "database/src/desktop/core/write_tree.h"
 
 #include <algorithm>
+#include <utility>
 
 #include "app/src/assert.h"
 #include "database/src/desktop/core/compound_write.h"
@@ -37,7 +38,8 @@ void WriteTree::AddOverwrite(const Path& path, const Variant& snap,
                              WriteId write_id, OverwriteVisibility visibility) {
   // Stacking an older write on top of newer ones.
   FIREBASE_DEV_ASSERT(write_id > last_write_id_);
-  all_writes_.emplace_back(write_id, path, snap, visibility == kOverwriteVisible);
+  all_writes_.emplace_back(write_id, path, snap,
+                           visibility == kOverwriteVisible);
   if (visibility == kOverwriteVisible) {
     visible_writes_.AddWriteInline(path, snap);
   }
@@ -434,8 +436,8 @@ CompoundWrite WriteTree::LayerTree(const std::vector<UserWriteRecord>& writes,
   return compound_write;
 }
 
-WriteTreeRef::WriteTreeRef(const Path& path, WriteTree* write_tree)
-    : path_(path), write_tree_(write_tree) {}
+WriteTreeRef::WriteTreeRef(Path path, WriteTree* write_tree)
+    : path_(std::move(path)), write_tree_(write_tree) {}
 
 Optional<Variant> WriteTreeRef::CalcCompleteEventCache(
     const Variant* complete_server_cache) const {

--- a/database/src/desktop/core/write_tree.cc
+++ b/database/src/desktop/core/write_tree.cc
@@ -37,8 +37,7 @@ void WriteTree::AddOverwrite(const Path& path, const Variant& snap,
                              WriteId write_id, OverwriteVisibility visibility) {
   // Stacking an older write on top of newer ones.
   FIREBASE_DEV_ASSERT(write_id > last_write_id_);
-  all_writes_.push_back(
-      UserWriteRecord(write_id, path, snap, visibility == kOverwriteVisible));
+  all_writes_.emplace_back(write_id, path, snap, visibility == kOverwriteVisible);
   if (visibility == kOverwriteVisible) {
     visible_writes_.AddWriteInline(path, snap);
   }
@@ -50,7 +49,7 @@ void WriteTree::AddMerge(const Path& path,
                          WriteId write_id) {
   // Stacking an older write on top of newer ones.
   FIREBASE_DEV_ASSERT(write_id > last_write_id_);
-  all_writes_.push_back(UserWriteRecord(write_id, path, changed_children));
+  all_writes_.emplace_back(write_id, path, changed_children);
   visible_writes_.AddWritesInline(path, changed_children);
   last_write_id_ = write_id;
 }

--- a/database/src/desktop/core/write_tree.h
+++ b/database/src/desktop/core/write_tree.h
@@ -53,7 +53,7 @@ enum IterationDirection {
 // WriteTree.
 class WriteTreeRef {
  public:
-  WriteTreeRef(const Path& path, WriteTree* write_tree);
+  WriteTreeRef(Path path, WriteTree* write_tree);
 
   Optional<Variant> CalcCompleteEventCache(
       const Variant* complete_server_cache) const;

--- a/database/src/desktop/core/write_tree.h
+++ b/database/src/desktop/core/write_tree.h
@@ -120,7 +120,7 @@ class WriteTree {
   // AddMerge(), and removed with RemoveWrite().
   WriteTree() : visible_writes_(), all_writes_(), last_write_id_(-1L) {}
 
-  virtual ~WriteTree() {}
+  virtual ~WriteTree() = default;
 
   // Create a new WriteTreeRef for the given path. For use with a new sync point
   // at the given path.

--- a/database/src/desktop/data_snapshot_desktop.cc
+++ b/database/src/desktop/data_snapshot_desktop.cc
@@ -14,8 +14,7 @@
 
 #include "database/src/desktop/data_snapshot_desktop.h"
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <string>
 #include <utility>
 

--- a/database/src/desktop/data_snapshot_desktop.cc
+++ b/database/src/desktop/data_snapshot_desktop.cc
@@ -39,17 +39,11 @@ DataSnapshotInternal::DataSnapshotInternal(DatabaseInternal* database,
 }
 
 DataSnapshotInternal::DataSnapshotInternal(const DataSnapshotInternal& internal)
-    : database_(internal.database_),
-      data_(internal.data_),
-      query_spec_(internal.query_spec_) {}
+    
+      = default;
 
 DataSnapshotInternal& DataSnapshotInternal::operator=(
-    const DataSnapshotInternal& internal) {
-  database_ = internal.database_;
-  data_ = internal.data_;
-  query_spec_ = internal.query_spec_;
-  return *this;
-}
+    const DataSnapshotInternal& internal) = default;
 
 #if defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 DataSnapshotInternal::DataSnapshotInternal(DataSnapshotInternal&& internal) {
@@ -67,7 +61,7 @@ DataSnapshotInternal& DataSnapshotInternal::operator=(
 }
 #endif  // defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 
-DataSnapshotInternal::~DataSnapshotInternal() {}
+DataSnapshotInternal::~DataSnapshotInternal() = default;
 
 bool DataSnapshotInternal::Exists() const { return data_ != Variant::Null(); }
 

--- a/database/src/desktop/data_snapshot_desktop.cc
+++ b/database/src/desktop/data_snapshot_desktop.cc
@@ -39,8 +39,8 @@ DataSnapshotInternal::DataSnapshotInternal(DatabaseInternal* database,
 }
 
 DataSnapshotInternal::DataSnapshotInternal(const DataSnapshotInternal& internal)
-    
-      = default;
+
+    = default;
 
 DataSnapshotInternal& DataSnapshotInternal::operator=(
     const DataSnapshotInternal& internal) = default;

--- a/database/src/desktop/data_snapshot_desktop.cc
+++ b/database/src/desktop/data_snapshot_desktop.cc
@@ -17,6 +17,7 @@
 #include <stddef.h>
 
 #include <string>
+#include <utility>
 
 #include "app/src/include/firebase/internal/common.h"
 #include "app/src/include/firebase/variant.h"
@@ -30,9 +31,10 @@ namespace database {
 namespace internal {
 
 DataSnapshotInternal::DataSnapshotInternal(DatabaseInternal* database,
-                                           const Variant& data,
-                                           const QuerySpec& query_spec)
-    : database_(database), data_(data), query_spec_(query_spec) {
+                                           Variant data, QuerySpec query_spec)
+    : database_(database),
+      data_(std::move(data)),
+      query_spec_(std::move(query_spec)) {
   if (HasVector(data_)) {
     ConvertVectorToMap(&data_);
   }

--- a/database/src/desktop/data_snapshot_desktop.h
+++ b/database/src/desktop/data_snapshot_desktop.h
@@ -15,8 +15,7 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_DATA_SNAPSHOT_DESKTOP_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_DATA_SNAPSHOT_DESKTOP_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <string>
 
 #include "app/src/include/firebase/variant.h"

--- a/database/src/desktop/data_snapshot_desktop.h
+++ b/database/src/desktop/data_snapshot_desktop.h
@@ -38,8 +38,8 @@ class DatabaseReferenceInternal;
 // Firebase Database location.
 class DataSnapshotInternal {
  public:
-  DataSnapshotInternal(DatabaseInternal* database, const Variant& data,
-                       const QuerySpec& query_spec);
+  DataSnapshotInternal(DatabaseInternal* database, Variant  data,
+                       QuerySpec  query_spec);
 
   DataSnapshotInternal(const DataSnapshotInternal& snapshot);
 

--- a/database/src/desktop/data_snapshot_desktop.h
+++ b/database/src/desktop/data_snapshot_desktop.h
@@ -38,8 +38,8 @@ class DatabaseReferenceInternal;
 // Firebase Database location.
 class DataSnapshotInternal {
  public:
-  DataSnapshotInternal(DatabaseInternal* database, Variant  data,
-                       QuerySpec  query_spec);
+  DataSnapshotInternal(DatabaseInternal* database, Variant data,
+                       QuerySpec query_spec);
 
   DataSnapshotInternal(const DataSnapshotInternal& snapshot);
 

--- a/database/src/desktop/database_desktop.cc
+++ b/database/src/desktop/database_desktop.cc
@@ -52,7 +52,7 @@ SingleValueListener::SingleValueListener(DatabaseInternal* database,
       future_(future),
       handle_(handle) {}
 
-SingleValueListener::~SingleValueListener() {}
+SingleValueListener::~SingleValueListener() = default;
 
 void SingleValueListener::OnValueChanged(const DataSnapshot& snapshot) {
   future_->CompleteWithResult<DataSnapshot>(handle_, kErrorNone, "", snapshot);

--- a/database/src/desktop/database_desktop.cc
+++ b/database/src/desktop/database_desktop.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <queue>
 #include <stack>
+#include <utility>
 
 #include "app/memory/shared_ptr.h"
 #include "app/src/app_common.h"
@@ -44,13 +45,13 @@ namespace internal {
 Mutex g_database_reference_constructor_mutex;  // NOLINT
 
 SingleValueListener::SingleValueListener(DatabaseInternal* database,
-                                         const QuerySpec& query_spec,
+                                         QuerySpec query_spec,
                                          ReferenceCountedFutureImpl* future,
                                          SafeFutureHandle<DataSnapshot> handle)
     : database_(database),
-      query_spec_(query_spec),
+      query_spec_(std::move(query_spec)),
       future_(future),
-      handle_(handle) {}
+      handle_(std::move(handle)) {}
 
 SingleValueListener::~SingleValueListener() = default;
 

--- a/database/src/desktop/database_desktop.h
+++ b/database/src/desktop/database_desktop.h
@@ -50,7 +50,7 @@ typedef int64_t WriteId;
 
 class SingleValueListener : public ValueListener {
  public:
-  SingleValueListener(DatabaseInternal* database, QuerySpec  query_spec,
+  SingleValueListener(DatabaseInternal* database, QuerySpec query_spec,
                       ReferenceCountedFutureImpl* future,
                       SafeFutureHandle<DataSnapshot> handle);
   // Unregister ourselves from the database.

--- a/database/src/desktop/database_desktop.h
+++ b/database/src/desktop/database_desktop.h
@@ -50,7 +50,7 @@ typedef int64_t WriteId;
 
 class SingleValueListener : public ValueListener {
  public:
-  SingleValueListener(DatabaseInternal* database, const QuerySpec& query_spec,
+  SingleValueListener(DatabaseInternal* database, QuerySpec  query_spec,
                       ReferenceCountedFutureImpl* future,
                       SafeFutureHandle<DataSnapshot> handle);
   // Unregister ourselves from the database.

--- a/database/src/desktop/database_reference_desktop.cc
+++ b/database/src/desktop/database_reference_desktop.cc
@@ -14,8 +14,7 @@
 
 #include "database/src/desktop/database_reference_desktop.h"
 
-#include <stdio.h>
-
+#include <cstdio>
 #include <sstream>
 
 #include "app/rest/util.h"

--- a/database/src/desktop/database_reference_desktop.h
+++ b/database/src/desktop/database_reference_desktop.h
@@ -33,7 +33,7 @@ class DatabaseReferenceInternal : public QueryInternal {
  public:
   DatabaseReferenceInternal(DatabaseInternal* database, const Path& path);
 
-  ~DatabaseReferenceInternal() override {}
+  ~DatabaseReferenceInternal() override = default;
 
   DatabaseReferenceInternal(const DatabaseReferenceInternal& reference);
 

--- a/database/src/desktop/disconnection_desktop.cc
+++ b/database/src/desktop/disconnection_desktop.cc
@@ -40,7 +40,7 @@ const char kVirtualChildKeyValue[] = ".value";
 const char kVirtualChildKeyPriority[] = ".priority";
 
 DisconnectionHandlerInternal::DisconnectionHandlerInternal(
-    DatabaseInternal* database, Path  path)
+    DatabaseInternal* database, Path path)
     : database_(database), path_(std::move(path)) {
   database_->future_manager().AllocFutureApi(this,
                                              kDisconnectionHandlerFnCount);

--- a/database/src/desktop/disconnection_desktop.cc
+++ b/database/src/desktop/disconnection_desktop.cc
@@ -14,6 +14,8 @@
 
 #include "database/src/desktop/disconnection_desktop.h"
 
+#include <utility>
+
 #include "app/src/future_manager.h"
 #include "database/src/common/database_reference.h"
 #include "database/src/desktop/core/repo.h"
@@ -38,8 +40,8 @@ const char kVirtualChildKeyValue[] = ".value";
 const char kVirtualChildKeyPriority[] = ".priority";
 
 DisconnectionHandlerInternal::DisconnectionHandlerInternal(
-    DatabaseInternal* database, const Path& path)
-    : database_(database), path_(path) {
+    DatabaseInternal* database, Path  path)
+    : database_(database), path_(std::move(path)) {
   database_->future_manager().AllocFutureApi(this,
                                              kDisconnectionHandlerFnCount);
 }

--- a/database/src/desktop/disconnection_desktop.h
+++ b/database/src/desktop/disconnection_desktop.h
@@ -32,7 +32,7 @@ class DatabaseInternal;
 class DisconnectionHandlerInternal {
  public:
   explicit DisconnectionHandlerInternal(DatabaseInternal* database,
-                                        const Path& path);
+                                        Path  path);
 
   ~DisconnectionHandlerInternal();
 

--- a/database/src/desktop/disconnection_desktop.h
+++ b/database/src/desktop/disconnection_desktop.h
@@ -31,8 +31,7 @@ class DatabaseInternal;
 // register server-side actions to occur when the client disconnects.
 class DisconnectionHandlerInternal {
  public:
-  explicit DisconnectionHandlerInternal(DatabaseInternal* database,
-                                        Path  path);
+  explicit DisconnectionHandlerInternal(DatabaseInternal* database, Path path);
 
   ~DisconnectionHandlerInternal();
 

--- a/database/src/desktop/mutable_data_desktop.cc
+++ b/database/src/desktop/mutable_data_desktop.cc
@@ -41,7 +41,7 @@ MutableDataInternal::MutableDataInternal(DatabaseInternal* database,
 }
 
 MutableDataInternal::MutableDataInternal(const MutableDataInternal& other,
-                                         Path  path)
+                                         Path path)
     : db_(other.db_), path_(std::move(path)), holder_(other.holder_) {}
 
 MutableDataInternal* MutableDataInternal::Clone() {

--- a/database/src/desktop/mutable_data_desktop.cc
+++ b/database/src/desktop/mutable_data_desktop.cc
@@ -14,9 +14,8 @@
 
 #include "database/src/desktop/mutable_data_desktop.h"
 
-#include <stdlib.h>
-
 #include <cassert>
+#include <cstdlib>
 #include <sstream>
 #include <utility>
 

--- a/database/src/desktop/mutable_data_desktop.cc
+++ b/database/src/desktop/mutable_data_desktop.cc
@@ -18,6 +18,7 @@
 
 #include <cassert>
 #include <sstream>
+#include <utility>
 
 #include "app/memory/shared_ptr.h"
 #include "app/src/log.h"
@@ -40,8 +41,8 @@ MutableDataInternal::MutableDataInternal(DatabaseInternal* database,
 }
 
 MutableDataInternal::MutableDataInternal(const MutableDataInternal& other,
-                                         const Path& path)
-    : db_(other.db_), path_(path), holder_(other.holder_) {}
+                                         Path  path)
+    : db_(other.db_), path_(std::move(path)), holder_(other.holder_) {}
 
 MutableDataInternal* MutableDataInternal::Clone() {
   // Just use the copy constructor

--- a/database/src/desktop/mutable_data_desktop.h
+++ b/database/src/desktop/mutable_data_desktop.h
@@ -87,7 +87,7 @@ class MutableDataInternal {
 
  private:
   explicit MutableDataInternal(const MutableDataInternal& other,
-                               const Path& path);
+                               Path  path);
 
   DatabaseInternal* db_;
   // Path relative to the root of holder_

--- a/database/src/desktop/mutable_data_desktop.h
+++ b/database/src/desktop/mutable_data_desktop.h
@@ -86,8 +86,7 @@ class MutableDataInternal {
   DatabaseInternal* database_internal() const { return db_; }
 
  private:
-  explicit MutableDataInternal(const MutableDataInternal& other,
-                               Path  path);
+  explicit MutableDataInternal(const MutableDataInternal& other, Path path);
 
   DatabaseInternal* db_;
   // Path relative to the root of holder_

--- a/database/src/desktop/persistence/in_memory_persistence_storage_engine.cc
+++ b/database/src/desktop/persistence/in_memory_persistence_storage_engine.cc
@@ -40,7 +40,7 @@ InMemoryPersistenceStorageEngine::InMemoryPersistenceStorageEngine(
     LoggerBase* logger)
     : server_cache_(), inside_transaction_(false), logger_(logger) {}
 
-InMemoryPersistenceStorageEngine::~InMemoryPersistenceStorageEngine() {}
+InMemoryPersistenceStorageEngine::~InMemoryPersistenceStorageEngine() = default;
 
 Variant InMemoryPersistenceStorageEngine::LoadServerCache() {
   // No persistence, so nothing to save.

--- a/database/src/desktop/persistence/level_db_persistence_storage_engine.cc
+++ b/database/src/desktop/persistence/level_db_persistence_storage_engine.cc
@@ -310,7 +310,7 @@ bool LevelDbPersistenceStorageEngine::Initialize(
   return status.ok();
 }
 
-LevelDbPersistenceStorageEngine::~LevelDbPersistenceStorageEngine() {}
+LevelDbPersistenceStorageEngine::~LevelDbPersistenceStorageEngine() = default;
 
 void LevelDbPersistenceStorageEngine::SaveUserOverwrite(const Path& path,
                                                         const Variant& data,

--- a/database/src/desktop/persistence/persistence_manager_interface.h
+++ b/database/src/desktop/persistence/persistence_manager_interface.h
@@ -33,7 +33,7 @@ namespace internal {
 
 class PersistenceManagerInterface {
  public:
-  virtual ~PersistenceManagerInterface() {}
+  virtual ~PersistenceManagerInterface() = default;
 
   // Persist a user write to the storage engine.
   //

--- a/database/src/desktop/persistence/persistence_storage_engine.h
+++ b/database/src/desktop/persistence/persistence_storage_engine.h
@@ -94,7 +94,7 @@ inline bool operator==(const UserWriteRecord& lhs, const UserWriteRecord& rhs) {
 //     query.
 class PersistenceStorageEngine {
  public:
-  virtual ~PersistenceStorageEngine() {}
+  virtual ~PersistenceStorageEngine() = default;
   // Write data to the local cache, overwriting the data at the given path.
   // Additionally, log that this write occurred so that when the database is
   // online again it can send updates.

--- a/database/src/desktop/persistence/persistence_storage_engine.h
+++ b/database/src/desktop/persistence/persistence_storage_engine.h
@@ -17,6 +17,7 @@
 
 #include <cstdint>
 #include <set>
+#include <utility>
 
 #include "app/src/include/firebase/variant.h"
 #include "app/src/path.h"
@@ -35,21 +36,20 @@ struct UserWriteRecord {
   UserWriteRecord()
       : write_id(), path(), overwrite(), merge(), visible(), is_overwrite() {}
 
-  UserWriteRecord(WriteId _write_id, const Path& _path,
-                  const Variant& _overwrite, bool _visible)
+  UserWriteRecord(WriteId _write_id, Path _path, Variant _overwrite,
+                  bool _visible)
       : write_id(_write_id),
-        path(_path),
-        overwrite(_overwrite),
+        path(std::move(_path)),
+        overwrite(std::move(_overwrite)),
         merge(),
         visible(_visible),
         is_overwrite(true) {}
 
-  UserWriteRecord(WriteId _write_id, const Path& _path,
-                  const CompoundWrite& _merge)
+  UserWriteRecord(WriteId _write_id, Path _path, CompoundWrite _merge)
       : write_id(_write_id),
-        path(_path),
+        path(std::move(_path)),
         overwrite(),
-        merge(_merge),
+        merge(std::move(_merge)),
         visible(true),
         is_overwrite(false) {}
 

--- a/database/src/desktop/push_child_name_generator.cc
+++ b/database/src/desktop/push_child_name_generator.cc
@@ -14,7 +14,7 @@
 
 #include "database/src/desktop/push_child_name_generator.h"
 
-#include <assert.h>
+#include <cassert>
 
 namespace firebase {
 namespace database {

--- a/database/src/desktop/query_desktop.cc
+++ b/database/src/desktop/query_desktop.cc
@@ -15,6 +15,7 @@
 #include "database/src/desktop/query_desktop.h"
 
 #include <sstream>
+#include <utility>
 
 #include "app/memory/unique_ptr.h"
 #include "app/rest/transport_builder.h"
@@ -89,9 +90,8 @@ static bool ValidateQueryEndpoints(const QueryParams& params, Logger* logger) {
   return true;
 }
 
-QueryInternal::QueryInternal(DatabaseInternal* database,
-                             const QuerySpec& query_spec)
-    : database_(database), query_spec_(query_spec) {
+QueryInternal::QueryInternal(DatabaseInternal* database, QuerySpec query_spec)
+    : database_(database), query_spec_(std::move(query_spec)) {
   if (database_) {
     database_->future_manager().AllocFutureApi(&future_api_id_, kQueryFnCount);
   }

--- a/database/src/desktop/query_desktop.cc
+++ b/database/src/desktop/query_desktop.cc
@@ -131,7 +131,7 @@ QueryInternal& QueryInternal::operator=(QueryInternal&& internal) {
 }
 #endif  // defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 
-QueryInternal::~QueryInternal() {}
+QueryInternal::~QueryInternal() = default;
 
 class SingleValueEventRegistration : public ValueEventRegistration {
  public:

--- a/database/src/desktop/query_desktop.h
+++ b/database/src/desktop/query_desktop.h
@@ -42,7 +42,7 @@ class QueryInternal {
  public:
   QueryInternal() : database_(nullptr) {}
 
-  QueryInternal(DatabaseInternal* database, QuerySpec  query_spec);
+  QueryInternal(DatabaseInternal* database, QuerySpec query_spec);
 
   QueryInternal(const QueryInternal& query);
 
@@ -124,14 +124,14 @@ class QueryInternal {
 };
 
 struct ValueListenerCleanupData {
-  explicit ValueListenerCleanupData(QuerySpec  query_spec)
+  explicit ValueListenerCleanupData(QuerySpec query_spec)
       : query_spec(std::move(query_spec)) {}
 
   QuerySpec query_spec;
 };
 
 struct ChildListenerCleanupData {
-  explicit ChildListenerCleanupData(QuerySpec  query_spec)
+  explicit ChildListenerCleanupData(QuerySpec query_spec)
       : query_spec(std::move(query_spec)) {}
 
   QuerySpec query_spec;

--- a/database/src/desktop/query_desktop.h
+++ b/database/src/desktop/query_desktop.h
@@ -17,6 +17,7 @@
 
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include "app/memory/unique_ptr.h"
 #include "app/src/include/firebase/future.h"
@@ -41,7 +42,7 @@ class QueryInternal {
  public:
   QueryInternal() : database_(nullptr) {}
 
-  QueryInternal(DatabaseInternal* database, const QuerySpec& query_spec);
+  QueryInternal(DatabaseInternal* database, QuerySpec  query_spec);
 
   QueryInternal(const QueryInternal& query);
 
@@ -123,15 +124,15 @@ class QueryInternal {
 };
 
 struct ValueListenerCleanupData {
-  explicit ValueListenerCleanupData(const QuerySpec& query_spec)
-      : query_spec(query_spec) {}
+  explicit ValueListenerCleanupData(QuerySpec  query_spec)
+      : query_spec(std::move(query_spec)) {}
 
   QuerySpec query_spec;
 };
 
 struct ChildListenerCleanupData {
-  explicit ChildListenerCleanupData(const QuerySpec& query_spec)
-      : query_spec(query_spec) {}
+  explicit ChildListenerCleanupData(QuerySpec  query_spec)
+      : query_spec(std::move(query_spec)) {}
 
   QuerySpec query_spec;
 };

--- a/database/src/desktop/transaction_data.h
+++ b/database/src/desktop/transaction_data.h
@@ -17,6 +17,7 @@
 
 #include <list>
 #include <queue>
+#include <utility>
 
 #include "app/memory/shared_ptr.h"
 #include "app/src/include/firebase/future.h"
@@ -60,13 +61,13 @@ struct TransactionData {
 
   // Constructor to capture all data for a RunTransaction request
   TransactionData(const SafeFutureHandle<DataSnapshot>& handle,
-                  ReferenceCountedFutureImpl* ref_future, const Path& path,
+                  ReferenceCountedFutureImpl* ref_future, Path  path,
                   DoTransactionWithContext function, void* context,
                   void (*delete_context)(void*), bool trigger_local_events,
                   UniquePtr<ValueListener> outstanding_listener)
       : future_handle(handle),
         ref_future(ref_future),
-        path(path),
+        path(std::move(path)),
         transaction_function(function),
         context(context),
         delete_context(delete_context),

--- a/database/src/desktop/transaction_data.h
+++ b/database/src/desktop/transaction_data.h
@@ -61,7 +61,7 @@ struct TransactionData {
 
   // Constructor to capture all data for a RunTransaction request
   TransactionData(const SafeFutureHandle<DataSnapshot>& handle,
-                  ReferenceCountedFutureImpl* ref_future, Path  path,
+                  ReferenceCountedFutureImpl* ref_future, Path path,
                   DoTransactionWithContext function, void* context,
                   void (*delete_context)(void*), bool trigger_local_events,
                   UniquePtr<ValueListener> outstanding_listener)

--- a/database/src/desktop/util_desktop.cc
+++ b/database/src/desktop/util_desktop.cc
@@ -912,8 +912,8 @@ void AppendHashRepAsContainer(std::stringstream* ss, const Variant& data) {
     for (int i = 0; i < data.vector().size(); ++i) {
       std::stringstream index_stream;
       index_stream << i;
-      index_variants.push_back(index_stream.str());
-      nodes.push_back(NodeSortingData(&index_variants[i], &data.vector()[i]));
+      index_variants.emplace_back(index_stream.str());
+      nodes.emplace_back(&index_variants[i], &data.vector()[i]);
       saw_priority =
           saw_priority || !GetVariantPriority(data.vector()[i]).is_null();
     }
@@ -921,7 +921,7 @@ void AppendHashRepAsContainer(std::stringstream* ss, const Variant& data) {
   } else if (data.is_map()) {
     bool saw_priority = false;
     for (auto& it_child : data.map()) {
-      nodes.push_back(NodeSortingData(&it_child.first, &it_child.second));
+      nodes.emplace_back(&it_child.first, &it_child.second);
       saw_priority =
           saw_priority || !GetVariantPriority(it_child.second).is_null();
     }

--- a/database/src/desktop/util_desktop.h
+++ b/database/src/desktop/util_desktop.h
@@ -148,7 +148,7 @@ void SetVariantAtPath(Variant* variant, const Path& path, const Variant& value);
 // * Validation for path
 // * Expect no params in the url or they all be part of the path
 struct ParseUrl {
-  ParseUrl() {}
+  ParseUrl() = default;
   enum ParseResult {
     kParseOk = 0,
     kParseErrorEmpty,

--- a/database/src/desktop/view/change.h
+++ b/database/src/desktop/view/change.h
@@ -16,6 +16,7 @@
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_CHANGE_H_
 
 #include <string>
+#include <utility>
 
 #include "app/src/include/firebase/variant.h"
 #include "database/src/desktop/core/indexed_variant.h"
@@ -42,20 +43,20 @@ struct Change {
         old_indexed_variant() {}
 
   Change(EventType _event_type, const IndexedVariant& _indexed_variant,
-         const std::string& _child_key)
+         std::string  _child_key)
       : event_type(_event_type),
         indexed_variant(_indexed_variant),
-        child_key(_child_key),
+        child_key(std::move(_child_key)),
         prev_name(),
         old_indexed_variant() {}
 
   Change(EventType _event_type, const IndexedVariant& _indexed_variant,
-         const std::string& _child_key, const std::string& _prev_name,
+         std::string  _child_key, std::string  _prev_name,
          const IndexedVariant& _old_indexed_variant)
       : event_type(_event_type),
         indexed_variant(_indexed_variant),
-        child_key(_child_key),
-        prev_name(_prev_name),
+        child_key(std::move(_child_key)),
+        prev_name(std::move(_prev_name)),
         old_indexed_variant(_old_indexed_variant) {}
 
   // The type of event that has occurred.

--- a/database/src/desktop/view/change.h
+++ b/database/src/desktop/view/change.h
@@ -43,7 +43,7 @@ struct Change {
         old_indexed_variant() {}
 
   Change(EventType _event_type, const IndexedVariant& _indexed_variant,
-         std::string  _child_key)
+         std::string _child_key)
       : event_type(_event_type),
         indexed_variant(_indexed_variant),
         child_key(std::move(_child_key)),
@@ -51,7 +51,7 @@ struct Change {
         old_indexed_variant() {}
 
   Change(EventType _event_type, const IndexedVariant& _indexed_variant,
-         std::string  _child_key, std::string  _prev_name,
+         std::string _child_key, std::string _prev_name,
          const IndexedVariant& _old_indexed_variant)
       : event_type(_event_type),
         indexed_variant(_indexed_variant),

--- a/database/src/desktop/view/event.h
+++ b/database/src/desktop/view/event.h
@@ -16,6 +16,7 @@
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_EVENT_H_
 
 #include <string>
+#include <utility>
 
 #include "app/memory/unique_ptr.h"
 #include "app/src/optional.h"
@@ -51,22 +52,22 @@ struct Event {
         path() {}
 
   Event(EventType _type, EventRegistration* _event_registration,
-        const DataSnapshotInternal& _snapshot, const std::string& _prev_name)
+        const DataSnapshotInternal& _snapshot, std::string  _prev_name)
       : type(_type),
         event_registration(_event_registration),
         snapshot(_snapshot),
-        prev_name(_prev_name),
+        prev_name(std::move(_prev_name)),
         error(kErrorNone),
         path() {}
 
   Event(UniquePtr<EventRegistration> _event_registration, Error _error,
-        const Path& _path)
+        Path  _path)
       : type(kEventTypeError),
         event_registration(_event_registration.get()),
         snapshot(),
         prev_name(),
         error(_error),
-        path(_path),
+        path(std::move(_path)),
         event_registration_ownership_ptr() {
     event_registration_ownership_ptr = std::move(_event_registration);
   }

--- a/database/src/desktop/view/event.h
+++ b/database/src/desktop/view/event.h
@@ -52,7 +52,7 @@ struct Event {
         path() {}
 
   Event(EventType _type, EventRegistration* _event_registration,
-        const DataSnapshotInternal& _snapshot, std::string  _prev_name)
+        const DataSnapshotInternal& _snapshot, std::string _prev_name)
       : type(_type),
         event_registration(_event_registration),
         snapshot(_snapshot),
@@ -61,7 +61,7 @@ struct Event {
         path() {}
 
   Event(UniquePtr<EventRegistration> _event_registration, Error _error,
-        Path  _path)
+        Path _path)
       : type(kEventTypeError),
         event_registration(_event_registration.get()),
         snapshot(),

--- a/database/src/desktop/view/event_generator.cc
+++ b/database/src/desktop/view/event_generator.cc
@@ -49,8 +49,7 @@ std::vector<Event> GenerateEventsForChanges(
   std::vector<Event> events;
   std::vector<Change> moves;
   QueryParamsComparator comparator(&query_spec.params);
-  for (auto iter = changes.begin(); iter != changes.end(); ++iter) {
-    const Change& change = *iter;
+  for (const auto & change : changes) {
     if (change.event_type == kEventTypeChildChanged) {
       const Variant& old_variant = change.old_indexed_variant.variant();
       const Variant& variant = change.indexed_variant.variant();
@@ -99,8 +98,7 @@ void GenerateEventsForType(
     const IndexedVariant& event_cache, std::vector<Event>* events) {
   std::vector<const Change*> filtered_changes;
   filtered_changes.reserve(changes.size());
-  for (auto iter = changes.begin(); iter != changes.end(); ++iter) {
-    const Change& change = *iter;
+  for (const auto & change : changes) {
     if (change.event_type != kEventTypeValue) {
       FIREBASE_DEV_ASSERT_MESSAGE(!change.child_key.empty(),
                                   "Child changes must have a child_key");
@@ -118,12 +116,8 @@ void GenerateEventsForType(
                                 "Value changes must occur one at a time");
   }
 
-  for (auto change_iter = filtered_changes.begin();
-       change_iter != filtered_changes.end(); ++change_iter) {
-    const Change* change = *change_iter;
-    for (auto registration_iter = event_registrations.begin();
-         registration_iter != event_registrations.end(); ++registration_iter) {
-      const UniquePtr<EventRegistration>& registration = *registration_iter;
+  for (auto change : filtered_changes) {
+    for (const auto & registration : event_registrations) {
       if (registration->RespondsTo(event_type)) {
         events->push_back(GenerateEvent(query_spec, *change, registration.get(),
                                         event_cache));

--- a/database/src/desktop/view/event_generator.cc
+++ b/database/src/desktop/view/event_generator.cc
@@ -49,7 +49,7 @@ std::vector<Event> GenerateEventsForChanges(
   std::vector<Event> events;
   std::vector<Change> moves;
   QueryParamsComparator comparator(&query_spec.params);
-  for (const auto & change : changes) {
+  for (const auto& change : changes) {
     if (change.event_type == kEventTypeChildChanged) {
       const Variant& old_variant = change.old_indexed_variant.variant();
       const Variant& variant = change.indexed_variant.variant();
@@ -98,7 +98,7 @@ void GenerateEventsForType(
     const IndexedVariant& event_cache, std::vector<Event>* events) {
   std::vector<const Change*> filtered_changes;
   filtered_changes.reserve(changes.size());
-  for (const auto & change : changes) {
+  for (const auto& change : changes) {
     if (change.event_type != kEventTypeValue) {
       FIREBASE_DEV_ASSERT_MESSAGE(!change.child_key.empty(),
                                   "Child changes must have a child_key");
@@ -117,7 +117,7 @@ void GenerateEventsForType(
   }
 
   for (auto change : filtered_changes) {
-    for (const auto & registration : event_registrations) {
+    for (const auto& registration : event_registrations) {
       if (registration->RespondsTo(event_type)) {
         events->push_back(GenerateEvent(query_spec, *change, registration.get(),
                                         event_cache));

--- a/database/src/desktop/view/indexed_filter.cc
+++ b/database/src/desktop/view/indexed_filter.cc
@@ -24,7 +24,7 @@ namespace firebase {
 namespace database {
 namespace internal {
 
-IndexedFilter::~IndexedFilter() {}
+IndexedFilter::~IndexedFilter() = default;
 
 IndexedVariant IndexedFilter::UpdateChild(
     const IndexedVariant& indexed_variant, const std::string& key,

--- a/database/src/desktop/view/limited_filter.cc
+++ b/database/src/desktop/view/limited_filter.cc
@@ -32,7 +32,7 @@ LimitedFilter::LimitedFilter(const QueryParams& params)
       limit_(params.limit_first ? params.limit_first : params.limit_last),
       reverse_(!!params.limit_last) {}
 
-LimitedFilter::~LimitedFilter() {}
+LimitedFilter::~LimitedFilter() = default;
 
 IndexedVariant LimitedFilter::UpdateChild(
     const IndexedVariant& indexed_variant, const std::string& key,

--- a/database/src/desktop/view/ranged_filter.cc
+++ b/database/src/desktop/view/ranged_filter.cc
@@ -33,7 +33,7 @@ RangedFilter::RangedFilter(const QueryParams& params)
       start_post_(GetStartPost(params)),
       end_post_(GetEndPost(params)) {}
 
-RangedFilter::~RangedFilter() {}
+RangedFilter::~RangedFilter() = default;
 
 IndexedVariant RangedFilter::UpdateChild(
     const IndexedVariant& indexed_variant, const std::string& key,

--- a/database/src/desktop/view/variant_filter.h
+++ b/database/src/desktop/view/variant_filter.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_VARIANT_FILTER_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_VARIANT_FILTER_H_
 
+#include <utility>
+
 #include "app/memory/unique_ptr.h"
 #include "app/src/include/firebase/variant.h"
 #include "app/src/path.h"
@@ -52,8 +54,8 @@ class CompleteChildSource {
 // of implementations of this interface.
 class VariantFilter {
  public:
-  explicit VariantFilter(const QueryParams& query_params)
-      : query_params_(query_params) {}
+  explicit VariantFilter(QueryParams query_params)
+      : query_params_(std::move(query_params)) {}
 
   virtual ~VariantFilter() = default;
 

--- a/database/src/desktop/view/variant_filter.h
+++ b/database/src/desktop/view/variant_filter.h
@@ -36,7 +36,7 @@ namespace internal {
 // in pulling into the view.
 class CompleteChildSource {
  public:
-  virtual ~CompleteChildSource() {}
+  virtual ~CompleteChildSource() = default;
   virtual Optional<Variant> GetCompleteChild(
       const std::string& child_key) const = 0;
 
@@ -55,7 +55,7 @@ class VariantFilter {
   explicit VariantFilter(const QueryParams& query_params)
       : query_params_(query_params) {}
 
-  virtual ~VariantFilter() {}
+  virtual ~VariantFilter() = default;
 
   // Update a single complete child in the snap. If the child equals the old
   // child in the snap, this is a no-op. The method expects an indexed snap.

--- a/database/src/desktop/view/view.cc
+++ b/database/src/desktop/view/view.cc
@@ -123,8 +123,8 @@ std::vector<Event> View::RemoveEventRegistration(void* listener_ptr,
     for (auto iter = event_registrations_.begin();
          iter != event_registrations_.end(); ++iter) {
       UniquePtr<EventRegistration>& event_registration = *iter;
-      cancel_events.push_back(
-          Event(std::move(event_registration), cancel_error, path));
+      cancel_events.emplace_back(std::move(event_registration), cancel_error,
+                                 path);
     }
     event_registrations_.clear();
     return cancel_events;

--- a/database/src/desktop/view/view.cc
+++ b/database/src/desktop/view/view.cc
@@ -92,7 +92,7 @@ View& View::operator=(View&& other) {
   return *this;
 }
 
-View::~View() {}
+View::~View() = default;
 
 const Variant* View::GetCompleteServerCache(const Path& path) const {
   const Variant* snap = view_cache_.GetCompleteServerSnap();

--- a/database/src/desktop/view/view.cc
+++ b/database/src/desktop/view/view.cc
@@ -120,9 +120,7 @@ std::vector<Event> View::RemoveEventRegistration(void* listener_ptr,
         "A cancel should cancel all event registrations");
     std::vector<Event> cancel_events;
     Path path(query_spec_.path);
-    for (auto iter = event_registrations_.begin();
-         iter != event_registrations_.end(); ++iter) {
-      UniquePtr<EventRegistration>& event_registration = *iter;
+    for (auto& event_registration : event_registrations_) {
       cancel_events.emplace_back(std::move(event_registration), cancel_error,
                                  path);
     }

--- a/database/src/desktop/view/view_cache.h
+++ b/database/src/desktop/view/view_cache.h
@@ -108,8 +108,9 @@ class ViewCache {
  public:
   ViewCache() : local_snap_(), server_snap_() {}
 
-  ViewCache(CacheNode  local_snap, CacheNode  server_snap)
-      : local_snap_(std::move(local_snap)), server_snap_(std::move(server_snap)) {}
+  ViewCache(CacheNode local_snap, CacheNode server_snap)
+      : local_snap_(std::move(local_snap)),
+        server_snap_(std::move(server_snap)) {}
 
   // Get the complete snapshot of the local cache, or null if it is not
   // present.

--- a/database/src/desktop/view/view_cache.h
+++ b/database/src/desktop/view/view_cache.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_VIEW_CACHE_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_DESKTOP_VIEW_VIEW_CACHE_H_
 
+#include <utility>
+
 #include "app/src/include/firebase/variant.h"
 #include "app/src/path.h"
 #include "database/src/desktop/core/indexed_variant.h"
@@ -106,8 +108,8 @@ class ViewCache {
  public:
   ViewCache() : local_snap_(), server_snap_() {}
 
-  ViewCache(const CacheNode& local_snap, const CacheNode& server_snap)
-      : local_snap_(local_snap), server_snap_(server_snap) {}
+  ViewCache(CacheNode  local_snap, CacheNode  server_snap)
+      : local_snap_(std::move(local_snap)), server_snap_(std::move(server_snap)) {}
 
   // Get the complete snapshot of the local cache, or null if it is not
   // present.

--- a/database/src/desktop/view/view_processor.cc
+++ b/database/src/desktop/view/view_processor.cc
@@ -15,6 +15,7 @@
 #include "database/src/desktop/view/view_processor.h"
 
 #include <algorithm>
+#include <utility>
 #include <vector>
 
 #include "app/src/assert.h"
@@ -41,11 +42,10 @@ namespace internal {
 // to have, as well as the writes that are pending to form a complete child.
 class WriteTreeCompleteChildSource : public CompleteChildSource {
  public:
-  WriteTreeCompleteChildSource(const WriteTreeRef& writes,
-                               const ViewCache& view_cache,
+  WriteTreeCompleteChildSource(WriteTreeRef writes, ViewCache view_cache,
                                const Variant* opt_complete_server_cache)
-      : writes_(writes),
-        view_cache_(view_cache),
+      : writes_(std::move(writes)),
+        view_cache_(std::move(view_cache)),
         opt_complete_server_cache_(
             OptionalFromPointer(opt_complete_server_cache)) {}
 

--- a/database/src/desktop/view/view_processor.cc
+++ b/database/src/desktop/view/view_processor.cc
@@ -106,7 +106,7 @@ class NoCompleteSource : public CompleteChildSource {
 ViewProcessor::ViewProcessor(UniquePtr<VariantFilter> filter)
     : filter_(std::move(filter)) {}
 
-ViewProcessor::~ViewProcessor() {}
+ViewProcessor::~ViewProcessor() = default;
 
 void ViewProcessor::ApplyOperation(const ViewCache& old_view_cache,
                                    const Operation& operation,

--- a/database/src/include/firebase/database/data_snapshot.h
+++ b/database/src/include/firebase/database/data_snapshot.h
@@ -15,8 +15,7 @@
 #ifndef FIREBASE_DATABASE_CLIENT_CPP_SRC_INCLUDE_FIREBASE_DATABASE_DATA_SNAPSHOT_H_
 #define FIREBASE_DATABASE_CLIENT_CPP_SRC_INCLUDE_FIREBASE_DATABASE_DATA_SNAPSHOT_H_
 
-#include <stddef.h>
-
+#include <cstddef>
 #include <string>
 
 #include "firebase/internal/common.h"

--- a/database/src/include/firebase/database/database_reference.h
+++ b/database/src/include/firebase/database/database_reference.h
@@ -50,7 +50,7 @@ class DatabaseReference : public Query {
   DatabaseReference() : Query(), internal_(nullptr) {}
 
   /// @brief Required virtual destructor.
-  virtual ~DatabaseReference();
+  ~DatabaseReference() override;
 
   /// @brief Copy constructor. It's totally okay (and efficient) to copy
   /// DatabaseReference instances, as they simply point to the same location in

--- a/dynamic_links/src/common.cc
+++ b/dynamic_links/src/common.cc
@@ -48,7 +48,7 @@ const char kDynamicLinksModuleName[] = "dynamic_links";
 class CachedListenerNotifier : public invites::internal::ReceiverInterface {
  public:
   CachedListenerNotifier() : listener_(nullptr) {}
-  virtual ~CachedListenerNotifier() { SetListener(nullptr); }
+  ~CachedListenerNotifier() override { SetListener(nullptr); }
 
   // Set the listener which should be notified of any cached or receiver
   // links.

--- a/dynamic_links/src/common.cc
+++ b/dynamic_links/src/common.cc
@@ -14,7 +14,7 @@
 
 #include "dynamic_links/src/common.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "app/src/cleanup_notifier.h"
 #include "app/src/invites/cached_receiver.h"

--- a/dynamic_links/src/common.h
+++ b/dynamic_links/src/common.h
@@ -28,8 +28,8 @@ enum DynamicLinksFn { kDynamicLinksFnGetShortLink, kDynamicLinksFnCount };
 // future required by this API.
 class FutureData {
  public:
-  FutureData() : api_(kDynamicLinksFnCount) {}
-  ~FutureData() {}
+  FutureData() : api_(kDynamicLinksFnCount) = default;
+  ~FutureData() = default;
 
   ReferenceCountedFutureImpl* api() { return &api_; }
 

--- a/dynamic_links/src/dynamic_links_stub.cc
+++ b/dynamic_links/src/dynamic_links_stub.cc
@@ -12,8 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-
+#include <cassert>
 #include <cstddef>
 #include <map>
 #include <string>

--- a/dynamic_links/src/listener.cc
+++ b/dynamic_links/src/listener.cc
@@ -19,7 +19,7 @@ namespace dynamic_links {
 
 // Non-inline implementation of Listener's virtual destructor
 // to prevent its vtable being emitted in each translation unit.
-Listener::~Listener() {}
+Listener::~Listener() = default;
 
 }  // namespace dynamic_links
 }  // namespace firebase

--- a/firestore/src/common/collection_reference.cc
+++ b/firestore/src/common/collection_reference.cc
@@ -25,7 +25,7 @@ namespace firestore {
 // Java CollectionReference) be subclass of QueryInternal (resp. Java Query),
 // which is already the case.
 
-CollectionReference::CollectionReference() {}
+CollectionReference::CollectionReference() = default;
 
 CollectionReference::CollectionReference(const CollectionReference& reference)
     : Query(reference.internal()
@@ -39,10 +39,7 @@ CollectionReference::CollectionReference(CollectionReferenceInternal* internal)
     : Query(internal) {}
 
 CollectionReference& CollectionReference::operator=(
-    const CollectionReference& reference) {
-  Query::operator=(reference);
-  return *this;
-}
+    const CollectionReference& reference) = default;
 
 CollectionReference& CollectionReference::operator=(
     CollectionReference&& reference) {

--- a/firestore/src/common/document_change.cc
+++ b/firestore/src/common/document_change.cc
@@ -25,7 +25,7 @@ using Type = DocumentChange::Type;
 const std::size_t DocumentChange::npos = static_cast<std::size_t>(-1);
 #endif  // defined(ANDROID)
 
-DocumentChange::DocumentChange() {}
+DocumentChange::DocumentChange() = default;
 
 DocumentChange::DocumentChange(const DocumentChange& value) {
   if (value.internal_) {

--- a/firestore/src/common/document_reference.cc
+++ b/firestore/src/common/document_reference.cc
@@ -25,7 +25,7 @@ namespace firestore {
 
 using CleanupFnDocumentReference = CleanupFn<DocumentReference>;
 
-DocumentReference::DocumentReference() {}
+DocumentReference::DocumentReference() = default;
 
 DocumentReference::DocumentReference(const DocumentReference& reference) {
   if (reference.internal_) {

--- a/firestore/src/common/document_snapshot.cc
+++ b/firestore/src/common/document_snapshot.cc
@@ -23,7 +23,7 @@ namespace firestore {
 
 using CleanupFnDocumentSnapshot = CleanupFn<DocumentSnapshot>;
 
-DocumentSnapshot::DocumentSnapshot() {}
+DocumentSnapshot::DocumentSnapshot() = default;
 
 DocumentSnapshot::DocumentSnapshot(const DocumentSnapshot& snapshot) {
   if (snapshot.internal_) {

--- a/firestore/src/common/field_path.cc
+++ b/firestore/src/common/field_path.cc
@@ -36,7 +36,7 @@
 namespace firebase {
 namespace firestore {
 
-FieldPath::FieldPath() {}
+FieldPath::FieldPath() = default;
 
 #if !defined(_STLPORT_VERSION)
 FieldPath::FieldPath(std::initializer_list<std::string> field_names)

--- a/firestore/src/common/field_value.cc
+++ b/firestore/src/common/field_value.cc
@@ -74,7 +74,7 @@ std::string ValueToString(const uint8_t* blob, size_t size) {
 
 }  // namespace
 
-FieldValue::FieldValue() {}
+FieldValue::FieldValue() = default;
 
 FieldValue::FieldValue(const FieldValue& value) {
   if (value.internal_) {

--- a/firestore/src/common/query.cc
+++ b/firestore/src/common/query.cc
@@ -24,7 +24,7 @@ namespace firestore {
 
 using CleanupFnQuery = CleanupFn<Query>;
 
-Query::Query() {}
+Query::Query() = default;
 
 Query::Query(const Query& query) {
   if (query.internal_) {

--- a/firestore/src/common/query_snapshot.cc
+++ b/firestore/src/common/query_snapshot.cc
@@ -20,7 +20,7 @@ namespace firestore {
 
 using CleanupFnQuerySnapshot = CleanupFn<QuerySnapshot>;
 
-QuerySnapshot::QuerySnapshot() {}
+QuerySnapshot::QuerySnapshot() = default;
 
 QuerySnapshot::QuerySnapshot(const QuerySnapshot& snapshot) {
   if (snapshot.internal_) {

--- a/firestore/src/common/set_options.cc
+++ b/firestore/src/common/set_options.cc
@@ -24,7 +24,7 @@ namespace firestore {
 SetOptions::SetOptions(Type type, std::vector<FieldPath> fields)
     : type_(type), fields_(firebase::Move(fields)) {}
 
-SetOptions::~SetOptions() {}
+SetOptions::~SetOptions() = default;
 
 /* static */
 SetOptions SetOptions::Merge() {

--- a/firestore/src/common/write_batch.cc
+++ b/firestore/src/common/write_batch.cc
@@ -20,7 +20,7 @@ namespace firestore {
 
 using CleanupFnWriteBatch = CleanupFn<WriteBatch>;
 
-WriteBatch::WriteBatch() {}
+WriteBatch::WriteBatch() = default;
 
 WriteBatch::WriteBatch(const WriteBatch& value) {
   if (value.internal_) {

--- a/firestore/src/include/firebase/firestore/transaction.h
+++ b/firestore/src/include/firebase/firestore/transaction.h
@@ -143,7 +143,7 @@ class Transaction {
  */
 class TransactionFunction {
  public:
-  virtual ~TransactionFunction() {}
+  virtual ~TransactionFunction() = default;
 
   /**
    * Subclass should override this method and put the transaction logic here.

--- a/functions/src/common/functions.cc
+++ b/functions/src/common/functions.cc
@@ -14,8 +14,7 @@
 
 #include "functions/src/include/firebase/functions.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <map>
 #include <string>
 

--- a/functions/src/desktop/functions_desktop.cc
+++ b/functions/src/desktop/functions_desktop.cc
@@ -26,7 +26,7 @@ namespace internal {
 FunctionsInternal::FunctionsInternal(App* app, const char* region)
     : app_(app), region_(region) {}
 
-FunctionsInternal::~FunctionsInternal() {}
+FunctionsInternal::~FunctionsInternal() = default;
 
 ::firebase::App* FunctionsInternal::app() const { return app_; }
 

--- a/functions/src/include/firebase/functions.h
+++ b/functions/src/include/firebase/functions.h
@@ -96,8 +96,8 @@ class Functions {
  private:
   /// @cond FIREBASE_APP_INTERNAL
   Functions(::firebase::App* app, const char* region);
-  Functions(const Functions& src);
-  Functions& operator=(const Functions& src);
+  Functions(const Functions& src) = delete;
+  Functions& operator=(const Functions& src) = delete;
 
   // Delete the internal_ data.
   void DeleteInternal();

--- a/functions/src/include/firebase/functions/callable_result.h
+++ b/functions/src/include/firebase/functions/callable_result.h
@@ -15,8 +15,10 @@
 #ifndef FIREBASE_FUNCTIONS_CLIENT_CPP_SRC_INCLUDE_FIREBASE_FUNCTIONS_CALLABLE_RESULT_H_
 #define FIREBASE_FUNCTIONS_CLIENT_CPP_SRC_INCLUDE_FIREBASE_FUNCTIONS_CALLABLE_RESULT_H_
 
-#include "firebase/variant.h"
+#include <utility>
+
 #include "firebase/functions/common.h"
+#include "firebase/variant.h"
 
 namespace firebase {
 namespace functions {
@@ -78,7 +80,7 @@ class HttpsCallableResult {
   /// @cond FIREBASE_APP_INTERNAL
   // Only functions are allowed to construct results.
   friend class ::firebase::functions::internal::HttpsCallableReferenceInternal;
-  HttpsCallableResult(const Variant& data) : data_(data) {}
+  HttpsCallableResult(Variant  data) : data_(std::move(data)) {}
 #if defined(FIREBASE_USE_MOVE_OPERATORS)
   HttpsCallableResult(Variant&& data) : data_(std::move(data)) {}
 #endif  // defined(FIREBASE_USE_MOVE_OPERATORS)

--- a/functions/src/include/firebase/functions/callable_result.h
+++ b/functions/src/include/firebase/functions/callable_result.h
@@ -31,24 +31,21 @@ class HttpsCallableReferenceInternal;
 class HttpsCallableResult {
  public:
   /// @brief Creates an HttpsCallableResult with null data.
-  HttpsCallableResult() {}
+  HttpsCallableResult() = default;
 
-  ~HttpsCallableResult() {}
+  ~HttpsCallableResult() = default;
 
   /// @brief Copy constructor. Copying is as efficient as copying a Variant.
   ///
   /// @param[in] other HttpsCallableResult to copy data from.
-  HttpsCallableResult(const HttpsCallableResult& other) : data_(other.data_) {}
+  HttpsCallableResult(const HttpsCallableResult& other)  = default;
 
   /// @brief Assignment operator. Copying is as efficient as copying a Variant.
   ///
   /// @param[in] other HttpsCallableResult to copy data from.
   ///
   /// @returns Reference to the destination HttpsCallableResult.
-  HttpsCallableResult& operator=(const HttpsCallableResult& other) {
-    data_ = other.data_;
-    return *this;
-  }
+  HttpsCallableResult& operator=(const HttpsCallableResult& other) = default;
 
 #if defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
   /// @brief Move constructor. Moving is an efficient operation for

--- a/installations/src/stub/installations_stub.cc
+++ b/installations/src/stub/installations_stub.cc
@@ -24,7 +24,7 @@ namespace internal {
 InstallationsInternal::InstallationsInternal(const firebase::App& app)
     : app_(app), future_impl_(kInstallationsFnCount) {}
 
-InstallationsInternal::~InstallationsInternal() {}
+InstallationsInternal::~InstallationsInternal() = default;
 
 bool InstallationsInternal::Initialized() const { return true; }
 

--- a/instance_id/src/instance_id_internal_base.cc
+++ b/instance_id/src/instance_id_internal_base.cc
@@ -56,7 +56,7 @@ InstanceIdInternalBase::InstanceIdInternalBase()
                reinterpret_cast<intptr_t>(this)));
 }
 
-InstanceIdInternalBase::~InstanceIdInternalBase() {}
+InstanceIdInternalBase::~InstanceIdInternalBase() = default;
 
 // Associate an InstanceId instance with an app.
 void InstanceIdInternalBase::RegisterInstanceIdForApp(App* app,

--- a/instance_id/src/instance_id_internal_base.cc
+++ b/instance_id/src/instance_id_internal_base.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <assert.h>
-#include <stdint.h>
-#include <stdio.h>
-#include <string.h>
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
 
 #include "app/src/app_common.h"
 #include "app/src/cleanup_notifier.h"

--- a/messaging/src/common.cc
+++ b/messaging/src/common.cc
@@ -14,8 +14,7 @@
 
 #include "messaging/src/common.h"
 
-#include <assert.h>
-
+#include <cassert>
 #include <queue>
 
 #include "app/src/cleanup_notifier.h"

--- a/messaging/src/common.h
+++ b/messaging/src/common.h
@@ -47,8 +47,8 @@ enum MessagingFn {
 // future required by this API (fetch_future_).
 class FutureData {
  public:
-  FutureData() : api_(kMessagingFnCount) {}
-  ~FutureData() {}
+  FutureData() : api_(kMessagingFnCount) = default;
+  ~FutureData() = default;
 
   ReferenceCountedFutureImpl* api() { return &api_; }
 

--- a/messaging/src/include/firebase/messaging.h
+++ b/messaging/src/include/firebase/messaging.h
@@ -15,8 +15,7 @@
 #ifndef FIREBASE_MESSAGING_CLIENT_CPP_INCLUDE_FIREBASE_MESSAGING_H_
 #define FIREBASE_MESSAGING_CLIENT_CPP_INCLUDE_FIREBASE_MESSAGING_H_
 
-#include <stdint.h>
-
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>

--- a/messaging/src/include/firebase/messaging.h
+++ b/messaging/src/include/firebase/messaging.h
@@ -660,15 +660,15 @@ class PollableListener : public Listener {
   PollableListener();
 
   /// @brief The required virtual destructor.
-  virtual ~PollableListener();
+  ~PollableListener() override;
 
   /// @brief An implementation of `OnMessage` which adds the incoming messages
   /// to a queue, which can be consumed by calling `PollMessage`.
-  virtual void OnMessage(const Message& message);
+  void OnMessage(const Message& message) override;
 
   /// @brief An implementation of `OnTokenReceived` which stores the incoming
   /// token so that it can be consumed by calling `PollRegistrationToken`.
-  virtual void OnTokenReceived(const char* token);
+  void OnTokenReceived(const char* token) override;
 
   /// @brief Returns the first message queued up, if any.
   ///

--- a/messaging/src/listener.cc
+++ b/messaging/src/listener.cc
@@ -19,7 +19,7 @@ namespace messaging {
 
 // Non-inline implementation of Listener's virtual destructor
 // to prevent its vtable being emitted in each translation unit.
-Listener::~Listener() {}
+Listener::~Listener() = default;
 
 }  // namespace messaging
 }  // namespace firebase

--- a/remote_config/src/common.cc
+++ b/remote_config/src/common.cc
@@ -14,7 +14,7 @@
 
 #include "remote_config/src/common.h"
 
-#include <assert.h>
+#include <cassert>
 
 #include "app/src/cleanup_notifier.h"
 #include "app/src/util.h"

--- a/remote_config/src/common.h
+++ b/remote_config/src/common.h
@@ -45,8 +45,8 @@ enum FutureStatus {
 // future required by this API (fetch_future_).
 class FutureData {
  public:
-  FutureData() : api_(kRemoteConfigFnCount) {}
-  ~FutureData() {}
+  FutureData() : api_(kRemoteConfigFnCount) = default;
+  ~FutureData() = default;
 
   ReferenceCountedFutureImpl* api() { return &api_; }
 

--- a/remote_config/src/desktop/config_data.cc
+++ b/remote_config/src/desktop/config_data.cc
@@ -14,6 +14,8 @@
 
 #include "remote_config/src/desktop/config_data.h"
 
+#include <utility>
+
 #include "flatbuffers/flexbuffers.h"
 #include "remote_config/src/desktop/metadata.h"
 
@@ -24,9 +26,9 @@ namespace internal {
 NamespacedConfigData::NamespacedConfigData()
     : config_(NamespaceKeyValueMap()), timestamp_(0) {}
 
-NamespacedConfigData::NamespacedConfigData(const NamespaceKeyValueMap& config,
+NamespacedConfigData::NamespacedConfigData(NamespaceKeyValueMap config,
                                            uint64_t timestamp)
-    : config_(config), timestamp_(timestamp) {}
+    : config_(std::move(config)), timestamp_(timestamp) {}
 
 std::string NamespacedConfigData::Serialize() const {
   flexbuffers::Builder fbb;
@@ -116,14 +118,14 @@ bool NamespacedConfigData::operator==(const NamespacedConfigData& right) const {
 }
 
 LayeredConfigs::LayeredConfigs() = default;
-LayeredConfigs::LayeredConfigs(const NamespacedConfigData& config_fetched,
-                               const NamespacedConfigData& config_active,
-                               const NamespacedConfigData& config_default,
-                               const RemoteConfigMetadata& fetch_metadata)
-    : fetched(config_fetched),
-      active(config_active),
-      defaults(config_default),
-      metadata(fetch_metadata) {}
+LayeredConfigs::LayeredConfigs(NamespacedConfigData config_fetched,
+                               NamespacedConfigData config_active,
+                               NamespacedConfigData config_default,
+                               RemoteConfigMetadata fetch_metadata)
+    : fetched(std::move(config_fetched)),
+      active(std::move(config_active)),
+      defaults(std::move(config_default)),
+      metadata(std::move(fetch_metadata)) {}
 
 std::string LayeredConfigs::Serialize() const {
   flexbuffers::Builder fbb;

--- a/remote_config/src/desktop/config_data.cc
+++ b/remote_config/src/desktop/config_data.cc
@@ -115,7 +115,7 @@ bool NamespacedConfigData::operator==(const NamespacedConfigData& right) const {
   return config_ == right.config_ && timestamp_ == right.timestamp_;
 }
 
-LayeredConfigs::LayeredConfigs() {}
+LayeredConfigs::LayeredConfigs() = default;
 LayeredConfigs::LayeredConfigs(const NamespacedConfigData& config_fetched,
                                const NamespacedConfigData& config_active,
                                const NamespacedConfigData& config_default,

--- a/remote_config/src/desktop/config_data.h
+++ b/remote_config/src/desktop/config_data.h
@@ -40,7 +40,7 @@ typedef std::map<std::string, std::map<std::string, std::string>>
 class NamespacedConfigData {
  public:
   NamespacedConfigData();
-  NamespacedConfigData(const NamespaceKeyValueMap& config, uint64_t timestamp);
+  NamespacedConfigData(NamespaceKeyValueMap  config, uint64_t timestamp);
 
   // Serialize to a buffer as a string.
   // This happens to be using Flexbuffers, but could be implemented with any
@@ -94,10 +94,10 @@ class NamespacedConfigData {
 // making HTTP requests.
 struct LayeredConfigs {
   LayeredConfigs();
-  LayeredConfigs(const NamespacedConfigData& config_fetched,
-                 const NamespacedConfigData& config_active,
-                 const NamespacedConfigData& config_default,
-                 const RemoteConfigMetadata& fetch_metadata);
+  LayeredConfigs(NamespacedConfigData  config_fetched,
+                 NamespacedConfigData  config_active,
+                 NamespacedConfigData  config_default,
+                 RemoteConfigMetadata  fetch_metadata);
 
   std::string Serialize() const;
   void Deserialize(const std::string& buffer);

--- a/remote_config/src/desktop/config_data.h
+++ b/remote_config/src/desktop/config_data.h
@@ -40,7 +40,7 @@ typedef std::map<std::string, std::map<std::string, std::string>>
 class NamespacedConfigData {
  public:
   NamespacedConfigData();
-  NamespacedConfigData(NamespaceKeyValueMap  config, uint64_t timestamp);
+  NamespacedConfigData(NamespaceKeyValueMap config, uint64_t timestamp);
 
   // Serialize to a buffer as a string.
   // This happens to be using Flexbuffers, but could be implemented with any
@@ -94,10 +94,10 @@ class NamespacedConfigData {
 // making HTTP requests.
 struct LayeredConfigs {
   LayeredConfigs();
-  LayeredConfigs(NamespacedConfigData  config_fetched,
-                 NamespacedConfigData  config_active,
-                 NamespacedConfigData  config_default,
-                 RemoteConfigMetadata  fetch_metadata);
+  LayeredConfigs(NamespacedConfigData config_fetched,
+                 NamespacedConfigData config_active,
+                 NamespacedConfigData config_default,
+                 RemoteConfigMetadata fetch_metadata);
 
   std::string Serialize() const;
   void Deserialize(const std::string& buffer);

--- a/remote_config/src/desktop/file_manager.cc
+++ b/remote_config/src/desktop/file_manager.cc
@@ -27,8 +27,8 @@ namespace firebase {
 namespace remote_config {
 namespace internal {
 
-RemoteConfigFileManager::RemoteConfigFileManager(const std::string& file_path)
-    : file_path_(file_path) {}
+RemoteConfigFileManager::RemoteConfigFileManager(std::string  file_path)
+    : file_path_(std::move(file_path)) {}
 
 bool RemoteConfigFileManager::Load(LayeredConfigs* configs) const {
   std::fstream input(file_path_, std::ios::in | std::ios::binary);

--- a/remote_config/src/desktop/file_manager.cc
+++ b/remote_config/src/desktop/file_manager.cc
@@ -27,7 +27,7 @@ namespace firebase {
 namespace remote_config {
 namespace internal {
 
-RemoteConfigFileManager::RemoteConfigFileManager(std::string  file_path)
+RemoteConfigFileManager::RemoteConfigFileManager(std::string file_path)
     : file_path_(std::move(file_path)) {}
 
 bool RemoteConfigFileManager::Load(LayeredConfigs* configs) const {

--- a/remote_config/src/desktop/file_manager.h
+++ b/remote_config/src/desktop/file_manager.h
@@ -27,7 +27,7 @@ namespace internal {
 // load from file.
 class RemoteConfigFileManager {
  public:
-  explicit RemoteConfigFileManager(const std::string& file_path);
+  explicit RemoteConfigFileManager(std::string  file_path);
 
   // Load `configs` from file. Will return `true` if success.
   bool Load(LayeredConfigs* configs) const;

--- a/remote_config/src/desktop/file_manager.h
+++ b/remote_config/src/desktop/file_manager.h
@@ -27,7 +27,7 @@ namespace internal {
 // load from file.
 class RemoteConfigFileManager {
  public:
-  explicit RemoteConfigFileManager(std::string  file_path);
+  explicit RemoteConfigFileManager(std::string file_path);
 
   // Load `configs` from file. Will return `true` if success.
   bool Load(LayeredConfigs* configs) const;

--- a/remote_config/src/desktop/remote_config_desktop.cc
+++ b/remote_config/src/desktop/remote_config_desktop.cc
@@ -65,8 +65,8 @@ struct RCDataHandle {
   std::vector<std::string> default_keys;
 };
 
-RemoteConfigInternal::RemoteConfigInternal(
-    const firebase::App& app, RemoteConfigFileManager  file_manager)
+RemoteConfigInternal::RemoteConfigInternal(const firebase::App& app,
+                                           RemoteConfigFileManager file_manager)
     : app_(app),
       file_manager_(std::move(file_manager)),
       is_fetch_process_have_task_(false),

--- a/remote_config/src/desktop/remote_config_desktop.cc
+++ b/remote_config/src/desktop/remote_config_desktop.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include <string>
 #include <thread>  // NOLINT
+#include <utility>
 #include <vector>
 
 #include "app/src/callback.h"
@@ -65,9 +66,9 @@ struct RCDataHandle {
 };
 
 RemoteConfigInternal::RemoteConfigInternal(
-    const firebase::App& app, const RemoteConfigFileManager& file_manager)
+    const firebase::App& app, RemoteConfigFileManager  file_manager)
     : app_(app),
-      file_manager_(file_manager),
+      file_manager_(std::move(file_manager)),
       is_fetch_process_have_task_(false),
       future_impl_(kRemoteConfigFnCount),
       safe_this_(this),

--- a/remote_config/src/desktop/remote_config_desktop.h
+++ b/remote_config/src/desktop/remote_config_desktop.h
@@ -70,7 +70,7 @@ class RemoteConfigInternal {
 #endif  // FIREBASE_TESTING
 
   explicit RemoteConfigInternal(const firebase::App& app,
-                                RemoteConfigFileManager  file_manager);
+                                RemoteConfigFileManager file_manager);
 
   explicit RemoteConfigInternal(const firebase::App& app);
 

--- a/remote_config/src/desktop/remote_config_desktop.h
+++ b/remote_config/src/desktop/remote_config_desktop.h
@@ -70,7 +70,7 @@ class RemoteConfigInternal {
 #endif  // FIREBASE_TESTING
 
   explicit RemoteConfigInternal(const firebase::App& app,
-                                const RemoteConfigFileManager& file_manager);
+                                RemoteConfigFileManager  file_manager);
 
   explicit RemoteConfigInternal(const firebase::App& app);
 

--- a/remote_config/src/desktop/remote_config_request.h
+++ b/remote_config/src/desktop/remote_config_request.h
@@ -36,7 +36,7 @@ class RemoteConfigRequest
   FRIEND_TEST(RemoteConfigRESTTest, SetupRESTRequest);
 #endif  // FIREBASE_TESTING
  public:
-  RemoteConfigRequest() : RemoteConfigRequest(request_resource_data) {}
+  RemoteConfigRequest() : RemoteConfigRequest(request_resource_data) = default;
   explicit RemoteConfigRequest(const char* schema);
 
   explicit RemoteConfigRequest(const unsigned char* schema)

--- a/remote_config/src/desktop/remote_config_response.h
+++ b/remote_config/src/desktop/remote_config_response.h
@@ -37,7 +37,7 @@ Variant FlexbufferVectorToVariant(const flexbuffers::Vector& vector);
 class RemoteConfigResponse
     : public firebase::rest::ResponseJson<fbs::Response, fbs::ResponseT> {
  public:
-  RemoteConfigResponse() : ResponseJson(response_resource_data) {}
+  RemoteConfigResponse() : ResponseJson(response_resource_data) = default;
   explicit RemoteConfigResponse(const char* schema);
 
   explicit RemoteConfigResponse(const unsigned char* schema)

--- a/storage/src/common/common.cc
+++ b/storage/src/common/common.cc
@@ -14,7 +14,7 @@
 
 #include "storage/src/include/firebase/storage/common.h"
 
-#include <string.h>
+#include <cstring>
 
 #include "app/src/include/firebase/internal/common.h"
 #include "storage/src/common/common_internal.h"

--- a/storage/src/common/storage.cc
+++ b/storage/src/common/storage.cc
@@ -14,9 +14,8 @@
 
 #include "storage/src/include/firebase/storage.h"
 
-#include <assert.h>
-#include <string.h>
-
+#include <cassert>
+#include <cstring>
 #include <map>
 #include <string>
 

--- a/storage/src/desktop/controller_desktop.cc
+++ b/storage/src/desktop/controller_desktop.cc
@@ -14,8 +14,8 @@
 
 #include "storage/src/desktop/controller_desktop.h"
 
-#include <stdint.h>
-#include <string.h>
+#include <cstdint>
+#include <cstring>
 
 namespace firebase {
 namespace storage {

--- a/storage/src/desktop/controller_desktop.h
+++ b/storage/src/desktop/controller_desktop.h
@@ -15,7 +15,7 @@
 #ifndef FIREBASE_STORAGE_CLIENT_CPP_SRC_DESKTOP_CONTROLLER_DESKTOP_H_
 #define FIREBASE_STORAGE_CLIENT_CPP_SRC_DESKTOP_CONTROLLER_DESKTOP_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "app/memory/unique_ptr.h"
 #include "app/rest/controller_curl.h"

--- a/storage/src/desktop/curl_requests.cc
+++ b/storage/src/desktop/curl_requests.cc
@@ -14,8 +14,7 @@
 
 #include "storage/src/desktop/curl_requests.h"
 
-#include <stdio.h>
-
+#include <cstdio>
 #include <string>
 #include <utility>
 

--- a/storage/src/desktop/curl_requests.cc
+++ b/storage/src/desktop/curl_requests.cc
@@ -17,6 +17,7 @@
 #include <stdio.h>
 
 #include <string>
+#include <utility>
 
 #include "app/rest/util.h"
 #include "storage/src/desktop/metadata_desktop.h"
@@ -62,7 +63,7 @@ Error HttpToErrorCode(int http_status) {
 // remains valid while the future handle isn't complete.
 BlockingResponse::BlockingResponse(FutureHandle handle,
                                    ReferenceCountedFutureImpl* ref_future)
-    : handle_(handle), ref_future_(ref_future) {}
+    : handle_(std::move(handle)), ref_future_(ref_future) {}
 
 BlockingResponse::~BlockingResponse() {
   // If the response isn't complete, cancel it.
@@ -243,9 +244,9 @@ void GetFileResponse::MarkCompleted() {
 
 ReturnedMetadataResponse::ReturnedMetadataResponse(
     SafeFutureHandle<Metadata> handle, ReferenceCountedFutureImpl* ref_future,
-    const StorageReference& storage_reference)
+    StorageReference  storage_reference)
     : BlockingResponse(handle.get(), ref_future),
-      storage_reference_(storage_reference) {}
+      storage_reference_(std::move(storage_reference)) {}
 
 bool ReturnedMetadataResponse::ProcessBody(const char* buffer, size_t length) {
   buffer_ += std::string(buffer, length);

--- a/storage/src/desktop/curl_requests.cc
+++ b/storage/src/desktop/curl_requests.cc
@@ -244,7 +244,7 @@ void GetFileResponse::MarkCompleted() {
 
 ReturnedMetadataResponse::ReturnedMetadataResponse(
     SafeFutureHandle<Metadata> handle, ReferenceCountedFutureImpl* ref_future,
-    StorageReference  storage_reference)
+    StorageReference storage_reference)
     : BlockingResponse(handle.get(), ref_future),
       storage_reference_(std::move(storage_reference)) {}
 

--- a/storage/src/desktop/curl_requests.h
+++ b/storage/src/desktop/curl_requests.h
@@ -239,7 +239,7 @@ class ReturnedMetadataResponse : public BlockingResponse {
  public:
   ReturnedMetadataResponse(SafeFutureHandle<Metadata> handle,
                            ReferenceCountedFutureImpl* ref_future,
-                           const StorageReference& storage_reference);
+                           StorageReference storage_reference);
   bool ProcessBody(const char* buffer, size_t length) override;
   void MarkCompleted() override;
 

--- a/storage/src/desktop/curl_requests.h
+++ b/storage/src/desktop/curl_requests.h
@@ -149,7 +149,7 @@ class BlockingResponse : public rest::Response {
   // ref_future must be allocated using FutureManager to ensure ref_future
   // remains valid while the future handle isn't complete.
   BlockingResponse(FutureHandle handle, ReferenceCountedFutureImpl* ref_future);
-  virtual ~BlockingResponse();
+  ~BlockingResponse() override;
 
   // NOTE: This does *not* call the UpdateCallback.  Each subclass needs to
   // manually complete with NotifyComplete.

--- a/storage/src/desktop/curl_requests.h
+++ b/storage/src/desktop/curl_requests.h
@@ -119,7 +119,7 @@ class Notifier {
 // Base request.
 class Request : public rest::Request {
  public:
-  Request() {}
+  Request() = default;
 
   FIREBASE_STORAGE_REQUEST_CLASS_BODY(rest::Request);
 };

--- a/storage/src/desktop/listener_desktop.cc
+++ b/storage/src/desktop/listener_desktop.cc
@@ -14,7 +14,7 @@
 
 #include "storage/src/desktop/listener_desktop.h"
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "app/src/mutex.h"
 #include "storage/src/desktop/rest_operation.h"

--- a/storage/src/desktop/listener_desktop.h
+++ b/storage/src/desktop/listener_desktop.h
@@ -15,7 +15,7 @@
 #ifndef FIREBASE_STORAGE_CLIENT_CPP_SRC_DESKTOP_LISTENER_DESKTOP_H_
 #define FIREBASE_STORAGE_CLIENT_CPP_SRC_DESKTOP_LISTENER_DESKTOP_H_
 
-#include <stdint.h>
+#include <cstdint>
 
 #include "app/src/mutex.h"
 #include "storage/src/desktop/rest_operation.h"

--- a/storage/src/desktop/metadata_desktop.cc
+++ b/storage/src/desktop/metadata_desktop.cc
@@ -54,7 +54,7 @@ const char* MetadataInternal::kBucketKey = "bucket";
 const char* MetadataInternal::kNameKey = "name";
 const char* MetadataInternal::kGenerationKey = "generation";
 
-MetadataInternal::MetadataInternal(StorageReference  storage_reference)
+MetadataInternal::MetadataInternal(StorageReference storage_reference)
     : storage_reference_(std::move(storage_reference)),
       generation_(-1),
       metadata_generation_(-1),
@@ -235,10 +235,8 @@ bool MetadataInternal::ImportFromJson(const char* json) {
   if (lookup != no_value) {
     Variant json_metadata = root.map()[kMetadataKey];
     if (json_metadata.is_map()) {
-      for (auto itr = json_metadata.map().begin();
-           itr != json_metadata.map().end(); ++itr) {
-        custom_metadata_[itr->first.string_value()] =
-            itr->second.string_value();
+      for (auto& itr : json_metadata.map()) {
+        custom_metadata_[itr.first.string_value()] = itr.second.string_value();
       }
     }
   }
@@ -300,19 +298,17 @@ std::string MetadataInternal::ExportAsJson() {
   // Make a nice comma-separated string for download tokens:
   bool first_in_list = true;
   std::string download_tokens;
-  for (auto itr = download_tokens_.begin(); itr != download_tokens_.end();
-       ++itr) {
+  for (auto& download_token : download_tokens_) {
     if (!first_in_list) download_tokens += ",";
     first_in_list = false;
-    download_tokens += *itr;
+    download_tokens += download_token;
   }
   if (!download_tokens.empty())
     root.map()[kDownloadTokensKey] = download_tokens;
 
   std::map<Variant, Variant> metadata_map;
-  for (auto itr = custom_metadata_.begin(); itr != custom_metadata_.end();
-       ++itr) {
-    metadata_map[Variant(itr->first)] = Variant(itr->second);
+  for (auto& itr : custom_metadata_) {
+    metadata_map[Variant(itr.first)] = Variant(itr.second);
   }
   if (!metadata_map.empty()) root.map()[kMetadataKey] = metadata_map;
 

--- a/storage/src/desktop/metadata_desktop.cc
+++ b/storage/src/desktop/metadata_desktop.cc
@@ -54,8 +54,8 @@ const char* MetadataInternal::kBucketKey = "bucket";
 const char* MetadataInternal::kNameKey = "name";
 const char* MetadataInternal::kGenerationKey = "generation";
 
-MetadataInternal::MetadataInternal(const StorageReference& storage_reference)
-    : storage_reference_(storage_reference),
+MetadataInternal::MetadataInternal(StorageReference  storage_reference)
+    : storage_reference_(std::move(storage_reference)),
       generation_(-1),
       metadata_generation_(-1),
       creation_time_(-1),

--- a/storage/src/desktop/metadata_desktop.cc
+++ b/storage/src/desktop/metadata_desktop.cc
@@ -14,10 +14,9 @@
 
 #include "storage/src/desktop/metadata_desktop.h"
 
-#include <stdio.h>
-#include <stdlib.h>
-#include <time.h>
-
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
 #include <iostream>
 #include <sstream>
 #include <utility>

--- a/storage/src/desktop/metadata_desktop.h
+++ b/storage/src/desktop/metadata_desktop.h
@@ -51,7 +51,7 @@ class MetadataInternal {
   static const char* kNameKey;
   static const char* kGenerationKey;
 
-  MetadataInternal(const StorageReference& storage_reference);
+  MetadataInternal(StorageReference storage_reference);
 
   MetadataInternal(const MetadataInternal& metadata);
 

--- a/storage/src/desktop/metadata_desktop.h
+++ b/storage/src/desktop/metadata_desktop.h
@@ -63,7 +63,7 @@ class MetadataInternal {
   MetadataInternal& operator=(MetadataInternal&& other);
 #endif  // defined(FIREBASE_USE_MOVE_OPERATORS) || defined(DOXYGEN)
 
-  ~MetadataInternal() {}
+  ~MetadataInternal() = default;
 
   // Return the owning Google Cloud Storage bucket for the StorageReference.
   const char* bucket() { return bucket_.c_str(); }

--- a/storage/src/desktop/rest_operation.cc
+++ b/storage/src/desktop/rest_operation.cc
@@ -15,6 +15,7 @@
 #include "storage/src/desktop/rest_operation.h"
 
 #include <memory>
+#include <utility>
 
 #include "app/rest/transport_curl.h"
 #include "app/src/mutex.h"
@@ -39,7 +40,7 @@ RestOperation::RestOperation(StorageInternal* storage_internal,
       request_notifier_(request_notifier),
       response_(response),
       listener_(nullptr),
-      handle_(handle),
+      handle_(std::move(handle)),
       is_complete_(false) {
   // Notify this operation when the response reports progress and clean up if
   // the response completes.

--- a/storage/src/desktop/storage_desktop.cc
+++ b/storage/src/desktop/storage_desktop.cc
@@ -124,13 +124,12 @@ void StorageInternal::RemoveOperation(RestOperation* operation) {
 void StorageInternal::CleanupCompletedOperations() {
   MutexLock lock(operations_mutex_);
   std::vector<RestOperation*> operations_to_delete;
-  for (auto it = operations_.begin(); it != operations_.end(); ++it) {
-    if ((*it)->is_complete()) operations_to_delete.push_back(*it);
+  for (auto & operation : operations_) {
+    if (operation->is_complete()) operations_to_delete.push_back(operation);
   }
-  for (auto it = operations_to_delete.begin(); it != operations_to_delete.end();
-       ++it) {
-    RemoveOperation(*it);
-    delete *it;
+  for (auto & it : operations_to_delete) {
+    RemoveOperation(it);
+    delete it;
   }
 }
 

--- a/storage/src/desktop/storage_desktop.cc
+++ b/storage/src/desktop/storage_desktop.cc
@@ -14,9 +14,8 @@
 
 #include "storage/src/desktop/storage_desktop.h"
 
-#include <assert.h>
-
 #include <algorithm>
+#include <cassert>
 
 #include "app/rest/transport_curl.h"
 #include "app/rest/util.h"
@@ -124,10 +123,10 @@ void StorageInternal::RemoveOperation(RestOperation* operation) {
 void StorageInternal::CleanupCompletedOperations() {
   MutexLock lock(operations_mutex_);
   std::vector<RestOperation*> operations_to_delete;
-  for (auto & operation : operations_) {
+  for (auto& operation : operations_) {
     if (operation->is_complete()) operations_to_delete.push_back(operation);
   }
-  for (auto & it : operations_to_delete) {
+  for (auto& it : operations_to_delete) {
     RemoveOperation(it);
     delete it;
   }

--- a/storage/src/desktop/storage_path.cc
+++ b/storage/src/desktop/storage_path.cc
@@ -14,8 +14,7 @@
 
 #include "storage/src/desktop/storage_path.h"
 
-#include <string.h>
-
+#include <cstring>
 #include <string>
 
 #include "app/rest/util.h"

--- a/storage/src/desktop/storage_path.h
+++ b/storage/src/desktop/storage_path.h
@@ -16,6 +16,7 @@
 #define FIREBASE_STORAGE_CLIENT_CPP_SRC_DESKTOP_STORAGE_PATH_H_
 
 #include <string>
+#include <utility>
 
 #include "app/src/path.h"
 
@@ -82,8 +83,8 @@ class StoragePath {
  private:
   static const char* const kSeparator;
 
-  StoragePath(const std::string& bucket, const Path& path)
-      : bucket_(bucket), path_(path) {}
+  StoragePath(std::string bucket, Path path)
+      : bucket_(std::move(bucket)), path_(std::move(path)) {}
 
   void ConstructFromGsUri(const std::string& uri, int path_start);
   void ConstructFromHttpUrl(const std::string& url, int path_start);

--- a/storage/src/desktop/storage_path.h
+++ b/storage/src/desktop/storage_path.h
@@ -31,7 +31,7 @@ extern const char kGsScheme[];
 class StoragePath {
  public:
   // Default constructor.
-  StoragePath() {}
+  StoragePath() = default;
 
   // Constructs a storage path, based on an input URL.  The URL can either be
   // an HTTP[s] link, or a gs URI.

--- a/storage/src/desktop/storage_reference_desktop.cc
+++ b/storage/src/desktop/storage_reference_desktop.cc
@@ -63,8 +63,8 @@ StorageReferenceInternal::StorageReferenceInternal(
   storage_->future_manager().AllocFutureApi(this, kStorageReferenceFnCount);
 }
 
-StorageReferenceInternal::StorageReferenceInternal(
-    StoragePath  storageUri, StorageInternal* storage)
+StorageReferenceInternal::StorageReferenceInternal(StoragePath storageUri,
+                                                   StorageInternal* storage)
     : storage_(storage), storageUri_(std::move(storageUri)) {
   storage_->future_manager().AllocFutureApi(this, kStorageReferenceFnCount);
 }
@@ -136,8 +136,7 @@ std::string StripProtocol(std::string s) {
 // Is deleted by the final call.
 struct MetadataChainData {
   MetadataChainData(SafeFutureHandle<Metadata> handle_,
-                    const Metadata* metadata_,
-                    StorageReference  storage_ref_,
+                    const Metadata* metadata_, StorageReference storage_ref_,
                     ReferenceCountedFutureImpl* original_future_)
       : handle(std::move(handle_)),
         storage_ref(std::move(storage_ref_)),

--- a/storage/src/desktop/storage_reference_desktop.cc
+++ b/storage/src/desktop/storage_reference_desktop.cc
@@ -16,6 +16,7 @@
 
 #include <limits>
 #include <memory>
+#include <utility>
 
 #include "app/memory/unique_ptr.h"
 #include "app/rest/request.h"
@@ -63,8 +64,8 @@ StorageReferenceInternal::StorageReferenceInternal(
 }
 
 StorageReferenceInternal::StorageReferenceInternal(
-    const StoragePath& storageUri, StorageInternal* storage)
-    : storage_(storage), storageUri_(storageUri) {
+    StoragePath  storageUri, StorageInternal* storage)
+    : storage_(storage), storageUri_(std::move(storageUri)) {
   storage_->future_manager().AllocFutureApi(this, kStorageReferenceFnCount);
 }
 
@@ -136,10 +137,10 @@ std::string StripProtocol(std::string s) {
 struct MetadataChainData {
   MetadataChainData(SafeFutureHandle<Metadata> handle_,
                     const Metadata* metadata_,
-                    const StorageReference& storage_ref_,
+                    StorageReference  storage_ref_,
                     ReferenceCountedFutureImpl* original_future_)
-      : handle(handle_),
-        storage_ref(storage_ref_),
+      : handle(std::move(handle_)),
+        storage_ref(std::move(storage_ref_)),
         original_future(original_future_) {
     if (metadata_) metadata = *metadata_;
     MetadataSetDefaults(&metadata);
@@ -479,7 +480,7 @@ Future<std::string> StorageReferenceInternal::GetDownloadUrl() {
   struct GetUrlOnCompletionData {
     GetUrlOnCompletionData(ReferenceCountedFutureImpl* future_,
                            SafeFutureHandle<std::string> handle_)
-        : future(future_), handle(handle_) {}
+        : future(future_), handle(std::move(handle_)) {}
     ReferenceCountedFutureImpl* future;
     SafeFutureHandle<std::string> handle;
   };

--- a/storage/src/desktop/storage_reference_desktop.h
+++ b/storage/src/desktop/storage_reference_desktop.h
@@ -36,8 +36,7 @@ class StorageReferenceInternal {
  public:
   StorageReferenceInternal(const std::string& storageUri,
                            StorageInternal* storage);
-  StorageReferenceInternal(StoragePath  storageUri,
-                           StorageInternal* storage);
+  StorageReferenceInternal(StoragePath storageUri, StorageInternal* storage);
   StorageReferenceInternal(const StorageReferenceInternal& other);
 
   ~StorageReferenceInternal();

--- a/storage/src/desktop/storage_reference_desktop.h
+++ b/storage/src/desktop/storage_reference_desktop.h
@@ -36,7 +36,7 @@ class StorageReferenceInternal {
  public:
   StorageReferenceInternal(const std::string& storageUri,
                            StorageInternal* storage);
-  StorageReferenceInternal(const StoragePath& storageUri,
+  StorageReferenceInternal(StoragePath  storageUri,
                            StorageInternal* storage);
   StorageReferenceInternal(const StorageReferenceInternal& other);
 

--- a/storage/src/include/firebase/storage.h
+++ b/storage/src/include/firebase/storage.h
@@ -145,8 +145,8 @@ class Storage {
   friend class internal::MetadataInternal;
 
   Storage(::firebase::App* app, const char* url);
-  Storage(const Storage& src);
-  Storage& operator=(const Storage& src);
+  Storage(const Storage& src) = delete;
+  Storage& operator=(const Storage& src) = delete;
 
   // Destroy the internal_ object.
   void DeleteInternal();


### PR DESCRIPTION
Applied the clang-tidy rules:

modernize-use-override
modernize-use-nullptr
modernize-use-equals-delete
modernize-use-equals-default
modernize-use-emplace
modernize-pass-by-value
modernize-loop-convert
modernize-deprecated-headers