### PR TITLE
Fix noformat_file / format_file discrepenency on iOS headers

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,14 +11,6 @@ env:
   statusLabelFailed: "tests: failed"
 
 jobs:
-  check_integration_test_labels:
-    # This check fails if integration tests are queued, in progress, or failed.
-    runs-on: ubuntu-latest
-    steps:
-    - uses: docker://agilepathway/pull-request-label-checker:latest
-      with:
-        none_of: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
-        repo_token: ${{ github.token }}
   file_format_check:
     runs-on: ubuntu-latest
     steps:
@@ -40,5 +32,14 @@ jobs:
       - name: Detect Formatting Changes
         shell: bash
         run: python3 scripts/format_code.py -git_diff -noformat_file -verbose
+  
+  check_integration_test_labels:
+    # This check fails if integration tests are queued, in progress, or failed.
+    runs-on: ubuntu-latest
+    steps:
+    - uses: docker://agilepathway/pull-request-label-checker:latest
+      with:
+        none_of: "${{ env.statusLabelInProgress }},${{ env.statusLabelFailed }},${{ env.triggerLabelFull }},${{ env.triggerLabelQuick }}"
+        repo_token: ${{ github.token }}
 
 

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -241,7 +241,7 @@ def main(argv):
   else:
     count = 0
     for filename in filenames:      
-      if does_file_need_formatting(filename):  
+      if does_file_need_formatting(filename) and not is_file_objc_header(filename):    
         exit_code = 1
         count += 1
         if FLAGS.verbose:


### PR DESCRIPTION
In `scripts/format_code.py` the format code path correctly ignored Objective C headers.   However in no-format code path reported that some Objective C headers required formatting.   This PR fixes that discrepancy.

Additionally reordered the workflow steps so that the format check is the first check returned.   I felt like there's a usability problem with the label checks failing which isn't a hard failure, and it being the first reported result.  People clicking through to the Github Action log should see the actionable hard failures first.