### PR TITLE
Reset Android Emulator on test errors

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -750,7 +750,7 @@ jobs:
         shell: bash
         run: |
           if [ ! -f testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json ]; then
-            echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
           fi
       - name: Upload Desktop test results artifact
         if: ${{ !cancelled() }}
@@ -836,7 +836,7 @@ jobs:
         shell: bash
         run: |
           if [ ! -f "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json" ]; then
-            echo "__SUMMARY_MISSING__" > "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json"
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json"
           fi
       - name: Upload Android test results artifact
         if: ${{ !cancelled() }}
@@ -921,7 +921,7 @@ jobs:
         shell: bash
         run: |
           if [ ! -f "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json" ]; then
-            echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json"
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json"
           fi
       - name: Upload iOS test results artifact
         if: ${{ !cancelled() }}
@@ -990,7 +990,7 @@ jobs:
         shell: bash
         run: |
           if [ ! -f "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json" ]; then
-            echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json"
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json"
           fi
       - name: Upload tvOS test results artifact
         if: ${{ !cancelled() }}

--- a/scripts/gha/it_workflow.py
+++ b/scripts/gha/it_workflow.py
@@ -62,7 +62,7 @@ _COMMENT_TITLE_PROGESS_FAIL = "### ❌&nbsp; Integration test FAILED (but still 
 _COMMENT_TITLE_FAIL = "### ❌&nbsp; Integration test FAILED\n"
 _COMMENT_TITLE_SUCCEED = "### ✅&nbsp; Integration test succeeded!\n"
 
-_COMMENT_FLAKY_TRACKER = "\nAdd flaky tests to **[go/fpl-cpp-flake-tracker](http://go/fpl-cpp-flake-tracker)**\n"
+_COMMENT_FLAKY_TRACKER = "\n\nAdd flaky tests to **[go/fpl-cpp-flake-tracker](http://go/fpl-cpp-flake-tracker)**\n"
 
 _COMMENT_IDENTIFIER = "integration-test-status-comment"
 _COMMENT_SUFFIX = f'\n\n\n<hidden value="{_COMMENT_IDENTIFIER}"></hidden>'
@@ -130,6 +130,7 @@ def test_progress(token, issue_number, actor, commit, run_id):
     comment = (_COMMENT_TITLE_PROGESS_FAIL +
                _get_description(actor, commit, run_id) +
                log_summary +
+               _COMMENT_FLAKY_TRACKER +
                _COMMENT_SUFFIX)
     _update_comment(token, issue_number, comment)
 
@@ -150,6 +151,7 @@ def test_end(token, issue_number, actor, commit, run_id, new_token):
     comment = (_COMMENT_TITLE_FAIL +
                _get_description(actor, commit, run_id) +
                log_summary +
+               _COMMENT_FLAKY_TRACKER +
                _COMMENT_SUFFIX)
     _update_comment(token, issue_number, comment)
 

--- a/scripts/gha/test_lab.py
+++ b/scripts/gha/test_lab.py
@@ -278,6 +278,7 @@ class Test(object):
       self.raw_result_link = raw_result_link.group(1)
 
     self.logs = self._get_testapp_log_text_from_gcs()
+    logging.info("Test result: %s", self.logs)
 
   @property
   def _gcloud_command(self):

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -503,9 +503,9 @@ def _setup_android(platform_version, build_tool_version, sdk_id):
   logging.info("Install packages: %s", " ".join(args))
   subprocess.run(args=args, check=True)
 
-  args = ["yes", "|", "sdkmanager", "--licenses"]
-  logging.info("Accept all licenses: %s", " ".join(args))
-  subprocess.run(" ".join(args), shell=True, check=False)
+  command = "yes | sdkmanager --licenses"
+  logging.info("Accept all licenses: %s", command)
+  subprocess.run(command, shell=True, check=False)
 
   args = ["sdkmanager", sdk_id]
   logging.info("Download an emulator: %s", " ".join(args))
@@ -521,16 +521,17 @@ def _shutdown_emulator():
   logging.info("Kill all running emulator: %s", command)
   subprocess.Popen(command, universal_newlines=True, shell=True, stdout=subprocess.PIPE)
 
+  args = ["adb", "kill-server"]
+  logging.info("Kill adb server: %s", " ".join(args))
+  subprocess.run(args=args, check=False)
+
+
 def _create_and_boot_emulator(sdk_id):
   _shutdown_emulator()
 
