### PR TITLE
Allow running integration tests on an external PR

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -413,7 +413,12 @@ jobs:
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         run: |
-          cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+          if [[ -r ta/summary.log ]]; then
+            cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+          else
+            # No summary was created, make a placeholder one.
+            echo "No summary found." > test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+          fi
       - name: Upload results summary artifact
         uses: actions/upload-artifact@v2.2.2
         if: ${{ !cancelled() }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -213,7 +213,7 @@ jobs:
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
-            echo "::warning ::Downloading SDK package from previous run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
+            echo "::warning ::Downloading SDK package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
             # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here. It won't actually matter later.
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
           else
@@ -224,15 +224,15 @@ jobs:
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
           if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
-            echo "::warning ::github_ref = $GITHUB_SHA"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$GITHUB_SHA"
             echo "::set-output name=github_ref::$GITHUB_SHA"
           elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
             # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::github_ref = $(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
             echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
             # Just the PR specified, use refs/pull/<number>/merge as the ref.
-            echo "::warning ::github_ref = refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/${{github.event.inputs.test_pull_request}}"
             echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
           fi
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ on:
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
       test_pull_request:
-        description: 'Optional: Test a pull request (use this for external PRs)'
+        description: 'Optional: Test a pull request (and optional commit hash, separated by a colon).'
 
 env:
   triggerLabelPrefix: "tests-requested: "
@@ -74,10 +74,19 @@ jobs:
         exit 1  # fail out if the cancellation above somehow failed.
     - id: get_pr_number
       run: |
+        # In this step, github_ref is only used for the status message below.
+        # It will be recalculated in prepare_matrix.
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
+          echo "::set-output name=github_ref::$GITHUB_REF"
+        elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
+          # If specified as pr:commit_hash, split them.
+          echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
+          echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
         else
+          # Just a PR number.
           echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
+          echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
         fi
     ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
@@ -138,23 +147,18 @@ jobs:
         comment_id: ${{ steps.find-comment.outputs.comment-id }}
         token: ${{ github.token }}
     - name: get current time for status comment
-      id: get-time-and-ref
+      id: get-time
       shell: bash
       run: |
         echo -n "::set-output name=time::"
         TZ=America/Los_Angeles date
-        if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
-          echo "::set-output name=github_ref::$GITHUB_SHA"
-        else
-          echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
-        fi
     - name: add in progress status comment
       uses: phulsechinmay/rewritable-pr-comment@v0.3.0
       with:
         message: |
           ### ⏳&nbsp; Integration test in progress...
-          Requested by @${{github.actor}} on commit ${{steps.get-time-and-ref.outputs.github_ref}}
-          Last updated: ${{ steps.get-time-and-ref.outputs.time }}
+          Requested by @${{github.actor}} on commit ${{steps.get_pr_number.outputs.github_ref}}
+          Last updated: ${{ steps.get-time.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
@@ -216,10 +220,15 @@ jobs:
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
           if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
-            echo "::warning ::$GITHUB_SHA"
+            echo "::warning ::github_ref = $GITHUB_SHA"
             echo "::set-output name=github_ref::$GITHUB_SHA"
+          elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
+            # If specified as pr:commit_hash, split them to get the exact hash.
+            echo "::warning ::github_ref = $(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
-            echo "::warning ::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+            # Just the PR specified, use refs/pull/<number>/merge as the ref.
+            echo "::warning ::github_ref = refs/pull/${{github.event.inputs.test_pull_request}}/merge"
             echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
           fi
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -412,6 +412,7 @@ jobs:
           python scripts/gha/test_lab.py --android_model ${{ needs.prepare_matrix.outputs.android_device }} --android_api ${{ needs.prepare_matrix.outputs.android_api }} --ios_model ${{ needs.prepare_matrix.outputs.ios_device }} --ios_version ${{ needs.prepare_matrix.outputs.ios_version }} --testapp_dir ta --code_platform cpp --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
+        shell: bash
         run: |
           if [[ -r ta/summary.log ]]; then
             cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ on:
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
       test_pull_request:
-        description: 'Optional: Test a pull request (and optional commit hash, separated by a colon).'
+        description: 'Optional: Pull request # to build and test? (with optional commit hash, separated by a colon)'
 
 env:
   triggerLabelPrefix: "tests-requested: "

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -24,24 +24,15 @@ on:
         description: 'CSV of desktop SSL variants to use'
         default: 'openssl,boringssl'
         required: true
-      android_device:
-        description: 'Android device model'
-        default: 'flame'
-      android_api:
-        description: 'Android API level'
-        default: '29'
-      ios_device:
-        description: 'iOS device model'
-        default: 'iphone8'
-      ios_version:
-        description: 'iOS device version'
-        default: '12.4'
       use_expanded_matrix:
         description: 'Use an expanded matrix? Note: above config will be ignored.'
         default: '0'
         required: true
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
+      test_pull_request:
+        description: 'Optional: Test a pull request (use this for external PRs)'
+
 env:
   triggerLabelPrefix: "tests-requested: "
   triggerLabelFull: "tests-requested: full"
@@ -51,6 +42,10 @@ env:
   statusLabelSucceeded: "tests: succeeded"
   statusCommentIdentifier: "integration-test-status-comment"
   mobileTestOn: "device"
+  default_android_device: "flame"
+  default_android_api: "29"
+  default_ios_device: "iphone8"
+  default_ios_version: "12.4"
 
 jobs:
   check_trigger:
@@ -60,31 +55,41 @@ jobs:
     ### outputs to control the test matrix (full or quick) and to tell
     ### subsequent steps to update the labels as well.
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request' && github.event.action == 'labeled'
+    if: |
+      (github.event_name == 'pull_request' && github.event.action == 'labeled') ||
+      (github.event.inputs.test_pull_request != '')
     outputs:
       should_update_labels: ${{ steps.set_outputs.outputs.should_update_labels }}
       requested_tests: ${{ steps.set_outputs.outputs.requested_tests }}
+      pr_number: ${{ steps.get_pr_number.outputs.pr_number }}
     steps:
     ### If the label isn't one of the test-request triggers, cancel the workflow.
     - name: cancel workflow if label is irrelevant
-      if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) }}
+      if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) && github.event.inputs.test_pull_request == '' }}
       uses: andymckay/cancel-action@0.2
     - name: wait for above cancellation if label is irrelevant
