### PR TITLE
Fix FTAViewController incorrectly calling openURL off the main thread.

### DIFF
--- a/testing/sample_framework/src/ios/ios_app_framework.mm
+++ b/testing/sample_framework/src/ios/ios_app_framework.mm
@@ -90,10 +90,11 @@ static NSString *g_file_url_path;
     delete[] argv[0];
     argv[0] = nullptr;
     [NSThread sleepForTimeInterval:kGameLoopSecondsToPauseBeforeQuitting];
-    [UIApplication.sharedApplication openURL:[NSURL URLWithString:kGameLoopCompleteUrlScheme]
-                                     options:[NSDictionary dictionary]
-                           completionHandler:nil];
-
+    dispatch_async(dispatch_get_main_queue(), ^{
+      [UIApplication.sharedApplication openURL:[NSURL URLWithString:kGameLoopCompleteUrlScheme]
+                                       options:[NSDictionary dictionary]
+                             completionHandler:nil];
+    });
   });
 }
 


### PR DESCRIPTION
The method `[FTAViewController viewDidLoad]` was incorrectly calling `[UIApplication openURL]` on a non-main thread. This resulted in the "main thread checker" in xcode always flagging this as an issue. It's also technically undefined behavior.

This PR fixes the bug by scheduling the `[UIApplication openURL]` to run on the main thread instead of calling it directly in a worker thread.