### PR TITLE
Deflake a few flaky tests

### DIFF
--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -236,7 +236,7 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
             // Desktop is a stub and returns the same token, but on mobile it
             // should return a new token.
-            FLAKY_EXPECT_EQ(*token.result(), first_token);
+            FLAKY_EXPECT_NE(*token.result(), first_token);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
 

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -147,15 +147,15 @@ TEST_F(FirebaseInstallationsTest, TestGettingIdTwiceMatches) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> id = installations->GetId();
-	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
-	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+            FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
+            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
             std::string first_id = *id.result();
             id = installations->GetId();
-	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
-	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+            FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
+            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
 
-	    // Ensure the second ID returned is the same as the first.
-	    FLAKY_EXPECT_EQ(*id.result(), first_id);
+            // Ensure the second ID returned is the same as the first.
+            FLAKY_EXPECT_EQ(*id.result(), first_id);
             return true;
           },
           installations_)) {
@@ -167,22 +167,21 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewIdNextTime) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> id = installations->GetId();
-	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
-	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+            FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
+            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
             std::string first_id = *id.result();
 
             firebase::Future<void> del = installations->Delete();
-	    FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
+            FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
 
             // Ensure that we now get a different installations id.
             id = installations->GetId();
-	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
-	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
-
+            FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
+            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
             // Desktop is a stub and returns the same ID, but on mobile it
             // should return a new ID.
-	    FLAKY_EXPECT_NE(*id.result(), first_id);
+            FLAKY_EXPECT_NE(*id.result(), first_id);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
 
@@ -204,13 +203,13 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> token =
                 installations->GetToken(false);
-	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
-	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
+            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
             std::string first_token = *token.result();
             token = installations->GetToken(false);
