### PR TITLE
Git Patch BoringSSL to disable Windows build warnings/errors

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -346,7 +346,7 @@ jobs:
           if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
             verbose_flag=--verbose
           fi
-          echo "VERBOSE_FLAG=${verbose_flag}"" >> $GITHUB_ENV
+          echo "VERBOSE_FLAG=${verbose_flag}" >> $GITHUB_ENV
       
       - name: Build desktop SDK
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -288,6 +288,9 @@ jobs:
           build_type: "Debug"
 
     steps:
+      - name: Check LongPathsEnabled
+        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
+
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -288,9 +288,6 @@ jobs:
           build_type: "Debug"
 
     steps:
-      - name: Check LongPathsEnabled
-        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
-
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
@@ -341,19 +338,39 @@ jobs:
       - name: Install prerequisites
         run: |
           python scripts/gha/install_prereqs_desktop.py
-
-      - name: Build desktop SDK
+      
+      - name: Export verbose flag
         shell: bash
         run: |
           verbose_flag=
           if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
             verbose_flag=--verbose
           fi
+          echo "VERBOSE_FLAG=${verbose_flag}"" >> $GITHUB_ENV
+      
+      - name: Build desktop SDK
+        run: |
           python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}" --linux_abi "${{ matrix.linux_abi }}" --build_dir out-sdk ${verbose_flag} ${{ matrix.additional_build_flags }}
-          # Make a list of all the source files, for debugging purposes.
+
+      - name: Archive SDK
+        shell: bash
+        run: |
           cd out-sdk
           find .. -type f -print > src_file_list.txt
           tar -czhf ../firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz .
+
+      #- name: Build desktop SDK
+      #  shell: bash
+      #  run: |
+      #    verbose_flag=
+      #    if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
+      #      verbose_flag=--verbose
+      #    fi
+      #    python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}" --linux_abi "${{ matrix.linux_abi }}" --build_dir out-sdk ${verbose_flag} ${{ matrix.additional_build_flags }}
+      #    # Make a list of all the source files, for debugging purposes.
+      #    cd out-sdk
+      #    find .. -type f -print > src_file_list.txt
+      #    tar -czhf ../firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz .
 
       - name: Print built libraries
         shell: bash

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -348,9 +348,10 @@ jobs:
           fi
           echo "VERBOSE_FLAG=${verbose_flag}" >> $GITHUB_ENV
       
+      # Run the build in the host OS default shell since Windows can't handle long path names in bash.
       - name: Build desktop SDK
         run: |
-          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}" --linux_abi "${{ matrix.linux_abi }}" --build_dir out-sdk ${verbose_flag} ${{ matrix.additional_build_flags }}
+          python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}" --linux_abi "${{ matrix.linux_abi }}" --build_dir out-sdk ${VERBOSE_FLAG} ${{ matrix.additional_build_flags }}
 
       - name: Archive SDK
         shell: bash
@@ -358,19 +359,6 @@ jobs:
           cd out-sdk
           find .. -type f -print > src_file_list.txt
           tar -czhf ../firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz .
-
-      #- name: Build desktop SDK
-      #  shell: bash
-      #  run: |
-      #    verbose_flag=
-      #    if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
-      #      verbose_flag=--verbose
-      #    fi
-      #    python scripts/gha/build_desktop.py --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}" --linux_abi "${{ matrix.linux_abi }}" --build_dir out-sdk ${verbose_flag} ${{ matrix.additional_build_flags }}
-      #    # Make a list of all the source files, for debugging purposes.
-      #    cd out-sdk
-      #    find .. -type f -print > src_file_list.txt
-      #    tar -czhf ../firebase-cpp-sdk-${{ env.SDK_NAME }}-build.tgz .
 
       - name: Print built libraries
         shell: bash

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -338,7 +338,7 @@ jobs:
       - name: Install prerequisites
         run: |
           python scripts/gha/install_prereqs_desktop.py
-      
+
       - name: Export verbose flag
         shell: bash
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -246,18 +246,18 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-2016, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-latest]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86"]
         msvc_runtime: ["static", "dynamic"]
         linux_abi: ["legacy", "c++11"]
         python_version: [3.7]
         include:
-        - os: windows-2016
+        - os: windows-latest
           vcpkg_triplet_suffix: "windows-static"
           additional_build_flags: "--build_tests"
           sdk_platform: "windows"
-        - os: windows-2016
+        - os: windows-latest
           msvc_runtime: "dynamic"
           vcpkg_triplet_suffix: "windows-static-md"
           additional_build_flags: "--build_tests"
