### PR TITLE
Workaround for issue with Doxygen doc generation.

### DIFF
--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -21,18 +21,18 @@
 
 #include <string>
 
-#include "firebase/internal/common.h"
 #include "firebase/auth/types.h"
+#include "firebase/internal/common.h"
 
 namespace firebase {
 
 // Predeclarations.
 class App;
 
-#if !defined(DOXYGEN)
+/// @cond FIREBASE_APP_INTERNAL
 template <typename T>
 class Future;
-#endif  // !defined(DOXYGEN)
+/// @endcond
 
 namespace auth {
 

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -29,8 +29,10 @@ namespace firebase {
 // Predeclarations.
 class App;
 
+#if !defined(DOXYGEN)
 template <typename T>
 class Future;
+#endif  // !defined(DOXYGEN)
 
 namespace auth {
 
@@ -204,7 +206,6 @@ class GoogleAuthProvider {
   /// The string used to identify this provider.
   static const char* const kProviderId;
 };
-
 
 /// @brief Use an access token provided by Microsoft to authenticate.
 class MicrosoftAuthProvider {
@@ -612,14 +613,12 @@ class TwitterAuthProvider {
   static const char* const kProviderId;
 };
 
-
 /// @brief Use an access token provided by Yahoo to authenticate.
 class YahooAuthProvider {
  public:
   /// The string used to identify this provider.
   static const char* const kProviderId;
 };
-
 
 }  // namespace auth
 }  // namespace firebase

--- a/firestore/src/include/firebase/firestore/collection_reference.h
+++ b/firestore/src/include/firebase/firestore/collection_reference.h
@@ -24,10 +24,10 @@
 
 namespace firebase {
 
-#if !defined(DOXYGEN)
+/// @cond FIREBASE_APP_INTERNAL
 template <typename T>
 class Future;
-#endif  // !defined(DOXYGEN)
+/// @endcond
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/collection_reference.h
+++ b/firestore/src/include/firebase/firestore/collection_reference.h
@@ -24,8 +24,10 @@
 
 namespace firebase {
 
+#if !defined(DOXYGEN)
 template <typename T>
 class Future;
+#endif  // !defined(DOXYGEN)
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/document_reference.h
+++ b/firestore/src/include/firebase/firestore/document_reference.h
@@ -33,10 +33,10 @@
 
 namespace firebase {
 
-#if !defined(DOXYGEN)
+/// @cond FIREBASE_APP_INTERNAL
 template <typename T>
 class Future;
-#endif  // !defined(DOXYGEN)
+/// @endcond
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/document_reference.h
+++ b/firestore/src/include/firebase/firestore/document_reference.h
@@ -33,8 +33,10 @@
 
 namespace firebase {
 
+#if !defined(DOXYGEN)
 template <typename T>
 class Future;
+#endif  // !defined(DOXYGEN)
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/query.h
+++ b/firestore/src/include/firebase/firestore/query.h
@@ -32,8 +32,10 @@
 #include "firebase/firestore/source.h"
 
 namespace firebase {
+#if !defined(DOXYGEN)
 template <typename T>
 class Future;
+#endif  // !defined(DOXYGEN)
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/query.h
+++ b/firestore/src/include/firebase/firestore/query.h
@@ -32,10 +32,10 @@
 #include "firebase/firestore/source.h"
 
 namespace firebase {
-#if !defined(DOXYGEN)
+/// @cond FIREBASE_APP_INTERNAL
 template <typename T>
 class Future;
-#endif  // !defined(DOXYGEN)
+/// @endcond
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/write_batch.h
+++ b/firestore/src/include/firebase/firestore/write_batch.h
@@ -22,8 +22,10 @@
 
 namespace firebase {
 
+#if !defined(DOXYGEN)
 template <typename T>
 class Future;
+#endif  // !defined(DOXYGEN)
 
 namespace firestore {
 

--- a/firestore/src/include/firebase/firestore/write_batch.h
+++ b/firestore/src/include/firebase/firestore/write_batch.h
@@ -22,10 +22,10 @@
 
 namespace firebase {
 
-#if !defined(DOXYGEN)
+/// @cond FIREBASE_APP_INTERNAL
 template <typename T>
 class Future;
-#endif  // !defined(DOXYGEN)
+/// @endcond
 
 namespace firestore {
 


### PR DESCRIPTION
Due to a bug (https://bugzilla.gnome.org/show_bug.cgi?id=735376) with
the version of doxygen we use to generate reference documentation,
forward declaration of template types results in them being
misclassified as singletons instead of classes. Omit the forward
declarations from Doxygen doc generation until we can update the version
of Doxygen that we use.