### PR TITLE
format_code.py changed to print the diff when not formatting files inline

### DIFF
--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -60,8 +60,8 @@ Used to filter out results when searching across directories or git diffs.
 
 # Functions:    
 def get_formatting_diff_lines(filename):
-  """Executes clang-format on the file and returns a human-friendly string
-  containing the diff of the original file against the formatted file.
+  """Calculates and returns a printable diff of the formatting changes that
+  would be applied to the given file by clang-format.
 
   Args:
     filename (string): path to the file whose formatting diff to calculate.
@@ -70,7 +70,7 @@ def get_formatting_diff_lines(filename):
     Iterable[str]: The diff of the formatted file against the original file;
       each string in the returned iterable is a "line" of the diff; they could
       be printed individually or joined into a single string using something
-      like os.linesep.join().
+      like os.linesep.join(diff_lines), where `diff_lines` is the return value.
   """
   args = ['clang-format', '-style=file', filename]
   result = subprocess.run(args, stdout=subprocess.PIPE, check=True)
@@ -80,7 +80,8 @@ def get_formatting_diff_lines(filename):
   with open(filename, 'rt', encoding='utf8', errors='replace') as f:
     original_lines = [line.rstrip('\r\n') for line in f]
 
-  return difflib.unified_diff(original_lines, formatted_lines)
+  return [line.rstrip()
+      for line in difflib.unified_diff(original_lines, formatted_lines)]
 
 def does_file_need_formatting(filename):
   """Executes clang-format on the file to determine if it includes any
@@ -272,7 +273,7 @@ def main(argv):
           print('  - Requires reformatting: "{0}"'.format(filename))
           print('------ BEGIN FORMATTING DIFF OF {0}'.format(filename))
           for diff_line in get_formatting_diff_lines(filename):
-            print(diff_line.rstrip())
+            print(diff_line)
           print('------ END FORMATTING DIFF OF {0}'.format(filename))
     if FLAGS.verbose:
       print('  > Done. {0} file(s) need formatting.'.format(count))

--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -28,6 +28,7 @@ Returns:
      because -noformat_file was set.
    2: The application wasn't configured properly and could not execute.
 """
+import difflib
 import io
 import os
 import subprocess
@@ -58,6 +59,29 @@ Used to filter out results when searching across directories or git diffs.
 """
 
 # Functions:    
+def get_formatting_diff_lines(filename):
+  """Executes clang-format on the file and returns a human-friendly string
+  containing the diff of the original file against the formatted file.
+
+  Args:
+    filename (string): path to the file whose formatting diff to calculate.
+
+  Returns:
+    Iterable[str]: The diff of the formatted file against the original file;
+      each string in the returned iterable is a "line" of the diff; they could
+      be printed individually or joined into a single string using something
+      like os.linesep.join().
+  """
+  args = ['clang-format', '-style=file', filename]
+  result = subprocess.run(args, stdout=subprocess.PIPE, check=True)
+
+  formatted_lines = [line.rstrip('\r\n')
+      for line in result.stdout.decode('utf8', errors='replace').splitlines()]
+  with open(filename, 'rt', encoding='utf8', errors='replace') as f:
+    original_lines = [line.rstrip('\r\n') for line in f]
+
+  return difflib.unified_diff(original_lines, formatted_lines)
+
 def does_file_need_formatting(filename):
   """Executes clang-format on the file to determine if it includes any
   formatting changes the user needs to fix.
@@ -246,6 +270,10 @@ def main(argv):
         count += 1
         if FLAGS.verbose:
           print('  - Requires reformatting: "{0}"'.format(filename))
+          print('------ BEGIN FORMATTING DIFF OF {0}'.format(filename))
+          for diff_line in get_formatting_diff_lines(filename):
+            print(diff_line.rstrip())
+          print('------ END FORMATTING DIFF OF {0}'.format(filename))
     if FLAGS.verbose:
       print('  > Done. {0} file(s) need formatting.'.format(count))
     else:


### PR DESCRIPTION
This PR modifies `format_code.py` to print a unified diff of incorrectly-formatted files when both `-noformat_file` and `-verbose` are specified. This can make it easier to correct formatting problems based on the output from GitHub Actions without having to run `clang-format` yourself. This is especially useful if the version of `clang-format` on the GitHub Actions runners differs from that on your local machine, as they may produce different results.

Here is an example output of `format_code.py`:

```
$ python3 scripts/format_code.py -noformat_file -verbose -f example.cc                  
Found 1 file(s). Checking their format.
  - Requires reformatting: "example.cc"
------ BEGIN FORMATTING DIFF OF example.cc
---
+++
@@ -1,9 +1,9 @@
+#include <string>
 #include <vector>
-#include <string>

 std::vector<std::string> GetStrings() {
-    std::vector<std::string> v;
+  std::vector<std::string> v;
   v.emplace_back("string1");
-  v.emplace_back( "string2" );
+  v.emplace_back("string2");
   return v;
 }
------ END FORMATTING DIFF OF example.cc
```