### PR TITLE
Fix regex replacement to properly quote meta characters.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,7 +203,7 @@ if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
          "([][+.*()^])" "\\\\\\1"  # Yes, this many \'s is correct.
          current_list_dir_regex
          "${CMAKE_CURRENT_LIST_DIR}")
-  # Figure out where app's binary_dir wasabi.
+  # Figure out where app's binary_dir was.
   string(REGEX REPLACE
     "${current_list_dir_regex}/[^/]+/(.*)"
     "${CMAKE_CURRENT_LIST_DIR}/app/\\1"

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,7 +197,7 @@ if(FIREBASE_INCLUDE_FIRESTORE AND DESKTOP)
 endif()
 
 if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
-  # Quote meta characters in "${CMAKE_CURRENT_LIST_DIR} so we can
+  # Quote meta characters in ${CMAKE_CURRENT_LIST_DIR} so we can
   # match it in a regex.
   string(REGEX REPLACE
          "([][+.*()^])" "\\\\\\1"  # Yes, this many \'s is correct.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -199,6 +199,8 @@ endif()
 if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
   # Quote meta characters in ${CMAKE_CURRENT_LIST_DIR} so we can
   # match it in a regex.
+  # For example, '/path/with/+meta/char.acters' will become
+  # '/path/with/\+meta/char\.acters'.
   string(REGEX REPLACE
          "([][+.*()^])" "\\\\\\1"  # Yes, this many \'s is correct.
          current_list_dir_regex

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -197,9 +197,15 @@ if(FIREBASE_INCLUDE_FIRESTORE AND DESKTOP)
 endif()
 
 if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
-  # Figure out where app's binary_dir was.
+  # Quote meta characters in "${CMAKE_CURRENT_LIST_DIR} so we can
+  # match it in a regex.
   string(REGEX REPLACE
-    "${CMAKE_CURRENT_LIST_DIR}/[^/]+/(.*)"
+         "([][+.*()^])" "\\\\\\1"  # Yes, this many \'s is correct.
+	 current_list_dir_regex
+         "${CMAKE_CURRENT_LIST_DIR}")
+  # Figure out where app's binary_dir wasabi.
+  string(REGEX REPLACE
+    "${current_list_dir_regex}/[^/]+/(.*)"
     "${CMAKE_CURRENT_LIST_DIR}/app/\\1"
     APP_BINARY_DIR "${FIREBASE_BINARY_DIR}")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -201,7 +201,7 @@ if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
   # match it in a regex.
   string(REGEX REPLACE
          "([][+.*()^])" "\\\\\\1"  # Yes, this many \'s is correct.
-	 current_list_dir_regex
+         current_list_dir_regex
          "${CMAKE_CURRENT_LIST_DIR}")
   # Figure out where app's binary_dir wasabi.
   string(REGEX REPLACE


### PR DESCRIPTION
Fix for #523, error building for Android when source path contains regex meta characters (e.g. +).
