### PR TITLE
Fix a use-after-free bug in BundleTest.CanDeleteFirestoreFromProgressUpdate

### DIFF
--- a/firestore/integration_test_internal/src/bundle_test.cc
+++ b/firestore/integration_test_internal/src/bundle_test.cc
@@ -177,8 +177,12 @@ TEST_F(BundleTest, CanDeleteFirestoreFromProgressUpdate) {
         progresses.push_back(progress);
         // Delete firestore before the final progress.
         if (progresses.size() == 3) {
+          // Save `db_deleted` to a local variable because this lambda gets
+          // deleted by the call to `DeleteFirestore()` below, and therefore it
+          // is undefined behavior to access any captured variables thereafter.
+          auto& db_deleted_local = db_deleted;
           DeleteFirestore(db);
-          db_deleted.set_value();
+          db_deleted_local.set_value();
         }
       });
 


### PR DESCRIPTION
Fix a heap-use-after-free bug in [`BundleTest.CanDeleteFirestoreFromProgressUpdate`](https://github.com/firebase/firebase-cpp-sdk/blob/8f6bb51314f2710e120a19c372d3ca6b365c5f4d/firestore/integration_test_internal/src/bundle_test.cc#L168-L198).

Here is the relevant code from the test that is problematic:

```
172 std::promise<void> db_deleted;
173 std::vector<LoadBundleTaskProgress> progresses;
174 Future<LoadBundleTaskProgress> result =
175     db->LoadBundle(bundle, [this, db, &progresses, &db_deleted](
176                                const LoadBundleTaskProgress& progress) {
177       progresses.push_back(progress);
178       // Delete firestore before the final progress.
179       if (progresses.size() == 3) {
180         DeleteFirestore(db);
181         db_deleted.set_value();
182       }
183     });
184
185 // Wait for the notification that the instance is deleted before verifying.
186 db_deleted.get_future().wait();
```

The memory access violation occurs on line 181: `db_deleted.set_value()`. The reason is that the preceding call to `DeleteFirestore(db)` causes the `FirestoreInternal` object to be deleted, which causes its [`bundle_listeners_`](https://github.com/firebase/firebase-cpp-sdk/blob/8f6bb51314f2710e120a19c372d3ca6b365c5f4d/firestore/src/android/firestore_android.h#L186) member to be deleted. Now `bundle_listeners_` is a `std::vector` that stores the lambda specified to `db->LoadBundle()`, the lambda that is currently executing. This lambda's capture expression captured `&db_deleted` and therefore the call to `db_deleted.set_value()` is technically `this->db_deleted.set_value()` where `this` is the lambda itself... but the lambda has been deleted.

The fix is to save `db_deleted` to a local variable prior to calling `DeleteFirestore(db)` and then invoke `set_value()` on the local variable, thus removing the reference to the deleted lambda.