### PR TITLE
Fix BoringSSL Windows CI targets failing with windows-latest

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -246,18 +246,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-2016, ubuntu-latest, macos-latest]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86"]
         msvc_runtime: ["static", "dynamic"]
         linux_abi: ["legacy", "c++11"]
         python_version: [3.7]
         include:
-        - os: windows-latest
+        - os: windows-2016
           vcpkg_triplet_suffix: "windows-static"
           additional_build_flags: "--build_tests"
           sdk_platform: "windows"
-        - os: windows-latest
+        - os: windows-2016
           msvc_runtime: "dynamic"
           vcpkg_triplet_suffix: "windows-static-md"
           additional_build_flags: "--build_tests"
@@ -272,7 +272,7 @@ jobs:
           sdk_platform: "darwin"
 
         exclude:
-        - os: windows-latest
+        - os: windows-2016
           linux_abi: "c++11"
         - os: macos-latest
           architecture: "x86"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,7 +18,7 @@ on:
         required: true
       operating_systems:
         description: 'CSV of VMs to run on'
-        default: 'ubuntu-latest,windows-latest,macos-latest'
+        default: 'ubuntu-latest,windows-2016,macos-latest'
         required: true
       desktop_ssl_variants:
         description: 'CSV of desktop SSL variants to use'

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -97,7 +97,7 @@ PARAMETERS = {
 
   "integration_tests": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
+      "os": ["ubuntu-latest", "macos-latest", "windows-2016"],
       "platform": ["Desktop", "Android", "iOS"],
       "ssl_lib": ["openssl", "boringssl"],
       "android_device": ["virtual:system-images;android-28;google_apis;x86_64+28.0.3", "real:flame+29"],


### PR DESCRIPTION
This change updates the Integration Test and Packaging workflows to use windows-2016 GHA runners.

Details:
GHA is rolling out a new version of windows server 2019 tools (windows-2019 / windows-latest alias) which produce a [C4255 warning](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-warnings/compiler-warning-level-4-c4255?view=msvc-160) in BoringSSL.

BoringSSL is configured to error on all warnings, and so our current CI is broken until we can figure out the best way to properly patch the BorginSSL cmake configuration.



