### PR TITLE
Add retry to iOS/tvOS/Android test on virtual device

### DIFF
--- a/scripts/gha/integration_testing/gameloop_android/app/src/androidTest/java/com/google/firebase/gameloop/GameLoopUITest.kt
+++ b/scripts/gha/integration_testing/gameloop_android/app/src/androidTest/java/com/google/firebase/gameloop/GameLoopUITest.kt
@@ -19,7 +19,7 @@ import org.junit.runner.RunWith
 class GameLoopUITest {
 
   companion object {
-    const val GAMELOOP_TIMEOUT = 15 * 60 * 1000L
+    const val GAMELOOP_TIMEOUT = 10 * 60 * 1000L
   }
 
   private lateinit var device: UiDevice

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -465,14 +465,13 @@ def _get_apple_test_log(bundle_id, app_path, device_id):
 
 def _read_file(path):
   """Extracts the contents of a file."""
-  with open(path, "r") as f:
-    test_result = f.read()
+  if os.path.isfile(path):
+    with open(path, "r") as f:
+      test_result = f.read()
 
-  logging.info("Reading file: %s", path)
-  logging.info("File contant: %s", test_result)
-  return test_result
-
-
+    logging.info("Reading file: %s", path)
+    logging.info("File contant: %s", test_result)
+    return test_result
 
 
 # -------------------Android Only-------------------

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -428,6 +428,7 @@ def _run_apple_gameloop_test(bundle_id, app_path, gameloop_app, device_id, retry
   if retry > 1:
     results = test_validation.validate_results_cpp(logs)
     if not results.complete:
+      logging.info("Retry _run_apple_gameloop_test. Remaining retry: %s", retry-1)
       return _run_apple_gameloop_test(bundle_id, app_path, gameloop_app, device_id, retry=retry-1)
   
   return logs
@@ -470,7 +471,7 @@ def _read_file(path):
       test_result = f.read()
 
     logging.info("Reading file: %s", path)
-    logging.info("File contant: %s", test_result)
+    logging.info("File content: %s", test_result)
     return test_result
 
 
@@ -567,6 +568,7 @@ def _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=1
   if retry > 1:
     results = test_validation.validate_results_cpp(logs)
     if not results.complete:
+      logging.info("Retry _run_android_gameloop_test. Remaining retry: %s", retry-1)
       return _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=retry-1)
   
   return logs

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -418,16 +418,16 @@ def _get_bundle_id(app_path, config):
       return api["bundle_id"]
 
 
-def _run_apple_gameloop_test(bundle_id, app_path, gameloop_app, device_id, retry=0):
+def _run_apple_gameloop_test(bundle_id, app_path, gameloop_app, device_id, retry=1):
   """Run gameloop test and collect test result."""
   logging.info("Running apple gameloop test: %s, %s, %s, %s", bundle_id, app_path, gameloop_app, device_id)
   _install_apple_app(app_path, device_id)
   _run_xctest(gameloop_app, device_id)
   logs = _get_apple_test_log(bundle_id, app_path, device_id)
   _uninstall_apple_app(bundle_id, device_id)
-  if retry > 0:
+  if retry > 1:
     results = test_validation.validate_results_cpp(logs)
-    if (not results.complete) or (results.fails > 0):
+    if not results.complete:
       return _run_apple_gameloop_test(bundle_id, app_path, gameloop_app, device_id, retry=retry-1)
   
   return logs
@@ -559,15 +559,15 @@ def _get_package_name(app_path):
   return package_name  
 
 
-def _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=0): 
+def _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=1): 
   logging.info("Running android gameloop test: %s, %s, %s", package_name, app_path, gameloop_project)
   _install_android_app(app_path)
   _run_instrumented_test()
   logs = _get_android_test_log(package_name)
   _uninstall_android_app(package_name)
-  if retry > 0:
+  if retry > 1:
     results = test_validation.validate_results_cpp(logs)
-    if (not results.complete) or (results.fails > 0):
+    if not results.complete:
       return _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=retry-1)
   
   return logs


### PR DESCRIPTION
Retry (maximum 3 times) on error, e.g. integration test ended unexpectedly .
Won't retry if tests failed.