### PR TITLE
Increase the visibility of the static methods in FirebaseTest

### DIFF
--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -28,7 +28,6 @@ Returns:
      because -noformat_file was set.
    2: The application wasn't configured properly and could not execute.
 """
-import difflib
 import io
 import os
 import subprocess
@@ -59,30 +58,6 @@ Used to filter out results when searching across directories or git diffs.
 """
 
 # Functions:    
-def get_formatting_diff_lines(filename):
-  """Calculates and returns a printable diff of the formatting changes that
-  would be applied to the given file by clang-format.
-
-  Args:
-    filename (string): path to the file whose formatting diff to calculate.
-
-  Returns:
-    Iterable[str]: The diff of the formatted file against the original file;
-      each string in the returned iterable is a "line" of the diff; they could
-      be printed individually or joined into a single string using something
-      like os.linesep.join(diff_lines), where `diff_lines` is the return value.
-  """
-  args = ['clang-format', '-style=file', filename]
-  result = subprocess.run(args, stdout=subprocess.PIPE, check=True)
-
-  formatted_lines = [line.rstrip('\r\n')
-      for line in result.stdout.decode('utf8', errors='replace').splitlines()]
-  with open(filename, 'rt', encoding='utf8', errors='replace') as f:
-    original_lines = [line.rstrip('\r\n') for line in f]
-
-  return [line.rstrip()
-      for line in difflib.unified_diff(original_lines, formatted_lines)]
-
 def does_file_need_formatting(filename):
   """Executes clang-format on the file to determine if it includes any
   formatting changes the user needs to fix.
@@ -271,10 +246,6 @@ def main(argv):
         count += 1
         if FLAGS.verbose:
           print('  - Requires reformatting: "{0}"'.format(filename))
-          print('------ BEGIN FORMATTING DIFF OF {0}'.format(filename))
-          for diff_line in get_formatting_diff_lines(filename):
-            print(diff_line)
-          print('------ END FORMATTING DIFF OF {0}'.format(filename))
     if FLAGS.verbose:
       print('  > Done. {0} file(s) need formatting.'.format(count))
     else:

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -28,6 +28,7 @@ Returns:
      because -noformat_file was set.
    2: The application wasn't configured properly and could not execute.
 """
+import difflib
 import io
 import os
 import subprocess
@@ -58,6 +59,30 @@ Used to filter out results when searching across directories or git diffs.
 """
 
 # Functions:    
+def get_formatting_diff_lines(filename):
+  """Calculates and returns a printable diff of the formatting changes that
+  would be applied to the given file by clang-format.
+
+  Args:
+    filename (string): path to the file whose formatting diff to calculate.
+
+  Returns:
+    Iterable[str]: The diff of the formatted file against the original file;
+      each string in the returned iterable is a "line" of the diff; they could
+      be printed individually or joined into a single string using something
+      like os.linesep.join(diff_lines), where `diff_lines` is the return value.
+  """
+  args = ['clang-format', '-style=file', filename]
+  result = subprocess.run(args, stdout=subprocess.PIPE, check=True)
+
+  formatted_lines = [line.rstrip('\r\n')
+      for line in result.stdout.decode('utf8', errors='replace').splitlines()]
+  with open(filename, 'rt', encoding='utf8', errors='replace') as f:
+    original_lines = [line.rstrip('\r\n') for line in f]
+
+  return [line.rstrip()
+      for line in difflib.unified_diff(original_lines, formatted_lines)]
+
 def does_file_need_formatting(filename):
   """Executes clang-format on the file to determine if it includes any
   formatting changes the user needs to fix.
@@ -246,6 +271,10 @@ def main(argv):
         count += 1
         if FLAGS.verbose:
           print('  - Requires reformatting: "{0}"'.format(filename))
+          print('------ BEGIN FORMATTING DIFF OF {0}'.format(filename))
+          for diff_line in get_formatting_diff_lines(filename):
+            print(diff_line)
+          print('------ END FORMATTING DIFF OF {0}'.format(filename))
     if FLAGS.verbose:
       print('  > Done. {0} file(s) need formatting.'.format(count))
     else:

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -236,9 +236,9 @@ class FirebaseTest : public testing::Test {
   // fully-automated tests should be run.
   bool AreInteractiveTestsAllowed();
 
- // Give the static helper methods "public" visibility so that they can be used
- // by helper functions defined outside of subclasses of `FirebaseTest`, such as
- // functions defined in anonymous namespaces.
+  // Give the static helper methods "public" visibility so that they can be used
+  // by helper functions defined outside of subclasses of `FirebaseTest`, such
+  // as functions defined in anonymous namespaces.
  public:
   // Get a persistent string value that was previously set via
   // SetPersistentString. Returns true if the value was set, false if not or if

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -236,6 +236,10 @@ class FirebaseTest : public testing::Test {
   // fully-automated tests should be run.
   bool AreInteractiveTestsAllowed();
 
+ // Give the static helper methods "public" visibility so that they can be used
+ // by helper functions defined outside of subclasses of `FirebaseTest`, such as
+ // functions defined in anonymous namespaces.
+ public:
   // Get a persistent string value that was previously set via
   // SetPersistentString. Returns true if the value was set, false if not or if
   // something went wrong.


### PR DESCRIPTION
There is a collection of generally-useful `static` methods in the `FirebaseTest` class that have `protected` visibility. These methods are generally useful even outside of subclasses, such as by "helper" functions defined in anonymous namespaces.

This PR increases the visibility of these `static` methods to `public` so that they can be used even outside of subclasses.

In the future, it may instead make sense to even move these static methods to free functions since there is no need that they be nested inside of `FirebaseTest`.