### PR TITLE
Update gitingore for integration test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ GoogleService-Info.plist
 uri_prefix.txt
 server_key.txt
 gcs_key_file.json
+**/integration_test/Info.plist
+**/integration_test/scr/integration_test.cc
 
 # Folders for cmake/test output
 *_build/
+testing/test_framework/external

--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,6 @@ GoogleService-Info.plist
 uri_prefix.txt
 server_key.txt
 gcs_key_file.json
-**/integration_test/Info.plist
-**/integration_test/scr/integration_test.cc
 
 # Folders for cmake/test output
 *_build/

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -191,7 +191,7 @@ def main(argv):
   platforms = FLAGS.platforms
   testapps = FLAGS.testapps
 
-  sdk_dir = _fix_path(FLAGS.packaged_sdk or os.path.join(FLAGS.repo_dir, "ios_build"))
+  sdk_dir = _fix_path(FLAGS.packaged_sdk or FLAGS.repo_dir)
   root_output_dir = _fix_path(FLAGS.output_directory)
   repo_dir = _fix_path(FLAGS.repo_dir)
 
@@ -503,6 +503,7 @@ def _build_ios(
   """Builds an iOS application (.app, .ipa or both)."""
   if not ios_framework_exist:
     _build_ios_framework_from_repo(repo_dir, api_config)
+    sdk_dir = os.path.join(sdk_dir, "ios_build")
 
   build_dir = os.path.join(project_dir, "ios_build")
   os.makedirs(build_dir)

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -209,7 +209,7 @@ def main(argv):
   ios_framework_dir = os.path.join(sdk_dir, "xcframeworks")
   ios_framework_exist = os.path.isdir(ios_framework_dir)
   if not ios_framework_exist and _IOS in platforms:
-    _generate_makefiles_from_repo(FLAGS.repo_dir)
+    _generate_makefiles_from_repo(repo_dir)
 
   if update_pod_repo and _IOS in platforms:
     _run(["pod", "repo", "update"])

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -503,7 +503,7 @@ def _build_ios(
   """Builds an iOS application (.app, .ipa or both)."""
   if not ios_framework_exist:
     _build_ios_framework_from_repo(repo_dir, api_config)
-    sdk_dir = os.path.join(sdk_dir, "ios_build")
+    sdk_dir = os.path.join(repo_dir, "ios_build")
 
   build_dir = os.path.join(project_dir, "ios_build")
   os.makedirs(build_dir)

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -458,8 +458,9 @@ def _validate_android_environment_variables():
     logging.warning("No NDK env var set. Set one of %s", ", ".join(ndk_vars))
 
 
-# If sdk_dir contains no framework, consider it is Github repo, then
-# generate makefiles for ios frameworks
+# If sdk_dir contains no xcframework, consider it is Github repo, then
+# generate makefiles for ios xcframeworks
+# the xcframeworks will be placed at repo_dir/ios_build
 def _generate_makefiles_from_repo(repo_dir):
   """Generates cmake makefiles for building iOS frameworks from SDK source."""
   ios_framework_builder = os.path.join(
@@ -474,7 +475,8 @@ def _generate_makefiles_from_repo(repo_dir):
   _run(framework_builder_args)
 
 
-# build required ios frameworks based on makefiles
+# build required ios xcframeworks based on makefiles
+# the xcframeworks locates at repo_dir/ios_build
 def _build_ios_framework_from_repo(repo_dir, api_config):
   """Builds iOS framework from SDK source."""
   ios_framework_builder = os.path.join(
@@ -506,6 +508,7 @@ def _build_ios(
   if not ios_framework_exist:
     _build_ios_framework_from_repo(repo_dir, api_config)
     sdk_dir = os.path.join(repo_dir, "ios_build")
+    logging.info("iOS xcframework created at: %s", " ".join(sdk_dir))
 
   build_dir = os.path.join(project_dir, "ios_build")
   os.makedirs(build_dir)

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -467,6 +467,7 @@ def _generate_makefiles_from_repo(repo_dir):
 
   framework_builder_args = [
       ios_framework_builder,
+      "-b", os.path.join(repo_dir, "ios_build"),
       "-s", repo_dir,
       "-c", "false"
   ]
@@ -491,6 +492,7 @@ def _build_ios_framework_from_repo(repo_dir, api_config):
 
   framework_builder_args = [
       ios_framework_builder,
+      "-b", os.path.join(repo_dir, "ios_build"),
       "-s", repo_dir,
       "-t", ",".join(target),
       "-g", "false"


### PR DESCRIPTION
1. ios intermediary build folder change to "ios_build", which is already in .gitignore
2. add "testing/test_framework/external" to .gitignore

note: there are few test files not ignored, plans to resolve them in another ticket:
**/integration_test/Info.plist
**/integration_test/scr/integration_test.cc