-  args = ["echo", "no", "|", "avdmanager", "-s", 
-    "create", "avd", 
-    "-n", "test_emulator", 
-    "-k", "'"+sdk_id+"'", 
-    "-f"] 
-  logging.info("Create an emulator: %s", " ".join(args))
-  subprocess.run(" ".join(args), shell=True, check=True)
+  command = "echo no | avdmanager -s create avd -n test_emulator -k '%s' -f" % sdk_id
+  logging.info("Create an emulator: %s", command)
+  subprocess.run(command, shell=True, check=True)
 
   args = ["adb", "start-server"]
   logging.info("Start adb server: %s", " ".join(args))
@@ -545,7 +546,7 @@ def _create_and_boot_emulator(sdk_id):
 
   args = ["adb", "wait-for-device"]
   logging.info("Wait for emulator to boot: %s", " ".join(args))
-  subprocess.run(args=args, check=True)
+  subprocess.run(args=args, check=False)
 
   if FLAGS.ci: 
     # wait extra 90 seconds to ensure emulator booted.
@@ -603,6 +604,7 @@ def _uninstall_android_app(package_name):
 def _install_android_gameloop_app(gameloop_project):
   os.chdir(gameloop_project)
   logging.info("CD to gameloop_project: %s", gameloop_project)
+  _uninstall_android_app("com.google.firebase.gameloop")
   args = ["./gradlew", "clean"]
   logging.info("Clean game-loop cache: %s", " ".join(args))
   subprocess.run(args=args, check=False)

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -609,7 +609,9 @@ def _run_instrumented_test():
   args = ["adb", "shell", "am", "instrument",
     "-w", "%s.test/androidx.test.runner.AndroidJUnitRunner" % _GAMELOOP_PACKAGE] 
   logging.info("Running game-loop test: %s", " ".join(args))
-  subprocess.run(args=args, check=False) 
+  result = subprocess.run(args=args, capture_output=True, text=True, check=False) 
+  logging.info("game-loop test result: %s", result.stdout)
+  logging.info("game-loop test error: %s", result.stderr)
 
 
 def _get_android_test_log(test_package):

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -520,10 +520,11 @@ def _shutdown_emulator():
   command = "adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done"
   logging.info("Kill all running emulator: %s", command)
   subprocess.Popen(command, universal_newlines=True, shell=True, stdout=subprocess.PIPE)
-
+  time.sleep(5)
   args = ["adb", "kill-server"]
   logging.info("Kill adb server: %s", " ".join(args))
   subprocess.run(args=args, check=False)
+  time.sleep(5)
 
 
 def _create_and_boot_emulator(sdk_id):

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -461,7 +461,9 @@ def _get_apple_test_log(bundle_id, app_path, device_id):
     return None
 
   log_path = os.path.join(result.stdout.strip(), "Documents", "GameLoopResults", _RESULT_FILE) 
-  return _read_file(log_path) 
+  log = _read_file(log_path) 
+  logging.info("Apple test result: %s", log)
+  return log
 
 
 def _read_file(path):
@@ -629,6 +631,7 @@ def _get_android_test_log(test_package):
   args = ["adb", "shell", "su", "0", "cat", path]
   logging.info("Get android test result: %s", " ".join(args))
   result = subprocess.run(args=args, capture_output=True, text=True, check=False)
+  logging.info("Android test result: %s", result.stdout)
   return result.stdout
 
 

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -503,12 +503,9 @@ def _setup_android(platform_version, build_tool_version, sdk_id):
   logging.info("Install packages: %s", " ".join(args))
   subprocess.run(args=args, check=True)
 
-  args = ["sdkmanager", "--licenses"]
+  args = ["yes", "|", "sdkmanager", "--licenses"]
   logging.info("Accept all licenses: %s", " ".join(args))
-  p_yes = subprocess.Popen(["echo", "yes"], stdout=subprocess.PIPE)
-  proc = subprocess.Popen(args, stdin=p_yes.stdout, stdout=subprocess.PIPE)
-  p_yes.stdout.close()
-  proc.communicate()
+  subprocess.run(" ".join(args), shell=True, check=False)
 
   args = ["sdkmanager", sdk_id]
   logging.info("Download an emulator: %s", " ".join(args))
