### PR TITLE
Fix ODR violation of FirestoreInternal on Android in integration_test_util.cc

### DIFF
--- a/firestore/integration_test_internal/src/util/integration_test_util.cc
+++ b/firestore/integration_test_internal/src/util/integration_test_util.cc
@@ -9,7 +9,12 @@
 #include "firebase/app.h"
 #include "firebase/firestore.h"
 #include "firestore/src/common/hard_assert_common.h"
+
+#if !defined(__ANDROID__)
 #include "firestore/src/main/firestore_main.h"
+#else
+#include "firestore/src/android/firestore_android.h"
+#endif  // !defined(__ANDROID__)
 
 namespace firebase {
 namespace firestore {


### PR DESCRIPTION
In the `TestFriend::CreateTestFirestoreInternal()` method defined in [integration_test_util.cc](https://github.com/firebase/firebase-cpp-sdk/blob/edad366983e6f4e7d8a1c3823d95c48c791a8853/firestore/integration_test_internal/src/util/integration_test_util.cc#L25) the expression `sizeof(FirestoreInternal)` is `116`.

In contrast, in [firestore_android.cc](https://github.com/firebase/firebase-cpp-sdk/blob/edad366983e6f4e7d8a1c3823d95c48c791a8853/firestore/src/android/firestore_android.cc#L243) the expression `sizeof(FirestoreInternal)` is `128`.

Before `bundle_listeners_mutex_` and `bundle_listeners_` were added to `FirestoreInternal` in https://github.com/firebase/firebase-cpp-sdk/pull/394 the expression `sizeof(FirestoreInternal)` was `112`.

So we were basically getting lucky that the ODR caused *more* memory to be allocated by the call to `new FirestoreInternal(app)` than was needed; however, now that those two members were added to `FirestoreInternal` the `new FirestoreInternal(app)` call is allocating *fewer* bytes than needed, causing the initialization of `FirestoreInternal` to run off the end of its allocated memory.

The fix is to include the Android-specific header when building for Android, and the "common" header on non-Android.

Googlers can see b/192351260#comment13 for details.