@@ -272,7 +272,7 @@ jobs:
           sdk_platform: "darwin"
 
         exclude:
-        - os: windows-2016
+        - os: windows-latest
           linux_abi: "c++11"
         - os: macos-latest
           architecture: "x86"

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -76,10 +76,7 @@ jobs:
             xcode_version: "12.4"
           - os: windows-latest
             xcode_version: "12.4"
-    steps:    
-      - name: Check LongPathsEnabled
-        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
-
+    steps:
       - name: Setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -78,8 +78,8 @@ jobs:
             xcode_version: "12.4"
     steps:    
       - name: Check LongPathsEnabled
-        run: |
-        (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled            
+        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
+
       - name: Setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -76,7 +76,7 @@ jobs:
             xcode_version: "12.4"
           - os: windows-latest
             xcode_version: "12.4"
-    steps:
+    steps:                
       - name: Setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer
@@ -149,6 +149,7 @@ jobs:
           python scripts/gha/install_prereqs_desktop.py
 
       - name: Build SDK
+        shell: bash
         run: |
           python scripts/gha/build_desktop.py --build_tests --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}"
 

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -76,7 +76,10 @@ jobs:
             xcode_version: "12.4"
           - os: windows-latest
             xcode_version: "12.4"
-    steps:                
+    steps:    
+      - name: Check LongPathsEnabled
+        run: |
+        (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled            
       - name: Setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -152,7 +152,6 @@ jobs:
           python scripts/gha/install_prereqs_desktop.py
 
       - name: Build SDK
-        shell: bash
         run: |
           python scripts/gha/build_desktop.py --build_tests --arch "${{ matrix.architecture }}" --config "${{ matrix.build_type }}" --msvc_runtime_library "${{ matrix.msvc_runtime }}"
 

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -253,8 +253,6 @@ jobs:
         with:
           ref: ${{needs.prepare_matrix.outputs.github_ref}}
           submodules: true
-      - name: Check LongPathsEnabled
-        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: echo "VCPKG_TRIPLET=x64-linux" >> $GITHUB_ENV

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -249,6 +249,9 @@ jobs:
         os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
         ssl_variant: ${{ fromJson(needs.prepare_matrix.outputs.matrix_ssl) }}
     steps:
+      - name: Check LongPathsEnabled
+        run: |
+        (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
       - uses: actions/checkout@v2
         with:
           ref: ${{needs.prepare_matrix.outputs.github_ref}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -249,13 +249,12 @@ jobs:
         os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
         ssl_variant: ${{ fromJson(needs.prepare_matrix.outputs.matrix_ssl) }}
     steps:
-      - name: Check LongPathsEnabled
-        run: |
-        (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
       - uses: actions/checkout@v2
         with:
           ref: ${{needs.prepare_matrix.outputs.github_ref}}
           submodules: true
+      - name: Check LongPathsEnabled
+        run: (Get-ItemProperty "HKLM:System\CurrentControlSet\Control\FileSystem").LongPathsEnabled
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         run: echo "VCPKG_TRIPLET=x64-linux" >> $GITHUB_ENV

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -18,7 +18,7 @@ on:
         required: true
       operating_systems:
         description: 'CSV of VMs to run on'
-        default: 'ubuntu-latest,windows-2016,macos-latest'
+        default: 'ubuntu-latest,windows-latest,macos-latest'
         required: true
       desktop_ssl_variants:
         description: 'CSV of desktop SSL variants to use'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -15,6 +15,9 @@
 # Top level CMake file that defines the entire Firebase C++ SDK build.
 
 cmake_minimum_required (VERSION 3.1)
+
+set( CMAKE_VERBOSE_MAKEFILE on )
+
 set (CMAKE_CXX_STANDARD 11)
 
 # Turn on virtual folders for visual studio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,8 +16,6 @@
 
 cmake_minimum_required (VERSION 3.1)
 
-set( CMAKE_VERBOSE_MAKEFILE on )
-
 set (CMAKE_CXX_STANDARD 11)
 
 # Turn on virtual folders for visual studio

--- a/cmake/external/boringssl.cmake
+++ b/cmake/external/boringssl.cmake
@@ -19,7 +19,7 @@ if(TARGET boringssl OR NOT DOWNLOAD_BORINGSSL)
 endif()
 
 set(patch_file 
-  ../../../../scripts/git/patches/boringssl/0001-disable-C4255-converting-empty-params-to-void.patch)
+  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/boringssl/0001-disable-C4255-converting-empty-params-to-void.patch)
 
 ExternalProject_Add(
   boringssl

--- a/cmake/external/boringssl.cmake
+++ b/cmake/external/boringssl.cmake
@@ -18,20 +18,16 @@ if(TARGET boringssl OR NOT DOWNLOAD_BORINGSSL)
   return()
 endif()
 
-# Based on https://github.com/grpc/grpc/blob/v1.27.0/bazel/grpc_deps.bzl
-# master-with-bazel@{2019-10-18}
-set(commit 83da28a68f32023fd3b95a8ae94991a07b1f6c62)
-# set(commit master)
+set(patch_file 
+  ../../../../scripts/git/patches/boringssl/0001-disable-C4255-converting-empty-params-to-void.patch)
 
 ExternalProject_Add(
   boringssl
 
-  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME boringssl-${commit}.tar.gz
-  URL https://github.com/google/boringssl/archive/${commit}.tar.gz
-
+  GIT_REPOSITORY https://github.com/google/boringssl/
+  GIT_TAG 83da28a68f32023fd3b95a8ae94991a07b1f6c62
+  PATCH_COMMAND git apply ${patch_file}
   PREFIX ${PROJECT_BINARY_DIR}
-
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -77,7 +77,7 @@ PARAMETERS = {
       "python_version": ["3.7"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-latest", "macos-latest", "windows-2016"],
+        "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
         "xcode_version": ["11.7", "12.4"],
       }
     }
@@ -85,19 +85,19 @@ PARAMETERS = {
 
   "android": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest", "windows-2016"],
+      "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
       "architecture": ["x64"],
       "python_version": ["3.7"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-latest", "macos-latest", "windows-2016"]
+        "os": ["ubuntu-latest", "macos-latest", "windows-latest"]
       }
     }
   },
 
   "integration_tests": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest", "windows-2016"],
+      "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
       "platform": ["Desktop", "Android", "iOS"],
       "ssl_lib": ["openssl", "boringssl"],
       "android_device": ["android_latest", "emulator_target"],
@@ -215,9 +215,9 @@ def print_value(value):
   """ Print Json formatted string that can be consumed in Github workflow."""
   # Eg: for lists,
   # print(json.dumps) ->
-  # ["ubuntu-latest", "macos-latest", "windows-2016"]
+  # ["ubuntu-latest", "macos-latest", "windows-latest"]
   # print(repr(json.dumps)) ->
-  # '["ubuntu-latest", "macos-latest", "windows-2016"]'
+  # '["ubuntu-latest", "macos-latest", "windows-latest"]'
 
   # Eg: for strings
   # print(json.dumps) -> "flame"

--- a/scripts/git/patches/boringssl/0001-disable-C4255-converting-empty-params-to-void.patch
+++ b/scripts/git/patches/boringssl/0001-disable-C4255-converting-empty-params-to-void.patch
@@ -1,0 +1,25 @@
+From 831806231dd360278dac2a37e3c3158420ad7bb3 Mon Sep 17 00:00:00 2001
+From: "google.com" <google.com>
+Date: Mon, 7 Jun 2021 13:57:27 -0400
+Subject: [PATCH] disable C4255 converting () to (void)
+
+---
+ src/CMakeLists.txt | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b7f468fe6..48f61bfd8 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -193,6 +193,8 @@ elseif(MSVC)
+               # possible loss of data
+       "C4244" # 'function' : conversion from 'int' to 'uint8_t',
+               # possible loss of data
++      "C4255" # 'function' : no function prototype given: converting '()' to
++              # '(void)'
+       "C4267" # conversion from 'size_t' to 'int', possible loss of data
+       "C4371" # layout of class may have changed from a previous version of the
+               # compiler due to better packing of member '...'
+-- 
+2.32.0.rc1.229.g3e70b5a671-goog
+


### PR DESCRIPTION
This change fixes the boringSSL sources so that they no longer causes warnings on `windows-latest` runners.  

- Switched the boringSSL dependency to a git checkout instead of a tarball download.
- Created a git patch to alter boringSSL's cmake files, adding C4255 as a warning that shall be suppressed.
- Updated GHA configuration to use windows-latest again.  This was previously changed to windows-2016 since those tools didn't report C4255 as a warning. See #444 for more information about these reverted changes.

Other tests:
 - [Packaging Test Run](https://github.com/firebase/firebase-cpp-sdk/actions/runs/922541062)