### PR TITLE
Revert Android test tool dependency

### DIFF
--- a/scripts/gha/integration_testing/gameloop_android/app/build.gradle
+++ b/scripts/gha/integration_testing/gameloop_android/app/build.gradle
@@ -25,9 +25,9 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.core:core-ktx:1.6.0-rc01'
-    implementation 'androidx.appcompat:appcompat:1.4.0-alpha02'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.0-beta02'
+    implementation 'androidx.core:core-ktx:1.1.0'
+    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
     androidTestImplementation 'androidx.test.ext:junit:1.1.1'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'


### PR DESCRIPTION
Android gameloop app's gradle updated in this [PR](https://github.com/firebase/firebase-cpp-sdk/commit/845c94765f216dc32c941e5746591b893aeabee0#diff-f20a1dc9cbd9ce5c49bb9510d8e044e73ca9c758021c46707bb9fb70ce430d2b), resulting in Android Emulator test failed.

Should exclude gameloop app's from the updating.