### PR TITLE
Ensure that argv specified to googletest has a null terminator.

### DIFF
--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -350,6 +350,10 @@ char** EditMainArgsForGoogleTest(int* argc, char* argv[]) {
   const std::vector<std::string> original_args = ArgcArgvToVector(*argc, argv);
   std::vector<std::string> modified_args(original_args);
 
+  // Add elements to the `modified_args` vector to specify to googletest.
+  // e.g. modified_args.push_back("--gtest_list_tests");
+  // e.g. modified_args.push_back("--gtest_filter=MyTestFixture.MyTest");
+
   // Create a new `argv` with the elements from the `modified_args` vector and
   // write the new count back to `argc`. The memory leaks produced by
   // `VectorToArgcArgv` acceptable because they last for the entire application.

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -309,7 +309,7 @@ std::vector<std::string> ArgcArgvToVector(int argc, char* argv[]) {
 
 char** VectorToArgcArgv(const std::vector<std::string>& args_vector,
                         int* argc) {
-  // Ensure that `argv` ends with a null terminator. This is a Poxis requirement
+  // Ensure that `argv` ends with a null terminator. This is a POSIX requirement
   // (see https://man7.org/linux/man-pages/man2/execve.2.html) and googletest
   // relies on it. Without this null terminator, the
   // `ParseGoogleTestFlagsOnlyImpl()` function in googletest accesses invalid

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -319,7 +319,7 @@ char** VectorToArgcArgv(const std::vector<std::string>& args_vector,
     std::strcpy(arg_copy, arg);
     argv[i] = arg_copy;
   }
-  argv[args_vector.size()] = 0;
+  argv[args_vector.size()] = nullptr;
   *argc = static_cast<int>(args_vector.size());
   return argv;
 }


### PR DESCRIPTION
According to https://man7.org/linux/man-pages/man2/execve.2.html, 

> The argv array must be terminated by a NULL pointer.  (Thus, in the new program, argv[argc] will be NULL.)

However, it appears that the `argv` specified to `common_main()` is not terminated in this way, at least on Android. This causes googletest's `ParseGoogleTestFlagsOnly()` function to read past the end of `argv`.

https://github.com/google/googletest/blob/8d51ffdfab10b3fba636ae69bc03da4b54f8c235/googletest/src/gtest.cc#L6634-L6649

This doesn't usually lead to issues; however, when run with Address Sanitizer this causes a crash since it is technically referencing unallocated memory.

This PR works around this by explicitly adding a null terminator to `argv`.

Googlers can see b/192351260#comment11 for more details.