### PR TITLE
Integration test workflow exclude tvOS build & test for certain apis

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -186,8 +186,9 @@ jobs:
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
-          echo "::set-output name=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})"
-          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" ${AUTO_DIFF_PARAM})"
+          apis=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
+          echo "::set-output name=apis::${apis}"
+          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} ${AUTO_DIFF_PARAM})"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
           # If building against a packaged SDK, only use boringssl.
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -187,7 +187,7 @@ jobs:
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
           apis=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
-          echo "::set-output name=apis::${apis}"
+          echo "::set-output name=${apis}"
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} ${AUTO_DIFF_PARAM})"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
           # If building against a packaged SDK, only use boringssl.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -186,8 +186,8 @@ jobs:
       - id: export-result
         # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
         run: |
-          apis=apis::$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
-          echo "::set-output name=${apis}"
+          apis=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
+          echo "::set-output name=apis::${apis}"
           echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} ${AUTO_DIFF_PARAM})"
           echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
           # If building against a packaged SDK, only use boringssl.

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -381,7 +381,7 @@ def parse_cmdline_args():
   parser.add_argument('-o', '--override', help='Override existing value with provided value')
   parser.add_argument('-d', '--device', action='store_true', help='Get the device type, used with -k $device')
   parser.add_argument('-t', '--device_type', default=['real', 'virtual'], help='Test on which type of mobile devices')
-  parser.add_argument('-p', '--apis', default=["admob,analytics,auth,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage"], 
+  parser.add_argument('--apis', default=PARAMETERS["integration_tests"]["config"]["apis"], 
                       help='Exclude platform based on apis. Certain platform does not support all apis. e.g. tvOS does not support messaging')
   args = parser.parse_args()
   return args

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -338,9 +338,8 @@ def filter_values_on_diff(parm_key, value, auto_diff):
 
 def filter_platforms_on_apis(platforms, apis):
   if "tvOS" in platforms:
-    api_list = apis.split(",")
     config = config_reader.read_config()
-    supported_apis = [api for api in api_list if config.get_api(api).tvos_target]
+    supported_apis = [api for api in apis if config.get_api(api).tvos_target]
     if not supported_apis:
       platforms.remove("tvOS")
   
@@ -354,7 +353,7 @@ def main():
     if not args.config:
       args.override = args.override.split(',')
     if args.parm_key == "platform" and args.apis:
-      args.override = filter_platforms_on_apis(args.override, args.apis)
+      args.override = filter_platforms_on_apis(args.override, json.load(args.apis))
 
     print_value(args.override)
     return

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -337,14 +337,12 @@ def filter_values_on_diff(parm_key, value, auto_diff):
 
 
 def filter_platforms_on_apis(platforms, apis):
-  platform_list = platforms.split(",")
-  if "tvOS" in platform_list:
+  if "tvOS" in platforms:
     api_list = apis.split(",")
     config = config_reader.read_config()
     supported_apis = [api for api in api_list if config.get_api(api).tvos_target]
     if not supported_apis:
-      platform_list.remove("tvOS")
-      return ",".join(platform_list)
+      platforms.remove("tvOS")
   
   return platforms
 
@@ -370,8 +368,6 @@ def main():
     value = filter_devices(value, args.device_type)
   if args.auto_diff:
     value = filter_values_on_diff(args.parm_key, value, args.auto_diff)
-  if args.parm_key == "platform" and args.apis:
-    value = filter_platforms_on_apis(args.parm_key, args.apis)
   print_value(value)
 
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -353,7 +353,7 @@ def main():
     if not args.config:
       args.override = args.override.split(',')
     if args.parm_key == "platform" and args.apis:
-      args.override = filter_platforms_on_apis(args.override, json.load(args.apis))
+      args.override = filter_platforms_on_apis(args.override, json.loads(args.apis))
 
     print_value(args.override)
     return

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -353,7 +353,6 @@ def main():
     if not args.config:
       args.override = args.override.split(',')
     if args.parm_key == "platform" and args.apis:
-      print_value(args.apis)
       # e.g. args.apis = "\"admob,analytics\""
       args.override = filter_platforms_on_apis(args.override, args.apis.strip('"').split(','))
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -353,7 +353,9 @@ def main():
     if not args.config:
       args.override = args.override.split(',')
     if args.parm_key == "platform" and args.apis:
-      args.override = filter_platforms_on_apis(args.override, json.loads(args.apis))
+      print_value(args.apis)
+      # e.g. args.apis = "\"admob,analytics\""
+      args.override = filter_platforms_on_apis(args.override, args.apis.strip('"').split(','))
 
     print_value(args.override)
     return


### PR DESCRIPTION
This is a quick fix that integration test workflow exclude tvOS build & test for certain apis (e.g. admob, analytics, messaging, etc.)
"admob,analytics" not trigger tvos: https://github.com/firebase/firebase-cpp-sdk/actions/runs/1046072350
"analytics,auth" trigger tvos: https://github.com/firebase/firebase-cpp-sdk/actions/runs/1046073504

Note that the `build_testapps` script also need to handle this type of exclusion. But I will fix it in a separate PR.