### PR TITLE
Remove STLPort from C++ packaging workflow.

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -194,7 +194,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        stl: ["c++", "gnustl", "stlport"]
+        stl: ["c++", "gnustl"]
     steps:
       - name: fetch SDK
         uses: actions/checkout@v2.3.1


### PR DESCRIPTION
STLPort is no longer included in the C++ SDK.