### PR TITLE
Add check for release notes update.

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
     # Don't bother doing this if the PR is already closed or has the no-release-notes label.
-    if: github.event.pull_request.state == 'open' && !contains(github.event.pull_request.labels.*.name, github.env.skipReleaseNotesLabel)
+    if: github.event.pull_request.state == 'open' && !contains(github.event.pull_request.labels.*.name, '${{env.skipReleaseNotesLabel}}')
     steps:
       - uses: actions/checkout@v2
         with:
@@ -107,13 +107,6 @@ jobs:
       - name: Check whether release notes have been updated
         run: |
           set -e
-          cat <<EOF
-          LABEL NAMES
-          ${{toJSON(github.event.pull_request.labels.*.name)}}
-
-          LABELS
-          ${{toJSON(github.event.pull_request.labels)}}
-          EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md
           # Determine the github merge base - same logic as integration_tests.yml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,16 +102,13 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: |
-          ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && github.event.pull_request.base.name == 'main'}}
-          ${{github.event.pull_request.head.name}} == 'main'
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.name == 'main')}}
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: |
-          ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && github.event.pull_request.base.name == 'main'}}
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.name == 'main')}}
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,18 +102,15 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.ref == 'main')}}
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.ref == 'main')}}
         run: |
           set -e
-          cat <<EOF
-          ${{toJSON(github.event.pull_request)}}
-          EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md
           # Determine the github merge base - same logic as integration_tests.yml

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,14 +112,11 @@ jobs:
           # Determine the github merge base - same logic as integration_tests.yml
           # "git merge-base main branch_name" will give the common ancestor of both branches.
           MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
-          echo "Merge base: ${MERGE_BASE}"
-          # If MERGE_BASE can't be determined, just use "main"
-          if [[ -z "${MERGE_BASE}" ]]; then
-            echo "Defaulting to origin/main"
-            MERGE_BASE=origin/main
-          fi
-          DIFF_RESULT_=$(git diff --name-only "origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" -- "${README_FILE}")
-          if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
-            echo "::error :Please update release notes (${README_FILE}) or add '${{env.skipReleaseNotesLabel}}' label."
-            exit 1
+          # If MERGE_BASE can't be determined, ignore this check, something odd is going on.
+          if [[ -n "${MERGE_BASE}" ]]; then
+            DIFF_RESULT_=$(git diff --name-only "origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" -- "${README_FILE}")
+            if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
+              echo "::error ::Please update release notes (${README_FILE}) or add '${{env.skipReleaseNotesLabel}}' label."
+              exit 1
+            fi
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,13 +98,15 @@ jobs:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
     # Don't bother doing this if the PR is already closed or has the no-release-notes label.
-    if: github.event.pull_request.state == 'open' && !contains(github.event.pull_request.labels.*.name, '${{env.skipReleaseNotesLabel}}')
+    if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
+        if: !contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
+        if: !contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,12 +101,12 @@ jobs:
     if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
-        if: !contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
-        if: !contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,8 +97,6 @@ jobs:
   release_notes_check:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
-    # Don't bother doing this if the PR is already closed.
-    if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,14 +101,17 @@ jobs:
     if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
-        # Skip this if the PR has the skipReleaseNotes label.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
+        if: |
+          ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && github.event.pull_request.base.name == 'main'}}
+          ${{github.event.pull_request.head.name}} == 'main'
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
-        # Skip this if the PR has the skipReleaseNotes label.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
+        if: |
+          ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && github.event.pull_request.base.name == 'main'}}
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -92,3 +92,30 @@ jobs:
         run: |
           set -e
           bash scripts/gha/check_copyright.sh -g
+
+  release_notes_check:
+    # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
+    runs-on: ubuntu-latest
+    # Don't bother doing this if the PR is already closed or has the no-release-notes label.
+    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, 'no-release-notes')
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          submodules: false
+      - name: Check if readme has been modified vs. the base ref.
+        run: |
+          set -e
+          # Filename to check.
+          README_FILE=release_build_files/readme.md
+          # Determine the github merge base - same logic as integration_tests.yml
+          # "git merge-base main branch_name" will give the common ancestor of both branches.
+          MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
+          # If MERGE_BASE can't be determined, just use "main"
+          if [[ -z "${MERGE_BASE}" ]]; then
+            MERGE_BASE=main
+          fi
+          DIFF_RESULT_=$(git diff --name-only "${MERGE_BASE}" -- "${README_FILE}")
+          if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
+            echo "::error :Please update release notes (${README_FILE}) or add no-release-notes label."
+            exit 1
+          fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -111,11 +111,13 @@ jobs:
           # Determine the github merge base - same logic as integration_tests.yml
           # "git merge-base main branch_name" will give the common ancestor of both branches.
           MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
+          echo "Merge base: ${MERGE_BASE}"
           # If MERGE_BASE can't be determined, just use "main"
           if [[ -z "${MERGE_BASE}" ]]; then
-            MERGE_BASE=main
+            echo "Defaulting to origin/main"
+            MERGE_BASE=origin/main
           fi
-          DIFF_RESULT_=$(git diff --name-only "${MERGE_BASE}" -- "${README_FILE}")
+          DIFF_RESULT_=$(git diff --name-only "origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" -- "${README_FILE}")
           if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
             echo "::error :Please update release notes (${README_FILE}) or add '${{env.skipReleaseNotesLabel}}' label."
             exit 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -95,7 +95,7 @@ jobs:
           bash scripts/gha/check_copyright.sh -g
 
   release_notes_check:
-    # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
+    # Check that the readme was updated, unless the PR has a specific label set (env.skipReleaseNotesLabel).
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -116,7 +116,7 @@ jobs:
           MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
           # If MERGE_BASE can't be determined, ignore this check, something odd is going on.
           if [[ -n "${MERGE_BASE}" ]]; then
-            DIFF_RESULT_=$(git diff --name-only "origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" -- "${README_FILE}")
+            DIFF_RESULT=$(git diff --name-only "origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" -- "${README_FILE}")
             if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
               echo "::error ::Please update release notes (${README_FILE}) or add '${{env.skipReleaseNotesLabel}}' label."
               exit 1

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           set -e
           cat <<EOF
-          ${{github.event.pull_request}}
+          ${{toJSON(github.event.pull_request)}}
           EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -104,9 +104,16 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
-      - name: Check if readme has been modified vs. the base ref.
+      - name: Check whether release notes have been updated
         run: |
           set -e
+          cat <<EOF
+          LABEL NAMES
+          ${{github.event.issue.labels.*.name}}
+
+          LABELS
+          ${{github.event.issue.labels}}
+          EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md
           # Determine the github merge base - same logic as integration_tests.yml
@@ -120,3 +127,4 @@ jobs:
               exit 1
             fi
           fi
+          

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -109,10 +109,10 @@ jobs:
           set -e
           cat <<EOF
           LABEL NAMES
-          ${{github.event.pull_request.labels.*.name}}
+          ${{toJSON(github.event.pull_request.labels.*.name)}}
 
           LABELS
-          ${{github.event.pull_request.labels}}
+          ${{toJSON(github.event.pull_request.labels)}}
           EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -101,12 +101,12 @@ jobs:
     if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        if: contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) == 0
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
+        if: contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) == 0
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -9,6 +9,7 @@ env:
   triggerLabelQuick: "tests-requested: quick"
   statusLabelInProgress: "tests: in-progress"
   statusLabelFailed: "tests: failed"
+  skipReleaseNotesLabel: "skip-release-notes"
 
 jobs:
   file_format_check:
@@ -97,7 +98,7 @@ jobs:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
     # Don't bother doing this if the PR is already closed or has the no-release-notes label.
-    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, 'no-release-notes')
+    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, env.skipReleaseNotesLabel)
     steps:
       - uses: actions/checkout@v2
         with:
@@ -116,6 +117,6 @@ jobs:
           fi
           DIFF_RESULT_=$(git diff --name-only "${MERGE_BASE}" -- "${README_FILE}")
           if [[ "${DIFF_RESULT}" != "${README_FILE}" ]]; then
-            echo "::error :Please update release notes (${README_FILE}) or add no-release-notes label."
+            echo "::error :Please update release notes (${README_FILE}) or add '${{env.skipReleaseNotesLabel}}' label."
             exit 1
           fi

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -97,16 +97,18 @@ jobs:
   release_notes_check:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
-    # Don't bother doing this if the PR is already closed or has the no-release-notes label.
+    # Don't bother doing this if the PR is already closed.
     if: github.event.pull_request.state == 'open'
     steps:
       - uses: actions/checkout@v2
-        if: contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) == 0
+        # Skip this if the PR has the skipReleaseNotes label.
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
-        if: contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) == 0
+        # Skip this if the PR has the skipReleaseNotes label.
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         run: |
           set -e
           # Filename to check.

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
     # Don't bother doing this if the PR is already closed or has the no-release-notes label.
-    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, env.skipReleaseNotesLabel)
+    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, github.env.skipReleaseNotesLabel)
     steps:
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -98,7 +98,7 @@ jobs:
     # Check that the readme was updated, unless the PR has the 'no-release-notes' flag.
     runs-on: ubuntu-latest
     # Don't bother doing this if the PR is already closed or has the no-release-notes label.
-    if: github.event.pull_request.state == 'open' && !contains(github.event.issue.labels.*.name, github.env.skipReleaseNotesLabel)
+    if: github.event.pull_request.state == 'open' && !contains(github.event.pull_request.labels.*.name, github.env.skipReleaseNotesLabel)
     steps:
       - uses: actions/checkout@v2
         with:
@@ -109,10 +109,10 @@ jobs:
           set -e
           cat <<EOF
           LABEL NAMES
-          ${{github.event.issue.labels.*.name}}
+          ${{github.event.pull_request.labels.*.name}}
 
           LABELS
-          ${{github.event.issue.labels}}
+          ${{github.event.pull_request.labels}}
           EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,6 +102,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         with:
+          fetch-depth: 0
           submodules: false
       - name: Check if readme has been modified vs. the base ref.
         run: |

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -102,15 +102,18 @@ jobs:
     steps:
       - uses: actions/checkout@v2
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.name == 'main')}}
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         with:
           fetch-depth: 0
           submodules: false
       - name: Check whether release notes have been updated
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
-        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.name == 'main')}}
+        if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel)}}
         run: |
           set -e
+          cat <<EOF
+          ${{github.event.pull_request}}
+          EOF
           # Filename to check.
           README_FILE=release_build_files/readme.md
           # Determine the github merge base - same logic as integration_tests.yml


### PR DESCRIPTION
All PRs merging to `main` must either modify `release_build_files/readme.md` or contain the label `skip-release-notes`.