-      if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) }}
+      if: ${{ !startsWith(github.event.label.name, env.triggerLabelPrefix) && github.event.inputs.test_pull_request == '' }}
       run: |
         sleep 300
         exit 1  # fail out if the cancellation above somehow failed.
+    - id: get_pr_number
+      run: |
+        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "::set-output name=pr_number::${{ github.event.number }}"
+        else
+          echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
+        fi
     ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}
     - name: remove triggering label
-      uses: buildsville/add-remove-label@v1
+      uses: actions-ecosystem/action-remove-labels@v1
       with:
-        token: ${{ github.token }}
-        label: "${{ github.event.label.name }}"
-        type: remove
+        github_token: ${{ github.token }}
+        number: "${{ steps.get_pr_number.outputs.pr_number }}"
+        labels: "${{ github.event.label.name }}"
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: check if user has permission to trigger tests
       uses: lannonbr/repo-permission-check-action@2.0.0
@@ -102,28 +107,24 @@ jobs:
         fi
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label
-      uses: buildsville/add-remove-label@v1
+      uses: actions-ecosystem/action-add-labels@v1
       with:
-        token: ${{ github.token }}
-        label: "${{ env.statusLabelInProgress }}"
-        type: add
-    - name: remove previous success label
-      uses: buildsville/add-remove-label@v1
+        github_token: ${{ github.token }}
+        number: "${{ steps.get_pr_number.outputs.pr_number }}"
+        labels: "${{ env.statusLabelInProgress }}"
+    - name: remove previous labels
+      uses: actions-ecosystem/action-remove-labels@v1
       with:
-        token: ${{ github.token }}
-        label: "${{ env.statusLabelSucceeded }}"
-        type: remove
-    - name: remove previous failure label
-      uses: buildsville/add-remove-label@v1
-      with:
-        token: ${{ github.token }}
-        label: "${{ env.statusLabelFailed }}"
-        type: remove
+        github_token: ${{ github.token }}
+        number: "${{ steps.get_pr_number.outputs.pr_number }}"
+        labels: |
+          "${{ env.statusLabelSucceeded }}"
+          "${{ env.statusLabelFailed }}"
     - name: find old status comment, if any
       uses: peter-evans/find-comment@v1
       id: find-comment
       with:
-        issue-number: ${{github.event.number}}
+        issue-number: ${{steps.get_pr_number.outputs.pr_number}}
         body-includes: ${{ env.statusCommentIdentifier }}
         token: ${{github.token}}
     - name: delete old status comment
@@ -149,6 +150,7 @@ jobs:
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
+        ISSUE_ID: ${{steps.get_pr_number.outputs.pr_number}}
 
   # To feed input into the job matrix, we first need to convert to a JSON
   # list. Then we can use fromJson to define the field in the matrix for the tests job.
@@ -194,10 +196,10 @@ jobs:
           else
             echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
           fi
-          echo "::set-output name=android_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_device -o "${{github.event.inputs.android_device}}" )"
-          echo "::set-output name=android_api::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_api -o "${{github.event.inputs.android_api}}" )"
-          echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{github.event.inputs.ios_device}}" )"
-          echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{github.event.inputs.ios_version}}" )"
+          echo "::set-output name=android_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_device -o "${{env.default_android_device}}" )"
+          echo "::set-output name=android_api::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_api -o "${{env.default_android_api}}" )"
+          echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
+          echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
 
   tests:
     name: ${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
@@ -387,11 +389,11 @@ jobs:
       - name: add failure label
         # We can do mark a failure as soon as any one test fails.
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
-        uses: buildsville/add-remove-label@v1
+        uses: actions-ecosystem/action-add-labels@v1
         with:
-          token: ${{ github.token }}
-          label: "${{ env.statusLabelFailed }}"
-          type: add
+          github_token: ${{ github.token }}
+          number: "${{needs.check_trigger.outputs.pr_number}}"
+          labels: "${{ env.statusLabelFailed }}"
       - name: get current time for status comment
         id: get-time
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
@@ -427,6 +429,7 @@ jobs:
             ${{ env.SUMMARY_TABLE }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
+          ISSUE_ID: ${{needs.check_trigger.outputs.pr_number}}
 
       - name: Summarize build and test results
         if: ${{ !cancelled() }}
@@ -444,11 +447,11 @@ jobs:
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
     steps:
       - name: add success label
-        uses: buildsville/add-remove-label@v1
-        with:
-          token: ${{github.token}}
-          label: "${{ env.statusLabelSucceeded }}"
-          type: add
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ github.token }}
+        number: "${{needs.check_trigger.outputs.pr_number}}"
+        labels: "${{ env.statusLabelSucceeded }}"
       - name: get current time for status comment
         id: get-time
         shell: bash
@@ -465,6 +468,7 @@ jobs:
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
+          ISSUE_ID: ${{needs.check_trigger.outputs.pr_number}}
 
   add_failure_label:
     name: "add-failure-label"
@@ -473,11 +477,11 @@ jobs:
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && failure() }}
     steps:
       - name: add failure label
-        uses: buildsville/add-remove-label@v1
+        uses: actions-ecosystem/action-remove-labels@v1
         with:
-          token: ${{ github.token }}
-          label: "${{ env.statusLabelFailed }}"
-          type: add
+          github_token: ${{ github.token }}
+          number: "${{needs.check_trigger.outputs.pr_number}}"
+          labels: "${{ env.statusLabelFailed }}"
       - name: get current time for status comment
         id: get-time
         shell: bash
@@ -518,6 +522,7 @@ jobs:
             ${{ env.SUMMARY_TABLE }}
           GITHUB_TOKEN: ${{ github.token }}
           COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
+          ISSUE_ID: ${{needs.check_trigger.outputs.pr_number}}
 
   remove_in_progress_label:
     name: "remove-in-progress-label"
@@ -534,11 +539,11 @@ jobs:
           app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
           private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
       - name: remove in progress label
-        uses: buildsville/add-remove-label@v1
+        uses: actions-ecosystem/action-remove-labels@v1
         with:
-          token: ${{steps.generate-token.outputs.token}}
-          label: "${{ env.statusLabelInProgress }}"
-          type: remove
+          github_token: ${{steps.generate-token.outputs.token}}
+          number: "${{needs.check_trigger.outputs.pr_number}}"
+          labels: "${{ env.statusLabelInProgress }}"
 
   summarize_results:
     name: "summarize-results"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -90,7 +90,7 @@ jobs:
         fi
     ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
