### PR TITLE
GitHub REST API: add timeout and retry 

### DIFF
--- a/scripts/gha/github.py
+++ b/scripts/gha/github.py
@@ -23,6 +23,13 @@ import json
 import shutil
 
 from absl import logging
+from requests.adapters import HTTPAdapter
+from requests.packages.urllib3.util.retry import Retry
+
+RETRIES = 3
+BACKOFF = 3
+RETRY_STATUS = (403, 500, 502, 504)
+TIMEOUT = 5
 
 OWNER = 'firebase'
 REPO = 'firebase-cpp-sdk'
@@ -31,12 +38,26 @@ BASE_URL = 'https://api.github.com'
 FIREBASE_URL = '%s/repos/%s/%s' % (BASE_URL, OWNER, REPO)
 logging.set_verbosity(logging.INFO)
 
+def requests_retry_session(retries=RETRIES, 
+                           backoff_factor=BACKOFF, 
+                           status_forcelist=RETRY_STATUS):
+    session = requests.Session()
+    retry = Retry(total=retries,
+                  read=retries,
+                  connect=retries,
+                  backoff_factor=backoff_factor,
+                  status_forcelist=status_forcelist)
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount('http://', adapter)
+    session.mount('https://', adapter)
+    return session
+
 def create_issue(token, title, label):
   """Create an issue: https://docs.github.com/en/rest/reference/issues#create-an-issue"""
   url = f'{FIREBASE_URL}/issues'
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
   data = {'title': title, 'labels': [label]}
-  with requests.post(url, headers=headers, data=json.dumps(data)) as response:
+  with requests.post(url, headers=headers, data=json.dumps(data), timeout=TIMEOUT) as response:
     logging.info("create_issue: %s response: %s", url, response)
     return response.json()
 
@@ -45,7 +66,7 @@ def update_issue(token, issue_number, data):
   """Update an issue: https://docs.github.com/en/rest/reference/issues#update-an-issue"""
   url = f'{FIREBASE_URL}/issues/{issue_number}'
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
-  with requests.patch(url, headers=headers, data=json.dumps(data)) as response:
+  with requests_retry_session().patch(url, headers=headers, data=json.dumps(data), timeout=TIMEOUT) as response:
     logging.info("update_issue: %s response: %s", url, response)
 
 
@@ -65,7 +86,7 @@ def search_issues_by_label(label):
   """https://docs.github.com/en/rest/reference/search#search-issues-and-pull-requests"""
   url = f'{BASE_URL}/search/issues?q=repo:{OWNER}/{REPO}+label:"{label}"+is:issue' 
   headers = {'Accept': 'application/vnd.github.v3+json'}
