### PR TITLE
Re-enable FirestoreIntegrationTest.AuthWorks on MacOS

### DIFF
--- a/firestore/integration_test_internal/src/firestore_test.cc
+++ b/firestore/integration_test_internal/src/firestore_test.cc
@@ -1488,15 +1488,6 @@ TEST_F(FirestoreIntegrationTest, DomainObjectsReferToSameFirestoreInstance) {
 }
 
 TEST_F(FirestoreIntegrationTest, AuthWorks) {
-  SKIP_TEST_ON_MACOS;  // TODO(b/183294303) Fix this test on Mac.
-
-  // This test only works locally or on guitar because it depends on a live
-  // Auth backend.
-  if (getenv("UNITTEST_ON_FORGE") != nullptr) {
-    LogWarning("Skipped AuthWorks test: incompatible with Forge");
-    return;
-  }
-
   // This app instance is managed by the text fixture.
   App* app = GetApp();
   EXPECT_NE(app, nullptr);


### PR DESCRIPTION
This test was disabled after being ported from google3 because it was failing. It doesn't appear to fail anymore so I've re-enabled it. This PR is part of a larger effort to re-enable tests that were disabled after migrating to GitHub (Googlers can see b/183294303 for full context).