### PR TITLE
Cause Firestore build error if non-Android headers get included in an Android build

### DIFF
--- a/firestore/src/main/collection_reference_main.h
+++ b/firestore/src/main/collection_reference_main.h
@@ -10,6 +10,10 @@
 #include "firestore/src/main/promise_factory_main.h"
 #include "firestore/src/main/query_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/converter_main.h
+++ b/firestore/src/main/converter_main.h
@@ -29,6 +29,10 @@
 #include "firestore/src/main/transaction_main.h"
 #include "firestore/src/main/write_batch_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/create_credentials_provider.h
+++ b/firestore/src/main/create_credentials_provider.h
@@ -7,6 +7,10 @@
 
 #include "Firestore/core/src/auth/credentials_provider.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 
 class App;

--- a/firestore/src/main/create_firebase_metadata_provider.h
+++ b/firestore/src/main/create_firebase_metadata_provider.h
@@ -7,6 +7,10 @@
 
 #include "Firestore/core/src/remote/firebase_metadata_provider.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 
 class App;

--- a/firestore/src/main/credentials_provider_desktop.h
+++ b/firestore/src/main/credentials_provider_desktop.h
@@ -14,6 +14,10 @@
 #include "app/src/include/firebase/app.h"
 #include "app/src/include/firebase/future.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/document_change_main.h
+++ b/firestore/src/main/document_change_main.h
@@ -9,6 +9,10 @@
 #include "firestore/src/include/firebase/firestore/document_change.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/document_reference_main.h
+++ b/firestore/src/main/document_reference_main.h
@@ -15,6 +15,10 @@
 #include "firestore/src/main/promise_factory_main.h"
 #include "firestore/src/main/user_data_converter_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/document_snapshot_main.h
+++ b/firestore/src/main/document_snapshot_main.h
@@ -16,6 +16,10 @@
 #include "firestore/src/include/firebase/firestore/snapshot_metadata.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/field_value_main.h
+++ b/firestore/src/main/field_value_main.h
@@ -16,6 +16,10 @@
 #include "firestore/src/include/firebase/firestore/field_value.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/firebase_metadata_provider_desktop.h
+++ b/firestore/src/main/firebase_metadata_provider_desktop.h
@@ -5,6 +5,10 @@
 
 #include "Firestore/core/src/remote/firebase_metadata_provider.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 
 namespace firestore {

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -22,6 +22,10 @@
 #include "firestore/src/include/firebase/firestore/settings.h"
 #include "firestore/src/main/promise_factory_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/listener_main.h
+++ b/firestore/src/main/listener_main.h
@@ -14,6 +14,10 @@
 #include "firestore/src/main/converter_main.h"
 #include "firestore/src/main/promise_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/listener_registration_main.h
+++ b/firestore/src/main/listener_registration_main.h
@@ -8,6 +8,10 @@
 #include "Firestore/core/src/api/listener_registration.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/promise_factory_main.h
+++ b/firestore/src/main/promise_factory_main.h
@@ -11,6 +11,10 @@
 #include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/main/promise_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 class CleanupNotifier;
 

--- a/firestore/src/main/promise_main.h
+++ b/firestore/src/main/promise_main.h
@@ -15,6 +15,10 @@
 #include "firebase/firestore/firestore_errors.h"
 #include "firestore/src/common/hard_assert_common.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/query_main.h
+++ b/firestore/src/main/query_main.h
@@ -16,6 +16,10 @@
 #include "firestore/src/main/promise_factory_main.h"
 #include "firestore/src/main/user_data_converter_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/query_snapshot_main.h
+++ b/firestore/src/main/query_snapshot_main.h
@@ -16,6 +16,10 @@
 #include "firestore/src/include/firebase/firestore/snapshot_metadata.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/set_options_main.h
+++ b/firestore/src/main/set_options_main.h
@@ -7,6 +7,10 @@
 
 #include "firestore/src/include/firebase/firestore/set_options.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/source_main.h
+++ b/firestore/src/main/source_main.h
@@ -7,6 +7,10 @@
 #include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/include/firebase/firestore/source.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/transaction_main.h
+++ b/firestore/src/main/transaction_main.h
@@ -13,6 +13,10 @@
 #include "firestore/src/main/firestore_main.h"
 #include "firestore/src/main/user_data_converter_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/user_data_converter_main.h
+++ b/firestore/src/main/user_data_converter_main.h
@@ -14,6 +14,10 @@
 #include "firestore/src/include/firebase/firestore/field_value.h"
 #include "firestore/src/include/firebase/firestore/map_field_value.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/util_main.h
+++ b/firestore/src/main/util_main.h
@@ -7,6 +7,10 @@
 #include "firestore/src/include/firebase/firestore.h"
 #include "firestore/src/main/firestore_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 

--- a/firestore/src/main/write_batch_main.h
+++ b/firestore/src/main/write_batch_main.h
@@ -11,6 +11,10 @@
 #include "firestore/src/main/promise_factory_main.h"
 #include "firestore/src/main/user_data_converter_main.h"
 
+#if defined(__ANDROID__)
+#error "This header should not be used on Android."
+#endif
+
 namespace firebase {
 namespace firestore {
 


### PR DESCRIPTION
This will help avoid ODR violations like the one fixed by #559.