### PR TITLE
Remove unnecessary guard around FieldValue::Increment.

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -342,6 +342,8 @@ add_custom_target(
   COMMENT "Copying internal Firestore headers"
 )
 
+# This is needed due to Firestore's dependence on some firebase::app APIs that
+# are guarded by this flag, such as GetUserAgent and function_registry.
 set(FIREBASE_FIRESTORE_CPP_DEFINES -DINTERNAL_EXPERIMENTAL=1)
 
 if (WIN32 AND NOT ANDROID AND NOT IOS)

--- a/firestore/src/include/firebase/firestore/field_value.h
+++ b/firestore/src/include/firebase/firestore/field_value.h
@@ -325,7 +325,6 @@ class FieldValue final {
    */
   static FieldValue ArrayRemove(std::vector<FieldValue> elements);
 
-#if defined(INTERNAL_EXPERIMENTAL) || defined(SWIG)
   /**
    * Returns a special value that can be used with `Set()` or `Update()` that
    * tells the server to increment the field's current value by the given
@@ -355,9 +354,6 @@ class FieldValue final {
     return IntegerIncrement(static_cast<int64_t>(by_value));
   }
 
-#endif  // if defined(INTERNAL_EXPERIMENTAL) || defined(SWIG)
-
-#if defined(INTERNAL_EXPERIMENTAL) || defined(SWIG)
   /**
    * Returns a special value that can be used with `Set()` or `Update()` that
    * tells the server to increment the field's current value by the given
@@ -387,8 +383,6 @@ class FieldValue final {
         "FieldValue::Increment().");
     return DoubleIncrement(static_cast<double>(by_value));
   }
-
-#endif  // if defined(INTERNAL_EXPERIMENTAL) || defined(SWIG)
 
   /**
    * Returns a string representation of this `FieldValue` for logging/debugging

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -572,6 +572,8 @@ code.
     -   Firestore: Removed the deprecated
         `Firestore::RunTransaction(TransactionFunction*)` function. Please use
         the overload that takes a `std::function` argument instead.
+    -   Firestore: `FieldValue::Increment` functions are no longer guarded by
+        the `INTERNAL_EXPERIMENTAL` macro.
 
 ### 8.2.0
 -   Changes


### PR DESCRIPTION
Firestore has been building with INTERNAL_EXPERIMENTAL=1 for quite some time. These methods should always be exposed. Test coverage for them is available in field_value_test.cc and numeric_transforms_test.cc.