### PR TITLE
Fix GetPlatformAppByName() crash on KitKat when the app was not found

### DIFF
--- a/app/src/app_android.cc
+++ b/app/src/app_android.cc
@@ -311,7 +311,13 @@ static jobject GetPlatformAppByName(JNIEnv* jni_env, const char* name) {
         name_string);
     jni_env->DeleteLocalRef(name_string);
   }
-  jni_env->ExceptionCheck();
+  if (jni_env->ExceptionCheck()) {
+    // Explicitly set `platform_app` to `NULL` if an exception was thrown
+    // because on KitKat (API 19) `CallStaticObjectMethod()` may return garbage
+    // instead of `NULL` if an exception was thrown, and callers of this
+    // function expect `NULL` to be returned if the app was not found.
+    platform_app = NULL;  // NOLINT
+  }
   jni_env->ExceptionClear();
   return platform_app;
 }

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -380,7 +380,7 @@ code.
         specific app object.
         ([#991](https://github.com/firebase/quickstart-unity/issues/991)).
     -   General (Android): Fixed a potential SIGABRT when an app was created
-        with non-default app name on Android KitKat
+        with a non-default app name on Android KitKat
         ([#429](https://github.com/firebase/firebase-cpp-sdk/pull/429)).
 
 ### 7.3.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -379,8 +379,8 @@ code.
     -   Remote Config(Android): Fix for getting Remote Config instance for a
         specific app object.
         ([#991](https://github.com/firebase/quickstart-unity/issues/991)).
-    -   General (Android): Fixed a potential SIGABRT when a non-default app name
-        was created on KitKat
+    -   General (Android): Fixed a potential SIGABRT when an app was created
+        with non-default app name on Android KitKat
         ([#429](https://github.com/firebase/firebase-cpp-sdk/pull/429)).
 
 ### 7.3.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -378,7 +378,10 @@ code.
         API.
     -   Remote Config(Android): Fix for getting Remote Config instance for a
         specific app object.
-        ([#991](https://github.com/firebase/quickstart-unity/issues/991).
+        ([#991](https://github.com/firebase/quickstart-unity/issues/991)).
+    -   General (Android): Fixed a potential SIGABRT when a non-default app name
+        was created on KitKat
+        ([#429](https://github.com/firebase/firebase-cpp-sdk/pull/429)).
 
 ### 7.3.0
 -   Changes


### PR DESCRIPTION
This PR fixes a bug in `GetPlatformAppByName()` if an exception is thrown by the Java method call. The issue is that if an exception is thrown then the return value from `CallStaticObjectMethod()` is `NULL`... *except* on KitKat, where it appears to return garbage instead. This garbage value was being returned and the caller was incorrectly treating it as a valid object reference. The fix is to check if an exception was thrown and explicitly returning `NULL` in that case, instead of relying on the return value from `CallStaticObjectMethod()` being `NULL`.

This bug surfaced in the integration test `FirestoreIntegrationTest.CanPageThroughItems` which was crashing on KitKat. The root cause was that it was using a custom app name and the call to `GetPlatformAppByName()` was returning garbage in that case.

https://github.com/firebase/firebase-cpp-sdk/blob/4a34eddf71866ec230b9d7b92c86814c9795161b/app/src/app_android.cc#L302-L317

https://github.com/firebase/firebase-cpp-sdk/blob/4a34eddf71866ec230b9d7b92c86814c9795161b/firestore/integration_test_internal/src/cursor_test.cc#L19-L26