-	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
-	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
-	    FLAKY_EXPECT_EQ(*token.result(), first_token);
+            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
+            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+            FLAKY_EXPECT_EQ(*token.result(), first_token);
             return true;
           },
           installations_)) {
@@ -223,22 +222,21 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> token =
                 installations->GetToken(false);
-	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
-	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
+            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
             std::string first_token = *token.result();
 
             firebase::Future<void> del = installations->Delete();
-	    FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
+            FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
 
             // Ensure that we now get a different installations token.
             token = installations->GetToken(false);
-	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
-	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
-
+            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
+            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
             // Desktop is a stub and returns the same token, but on mobile it
             // should return a new token.
-	    FLAKY_EXPECT_EQ(*token.result(), first_token);
+            FLAKY_EXPECT_EQ(*token.result(), first_token);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
 

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -265,7 +265,8 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
             }
             if (*token.result() != first_token) {
               LogError(
-                  "GetToken 2 returned non-matching token: first(%s) vs second(%s)",
+                  "GetToken 2 returned non-matching token: first(%s) vs "
+                  "second(%s)",
                   first_token.c_str(), token.result()->c_str());
               return false;
             }

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -239,8 +239,9 @@ TEST_F(FirebaseInstallationsTest, TestCanGetToken) {
 TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
-	    firebase::Future<std::string> token = installations->GetToken(false);
-	    WaitForCompletionAnyResult(token, "GetToken");
+            firebase::Future<std::string> token =
+                installations->GetToken(false);
+            WaitForCompletionAnyResult(token, "GetToken");
             if (token.error() != 0) {
               LogError("GetToken returned error %d: %s", token.error(),
                        token.error_message());
@@ -250,9 +251,9 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
               LogError("GetToken returned blank");
               return false;
             }
-	    std::string first_token = *token.result();
-	    token = installations->GetToken(false);
-	    WaitForCompletionAnyResult(token, "GetToken 2");
+            std::string first_token = *token.result();
+            token = installations->GetToken(false);
+            WaitForCompletionAnyResult(token, "GetToken 2");
             if (token.error() != 0) {
               LogError("GetId 2 returned error %d: %s", token.error(),
                        token.error_message());

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -280,7 +280,8 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
 TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
-            firebase::Future<std::string> token = installations->GetToken(false);
+            firebase::Future<std::string> token =
+                installations->GetToken(false);
             WaitForCompletionAnyResult(token, "GetToken");
             if (token.error() != 0) {
               LogError("GetToken returned error %d: %s", token.error(),
@@ -317,7 +318,8 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
             // Desktop is a stub and returns the same token, but on mobile it
             // should return a new token.
             if (*token.result() == first_token) {
-              LogError("Tokens match (should be different): %s", first_token.c_str());
+              LogError("Tokens match (should be different): %s",
+                       first_token.c_str());
               return false;
             }
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -147,30 +147,15 @@ TEST_F(FirebaseInstallationsTest, TestGettingIdTwiceMatches) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> id = installations->GetId();
-            WaitForCompletionAnyResult(id, "GetId");
-            if (id.error() != 0) {
-              LogError("GetId returned error %d: %s", id.error(),
-                       id.error_message());
-              return false;
-            }
-            if (*id.result() == "") {
-              LogError("GetId returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
+	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
             std::string first_id = *id.result();
             id = installations->GetId();
-            WaitForCompletionAnyResult(id, "GetId 2");
-            if (id.error() != 0) {
-              LogError("GetId 2 returned error %d: %s", id.error(),
-                       id.error_message());
-              return false;
-            }
-            if (*id.result() != first_id) {
-              LogError(
-                  "GetId 2 returned non-matching ID: first(%s) vs second(%s)",
-                  first_id.c_str(), id.result()->c_str());
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
+	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+
+	    // Ensure the second ID returned is the same as the first.
+	    FLAKY_EXPECT_EQ(*id.result(), first_id);
             return true;
           },
           installations_)) {
@@ -182,47 +167,25 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewIdNextTime) {
   if (!RunFlakyBlock(
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> id = installations->GetId();
-            WaitForCompletionAnyResult(id, "GetId");
-            if (id.error() != 0) {
-              LogError("GetId returned error %d: %s", id.error(),
-                       id.error_message());
-              return false;
-            }
-            if (*id.result() == "") {
-              LogError("GetId returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
+	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
             std::string first_id = *id.result();
 
             firebase::Future<void> del = installations->Delete();
-            WaitForCompletionAnyResult(del, "Delete");
-            if (del.error() != 0) {
-              LogError("Delete returned error %d: %s", id.error(),
-                       id.error_message());
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
 
             // Ensure that we now get a different installations id.
             id = installations->GetId();
-            WaitForCompletionAnyResult(id, "GetId 2");
-            if (id.error() != 0) {
-              LogError("GetId 2 returned error %d: %s", id.error(),
-                       id.error_message());
-              return false;
-            }
-            if (*id.result() == "") {
-              LogError("GetId 2 returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
+	    FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
             // Desktop is a stub and returns the same ID, but on mobile it
             // should return a new ID.
-            if (*id.result() == first_id) {
-              LogError("IDs match (should be different): %s", first_id.c_str());
-              return false;
-            }
+	    FLAKY_EXPECT_NE(*id.result(), first_id);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
+
             return true;
           },
           installations_)) {
@@ -241,35 +204,13 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> token =
                 installations->GetToken(false);
-            WaitForCompletionAnyResult(token, "GetToken");
-            if (token.error() != 0) {
-              LogError("GetToken returned error %d: %s", token.error(),
-                       token.error_message());
-              return false;
-            }
-            if (*token.result() == "") {
-              LogError("GetToken returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
+	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
             std::string first_token = *token.result();
             token = installations->GetToken(false);
-            WaitForCompletionAnyResult(token, "GetToken 2");
-            if (token.error() != 0) {
-              LogError("GetId 2 returned error %d: %s", token.error(),
-                       token.error_message());
-              return false;
-            }
-            if (*token.result() == "") {
-              LogError("GetToken 2 returned blank");
-              return false;
-            }
-            if (*token.result() != first_token) {
-              LogError(
-                  "GetToken 2 returned non-matching token: first(%s) vs "
-                  "second(%s)",
-                  first_token.c_str(), token.result()->c_str());
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
+	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+	    FLAKY_EXPECT_EQ(*token.result(), first_token);
             return true;
           },
           installations_)) {
@@ -282,48 +223,25 @@ TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
           [](firebase::installations::Installations* installations) {
             firebase::Future<std::string> token =
                 installations->GetToken(false);
-            WaitForCompletionAnyResult(token, "GetToken");
-            if (token.error() != 0) {
-              LogError("GetToken returned error %d: %s", token.error(),
-                       token.error_message());
-              return false;
-            }
-            if (*token.result() == "") {
-              LogError("GetToken returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
+	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
             std::string first_token = *token.result();
 
             firebase::Future<void> del = installations->Delete();
-            WaitForCompletionAnyResult(del, "Delete");
-            if (del.error() != 0) {
-              LogError("Delete returned error %d: %s", token.error(),
-                       token.error_message());
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
 
             // Ensure that we now get a different installations token.
             token = installations->GetToken(false);
-            WaitForCompletionAnyResult(token, "GetToken 2");
-            if (token.error() != 0) {
-              LogError("GetToken 2 returned error %d: %s", token.error(),
-                       token.error_message());
-              return false;
-            }
-            if (*token.result() == "") {
-              LogError("GetToken 2 returned blank");
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
+	    FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
             // Desktop is a stub and returns the same token, but on mobile it
             // should return a new token.
-            if (*token.result() == first_token) {
-              LogError("Tokens match (should be different): %s",
-                       first_token.c_str());
-              return false;
-            }
+	    FLAKY_EXPECT_EQ(*token.result(), first_token);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
+
             return true;
           },
           installations_)) {

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -263,6 +263,12 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
               LogError("GetToken 2 returned blank");
               return false;
             }
+            if (*token.result() != first_token) {
+              LogError(
+                  "GetToken 2 returned non-matching token: first(%s) vs second(%s)",
+                  first_token.c_str(), token.result()->c_str());
+              return false;
+            }
             return true;
           },
           installations_)) {

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -565,7 +565,7 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
                 firebase::messaging::Unsubscribe(topic.c_str());
             WaitForCompletionAnyResult(unsub, "Unsubscribe");
             if (unsub.error() != 0) {
-              LogError("Unsubscribe returned error %d: %s", sub.error(),
+              LogError("Unsubscribe returned error %d: %s", unsub.error(),
                        unsub.error_message());
             }
 

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -528,7 +528,7 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
             std::string topic = "FCMTestTopic" + unique_id_tag;
             firebase::Future<void> sub =
                 firebase::messaging::Subscribe(topic.c_str());
-	    FLAKY_WAIT_FOR_COMPLETION(sub, "Subscribe");
+            FLAKY_WAIT_FOR_COMPLETION(sub, "Subscribe");
             this_->SendTestMessage(
                 ("/topics/" + topic).c_str(), kNotificationTitle,
                 kNotificationBody,
@@ -536,14 +536,14 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
             firebase::messaging::Message message;
             FLAKY_EXPECT_TRUE(this_->WaitForMessage(&message));
 
-	    FLAKY_EXPECT_EQ(message.data["unique_id"], unique_id);
+            FLAKY_EXPECT_EQ(message.data["unique_id"], unique_id);
             if (message.notification) {
-	      FLAKY_EXPECT_EQ(message.notification->title, kNotificationTitle);
-	      FLAKY_EXPECT_EQ(message.notification->body, kNotificationBody);
+              FLAKY_EXPECT_EQ(message.notification->title, kNotificationTitle);
+              FLAKY_EXPECT_EQ(message.notification->body, kNotificationBody);
             }
             firebase::Future<void> unsub =
                 firebase::messaging::Unsubscribe(topic.c_str());
-	    FLAKY_WAIT_FOR_COMPLETION(unsub, "Unsubscribe");
+            FLAKY_WAIT_FOR_COMPLETION(unsub, "Unsubscribe");
 
             // Ensure that we *don't* receive a message now.
             unique_id = this_->GetUniqueMessageId();
@@ -551,8 +551,9 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
                 ("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
                 {{"message", "Hello, world!"}, {"unique_id", unique_id}});
 
-	    // If this returns true, it means we received a message but shouldn't have.
-	    FLAKY_EXPECT_FALSE(this_->WaitForMessage(&message, 5));
+            // If this returns true, it means we received a message but
+            // shouldn't have.
+            FLAKY_EXPECT_FALSE(this_->WaitForMessage(&message, 5));
 
             return true;
           },

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -221,7 +221,9 @@ bool FirebaseMessagingTest::CreateTestMessage(
     return false;
   }
   if (strcmp(kFcmServerKey, "REPLACE_WITH_YOUR_SERVER_KEY") == 0) {
-    LogWarning("Please put your Firebase Cloud Messaging server key in kFcmServerKey.");
+    LogWarning(
+        "Please put your Firebase Cloud Messaging server key in "
+        "kFcmServerKey.");
     LogWarning("Without a server key, most of these tests will fail.");
     return false;
   }
@@ -260,7 +262,7 @@ void FirebaseMessagingTest::SendTestMessage(
   std::string request;
   std::map<std::string, std::string> headers;
   EXPECT_TRUE(CreateTestMessage(send_to, notification_title, notification_body,
-				message_fields, &request, &headers));
+                                message_fields, &request, &headers));
   SendTestMessage(request, headers);
 }
 
@@ -439,7 +441,7 @@ TEST_F(FirebaseMessagingTest, TestNotification) {
     };
     EXPECT_TRUE(CreateTestMessage(shared_token_->c_str(), kNotificationTitle,
                                   kNotificationBody, message_fields, &request,
-				  &headers));
+                                  &headers));
     std::string html = ConstructHtmlToSendMessage(request, headers, 5);
     // We now have some HTML/Javascript to send the message request. Embed it in
     // a data: url so we can try receiving a message with the app in the
@@ -512,66 +514,74 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
   EXPECT_TRUE(RequestPermission());
   EXPECT_TRUE(WaitForToken());
 
-  if (!RunFlakyBlock([](FirebaseMessagingTest* this_) {
-		       std::string unique_id = this_->GetUniqueMessageId();
-		       const char kNotificationTitle[] = "Topic Test";
-		       const char kNotificationBody[] = "Topic Test notification body";
-		       // Create a somewhat unique topic name using 2 digits near the end of
-		       // unique_id (but not the LAST 2 digits, due to timestamp resolution on some
-		       // platforms).
-		       std::string unique_id_tag =
-			 (unique_id.length() >= 7 ? unique_id.substr(unique_id.length() - 5, 2)
-			  : "00");
-		       std::string topic = "FCMTestTopic" + unique_id_tag;
-		       firebase::Future<void> sub = firebase::messaging::Subscribe(topic.c_str());
-		       WaitForCompletionAnyResult(sub, "Subscribe");
-		       if (sub.error() != 0) {
-			 LogError("Subscribe returned error %d: %s", sub.error(),
-				  sub.error_message());
-		       }
-		       this_->SendTestMessage(("/topics/" + topic).c_str(), kNotificationTitle,
-					      kNotificationBody,
-					      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
-		       firebase::messaging::Message message;
-		       if (!this_->WaitForMessage(&message)) {
-			 LogError("WaitForMessage failed");
-			 return false;
-		       }
-		       if(message.data["unique_id"] != unique_id) {
-			 LogError("unique_id doesn't match: got %s, expected %s",
-				  unique_id.c_str(), message.data["unique_id"].c_str());
-			 return false;
-		       }
-		       if (message.notification) {
-			 if (message.notification->title != kNotificationTitle) {
-			   LogError("notification.title doesn't match: got %s, expected %s",
-				    message.notification->title.c_str(), kNotificationTitle);
-			   return false;
-			 }
-			 if (message.notification->body != kNotificationBody) {
-			   LogError("notification.body doesn't match: got %s, expected %s",
-				    message.notification->body.c_str(), kNotificationBody);
-			   return false;
-			 }
-		       }
-		       firebase::Future<void> unsub = firebase::messaging::Unsubscribe(topic.c_str());
-		       WaitForCompletionAnyResult(unsub, "Unsubscribe");
-		       if (unsub.error() != 0) {
-			 LogError("Unsubscribe returned error %d: %s", sub.error(),
-				  unsub.error_message());
-		       }
-		       
-		       // Ensure that we *don't* receive a message now.
-		       unique_id = this_->GetUniqueMessageId();
-		       this_->SendTestMessage(("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
-					      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
-		       if (this_->WaitForMessage(&message, 5)) {
-			 LogError("WaitForMessage received a message but shouldn't have.");
-			 return false;
-		       }
+  if (!RunFlakyBlock(
+          [](FirebaseMessagingTest* this_) {
+            std::string unique_id = this_->GetUniqueMessageId();
+            const char kNotificationTitle[] = "Topic Test";
+            const char kNotificationBody[] = "Topic Test notification body";
+            // Create a somewhat unique topic name using 2 digits near the end
+            // of unique_id (but not the LAST 2 digits, due to timestamp
+            // resolution on some platforms).
+            std::string unique_id_tag =
+                (unique_id.length() >= 7
+                     ? unique_id.substr(unique_id.length() - 5, 2)
+                     : "00");
+            std::string topic = "FCMTestTopic" + unique_id_tag;
+            firebase::Future<void> sub =
+                firebase::messaging::Subscribe(topic.c_str());
+            WaitForCompletionAnyResult(sub, "Subscribe");
+            if (sub.error() != 0) {
+              LogError("Subscribe returned error %d: %s", sub.error(),
+                       sub.error_message());
+            }
+            this_->SendTestMessage(
+                ("/topics/" + topic).c_str(), kNotificationTitle,
+                kNotificationBody,
+                {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+            firebase::messaging::Message message;
+            if (!this_->WaitForMessage(&message)) {
+              LogError("WaitForMessage failed");
+              return false;
+            }
+            if (message.data["unique_id"] != unique_id) {
+              LogError("unique_id doesn't match: got %s, expected %s",
+                       unique_id.c_str(), message.data["unique_id"].c_str());
+              return false;
+            }
+            if (message.notification) {
+              if (message.notification->title != kNotificationTitle) {
+                LogError(
+                    "notification.title doesn't match: got %s, expected %s",
+                    message.notification->title.c_str(), kNotificationTitle);
+                return false;
+              }
+              if (message.notification->body != kNotificationBody) {
+                LogError("notification.body doesn't match: got %s, expected %s",
+                         message.notification->body.c_str(), kNotificationBody);
+                return false;
+              }
+            }
+            firebase::Future<void> unsub =
+                firebase::messaging::Unsubscribe(topic.c_str());
+            WaitForCompletionAnyResult(unsub, "Unsubscribe");
+            if (unsub.error() != 0) {
+              LogError("Unsubscribe returned error %d: %s", sub.error(),
+                       unsub.error_message());
+            }
 
-		       return true;
-		     }, this)) {
+            // Ensure that we *don't* receive a message now.
+            unique_id = this_->GetUniqueMessageId();
+            this_->SendTestMessage(
+                ("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
+                {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+            if (this_->WaitForMessage(&message, 5)) {
+              LogError("WaitForMessage received a message but shouldn't have.");
+              return false;
+            }
+
+            return true;
+          },
+          this)) {
     FAIL() << "Test failed, check error log for details.";
   }
 }

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -711,7 +711,7 @@ TEST_F(FirebaseStorageTest, TestLargeFilePauseResumeAndDownloadCancel) {
 
             // Ensure the Controller is valid now that we have associated it
             // with an operation.
-	    FLAKY_EXPECT_TRUE(controller.is_valid());
+            FLAKY_EXPECT_TRUE(controller.is_valid());
 
             while (controller.bytes_transferred() == 0) {
 #if FIREBASE_PLATFORM_DESKTOP
@@ -737,17 +737,17 @@ TEST_F(FirebaseStorageTest, TestLargeFilePauseResumeAndDownloadCancel) {
             // The StorageListener's OnPaused will call Resume().
 
             LogDebug("Waiting for future.");
-	    FLAKY_WAIT_FOR_COMPLETION(future, "WriteLargeFile");
+            FLAKY_WAIT_FOR_COMPLETION(future, "WriteLargeFile");
             LogDebug("Upload complete.");
 
             // Ensure the various callbacks were called.
-	    FLAKY_EXPECT_TRUE(listener.on_paused_was_called());
-	    FLAKY_EXPECT_TRUE(listener.on_progress_was_called());
-	    FLAKY_EXPECT_TRUE(listener.resume_succeeded());
+            FLAKY_EXPECT_TRUE(listener.on_paused_was_called());
+            FLAKY_EXPECT_TRUE(listener.on_progress_was_called());
+            FLAKY_EXPECT_TRUE(listener.resume_succeeded());
 
             auto metadata = future.result();
-	    // If metadata reports incorrect size, file failed to upload.
-	    FLAKY_EXPECT_EQ(metadata->size_bytes(), test_file_size);
+            // If metadata reports incorrect size, file failed to upload.
+            FLAKY_EXPECT_EQ(metadata->size_bytes(), test_file_size);
             return true;
           },
           &context, "PutBytes")) {

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -711,10 +711,7 @@ TEST_F(FirebaseStorageTest, TestLargeFilePauseResumeAndDownloadCancel) {
 
             // Ensure the Controller is valid now that we have associated it
             // with an operation.
-            if (!controller.is_valid()) {
-              LogError("Controller is invalid");
-              return false;
-            }
+	    FLAKY_EXPECT_TRUE(controller.is_valid());
 
             while (controller.bytes_transferred() == 0) {
 #if FIREBASE_PLATFORM_DESKTOP
@@ -740,34 +737,17 @@ TEST_F(FirebaseStorageTest, TestLargeFilePauseResumeAndDownloadCancel) {
             // The StorageListener's OnPaused will call Resume().
 
             LogDebug("Waiting for future.");
-            WaitForCompletionAnyResult(future, "WriteLargeFile");
-            if (future.error() != firebase::storage::kErrorNone) {
-              LogError("PutBytes returned error %d: %s", future.error(),
-                       future.error_message());
-              return false;
-            }
+	    FLAKY_WAIT_FOR_COMPLETION(future, "WriteLargeFile");
             LogDebug("Upload complete.");
 
             // Ensure the various callbacks were called.
-            if (!listener.on_paused_was_called()) {
-              LogError("Listener::OnPaused was not called");
-              return false;
-            }
-            if (!listener.on_progress_was_called()) {
-              LogError("Listener::OnProgress was not called");
-              return false;
-            }
-            if (!listener.resume_succeeded()) {
-              LogError("Resume failed");
-              return false;
-            }
+	    FLAKY_EXPECT_TRUE(listener.on_paused_was_called());
+	    FLAKY_EXPECT_TRUE(listener.on_progress_was_called());
+	    FLAKY_EXPECT_TRUE(listener.resume_succeeded());
 
             auto metadata = future.result();
-            if (metadata->size_bytes() != test_file_size) {
-              LogError(
-                  "Metadata reports incorrect size, file failed to upload.");
-              return false;
-            }
+	    // If metadata reports incorrect size, file failed to upload.
+	    FLAKY_EXPECT_EQ(metadata->size_bytes(), test_file_size);
             return true;
           },
           &context, "PutBytes")) {

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -16,6 +16,7 @@
 #define FIREBASE_TEST_FRAMEWORK_H_  // NOLINT
 
 #include <iostream>
+#include <sstream>
 
 #include "app_framework.h"  // NOLINT
 #include "firebase/app.h"
@@ -178,6 +179,63 @@ namespace firebase_test_framework {
 #else
 #define DEATHTEST_SIGABRT ""
 #endif
+
+
+// Helper macros to assist with RunFlakyBlock.
+// Unlike EXPECT_*, FLAKY_EXPECT_* just prints out the error and returns
+// false, which will cause RunFlakyBlock to retry.
+#define FLAKY_EXPECT_EQ(a, b) {                                                \
+  auto a_result = (a);                                                         \
+  auto b_result = (b);                                                         \
+  std::stringstream a_str, b_str;                                              \
+  a_str << a_result;                                                           \
+  b_str << b_result;                                                           \
+  if ((a_result) != (b_result)) {                                              \
+    app_framework::LogError(                                                   \
+      "%s and %s expected to be equal, but differ. first(%s) vs second(%s)",   \
+      #a, #b, a_str.str().c_str(), b_str.str().c_str());                       \
+  return false;                                                                \
+  }                                                                            \
+}
+
+#define FLAKY_EXPECT_NE(a, b) {                                                \
+  auto a_result = (a);                                                         \
+  auto b_result = (b);                                                         \
+  std::stringstream a_str, b_str;                                              \
+  a_str << a_result;                                                           \
+  b_str << b_result;                                                           \
+  if ((a_result) == (b_result)) {                                              \
+    app_framework::LogError(                                                   \
+      "%s and %s expected to differ, but are equal. first(%s) vs second(%s)",  \
+      #a, #b, a_str.str().c_str(), b_str.str().c_str());                       \
+    return false;                                                              \
+  }                                                                            \
+}
+
+#define FLAKY_EXPECT_TRUE(a) {                                                 \
+  if (!(a)) {                                                                  \
+    app_framework::LogError("%s expected to be true, but was false.", #a);     \
+    return false;                                                              \
+  }                                                                            \
+}
+
+#define FLAKY_EXPECT_FALSE(a) {                                                \
+  if ((a)) {                                                                   \
+    app_framework::LogError("%s expected to be false, but was true.", #a);     \
+    return false;                                                              \
+  }                                                                            \
+}
+
+#define FLAKY_WAIT_FOR_COMPLETION(future, name) {                              \
+  auto f = (future);                                                           \
+  WaitForCompletionAnyResult(f, name);                                         \
+  if (f.error() != 0) {                                                        \
+    app_framework::LogError(                                                   \
+      "%s returned error %d: %s",                                              \
+      name, f.error(), f.error_message());                                     \
+    return false;                                                              \
+  }                                                                            \
+}
 
 class FirebaseTest : public testing::Test {
  public:

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -183,52 +183,52 @@ namespace firebase_test_framework {
 // Helper macros to assist with RunFlakyBlock.
 // Unlike EXPECT_*, FLAKY_EXPECT_* just prints out the error and returns
 // false, which will cause RunFlakyBlock to retry.
-#define FLAKY_EXPECT_EQ(a, b)                                         \
-  {                                                                   \
-    auto a_result = (a);                                              \
-    auto b_result = (b);                                              \
-    std::stringstream a_str, b_str;                                   \
-    a_str << a_result;                                                \
-    b_str << b_result;                                                \
-    if ((a_result) != (b_result)) {                                   \
-      app_framework::LogError(                                        \
-          "%s and %s expected to be equal, but differ. first(%s) vs " \
-          "second(%s)",                                               \
-          #a, #b, a_str.str().c_str(), b_str.str().c_str());          \
-      return false;                                                   \
-    }                                                                 \
+#define FLAKY_EXPECT_EQ(a, b)                                \
+  {                                                          \
+    auto a_result = (a);                                     \
+    auto b_result = (b);                                     \
+    std::stringstream a_str, b_str;                          \
+    a_str << a_result;                                       \
+    b_str << b_result;                                       \
+    if ((a_result) != (b_result)) {                          \
+      app_framework::LogError(                               \
+          "Expected %s and %s to be equal, but they differ." \
+          "first(%s) vs second(%s)",                         \
+          #a, #b, a_str.str().c_str(), b_str.str().c_str()); \
+      return false;                                          \
+    }                                                        \
   }
 
-#define FLAKY_EXPECT_NE(a, b)                                          \
-  {                                                                    \
-    auto a_result = (a);                                               \
-    auto b_result = (b);                                               \
-    std::stringstream a_str, b_str;                                    \
-    a_str << a_result;                                                 \
-    b_str << b_result;                                                 \
-    if ((a_result) == (b_result)) {                                    \
-      app_framework::LogError(                                         \
-          "%s and %s expected to differ, but are equal. first(%s) vs " \
-          "second(%s)",                                                \
-          #a, #b, a_str.str().c_str(), b_str.str().c_str());           \
-      return false;                                                    \
-    }                                                                  \
+#define FLAKY_EXPECT_NE(a, b)                                               \
+  {                                                                         \
+    auto a_result = (a);                                                    \
+    auto b_result = (b);                                                    \
+    std::stringstream a_str, b_str;                                         \
+    a_str << a_result;                                                      \
+    b_str << b_result;                                                      \
+    if ((a_result) == (b_result)) {                                         \
+      app_framework::LogError(                                              \
+          "Expected %s and %s to differ, but they are equal. first(%s) vs " \
+          "second(%s)",                                                     \
+          #a, #b, a_str.str().c_str(), b_str.str().c_str());                \
+      return false;                                                         \
+    }                                                                       \
   }
 
-#define FLAKY_EXPECT_TRUE(a)                                                 \
-  {                                                                          \
-    if (!(a)) {                                                              \
-      app_framework::LogError("%s expected to be true, but was false.", #a); \
-      return false;                                                          \
-    }                                                                        \
+#define FLAKY_EXPECT_TRUE(a)                                                   \
+  {                                                                            \
+    if (!(a)) {                                                                \
+      app_framework::LogError("Expected %s to be true, but it is false.", #a); \
+      return false;                                                            \
+    }                                                                          \
   }
 
-#define FLAKY_EXPECT_FALSE(a)                                                \
-  {                                                                          \
-    if ((a)) {                                                               \
-      app_framework::LogError("%s expected to be false, but was true.", #a); \
-      return false;                                                          \
-    }                                                                        \
+#define FLAKY_EXPECT_FALSE(a)                                                  \
+  {                                                                            \
+    if ((a)) {                                                                 \
+      app_framework::LogError("Expected %s to be false, but it is true.", #a); \
+      return false;                                                            \
+    }                                                                          \
   }
 
 #define FLAKY_WAIT_FOR_COMPLETION(future, name)                            \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -180,62 +180,67 @@ namespace firebase_test_framework {
 #define DEATHTEST_SIGABRT ""
 #endif
 
-
 // Helper macros to assist with RunFlakyBlock.
 // Unlike EXPECT_*, FLAKY_EXPECT_* just prints out the error and returns
 // false, which will cause RunFlakyBlock to retry.
-#define FLAKY_EXPECT_EQ(a, b) {                                                \
-  auto a_result = (a);                                                         \
-  auto b_result = (b);                                                         \
-  std::stringstream a_str, b_str;                                              \
-  a_str << a_result;                                                           \
-  b_str << b_result;                                                           \
-  if ((a_result) != (b_result)) {                                              \
-    app_framework::LogError(                                                   \
-      "%s and %s expected to be equal, but differ. first(%s) vs second(%s)",   \
-      #a, #b, a_str.str().c_str(), b_str.str().c_str());                       \
-  return false;                                                                \
-  }                                                                            \
-}
+#define FLAKY_EXPECT_EQ(a, b)                                         \
+  {                                                                   \
+    auto a_result = (a);                                              \
+    auto b_result = (b);                                              \
+    std::stringstream a_str, b_str;                                   \
+    a_str << a_result;                                                \
+    b_str << b_result;                                                \
+    if ((a_result) != (b_result)) {                                   \
+      app_framework::LogError(                                        \
+          "%s and %s expected to be equal, but differ. first(%s) vs " \
+          "second(%s)",                                               \
+          #a, #b, a_str.str().c_str(), b_str.str().c_str());          \
+      return false;                                                   \
+    }                                                                 \
+  }
 
-#define FLAKY_EXPECT_NE(a, b) {                                                \
-  auto a_result = (a);                                                         \
-  auto b_result = (b);                                                         \
-  std::stringstream a_str, b_str;                                              \
-  a_str << a_result;                                                           \
-  b_str << b_result;                                                           \
-  if ((a_result) == (b_result)) {                                              \
-    app_framework::LogError(                                                   \
-      "%s and %s expected to differ, but are equal. first(%s) vs second(%s)",  \
-      #a, #b, a_str.str().c_str(), b_str.str().c_str());                       \
-    return false;                                                              \
-  }                                                                            \
-}
+#define FLAKY_EXPECT_NE(a, b)                                          \
+  {                                                                    \
+    auto a_result = (a);                                               \
+    auto b_result = (b);                                               \
+    std::stringstream a_str, b_str;                                    \
+    a_str << a_result;                                                 \
+    b_str << b_result;                                                 \
+    if ((a_result) == (b_result)) {                                    \
+      app_framework::LogError(                                         \
+          "%s and %s expected to differ, but are equal. first(%s) vs " \
+          "second(%s)",                                                \
+          #a, #b, a_str.str().c_str(), b_str.str().c_str());           \
+      return false;                                                    \
+    }                                                                  \
+  }
 
-#define FLAKY_EXPECT_TRUE(a) {                                                 \
-  if (!(a)) {                                                                  \
-    app_framework::LogError("%s expected to be true, but was false.", #a);     \
-    return false;                                                              \
-  }                                                                            \
-}
+#define FLAKY_EXPECT_TRUE(a)                                                 \
+  {                                                                          \
+    if (!(a)) {                                                              \
+      app_framework::LogError("%s expected to be true, but was false.", #a); \
+      return false;                                                          \
+    }                                                                        \
+  }
 
-#define FLAKY_EXPECT_FALSE(a) {                                                \
-  if ((a)) {                                                                   \
-    app_framework::LogError("%s expected to be false, but was true.", #a);     \
-    return false;                                                              \
-  }                                                                            \
-}
+#define FLAKY_EXPECT_FALSE(a)                                                \
+  {                                                                          \
+    if ((a)) {                                                               \
+      app_framework::LogError("%s expected to be false, but was true.", #a); \
+      return false;                                                          \
+    }                                                                        \
+  }
 
-#define FLAKY_WAIT_FOR_COMPLETION(future, name) {                              \
-  auto f = (future);                                                           \
-  WaitForCompletionAnyResult(f, name);                                         \
-  if (f.error() != 0) {                                                        \
-    app_framework::LogError(                                                   \
-      "%s returned error %d: %s",                                              \
-      name, f.error(), f.error_message());                                     \
-    return false;                                                              \
-  }                                                                            \
-}
+#define FLAKY_WAIT_FOR_COMPLETION(future, name)                            \
+  {                                                                        \
+    auto f = (future);                                                     \
+    WaitForCompletionAnyResult(f, name);                                   \
+    if (f.error() != 0) {                                                  \
+      app_framework::LogError("%s returned error %d: %s", name, f.error(), \
+                              f.error_message());                          \
+      return false;                                                        \
+    }                                                                      \
+  }
 
 class FirebaseTest : public testing::Test {
  public:

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -187,10 +187,10 @@ namespace firebase_test_framework {
   {                                                          \
     auto a_result = (a);                                     \
     auto b_result = (b);                                     \
-    std::stringstream a_str, b_str;                          \
-    a_str << a_result;                                       \
-    b_str << b_result;                                       \
     if ((a_result) != (b_result)) {                          \
+      std::stringstream a_str, b_str;                        \
+      a_str << a_result;                                     \
+      b_str << b_result;                                     \
       app_framework::LogError(                               \
           "Expected %s and %s to be equal, but they differ." \
           "first(%s) vs second(%s)",                         \
@@ -203,10 +203,10 @@ namespace firebase_test_framework {
   {                                                                         \
     auto a_result = (a);                                                    \
     auto b_result = (b);                                                    \
-    std::stringstream a_str, b_str;                                         \
-    a_str << a_result;                                                      \
-    b_str << b_result;                                                      \
     if ((a_result) == (b_result)) {                                         \
+      std::stringstream a_str, b_str;                                       \
+      a_str << a_result;                                                    \
+      b_str << b_result;                                                    \
       app_framework::LogError(                                              \
           "Expected %s and %s to differ, but they are equal. first(%s) vs " \
           "second(%s)",                                                     \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -183,20 +183,20 @@ namespace firebase_test_framework {
 // Helper macros to assist with RunFlakyBlock.
 // Unlike EXPECT_*, FLAKY_EXPECT_* just prints out the error and returns
 // false, which will cause RunFlakyBlock to retry.
-#define FLAKY_EXPECT_EQ(a, b)                                \
-  {                                                          \
-    auto a_result = (a);                                     \
-    auto b_result = (b);                                     \
-    if ((a_result) != (b_result)) {                          \
-      std::stringstream a_str, b_str;                        \
-      a_str << a_result;                                     \
-      b_str << b_result;                                     \
-      app_framework::LogError(                               \
-          "Expected %s and %s to be equal, but they differ. "\
-          "first(%s) vs second(%s)",                         \
-          #a, #b, a_str.str().c_str(), b_str.str().c_str()); \
-      return false;                                          \
-    }                                                        \
+#define FLAKY_EXPECT_EQ(a, b)                                 \
+  {                                                           \
+    auto a_result = (a);                                      \
+    auto b_result = (b);                                      \
+    if ((a_result) != (b_result)) {                           \
+      std::stringstream a_str, b_str;                         \
+      a_str << a_result;                                      \
+      b_str << b_result;                                      \
+      app_framework::LogError(                                \
+          "Expected %s and %s to be equal, but they differ. " \
+          "first(%s) vs second(%s)",                          \
+          #a, #b, a_str.str().c_str(), b_str.str().c_str());  \
+      return false;                                           \
+    }                                                         \
   }
 
 #define FLAKY_EXPECT_NE(a, b)                                               \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -192,7 +192,7 @@ namespace firebase_test_framework {
       a_str << a_result;                                     \
       b_str << b_result;                                     \
       app_framework::LogError(                               \
-          "Expected %s and %s to be equal, but they differ." \
+          "Expected %s and %s to be equal, but they differ. "\
           "first(%s) vs second(%s)",                         \
           #a, #b, a_str.str().c_str(), b_str.str().c_str()); \
       return false;                                          \


### PR DESCRIPTION
Refactor a few tests to use [`RunFlakyBlock`](https://github.com/firebase/firebase-cpp-sdk/blob/acac90f7939f30a48c24ba5aa8d69fffe1ef6927/testing/test_framework/src/firebase_test_framework.h#L204):
- FirebaseInstallationsTest.TestGettingTokenTwiceMatches (copied logic from TestGettingIdTwiceMatches)
- FirebaseInstallationsTest.TestDeleteGivesNewTokenNextTime (copied logic from TestDeleteGivesNewIdNextTime)
- FirebaseMessagingTest.TestSendMessageToTopic

Additionally, to make the RunFlakyBlock tests more readable, this PR adds some FLAKY_EXPECT_* macros for equality and boolean values, as well as FLAKY_WAIT_FOR_COMPLETION. Refactored a Storage test to use these.