-  with requests.get(url, headers=headers) as response:
+  with requests_retry_session().get(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("search_issues_by_label: %s response: %s", url, response)
     return response.json()["items"]
 
@@ -74,7 +95,7 @@ def list_comments(issue_number):
   """https://docs.github.com/en/rest/reference/issues#list-issue-comments"""
   url = f'{FIREBASE_URL}/issues/{issue_number}/comments' 
   headers = {'Accept': 'application/vnd.github.v3+json'}
-  with requests.get(url, headers=headers) as response:
+  with requests_retry_session().get(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("list_comments: %s response: %s", url, response)
     return response.json()
 
@@ -84,7 +105,7 @@ def add_comment(token, issue_number, comment):
   url = f'{FIREBASE_URL}/issues/{issue_number}/comments' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
   data = {'body': comment}
-  with requests.post(url, headers=headers, data=json.dumps(data)) as response:
+  with requests.post(url, headers=headers, data=json.dumps(data), timeout=TIMEOUT) as response:
     logging.info("add_comment: %s response: %s", url, response)
 
 
@@ -93,7 +114,7 @@ def update_comment(token, comment_id, comment):
   url = f'{FIREBASE_URL}/issues/comments/{comment_id}' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
   data = {'body': comment}
-  with requests.patch(url, headers=headers, data=json.dumps(data)) as response:
+  with requests_retry_session().patch(url, headers=headers, data=json.dumps(data), timeout=TIMEOUT) as response:
     logging.info("update_comment: %s response: %s", url, response)
 
 
@@ -101,7 +122,7 @@ def delete_comment(token, comment_id):
   """https://docs.github.com/en/rest/reference/issues#delete-an-issue-comment"""
   url = f'{FIREBASE_URL}/issues/comments/{comment_id}' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
-  with requests.delete(url, headers=headers) as response:
+  with requests.delete(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("delete_comment: %s response: %s", url, response)
 
 
@@ -111,7 +132,7 @@ def add_label(token, issue_number, label):
   headers={}
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
   data = [label]
-  with requests.post(url, headers=headers, data=json.dumps(data)) as response:
+  with requests.post(url, headers=headers, data=json.dumps(data), timeout=TIMEOUT) as response:
     logging.info("add_label: %s response: %s", url, response)
 
 
@@ -119,7 +140,7 @@ def delete_label(token, issue_number, label):
   """https://docs.github.com/en/rest/reference/issues#delete-a-label"""
   url = f'{FIREBASE_URL}/issues/{issue_number}/labels/{label}' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
-  with requests.delete(url, headers=headers) as response:
+  with requests.delete(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("delete_label: %s response: %s", url, response)
 
 
@@ -127,7 +148,7 @@ def list_artifacts(token, run_id):
   """https://docs.github.com/en/rest/reference/actions#list-workflow-run-artifacts"""
   url = f'{FIREBASE_URL}/actions/runs/{run_id}/artifacts' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
-  with requests.get(url, headers=headers) as response:
+  with requests_retry_session().get(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("list_artifacts: %s response: %s", url, response)
     return response.json()["artifacts"]
 
@@ -136,7 +157,7 @@ def download_artifact(token, artifact_id, output_path):
   """https://docs.github.com/en/rest/reference/actions#download-an-artifact"""
   url = f'{FIREBASE_URL}/actions/artifacts/{artifact_id}/zip' 
   headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
-  with requests.get(url, headers=headers, stream=True) as response:
+  with requests.get(url, headers=headers, stream=True, timeout=TIMEOUT) as response:
     logging.info("download_artifact: %s response: %s", url, response)
     with open(output_path, 'wb') as file:
         shutil.copyfileobj(response.raw, file)

--- a/scripts/gha/github.py
+++ b/scripts/gha/github.py
@@ -27,7 +27,7 @@ from requests.adapters import HTTPAdapter
 from requests.packages.urllib3.util.retry import Retry
 
 RETRIES = 3
-BACKOFF = 3
+BACKOFF = 5
 RETRY_STATUS = (403, 500, 502, 504)
 TIMEOUT = 5
 
@@ -91,10 +91,10 @@ def search_issues_by_label(label):
     return response.json()["items"]
 
 
-def list_comments(issue_number):
+def list_comments(token, issue_number):
   """https://docs.github.com/en/rest/reference/issues#list-issue-comments"""
   url = f'{FIREBASE_URL}/issues/{issue_number}/comments' 
-  headers = {'Accept': 'application/vnd.github.v3+json'}
+  headers = {'Accept': 'application/vnd.github.v3+json', 'Authorization': f'token {token}'}
   with requests_retry_session().get(url, headers=headers, timeout=TIMEOUT) as response:
     logging.info("list_comments: %s response: %s", url, response)
     return response.json()

--- a/scripts/gha/it_workflow.py
+++ b/scripts/gha/it_workflow.py
@@ -192,15 +192,15 @@ def _get_issue_number(token, title, label):
 
 
 def _update_comment(token, issue_number, comment):
-  comment_id = _get_comment_id(issue_number, _COMMENT_SUFFIX)
+  comment_id = _get_comment_id(token, issue_number, _COMMENT_SUFFIX)
   if not comment_id:
     github.add_comment(token, issue_number, comment)
   else:
     github.update_comment(token, comment_id, comment)
 
   
-def _get_comment_id(issue_number, comment_identifier):
-  comments = github.list_comments(issue_number)
+def _get_comment_id(token, issue_number, comment_identifier):
+  comments = github.list_comments(token, issue_number)
   for comment in comments:
     if comment_identifier in comment['body']:
       return comment['id']


### PR DESCRIPTION
Existing http request flakiness in step "Update PR label and comment": https://github.com/firebase/firebase-cpp-sdk/runs/2945372323?check_suite_focus=true#step:18:23
Should be fixed now.

Add timeout (5s) to all GitHub REST API requests.
Add retry (3 times) to all query and update requests. 