-      if: github.event.inputs.test_pull_request == ''
+      if: github.event_name == 'pull_request'
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -229,7 +229,7 @@ jobs:
             echo "::set-output name=github_ref::$GITHUB_SHA"
           elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
             # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1) on commit https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
             echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
             # Just the PR specified, use refs/pull/<number>/merge as the ref.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -124,14 +124,18 @@ jobs:
         github_token: ${{ github.token }}
         number: "${{ steps.get_pr_number.outputs.pr_number }}"
         labels: "${{ env.statusLabelInProgress }}"
-    - name: remove previous labels
+    - name: remove previous succeeded label
       uses: actions-ecosystem/action-remove-labels@v1
       with:
         github_token: ${{ github.token }}
         number: "${{ steps.get_pr_number.outputs.pr_number }}"
-        labels: |
-          "${{ env.statusLabelSucceeded }}"
-          "${{ env.statusLabelFailed }}"
+        labels: "${{ env.statusLabelSucceeded }}"
+    - name: remove previous failed label
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        github_token: ${{ github.token }}
+        number: "${{ steps.get_pr_number.outputs.pr_number }}"
+        labels: "${{ env.statusLabelFailed }}"
     - name: find old status comment, if any
       uses: peter-evans/find-comment@v1
       id: find-comment

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -459,11 +459,11 @@ jobs:
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
     steps:
       - name: add success label
-      uses: actions-ecosystem/action-add-labels@v1
-      with:
-        github_token: ${{ github.token }}
-        number: "${{needs.check_trigger.outputs.pr_number}}"
-        labels: "${{ env.statusLabelSucceeded }}"
+        uses: actions-ecosystem/action-add-labels@v1
+        with:
+          github_token: ${{ github.token }}
+          number: "${{needs.check_trigger.outputs.pr_number}}"
+          labels: "${{ env.statusLabelSucceeded }}"
       - name: get current time for status comment
         id: get-time
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -224,11 +224,11 @@ jobs:
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
           if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commit/$GITHUB_SHA"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$GITHUB_SHA"
             echo "::set-output name=github_ref::$GITHUB_SHA"
           elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
             # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commit/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
             echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
             # Just the PR specified, use refs/pull/<number>/merge as the ref.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -417,7 +417,7 @@ jobs:
             cp ta/summary.log test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
           else
             # No summary was created, make a placeholder one.
-            echo "No summary found." > test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
+            echo "__SUMMARY_MISSING__" > test-results-${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}.txt
           fi
       - name: Upload results summary artifact
         uses: actions/upload-artifact@v2.2.2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -478,7 +478,7 @@ jobs:
 
   add_success_label:
     name: "add-success-label"
-    needs: [check_trigger, tests]
+    needs: [check_trigger, prepare_matrix, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && !failure() }}
     steps:
@@ -508,7 +508,7 @@ jobs:
 
   add_failure_label:
     name: "add-failure-label"
-    needs: [check_trigger, tests]
+    needs: [check_trigger, prepare_matrix, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() && failure() }}
     steps:
@@ -564,7 +564,7 @@ jobs:
 
   remove_in_progress_label:
     name: "remove-in-progress-label"
-    needs: [check_trigger, tests]
+    needs: [check_trigger, prepare_matrix, tests]
     runs-on: ubuntu-latest
     if: ${{ needs.check_trigger.outputs.should_update_labels && !cancelled() }}
     steps:
@@ -585,7 +585,7 @@ jobs:
 
   summarize_results:
     name: "summarize-results"
-    needs: [add_failure_label, add_success_label, remove_in_progress_label, tests]
+    needs: [add_failure_label, add_success_label, remove_in_progress_label, prepare_matrix, tests]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -170,6 +170,7 @@ jobs:
       android_api: ${{ steps.export-result.outputs.android_api }}
       ios_device: ${{ steps.export-result.outputs.ios_device }}
       ios_version: ${{ steps.export-result.outputs.ios_version }}
