### PR TITLE
Test/gha windows build errors

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -85,6 +85,8 @@ jobs:
         with:
           submodules: true
       
+      # TODO: remove this after we fix issues with our SDK
+      # build and cmake 3.21 on Windows.
       - name: Setup cmake
         if: startsWith(matrix.os, 'windows')
         uses: jwlawson/actions-setup-cmake@v1.9

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -85,6 +85,12 @@ jobs:
         with:
           submodules: true
       
+      - name: Setup cmake
+        if: startsWith(matrix.os, 'windows')
+        uses: jwlawson/actions-setup-cmake@v1.9
+        with:
+          cmake-version: '3.20.5'
+
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -249,6 +249,13 @@ jobs:
       - name: Add msbuild to PATH (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
+      # TODO: remove this after we fix issues with our SDK
+      # build and cmake 3.21 on Windows.
+      - name: Setup cmake
+        if: startsWith(matrix.os, 'windows')
+        uses: jwlawson/actions-setup-cmake@v1.9
+        with:
+          cmake-version: '3.20.5'
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg
         uses: actions/cache@v2
@@ -407,6 +414,13 @@ jobs:
       - name: Add msbuild to PATH (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2
+      # TODO: remove this after we fix issues with our SDK
+      # build and cmake 3.21 on Windows.
+      - name: Setup cmake
+        if: startsWith(matrix.os, 'windows')
+        uses: jwlawson/actions-setup-cmake@v1.9
+        with:
+          cmake-version: '3.20.5'
       - name: Cache NDK
         id: cache_ndk
         uses: actions/cache@v2


### PR DESCRIPTION
All of our windows builds that ran on Github runners with the updated Windows software (20210719.0) had errors yesterday. Those that ran on older software worked just fine. After some trial and error, it looks like the CMake update from 3.20.5 to 3.21 seems to be breaking our builds. 
Temporarily, am using a github action to force using a specific (older) cmake version that worked for us. Note that 3.21 works fine on linux and mac. It is only causing issues on Windows. 

[Windows software update comparison 20210719 vs 20210711](https://github.com/actions/virtual-environments/commit/a2b7ff271cac82fed6ac6d874af59c0967942d6d#diff-816219d3c9f30fcc1c40f88ca826c1662bf99eded781c1b419dd2dfb577ae227)

This is an example error that was happening with CMake 3.21 on Windows,
```
CMake Error at build/external/src/zlib/CMakeLists.txt:234 (target_link_libraries):
  Attempt to add link library "zlib" to target "example" which is not built
  in this directory.
  This is allowed only when policy CMP0079 is set to NEW.
```

Digging some more, it looks like this policy is set to OLD from CMake 3.21
`This policy was introduced in CMake version 3.13. CMake version 3.21.0 warns when the policy is not set and uses OLD behavior`