@@ -527,16 +524,13 @@ def _shutdown_emulator():
 def _create_and_boot_emulator(sdk_id):
   _shutdown_emulator()
 
-  args = ["avdmanager", "-s", 
+  args = ["echo", "no", "|", "avdmanager", "-s", 
     "create", "avd", 
     "-n", "test_emulator", 
-    "-k", sdk_id, 
-    "-f"]
+    "-k", "'"+sdk_id+"'", 
+    "-f"] 
   logging.info("Create an emulator: %s", " ".join(args))
-  p_no = subprocess.Popen(["echo", "no"], stdout=subprocess.PIPE)
-  proc = subprocess.Popen(args, stdin=p_no.stdout, stdout=subprocess.PIPE)
-  p_no.stdout.close()
-  proc.communicate()
+  subprocess.run(" ".join(args), shell=True, check=True)
 
   args = ["adb", "start-server"]
   logging.info("Start adb server: %s", " ".join(args))

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -608,6 +608,10 @@ def _uninstall_android_app(package_name):
 
 def _install_android_gameloop_app(gameloop_project):
   os.chdir(gameloop_project)
+  logging.info("CD to gameloop_project: %s", gameloop_project)
+  args = ["./gradlew", "clean"]
+  logging.info("Clean game-loop cache: %s", " ".join(args))
+  subprocess.run(args=args, check=False)
   args = ["./gradlew", "installDebug", "installDebugAndroidTest"]
   logging.info("Installing game-loop app and test: %s", " ".join(args))
   subprocess.run(args=args, check=True)

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -558,14 +558,13 @@ def _create_and_boot_emulator(sdk_id):
     time.sleep(45)
 
 
-def _reset_emulator_on_error(instrumented_test_result):
+def _reset_emulator_on_error(gameloop_project, instrumented_test_result):
   logging.info("game-loop test result: %s", instrumented_test_result)
   if "FAILURES!!!" in instrumented_test_result:
+    logging.info("game-loop test error!!! reset emualtor...")
     sdk_id = TEST_DEVICES.get(FLAGS.android_device).get("image") if FLAGS.android_device else FLAGS.android_sdk
     _create_and_boot_emulator(sdk_id)
-    current_dir = pathlib.Path(__file__).parent.absolute()
-    android_gameloop_project = os.path.join(current_dir, "integration_testing", "gameloop_android")
-    _install_android_gameloop_app(android_gameloop_project)
+    _install_android_gameloop_app(gameloop_project)
 
 
 def _get_package_name(app_path):
@@ -579,7 +578,7 @@ def _get_package_name(app_path):
 def _run_android_gameloop_test(package_name, app_path, gameloop_project, retry=1): 
   logging.info("Running android gameloop test: %s, %s, %s", package_name, app_path, gameloop_project)
   _install_android_app(app_path)
-  _run_instrumented_test()
+  _run_instrumented_test(gameloop_project)
   log = _get_android_test_log(package_name)
   _uninstall_android_app(package_name)
   if retry > 1:
@@ -612,7 +611,7 @@ def _install_android_gameloop_app(gameloop_project):
   subprocess.run(args=args, check=True)
 
 
-def _run_instrumented_test():
+def _run_instrumented_test(gameloop_project):
   """Run the gameloop UI Test app.
     This gameloop app can run integration_test app automatically.
   """
@@ -620,7 +619,7 @@ def _run_instrumented_test():
     "-w", "%s.test/androidx.test.runner.AndroidJUnitRunner" % _GAMELOOP_PACKAGE] 
   logging.info("Running game-loop test: %s", " ".join(args))
   result = subprocess.run(args=args, capture_output=True, text=True, check=False) 
-  _reset_emulator_on_error(result.stdout)
+  _reset_emulator_on_error(gameloop_project, result.stdout)
 
 
 def _get_android_test_log(test_package):


### PR DESCRIPTION
1. Reset Android Emulator on test errors (fix [error](https://github.com/firebase/firebase-cpp-sdk/runs/3160571123?check_suite_focus=true#step:7:1595))
2. Create directory if not exist (fix [error](https://github.com/firebase/firebase-cpp-sdk/runs/3160481427?check_suite_focus=true#step:10:17))
3. Insert two newline after markdown table (fix [report](https://github.com/firebase/firebase-cpp-sdk/issues/464#issue-919307237))
4. Print out full integration test logs as required.