+      github_ref: ${{ steps.export-result.outputs.github_ref }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -203,6 +204,13 @@ jobs:
           echo "::set-output name=android_api::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k android_api -o "${{env.default_android_api}}" )"
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
+          if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
+            echo "::warning ::$GITHUB_SHA"
+            echo "::set-output name=github_ref::$GITHUB_SHA"
+          else
+            echo "::warning ::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+            echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+          fi
 
   tests:
     name: ${{ matrix.os }}-${{ matrix.target_platform }}-${{ matrix.ssl_variant }}
@@ -230,6 +238,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          ref: ${{needs.prepare_matrix.outputs.github_ref}}
           submodules: true
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
@@ -492,6 +501,8 @@ jobs:
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
       - uses: actions/checkout@v2
+        with:
+          ref: ${{needs.prepare_matrix.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -555,6 +566,8 @@ jobs:
     if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@v2
+        with:
+          ref: ${{needs.prepare_matrix.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -138,18 +138,23 @@ jobs:
         comment_id: ${{ steps.find-comment.outputs.comment-id }}
         token: ${{ github.token }}
     - name: get current time for status comment
-      id: get-time
+      id: get-time-and-ref
       shell: bash
       run: |
         echo -n "::set-output name=time::"
         TZ=America/Los_Angeles date
+        if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
+          echo "::set-output name=github_ref::$GITHUB_SHA"
+        else
+          echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+        fi
     - name: add in progress status comment
       uses: phulsechinmay/rewritable-pr-comment@v0.3.0
       with:
         message: |
           ### ⏳&nbsp; Integration test in progress...
-          Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
-          Last updated: ${{ steps.get-time.outputs.time }}
+          Requested by @${{github.actor}} on commit ${{steps.get-time-and-ref.outputs.github_ref}}
+          Last updated: ${{ steps.get-time-and-ref.outputs.time }}
           **[View integration test run](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
         GITHUB_TOKEN: ${{ github.token }}
         COMMENT_IDENTIFIER: ${{ env.statusCommentIdentifier }}
@@ -441,7 +446,7 @@ jobs:
         with:
           message: |
             ### ❌&nbsp; Integration test FAILED (but still ⏳&nbsp; in progress)
-            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
+            Requested by @${{github.actor}} on commit ${{needs.prepare_matrix.outputs.github_ref}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
             ${{ env.SUMMARY_TABLE }}
@@ -481,7 +486,7 @@ jobs:
         with:
           message: |
             ### ✅&nbsp; Integration test succeeded!
-            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
+            Requested by @${{github.actor}} on commit ${{needs.prepare_matrix.outputs.github_ref}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
           GITHUB_TOKEN: ${{ github.token }}
@@ -536,7 +541,7 @@ jobs:
         with:
           message: |
             ### ❌&nbsp; Integration test FAILED
-            Requested by @${{github.actor}} on commit ${{github.event.pull_request.head.sha}}
+            Requested by @${{github.actor}} on commit ${{needs.prepare_matrix.outputs.github_ref}}
             Last updated: ${{ steps.get-time.outputs.time }}
             **[View integration test results](https://github.com/${{github.repository}}/actions/runs/${{github.run_id}})**
             ${{ env.SUMMARY_TABLE }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -144,7 +144,7 @@ jobs:
         echo -n "::set-output name=time::"
         TZ=America/Los_Angeles date
     - name: add in progress status comment
-      uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+      uses: phulsechinmay/rewritable-pr-comment@v0.3.0
       with:
         message: |
           ### ⏳&nbsp; Integration test in progress...
@@ -430,7 +430,7 @@ jobs:
           python scripts/gha/summarize_test_results.py --dir test_results --markdown >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: add failure status comment
-        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        uses: phulsechinmay/rewritable-pr-comment@v0.3.0
         if: ${{ needs.check_trigger.outputs.should_update_labels && failure() && !cancelled() }}
         with:
           message: |
@@ -471,7 +471,7 @@ jobs:
           echo -n "::set-output name=time::"
           TZ=America/Los_Angeles date
       - name: add success status comment
-        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        uses: phulsechinmay/rewritable-pr-comment@v0.3.0
         with:
           message: |
             ### ✅&nbsp; Integration test succeeded!
@@ -526,7 +526,7 @@ jobs:
           python scripts/gha/summarize_test_results.py --dir test_results --markdown >> $GITHUB_ENV
           echo 'EOF' >> $GITHUB_ENV
       - name: add failure status comment
-        uses: phulsechinmay/rewritable-pr-comment@v0.2.1
+        uses: phulsechinmay/rewritable-pr-comment@v0.3.0
         with:
           message: |
             ### ❌&nbsp; Integration test FAILED

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ on:
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
       test_pull_request:
-        description: 'Optional: Pull request # to build and test? (With optional commit hash, separated by a colon. You must specify the FULL hash.)'
+        description: 'Optional: Pull request # to build and test? (With optional commit hash, separated by a colon. Specify the FULL hash.)'
 
 env:
   triggerLabelPrefix: "tests-requested: "

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -78,7 +78,7 @@ jobs:
         # It will be recalculated in prepare_matrix.
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
-          echo "::set-output name=github_ref::$GITHUB_REF"
+          echo "::set-output name=github_ref::$GITHUB_SHA"
         elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
           # If specified as pr:commit_hash, split them.
           echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -90,6 +90,7 @@ jobs:
         fi
     ### Below this line, the label is one of the test-request triggers.
     - name: cancel previous runs on the same PR
+      if: github.event.inputs.test_pull_request == ''
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -184,7 +184,13 @@ jobs:
         if: needs.check_trigger.outputs.requested_tests == 'auto'
         run: |
           echo "Autodetecting which tests to run."
-          echo "AUTO_DIFF_PARAM=--auto_diff ${{github.event.pull_request.base.sha}}" >> $GITHUB_ENV
+          if [[ -n "${{github.event.inputs.test_pull_request}}" ]]; then
+            # If running this manually, diff against main.
+            echo "AUTO_DIFF_PARAM=--auto_diff main" >> $GITHUB_ENV
+          else
+            # If running in a PR, diff against the PR's base.
+            echo "AUTO_DIFF_PARAM=--auto_diff ${{github.event.pull_request.base.sha}}" >> $GITHUB_ENV
+          fi
 
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -75,7 +75,7 @@ jobs:
     - id: get_pr_number
       run: |
         if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          echo "::set-output name=pr_number::${{ github.event.number }}"
+          echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
         else
           echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
         fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -104,6 +104,9 @@ jobs:
           echo "::set-output name=requested_tests::full"
         elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
           echo "::set-output name=requested_tests::auto"
+        else
+          # For manual PR testing, use auto mode.
+          echo "::set-output name=requested_tests::auto"
         fi
     ### Add the in-progress label and remove any previous success/fail labels.
     - name: add in-progress label

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -224,11 +224,11 @@ jobs:
           echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_device -o "${{env.default_ios_device}}" )"
           echo "::set-output name=ios_version::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k ios_version -o "${{env.default_ios_version}}" )"
           if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$GITHUB_SHA"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commit/$GITHUB_SHA"
             echo "::set-output name=github_ref::$GITHUB_SHA"
           elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
             # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/commit/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
             echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
             # Just the PR specified, use refs/pull/<number>/merge as the ref.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -229,7 +229,7 @@ jobs:
             echo "::set-output name=github_ref::$GITHUB_SHA"
           elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
             # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1) on commit https://github.com/${{github.repository}}/commits/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1) on commit https://github.com/${{github.repository}}/commit/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
             echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
           else
             # Just the PR specified, use refs/pull/<number>/merge as the ref.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -31,7 +31,7 @@ on:
       test_packaged_sdk:
         description: 'Optional: Packaging run # to build against?'
       test_pull_request:
-        description: 'Optional: Pull request # to build and test? (with optional commit hash, separated by a colon)'
+        description: 'Optional: Pull request # to build and test? (With optional commit hash, separated by a colon. You must specify the FULL hash.)'
 
 env:
   triggerLabelPrefix: "tests-requested: "

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -277,7 +277,7 @@ def main(argv):
     if platform not in log_results:
       log_results[platform] = { "build_failures": set(), "test_failures": set(),
                                 "attempted": set(), "successful": set() }
-    if "No summary found." in log_text:
+    if "__SUMMARY_MISSING__" in log_text:
       log_results[platform]["build_failures"].add('[log file missing]')
     # Get a full list of the products built.
     m = re.search(r'TRIED TO BUILD: ([^\n]*)', log_text)

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -277,6 +277,8 @@ def main(argv):
     if platform not in log_results:
       log_results[platform] = { "build_failures": set(), "test_failures": set(),
                                 "attempted": set(), "successful": set() }
+    if "No summary found." in log_text:
+      log_results[platform]["build_failures"].add('[log file missing]')
     # Get a full list of the products built.
     m = re.search(r'TRIED TO BUILD: ([^\n]*)', log_text)
     if m:


### PR DESCRIPTION
Add an input parameter to the integration tests workflow that allows you to specify a PR number (and optionally a commit hash within that PR) to run tests on.

This lets admins manually trigger integration tests on an external PR.