### PR TITLE
Disable more bundles tests that fail in Windows CI

### DIFF
--- a/firestore/integration_test_internal/src/bundle_test.cc
+++ b/firestore/integration_test_internal/src/bundle_test.cc
@@ -231,6 +231,10 @@ TEST_F(BundleTest, LoadInvalidBundlesShouldFail) {
 }
 
 TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
+  // TODO(wuandy, b/189477267): This test fails on Windows CI, but
+  // local run is fine. We need to figure out why and re-enable it.
+  SKIP_TEST_ON_WINDOWS;
+
   Firestore* db = TestFirestore();
   auto collection = db->Collection("coll-1");
   WriteDocuments(collection,
@@ -273,6 +277,10 @@ TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
 }
 
 TEST_F(BundleTest, LoadedDocumentsShouldNotBeGarbageCollectedRightAway) {
+  // TODO(wuandy, b/189477267): This test fails on Windows CI, but
+  // local run is fine. We need to figure out why and re-enable it.
+  SKIP_TEST_ON_WINDOWS;
+
   Firestore* db = TestFirestore();
   // This test really only makes sense with memory persistence, as disk
   // persistence only ever lazily deletes data.


### PR DESCRIPTION
The following two tests are being disabled:

- BundleTest.LoadBundleWithDocumentsAlreadyPulledFromBackend
- BundleTest.LoadedDocumentsShouldNotBeGarbageCollectedRightAway