### PR TITLE
Clean up all flaky tests to be much more straightforward.

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -132,26 +132,28 @@ TEST_F(FirebaseAnalyticsTest, TestLogEventWithMultipleParameters) {
 
 TEST_F(FirebaseAnalyticsTest, TestResettingGivesNewInstanceId) {
   // Test is flaky on iPhone due to a known issue in iOS.  See b/143656277.
-  if (!RunFlakyBlock([&]() {
-        firebase::Future<std::string> future =
-            firebase::analytics::GetAnalyticsInstanceId();
-        FLAKY_WAIT_FOR_COMPLETION(future, "GetAnalyticsInstanceId");
-        FLAKY_EXPECT_FALSE(future.result()->empty());
-        std::string instance_id = *future.result();
+#if TARGET_OS_IPHONE
+  FLAKY_TEST_SECTION_BEGIN();
+#endif  // TARGET_OS_IPHONE
 
-        firebase::analytics::ResetAnalyticsData();
+  firebase::Future<std::string> future =
+      firebase::analytics::GetAnalyticsInstanceId();
+  WaitForCompletion(future, "GetAnalyticsInstanceId");
+  EXPECT_FALSE(future.result()->empty());
+  std::string instance_id = *future.result();
 
-        future = firebase::analytics::GetAnalyticsInstanceId();
-        FLAKY_WAIT_FOR_COMPLETION(
-            future, "GetAnalyticsInstanceId after ResetAnalyticsData");
-        std::string new_instance_id = *future.result();
-        FLAKY_EXPECT_FALSE(future.result()->empty());
-        FLAKY_EXPECT_NE(instance_id, new_instance_id);
+  firebase::analytics::ResetAnalyticsData();
 
-        FLAKY_SUCCESS();
-      })) {
-    FAIL() << "Failed, see error log for details.";
-  }
+  future = firebase::analytics::GetAnalyticsInstanceId();
+  WaitForCompletion(
+      future, "GetAnalyticsInstanceId after ResetAnalyticsData");
+  std::string new_instance_id = *future.result();
+  EXPECT_FALSE(future.result()->empty());
+  EXPECT_NE(instance_id, new_instance_id);
+
+#if TARGET_OS_IPHONE
+  FLAKY_TEST_SECTION_END();
+#endif  // TARGET_OS_IPHONE
 }
 
 }  // namespace firebase_testapp_automated

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -145,8 +145,7 @@ TEST_F(FirebaseAnalyticsTest, TestResettingGivesNewInstanceId) {
   firebase::analytics::ResetAnalyticsData();
 
   future = firebase::analytics::GetAnalyticsInstanceId();
-  WaitForCompletion(
-      future, "GetAnalyticsInstanceId after ResetAnalyticsData");
+  WaitForCompletion(future, "GetAnalyticsInstanceId after ResetAnalyticsData");
   std::string new_instance_id = *future.result();
   EXPECT_FALSE(future.result()->empty());
   EXPECT_NE(instance_id, new_instance_id);

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -909,7 +909,7 @@ TEST_F(FirebaseAuthTest, TestPhoneAuth) {
     FAIL() << "Automatic verification failed.";
   } else {
     // Did not automatically verify, submit verification code manually.
-    EXPECT_TRUE(listener.on_code_auto_retrieval_time_out_count() > 0);
+    EXPECT_GT(listener.on_code_auto_retrieval_time_out_count(), 0);
     EXPECT_NE(listener.verification_id(), "");
     LogDebug("Signing in with verification code.");
     const firebase::auth::Credential phone_credential =

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -725,8 +725,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
 
   FLAKY_TEST_SECTION_BEGIN();
 
-  WaitForCompletion(auth_->SignInAnonymously(),
-                    "SignInAnonymously");
+  WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
   EXPECT_NE(auth_->current_user(), nullptr);
   EXPECT_TRUE(auth_->current_user()->is_anonymous());
   Terminate();
@@ -755,8 +754,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Save the old provider ID list so we can make sure it's the same once
   // it's loaded again.
   std::vector<std::string> prev_provider_data_ids;
-  for (int i = 0; i < auth_->current_user()->provider_data().size();
-       i++) {
+  for (int i = 0; i < auth_->current_user()->provider_data().size(); i++) {
     prev_provider_data_ids.push_back(
         auth_->current_user()->provider_data()[i]->provider_id());
   }
@@ -769,8 +767,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Make sure the provider IDs are the same as they were before.
   EXPECT_EQ(auth_->current_user()->provider_id(), prev_provider_id);
   std::vector<std::string> loaded_provider_data_ids;
-  for (int i = 0; i < auth_->current_user()->provider_data().size();
-       i++) {
+  for (int i = 0; i < auth_->current_user()->provider_data().size(); i++) {
     loaded_provider_data_ids.push_back(
         auth_->current_user()->provider_data()[i]->provider_id());
   }
@@ -883,8 +880,8 @@ TEST_F(FirebaseAuthTest, TestPhoneAuth) {
       app_framework::GetCurrentTimeInMicroseconds() %
       kPhoneAuthTestNumPhoneNumbers;
   phone_provider.VerifyPhoneNumber(
-      kPhoneAuthTestPhoneNumbers[random_phone_number],
-      kPhoneAuthTimeoutMs, nullptr, &listener);
+      kPhoneAuthTestPhoneNumbers[random_phone_number], kPhoneAuthTimeoutMs,
+      nullptr, &listener);
 
   // Wait for OnCodeSent() callback.
   int wait_ms = 0;
@@ -906,24 +903,21 @@ TEST_F(FirebaseAuthTest, TestPhoneAuth) {
   }
   if (listener.on_verification_complete_count() > 0) {
     LogDebug("Signing in with automatic verification code.");
-    WaitForCompletion(
-        auth_->SignInWithCredential(listener.credential()),
-        "SignInWithCredential(PhoneCredential) automatic");
+    WaitForCompletion(auth_->SignInWithCredential(listener.credential()),
+                      "SignInWithCredential(PhoneCredential) automatic");
   } else if (listener.on_verification_failed_count() > 0) {
-    FAIL() << "Automatic verification failed." ;
+    FAIL() << "Automatic verification failed.";
   } else {
     // Did not automatically verify, submit verification code manually.
-    EXPECT_TRUE(listener.on_code_auto_retrieval_time_out_count() >
-                      0);
+    EXPECT_TRUE(listener.on_code_auto_retrieval_time_out_count() > 0);
     EXPECT_NE(listener.verification_id(), "");
     LogDebug("Signing in with verification code.");
     const firebase::auth::Credential phone_credential =
         phone_provider.GetCredential(listener.verification_id().c_str(),
                                      kPhoneAuthTestVerificationCode);
 
-    WaitForCompletion(
-        auth_->SignInWithCredential(phone_credential),
-        "SignInWithCredential(PhoneCredential)");
+    WaitForCompletion(auth_->SignInWithCredential(phone_credential),
+                      "SignInWithCredential(PhoneCredential)");
   }
 
   ProcessEvents(1000);

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -721,7 +721,7 @@ TEST_F(FirebaseAuthTest, TestWithCustomEmailAndPassword) {
 
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
   // Automated test is disabled on linux due to the need to unlock the keystore.
-  if (!IsUserInteractionAllowed()) SKIP_TEST_ON_LINUX;
+  SKIP_TEST_ON_LINUX;
 
   FLAKY_TEST_SECTION_BEGIN();
 
@@ -740,7 +740,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithAnonymousSignin) {
 }
 TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Automated test is disabled on linux due to the need to unlock the keystore.
-  if (!IsUserInteractionAllowed()) SKIP_TEST_ON_LINUX;
+  SKIP_TEST_ON_LINUX;
 
   FLAKY_TEST_SECTION_BEGIN();
 

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -194,8 +194,7 @@ TEST_F(FirebaseInstallationsTest, TestCanGetToken) {
 TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
   FLAKY_TEST_SECTION_BEGIN();
 
-  firebase::Future<std::string> token =
-      installations_->GetToken(false);
+  firebase::Future<std::string> token = installations_->GetToken(false);
   WaitForCompletion(token, "GetToken");
   EXPECT_NE(*token.result(), "");  // ensure non-blank
   std::string first_token = *token.result();
@@ -210,8 +209,7 @@ TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
 TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
   FLAKY_TEST_SECTION_BEGIN();
 
-  firebase::Future<std::string> token =
-      installations_->GetToken(false);
+  firebase::Future<std::string> token = installations_->GetToken(false);
   WaitForCompletion(token, "GetToken");
   EXPECT_NE(*token.result(), "");  // ensure non-blank
   std::string first_token = *token.result();

--- a/installations/integration_test/src/integration_test.cc
+++ b/installations/integration_test/src/integration_test.cc
@@ -144,52 +144,45 @@ TEST_F(FirebaseInstallationsTest, TestCanGetId) {
 }
 
 TEST_F(FirebaseInstallationsTest, TestGettingIdTwiceMatches) {
-  if (!RunFlakyBlock(
-          [](firebase::installations::Installations* installations) {
-            firebase::Future<std::string> id = installations->GetId();
-            FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
-            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
-            std::string first_id = *id.result();
-            id = installations->GetId();
-            FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
-            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+  FLAKY_TEST_SECTION_BEGIN();
 
-            // Ensure the second ID returned is the same as the first.
-            FLAKY_EXPECT_EQ(*id.result(), first_id);
-            return true;
-          },
-          installations_)) {
-    FAIL() << "Test failed, check error log for details.";
-  }
+  firebase::Future<std::string> id = installations_->GetId();
+  WaitForCompletion(id, "GetId");
+  EXPECT_NE(*id.result(), "");  // ensure non-blank
+  std::string first_id = *id.result();
+  id = installations_->GetId();
+  WaitForCompletion(id, "GetId 2");
+  EXPECT_NE(*id.result(), "");  // ensure non-blank
+
+  // Ensure the second ID returned is the same as the first.
+  EXPECT_EQ(*id.result(), first_id);
+
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewIdNextTime) {
-  if (!RunFlakyBlock(
-          [](firebase::installations::Installations* installations) {
-            firebase::Future<std::string> id = installations->GetId();
-            FLAKY_WAIT_FOR_COMPLETION(id, "GetId");
-            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
-            std::string first_id = *id.result();
+  FLAKY_TEST_SECTION_BEGIN();
 
-            firebase::Future<void> del = installations->Delete();
-            FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
+  firebase::Future<std::string> id = installations_->GetId();
+  WaitForCompletion(id, "GetId");
+  EXPECT_NE(*id.result(), "");  // ensure non-blank
+  std::string first_id = *id.result();
 
-            // Ensure that we now get a different installations id.
-            id = installations->GetId();
-            FLAKY_WAIT_FOR_COMPLETION(id, "GetId 2");
-            FLAKY_EXPECT_NE(*id.result(), "");  // ensure non-blank
+  firebase::Future<void> del = installations_->Delete();
+  WaitForCompletion(del, "Delete");
+
+  // Ensure that we now get a different installations id.
+  id = installations_->GetId();
+  WaitForCompletion(id, "GetId 2");
+  EXPECT_NE(*id.result(), "");  // ensure non-blank
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
-            // Desktop is a stub and returns the same ID, but on mobile it
-            // should return a new ID.
-            FLAKY_EXPECT_NE(*id.result(), first_id);
+  // Desktop is a stub and returns the same ID, but on mobile it
+  // should return a new ID.
+  EXPECT_NE(*id.result(), first_id);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
 
-            return true;
-          },
-          installations_)) {
-    FAIL() << "Test failed, check error log for details.";
-  }
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseInstallationsTest, TestCanGetToken) {
@@ -199,52 +192,45 @@ TEST_F(FirebaseInstallationsTest, TestCanGetToken) {
 }
 
 TEST_F(FirebaseInstallationsTest, TestGettingTokenTwiceMatches) {
-  if (!RunFlakyBlock(
-          [](firebase::installations::Installations* installations) {
-            firebase::Future<std::string> token =
-                installations->GetToken(false);
-            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
-            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
-            std::string first_token = *token.result();
-            token = installations->GetToken(false);
-            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
-            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
-            FLAKY_EXPECT_EQ(*token.result(), first_token);
-            return true;
-          },
-          installations_)) {
-    FAIL() << "Test failed, check error log for details.";
-  }
+  FLAKY_TEST_SECTION_BEGIN();
+
+  firebase::Future<std::string> token =
+      installations_->GetToken(false);
+  WaitForCompletion(token, "GetToken");
+  EXPECT_NE(*token.result(), "");  // ensure non-blank
+  std::string first_token = *token.result();
+  token = installations_->GetToken(false);
+  WaitForCompletion(token, "GetToken 2");
+  EXPECT_NE(*token.result(), "");  // ensure non-blank
+  EXPECT_EQ(*token.result(), first_token);
+
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseInstallationsTest, TestDeleteGivesNewTokenNextTime) {
-  if (!RunFlakyBlock(
-          [](firebase::installations::Installations* installations) {
-            firebase::Future<std::string> token =
-                installations->GetToken(false);
-            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken");
-            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
-            std::string first_token = *token.result();
+  FLAKY_TEST_SECTION_BEGIN();
 
-            firebase::Future<void> del = installations->Delete();
-            FLAKY_WAIT_FOR_COMPLETION(del, "Delete");
+  firebase::Future<std::string> token =
+      installations_->GetToken(false);
+  WaitForCompletion(token, "GetToken");
+  EXPECT_NE(*token.result(), "");  // ensure non-blank
+  std::string first_token = *token.result();
 
-            // Ensure that we now get a different installations token.
-            token = installations->GetToken(false);
-            FLAKY_WAIT_FOR_COMPLETION(token, "GetToken 2");
-            FLAKY_EXPECT_NE(*token.result(), "");  // ensure non-blank
+  firebase::Future<void> del = installations_->Delete();
+  WaitForCompletion(del, "Delete");
+
+  // Ensure that we now get a different installations token.
+  token = installations_->GetToken(false);
+  WaitForCompletion(token, "GetToken 2");
+  EXPECT_NE(*token.result(), "");  // ensure non-blank
 #if defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)
-            // Desktop is a stub and returns the same token, but on mobile it
-            // should return a new token.
-            FLAKY_EXPECT_NE(*token.result(), first_token);
+  // Desktop is a stub and returns the same token, but on mobile it
+  // should return a new token.
+  EXPECT_NE(*token.result(), first_token);
 #endif  // defined(__ANDROID__) || (defined(TARGET_OS_IPHONE) &&
         // TARGET_OS_IPHONE)
 
-            return true;
-          },
-          installations_)) {
-    FAIL() << "Test failed, check error log for details.";
-  }
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseInstallationsTest, TestCanGetIdAndTokenTogether) {

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -489,31 +489,29 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToToken) {
 
   EXPECT_TRUE(RequestPermission());
   EXPECT_TRUE(WaitForToken());
-  if (!RunFlakyBlock(
-          [](FirebaseMessagingTest* this_) {
-            std::string unique_id = this_->GetUniqueMessageId();
-            const char kNotificationTitle[] = "Token Test";
-            const char kNotificationBody[] = "Token Test notification body";
-            this_->SendTestMessage(this_->shared_token()->c_str(),
-                                   kNotificationTitle, kNotificationBody,
-                                   {{"message", "Hello, world!"},
-                                    {"unique_id", unique_id},
-                                    {kNotificationLinkKey, kTestLink}});
-            LogDebug("Waiting for message.");
-            firebase::messaging::Message message;
-            FLAKY_EXPECT_TRUE(this_->WaitForMessage(&message));
-            FLAKY_EXPECT_EQ(message.data["unique_id"], unique_id);
-            FLAKY_EXPECT_NOTNULL(message.notification);
-            if (message.notification) {
-              FLAKY_EXPECT_EQ(message.notification->title, kNotificationTitle);
-              FLAKY_EXPECT_EQ(message.notification->body, kNotificationBody);
-            }
-            FLAKY_EXPECT_EQ(message.link, kTestLink);
-            return true;
-          },
-          this)) {
-    FAIL() << "Test failed, check error log for details.";
+
+  FLAKY_TEST_SECTION_BEGIN();
+
+  std::string unique_id = GetUniqueMessageId();
+  const char kNotificationTitle[] = "Token Test";
+  const char kNotificationBody[] = "Token Test notification body";
+  SendTestMessage(shared_token()->c_str(),
+                  kNotificationTitle, kNotificationBody,
+                  {{"message", "Hello, world!"},
+                   {"unique_id", unique_id},
+                   {kNotificationLinkKey, kTestLink}});
+  LogDebug("Waiting for message.");
+  firebase::messaging::Message message;
+  EXPECT_TRUE(WaitForMessage(&message));
+  EXPECT_EQ(message.data["unique_id"], unique_id);
+  EXPECT_NE(message.notification, nullptr);
+  if (message.notification) {
+    EXPECT_EQ(message.notification->title, kNotificationTitle);
+    EXPECT_EQ(message.notification->body, kNotificationBody);
   }
+  EXPECT_EQ(message.link, kTestLink);
+
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
@@ -523,53 +521,49 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
   EXPECT_TRUE(RequestPermission());
   EXPECT_TRUE(WaitForToken());
 
-  if (!RunFlakyBlock(
-          [](FirebaseMessagingTest* this_) {
-            std::string unique_id = this_->GetUniqueMessageId();
-            const char kNotificationTitle[] = "Topic Test";
-            const char kNotificationBody[] = "Topic Test notification body";
-            // Create a somewhat unique topic name using 2 digits near the end
-            // of unique_id (but not the LAST 2 digits, due to timestamp
-            // resolution on some platforms).
-            std::string unique_id_tag =
-                (unique_id.length() >= 7
-                     ? unique_id.substr(unique_id.length() - 5, 2)
-                     : "00");
-            std::string topic = "FCMTestTopic" + unique_id_tag;
-            firebase::Future<void> sub =
-                firebase::messaging::Subscribe(topic.c_str());
-            FLAKY_WAIT_FOR_COMPLETION(sub, "Subscribe");
-            this_->SendTestMessage(
-                ("/topics/" + topic).c_str(), kNotificationTitle,
-                kNotificationBody,
-                {{"message", "Hello, world!"}, {"unique_id", unique_id}});
-            firebase::messaging::Message message;
-            FLAKY_EXPECT_TRUE(this_->WaitForMessage(&message));
+  FLAKY_TEST_SECTION_BEGIN();
 
-            FLAKY_EXPECT_EQ(message.data["unique_id"], unique_id);
-            if (message.notification) {
-              FLAKY_EXPECT_EQ(message.notification->title, kNotificationTitle);
-              FLAKY_EXPECT_EQ(message.notification->body, kNotificationBody);
-            }
-            firebase::Future<void> unsub =
-                firebase::messaging::Unsubscribe(topic.c_str());
-            FLAKY_WAIT_FOR_COMPLETION(unsub, "Unsubscribe");
+  std::string unique_id = GetUniqueMessageId();
+  const char kNotificationTitle[] = "Topic Test";
+  const char kNotificationBody[] = "Topic Test notification body";
+  // Create a somewhat unique topic name using 2 digits near the end
+  // of unique_id (but not the LAST 2 digits, due to timestamp
+  // resolution on some platforms).
+  std::string unique_id_tag =
+      (unique_id.length() >= 7
+       ? unique_id.substr(unique_id.length() - 5, 2)
+       : "00");
+  std::string topic = "FCMTestTopic" + unique_id_tag;
+  firebase::Future<void> sub =
+      firebase::messaging::Subscribe(topic.c_str());
+  WaitForCompletion(sub, "Subscribe");
+  SendTestMessage(
+      ("/topics/" + topic).c_str(), kNotificationTitle,
+      kNotificationBody,
+      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+  firebase::messaging::Message message;
+  EXPECT_TRUE(WaitForMessage(&message));
 
-            // Ensure that we *don't* receive a message now.
-            unique_id = this_->GetUniqueMessageId();
-            this_->SendTestMessage(
-                ("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
-                {{"message", "Hello, world!"}, {"unique_id", unique_id}});
-
-            // If this returns true, it means we received a message but
-            // shouldn't have.
-            FLAKY_EXPECT_FALSE(this_->WaitForMessage(&message, 5));
-
-            return true;
-          },
-          this)) {
-    FAIL() << "Test failed, check error log for details.";
+  EXPECT_EQ(message.data["unique_id"], unique_id);
+  if (message.notification) {
+    EXPECT_EQ(message.notification->title, kNotificationTitle);
+    EXPECT_EQ(message.notification->body, kNotificationBody);
   }
+  firebase::Future<void> unsub =
+      firebase::messaging::Unsubscribe(topic.c_str());
+  WaitForCompletion(unsub, "Unsubscribe");
+
+  // Ensure that we *don't* receive a message now.
+  unique_id = GetUniqueMessageId();
+  SendTestMessage(
+      ("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
+      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+
+  // If this returns true, it means we received a message but
+  // shouldn't have.
+  EXPECT_FALSE(WaitForMessage(&message, 5));
+
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseMessagingTest, TestChangingListener) {
@@ -579,39 +573,37 @@ TEST_F(FirebaseMessagingTest, TestChangingListener) {
   EXPECT_TRUE(RequestPermission());
   EXPECT_TRUE(WaitForToken());
 
-  if (!RunFlakyBlock([&]() {
-        // Back up the previous listener object and create a new one.
-        firebase::messaging::PollableListener* old_listener_ = shared_listener_;
-        // WaitForMessage() uses whatever shared_listener_ is set to.
-        shared_listener_ = new firebase::messaging::PollableListener();
-        firebase::messaging::SetListener(shared_listener_);
-        // Pause a moment to make sure old listeners are deleted.
-        ProcessEvents(1000);
+  FLAKY_TEST_SECTION_BEGIN();
 
-        std::string unique_id = GetUniqueMessageId();
-        const char kNotificationTitle[] = "New Listener Test";
-        const char kNotificationBody[] = "New Listener Test notification body";
-        SendTestMessage(
-            shared_token_->c_str(), kNotificationTitle, kNotificationBody,
-            {{"message", "Hello, world!"}, {"unique_id", unique_id}});
-        LogDebug("Waiting for message.");
-        firebase::messaging::Message message;
-        FLAKY_EXPECT_TRUE(WaitForMessage(&message));
-        FLAKY_EXPECT_EQ(message.data["unique_id"], unique_id);
-        if (message.notification) {
-          FLAKY_EXPECT_EQ(message.notification->title, kNotificationTitle);
-          FLAKY_EXPECT_EQ(message.notification->body, kNotificationBody);
-        }
+  // Back up the previous listener object and create a new one.
+  firebase::messaging::PollableListener* old_listener_ = shared_listener_;
+  // WaitForMessage() uses whatever shared_listener_ is set to.
+  shared_listener_ = new firebase::messaging::PollableListener();
+  firebase::messaging::SetListener(shared_listener_);
+  // Pause a moment to make sure old listeners are deleted.
+  ProcessEvents(1000);
 
-        // Set back to the previous listener.
-        firebase::messaging::SetListener(old_listener_);
-        delete shared_listener_;
-        shared_listener_ = old_listener_;
-
-        FLAKY_SUCCESS();
-      })) {
-    FAIL() << "Test failed, see error log for details.";
+  std::string unique_id = GetUniqueMessageId();
+  const char kNotificationTitle[] = "New Listener Test";
+  const char kNotificationBody[] = "New Listener Test notification body";
+  SendTestMessage(
+      shared_token_->c_str(), kNotificationTitle, kNotificationBody,
+      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+  LogDebug("Waiting for message.");
+  firebase::messaging::Message message;
+  EXPECT_TRUE(WaitForMessage(&message));
+  EXPECT_EQ(message.data["unique_id"], unique_id);
+  if (message.notification) {
+    EXPECT_EQ(message.notification->title, kNotificationTitle);
+    EXPECT_EQ(message.notification->body, kNotificationBody);
   }
+
+  // Set back to the previous listener.
+  firebase::messaging::SetListener(old_listener_);
+  delete shared_listener_;
+  shared_listener_ = old_listener_;
+
+  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseMessagingTest, DeliverMetricsToBigQuery) {

--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -495,8 +495,8 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToToken) {
   std::string unique_id = GetUniqueMessageId();
   const char kNotificationTitle[] = "Token Test";
   const char kNotificationBody[] = "Token Test notification body";
-  SendTestMessage(shared_token()->c_str(),
-                  kNotificationTitle, kNotificationBody,
+  SendTestMessage(shared_token()->c_str(), kNotificationTitle,
+                  kNotificationBody,
                   {{"message", "Hello, world!"},
                    {"unique_id", unique_id},
                    {kNotificationLinkKey, kTestLink}});
@@ -530,17 +530,14 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
   // of unique_id (but not the LAST 2 digits, due to timestamp
   // resolution on some platforms).
   std::string unique_id_tag =
-      (unique_id.length() >= 7
-       ? unique_id.substr(unique_id.length() - 5, 2)
-       : "00");
+      (unique_id.length() >= 7 ? unique_id.substr(unique_id.length() - 5, 2)
+                               : "00");
   std::string topic = "FCMTestTopic" + unique_id_tag;
-  firebase::Future<void> sub =
-      firebase::messaging::Subscribe(topic.c_str());
+  firebase::Future<void> sub = firebase::messaging::Subscribe(topic.c_str());
   WaitForCompletion(sub, "Subscribe");
-  SendTestMessage(
-      ("/topics/" + topic).c_str(), kNotificationTitle,
-      kNotificationBody,
-      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+  SendTestMessage(("/topics/" + topic).c_str(), kNotificationTitle,
+                  kNotificationBody,
+                  {{"message", "Hello, world!"}, {"unique_id", unique_id}});
   firebase::messaging::Message message;
   EXPECT_TRUE(WaitForMessage(&message));
 
@@ -555,9 +552,8 @@ TEST_F(FirebaseMessagingTest, TestSendMessageToTopic) {
 
   // Ensure that we *don't* receive a message now.
   unique_id = GetUniqueMessageId();
-  SendTestMessage(
-      ("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
-      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+  SendTestMessage(("/topics/" + topic).c_str(), "Topic Title 2", "Topic Body 2",
+                  {{"message", "Hello, world!"}, {"unique_id", unique_id}});
 
   // If this returns true, it means we received a message but
   // shouldn't have.
@@ -586,9 +582,8 @@ TEST_F(FirebaseMessagingTest, TestChangingListener) {
   std::string unique_id = GetUniqueMessageId();
   const char kNotificationTitle[] = "New Listener Test";
   const char kNotificationBody[] = "New Listener Test notification body";
-  SendTestMessage(
-      shared_token_->c_str(), kNotificationTitle, kNotificationBody,
-      {{"message", "Hello, world!"}, {"unique_id", unique_id}});
+  SendTestMessage(shared_token_->c_str(), kNotificationTitle, kNotificationBody,
+                  {{"message", "Hello, world!"}, {"unique_id", unique_id}});
   LogDebug("Waiting for message.");
   firebase::messaging::Message message;
   EXPECT_TRUE(WaitForMessage(&message));

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <iostream>
 #include <sstream>
+#include <vector>
 
 #include "app_framework.h"  // NOLINT
 #include "firebase/app.h"

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -28,6 +28,11 @@
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
+// Include this internal header so we have access to UnitTestImpl and
+// ClearTestPartResults. We are not supposed to use these, but we do anyway as a
+// workaround for handling flaky test sections.
+#include "gtest/../../src/gtest-internal-inl.h"
+
 namespace firebase_test_framework {
 
 // Use this macro to skip an entire test if it requires interactivity and we are
@@ -181,108 +186,11 @@ namespace firebase_test_framework {
 #define DEATHTEST_SIGABRT ""
 #endif
 
-// Helper macros to assist with RunFlakyBlock.
-// Unlike EXPECT_*, FLAKY_EXPECT_* just prints out the error and returns
-// false, which will cause RunFlakyBlock to retry.
-
-// This returns false, which will make RunFlakyBlock retry.
-#define FLAKY_FAIL() \
-  { return false; }
-// Put this at the end of each RunFlakyBlock function. It will return true.
-#define FLAKY_SUCCESS() \
-  { return true; }
-
-#define FLAKY_EXPECT_EQ(a, b)                                 \
-  {                                                           \
-    auto a_result = (a);                                      \
-    auto b_result = (b);                                      \
-    if ((a_result) != (b_result)) {                           \
-      std::stringstream a_str, b_str;                         \
-      a_str << a_result;                                      \
-      b_str << b_result;                                      \
-      app_framework::LogError(                                \
-          "Expected %s and %s to be equal, but they differ. " \
-          "first(%s) vs second(%s)",                          \
-          #a, #b, a_str.str().c_str(), b_str.str().c_str());  \
-      return false;                                           \
-    }                                                         \
-  }
-
-#define FLAKY_EXPECT_NE(a, b)                                               \
-  {                                                                         \
-    auto a_result = (a);                                                    \
-    auto b_result = (b);                                                    \
-    if ((a_result) == (b_result)) {                                         \
-      std::stringstream a_str, b_str;                                       \
-      a_str << a_result;                                                    \
-      b_str << b_result;                                                    \
-      app_framework::LogError(                                              \
-          "Expected %s and %s to differ, but they are equal. first(%s) vs " \
-          "second(%s)",                                                     \
-          #a, #b, a_str.str().c_str(), b_str.str().c_str());                \
-      return false;                                                         \
-    }                                                                       \
-  }
-
-#define FLAKY_EXPECT_NULL(a)                                           \
-  {                                                                    \
-    auto a_result = (a);                                               \
-    if ((a_result) != nullptr) {                                       \
-      std::stringstream a_str;                                         \
-      a_str << a_result;                                               \
-      app_framework::LogError(                                         \
-          "Expected %s to be null, but it is not null. value(%s)", #a, \
-          a_str.str().c_str());                                        \
-      return false;                                                    \
-    }                                                                  \
-  }
-#define FLAKY_EXPECT_NOTNULL(a)                                              \
-  {                                                                          \
-    if ((a) == nullptr) {                                                    \
-      app_framework::LogError("Expected %s to be non-null, but it is null.", \
-                              #a);                                           \
-      return false;                                                          \
-    }                                                                        \
-  }
-#define FLAKY_EXPECT_NONNULL(a) FLAKY_EXPECT_NOTNULL(a)
-#define FLAKY_EXPECT_TRUE(a)                                                   \
-  {                                                                            \
-    if (!(a)) {                                                                \
-      app_framework::LogError("Expected %s to be true, but it is false.", #a); \
-      return false;                                                            \
-    }                                                                          \
-  }
-
-#define FLAKY_EXPECT_FALSE(a)                                                  \
-  {                                                                            \
-    if ((a)) {                                                                 \
-      app_framework::LogError("Expected %s to be false, but it is true.", #a); \
-      return false;                                                            \
-    }                                                                          \
-  }
-
-#define FLAKY_WAIT_FOR_COMPLETION(future, name)                            \
-  {                                                                        \
-    auto f = (future);                                                     \
-    WaitForCompletionAnyResult(f, name);                                   \
-    if (f.error() != 0) {                                                  \
-      app_framework::LogError("%s returned error %d: %s", name, f.error(), \
-                              f.error_message());                          \
-      return false;                                                        \
-    }                                                                      \
-  }
-
-#define FLAKY_WAIT_FOR_COMPLETION_WITH_ERROR(future, name, expected_error) \
-  {                                                                        \
-    auto f = (future);                                                     \
-    WaitForCompletionAnyResult(f, name);                                   \
-    if (f.error() != expected_error) {                                     \
-      app_framework::LogError(                                             \
-          "%s expected error %d but returned error %d: %s", name,          \
-          expected_error, f.error(), f.error_message());                   \
-      return false;                                                        \
-    }                                                                      \
-  }
+// Macros to surround a flaky section of your test.
+// If this section fails, it will retry several times until it succeeds.
+#define FLAKY_TEST_SECTION_BEGIN() RunFlakyTestSection([&]() { (void)0
+#define FLAKY_TEST_SECTION_END() \
+  })
 
 class FirebaseTest : public testing::Test {
  public:
@@ -378,6 +286,33 @@ class FirebaseTest : public testing::Test {
   // it's not Invalid). Returns true, unless Invalid.
   static bool WaitForCompletionAnyResult(const firebase::FutureBase& future,
                                          const char* name);
+
+  // Run a flaky section of a test. If any expectations fail, it will clear
+  // those failures and retry the section.
+  //
+  // Typically, you wouldn't use this method directly. Instead, you should use
+  // it via the FLAKY_TEST_SECTION_BEGIN() and FLAKY_TEST_SECTION_END() macros
+  // defined above.
+  //
+  // For example:
+  // TEST_F(MyTestClass, MyTestCase) {
+  //   /* do some non-flaky stuff here */
+  //   FLAKY_TEST_SECTION_BEGIN();
+  //   /* do some stuff that might need to be retried here */
+  //   FLAKY_TEST_SECTION_END();
+  //   /* do some more non-flaky stuff here */
+  // }
+  void RunFlakyTestSection(std::function<void()> flaky_test_section) {
+    // Save the current state of test results.
+    auto saved_test_results = SaveTestPartResults();
+    RunFlakyBlock([&]() {
+      RestoreTestPartResults(saved_test_results);
+
+      flaky_test_section();
+
+      return !HasFailure();
+    });
+  }
 
   // Run an operation that returns a Future (via a callback), retrying with
   // exponential backoff if the operation fails.
@@ -523,6 +458,22 @@ class FirebaseTest : public testing::Test {
   // for type safety.
   static bool RunFlakyBlockBase(bool (*flaky_block)(void* context),
                                 void* context, const char* name = "");
+
+  std::vector<::testing::TestPartResult> SaveTestPartResults() {
+    return ::testing::internal::TestResultAccessor::test_part_results(
+        *::testing::internal::GetUnitTestImpl()->current_test_result());
+  }
+
+  void RestoreTestPartResults(
+      const std::vector<::testing::TestPartResult>& test_part_results) {
+    const std::vector<testing::TestPartResult>& existing_results =
+        ::testing::internal::TestResultAccessor::test_part_results(
+            *::testing::internal::GetUnitTestImpl()->current_test_result());
+    // Overwrite the existing test_part_results with the previously-saved
+    // version.
+    const_cast<std::vector<testing::TestPartResult>&>(existing_results)
+        .assign(test_part_results.begin(), test_part_results.end());
+  }
 };
 
 }  // namespace firebase_test_framework


### PR DESCRIPTION
This PR adds  RunFlakyTestSection, which lets you use regular EXPECT macros.
    
(This touches some internal googletest stuff, so it may break in the future if we update to a later googletest version.)
    
Rather than using RunFlakyTestSection directly, you should use the following two macros:
FLAKY_TEST_SECTION_BEGIN();
FLAKY_TEST_SECTION_END();

This PR also cleans up existing tests to use this new method.
