### PR TITLE
Fix Firestore's snapshot_metadata_android_test

### DIFF
--- a/firestore/integration_test_internal/src/android/snapshot_metadata_android_test.cc
+++ b/firestore/integration_test_internal/src/android/snapshot_metadata_android_test.cc
@@ -3,6 +3,7 @@
 #include "android/firestore_integration_test_android.h"
 #include "firebase_test_framework.h"
 #include "firestore/src/include/firebase/firestore/snapshot_metadata.h"
+#include "firestore/src/jni/declaration.h"
 #include "firestore/src/jni/env.h"
 #include "firestore_integration_test.h"
 #include "gmock/gmock.h"
@@ -14,30 +15,33 @@ namespace firestore {
 using SnapshotMetadataAndroidTest = FirestoreAndroidIntegrationTest;
 
 using jni::Class;
+using jni::Constructor;
 using jni::Env;
 using jni::Local;
 
 TEST_F(SnapshotMetadataAndroidTest, Converts) {
-  SKIP_TEST_ON_ANDROID;  // TODO(b/183294303): Fix this test on Android.
-
   Env env;
+  Constructor<SnapshotMetadataInternal> ctor("(ZZ)V");
+  loader().LoadClass("com/google/firebase/firestore/SnapshotMetadata", ctor);
+  ASSERT_TRUE(loader().ok());
 
-  Local<Class> clazz =
-      env.FindClass("com/google/firebase/firestore/SnapshotMetadata");
-  jmethodID ctor = env.GetMethodId(clazz, "<init>", "(ZZ)V");
+  {
+    auto java_metadata =
+        env.New(ctor, /*has_pending_writes=*/true, /*is_from_cache=*/false);
+    SnapshotMetadata result = java_metadata.ToPublic(env);
+    EXPECT_TRUE(env.ok());
+    EXPECT_TRUE(result.has_pending_writes());
+    EXPECT_FALSE(result.is_from_cache());
+  }
 
-  auto java_metadata = env.New<SnapshotMetadataInternal>(
-      clazz, ctor, /*has_pending_writes=*/true, /*is_from_cache=*/false);
-  SnapshotMetadata result = java_metadata.ToPublic(env);
-  EXPECT_TRUE(result.has_pending_writes());
-  EXPECT_FALSE(result.is_from_cache());
-
-  java_metadata = env.New<SnapshotMetadataInternal>(
-      clazz, ctor, /*has_pending_writes=*/false,
-      /*is_from_cache=*/true);
-  result = java_metadata.ToPublic(env);
-  EXPECT_FALSE(result.has_pending_writes());
-  EXPECT_TRUE(result.is_from_cache());
+  {
+    auto java_metadata =
+        env.New(ctor, /*has_pending_writes=*/false, /*is_from_cache=*/true);
+    SnapshotMetadata result = java_metadata.ToPublic(env);
+    EXPECT_TRUE(env.ok());
+    EXPECT_FALSE(result.has_pending_writes());
+    EXPECT_TRUE(result.is_from_cache());
+  }
 }
 
 }  // namespace firestore


### PR DESCRIPTION
For some reason, the call to `env.FindClass()` was failing because it couldn't find the class. So I updated the code to use our new, modern JNI wrapper and it all worked. I'm not sure why but I'm happy with the result.