### PR TITLE
Re-enable FirestoreIntegrationTest.FirestoreCanBeDeletedFromTransaction

### DIFF
--- a/firestore/integration_test_internal/src/firestore_test.cc
+++ b/firestore/integration_test_internal/src/firestore_test.cc
@@ -1538,8 +1538,6 @@ TEST_F(FirestoreIntegrationTest, AuthWorks) {
 // This test is to ensure b/172986326 doesn't regress.
 // Note: this test only exists in C++.
 TEST_F(FirestoreIntegrationTest, FirestoreCanBeDeletedFromTransaction) {
-  SKIP_TEST_ON_MACOS;  // TODO(b/183294303) Fix this test on Mac.
-
   auto* app = App::Create(this->app()->options(), "foo");
   auto* db = Firestore::GetInstance(app);
 


### PR DESCRIPTION
This test was disabled after being ported from google3 because it was failing. It doesn't appear to fail anymore so I've re-enabled it. This PR is part of a larger effort to re-enable tests that were disabled after migrating to GitHub (Googlers can see b/183294303 for full context).