### PR TITLE
Fix "Undefined symbols" linker error when DocumentChange::npos was used

### DIFF
--- a/firestore/integration_test/src/integration_test.cc
+++ b/firestore/integration_test/src/integration_test.cc
@@ -651,6 +651,14 @@ TEST_F(FirebaseFirestoreBasicTest, TestQuery) {
                   "int", firebase::firestore::FieldValue::Integer(101))))));
 }
 
+TEST_F(FirebaseFirestoreBasicTest, TestDocumentChangeNpos) {
+  // This test may seem pointless, but it exists to avoid the long-standing
+  // latent bug that `npos` was not defined on non-Android platforms and
+  // would therefore fail to link if used.
+  EXPECT_EQ(firebase::firestore::DocumentChange::npos,
+            static_cast<std::size_t>(-1));
+}
+
 TEST_F(FirebaseFirestoreBasicTest,
        TestInvalidatingReferencesWhenDeletingFirestore) {
   delete firestore_;

--- a/firestore/integration_test_internal/src/integration_test.cc
+++ b/firestore/integration_test_internal/src/integration_test.cc
@@ -651,6 +651,14 @@ TEST_F(FirebaseFirestoreBasicTest, TestQuery) {
                   "int", firebase::firestore::FieldValue::Integer(101))))));
 }
 
+TEST_F(FirebaseFirestoreBasicTest, TestDocumentChangeNpos) {
+  // This test may seem pointless, but it exists to avoid the long-standing
+  // latent bug that `npos` was not defined on non-Android platforms and
+  // would therefore fail to link if used.
+  EXPECT_EQ(firebase::firestore::DocumentChange::npos,
+            static_cast<std::size_t>(-1));
+}
+
 TEST_F(FirebaseFirestoreBasicTest,
        TestInvalidatingReferencesWhenDeletingFirestore) {
   delete firestore_;

--- a/firestore/src/common/document_change.cc
+++ b/firestore/src/common/document_change.cc
@@ -23,6 +23,8 @@ using Type = DocumentChange::Type;
 // Older NDK (r16b) fails to define this properly. Fix this when support for
 // the older NDK is removed.
 const std::size_t DocumentChange::npos = static_cast<std::size_t>(-1);
+#else
+constexpr std::size_t DocumentChange::npos;
 #endif  // defined(ANDROID)
 
 DocumentChange::DocumentChange() {}

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -567,7 +567,7 @@ code.
 
 ## Release Notes
 
-### 8.0.1
+### 8.1.0
 -   Changes
     -   Firestore: Fixed a linker error when DocumentChange::npos was used.
         ([#474](https://github.com/firebase/firebase-cpp-sdk/pull/474)).

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -569,7 +569,7 @@ code.
 
 ### 8.1.0
 -   Changes
-    -   Firestore: Fixed a linker error when DocumentChange::npos was used.
+    -   Firestore: Fixed a linker error when `DocumentChange::npos` was used.
         ([#474](https://github.com/firebase/firebase-cpp-sdk/pull/474)).
 
 ### 8.0.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -567,6 +567,11 @@ code.
 
 ## Release Notes
 
+### 8.0.1
+-   Changes
+    -   Firestore: Fixed a linker error when DocumentChange::npos was used.
+        ([#474](https://github.com/firebase/firebase-cpp-sdk/pull/474)).
+
 ### 8.0.0
 -   Changes
     -   Analytics: Removed `SetCurrentScreen()` following its removal from iOS SDK


### PR DESCRIPTION
Fix a bug where accessing `firebase::firestore::DocumentChange::npos` from a non-Android platform results in a linker error:

```
Undefined symbols for architecture x86_64:
  "firebase::firestore::DocumentChange::npos", referenced from:
      firebase_testapp_automated::FirebaseFirestoreBasicTest_TestDocumentChangeNpos_Test::TestBody() in integration_test.cc.o
ld: symbol(s) not found for architecture x86_64
```

Here is the declaration of `npos`:

https://github.com/firebase/firebase-cpp-sdk/blob/7ae9569eb9aa8628d7206bdf9553b2f639b02462/firestore/src/include/firebase/firestore/document_change.h#L66-L72

The fix is to add a *definition* of `npos` into the corresponding .cc file