### PR TITLE
Add a "wrapper" header that includes `firestore_exceptions.h` from the iOS repo

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -32,6 +32,7 @@ set(common_SRCS
     src/common/field_path.cc
     src/common/field_value.cc
     src/common/firestore.cc
+    src/common/firestore_exceptions_main.h
     src/common/futures.cc
     src/common/futures.h
     src/common/hard_assert_common.cc
@@ -192,7 +193,6 @@ set(main_SRCS
     src/main/field_value_main.h
     src/main/firestore_main.cc
     src/main/firestore_main.h
-    src/main/firestore_exceptions_main.h
     src/main/listener_main.h
     src/main/listener_registration_main.cc
     src/main/listener_registration_main.h

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -192,6 +192,7 @@ set(main_SRCS
     src/main/field_value_main.h
     src/main/firestore_main.cc
     src/main/firestore_main.h
+    src/main/firestore_exceptions_main.h
     src/main/listener_main.h
     src/main/listener_registration_main.cc
     src/main/listener_registration_main.h

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -32,7 +32,7 @@ set(common_SRCS
     src/common/field_path.cc
     src/common/field_value.cc
     src/common/firestore.cc
-    src/common/firestore_exceptions_main.h
+    src/common/firestore_exceptions_common.h
     src/common/futures.cc
     src/common/futures.h
     src/common/hard_assert_common.cc

--- a/firestore/src/common/firestore_exceptions_common.h
+++ b/firestore/src/common/firestore_exceptions_common.h
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
-#define FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+#ifndef FIREBASE_FIRESTORE_SRC_COMMON_FIRESTORE_EXCEPTIONS_COMMON_H_
+#define FIREBASE_FIRESTORE_SRC_COMMON_FIRESTORE_EXCEPTIONS_COMMON_H_
 
 // Note: this header only exists to simplify the Unity build (the SWIG build has
 // trouble directly including a header that comes from the iOS repo).
 #include "Firestore/core/src/util/firestore_exceptions.h"
 
-#endif  // FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+#endif  // FIREBASE_FIRESTORE_SRC_COMMON_FIRESTORE_EXCEPTIONS_COMMON_H_

--- a/firestore/src/common/firestore_exceptions_common.h
+++ b/firestore/src/common/firestore_exceptions_common.h
@@ -1,0 +1,22 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+#define FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+
+// Note: this header only exists to simplify the Unity build (the SWIG build has
+// trouble directly including a header that comes from the iOS repo).
+#include "Firestore/core/src/util/firestore_exceptions.h"
+
+#endif  // FIREBASE_FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_

--- a/firestore/src/main/firestore_exceptions_main.h
+++ b/firestore/src/main/firestore_exceptions_main.h
@@ -1,0 +1,8 @@
+#ifndef FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+#define FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
+
+// Note: this header only exists to simplify the Unity build (the SWIG build has
+// trouble directly including a header that comes from the iOS repo).
+#include "Firestore/core/src/util/firestore_exceptions.h"
+
+#endif  // FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_

--- a/firestore/src/main/firestore_exceptions_main.h
+++ b/firestore/src/main/firestore_exceptions_main.h
@@ -1,8 +1,0 @@
-#ifndef FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
-#define FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_
-
-// Note: this header only exists to simplify the Unity build (the SWIG build has
-// trouble directly including a header that comes from the iOS repo).
-#include "Firestore/core/src/util/firestore_exceptions.h"
-
-#endif  // FIRESTORE_SRC_MAIN_FIRESTORE_EXCEPTIONS_MAIN_H_


### PR DESCRIPTION
This simplifies the Unity build (the SWIG part of the build has issues with directly including a header that comes from the iOS repo).