### PR TITLE
Fix ReferenceCountedFutureImpl to avoid using FirestoreInternal after its deletion.

### DIFF
--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -110,6 +110,7 @@ set(FIREBASE_INTEGRATION_TEST_ANDROID_TEST_SRCS
     src/android/geo_point_android_test.cc
     src/android/jni_runnable_android_test.cc
     src/android/promise_android_test.cc
+    src/android/promise_factory_android_test.cc
     src/android/settings_android_test.cc
     src/android/snapshot_metadata_android_test.cc
     src/android/timestamp_android_test.cc

--- a/firestore/integration_test_internal/src/android/promise_android_test.cc
+++ b/firestore/integration_test_internal/src/android/promise_android_test.cc
@@ -403,6 +403,24 @@ TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskCancels) {
   EXPECT_EQ(completion.result(), nullptr);
 }
 
+TEST_F(PromiseTest, RegisterForTaskShouldNotCrashIfFirestoreWasDeleted) {
+  jni::Env env = GetEnv();
+  auto promise = promises().MakePromise<void>();
+  DeleteFirestore(TestFirestore());
+
+  promise.RegisterForTask(env, AsyncFn::kFn, GetTask());
+}
+
+TEST_F(PromiseTest, GetFutureShouldNotCrashIfFirestoreWasDeleted) {
+  jni::Env env = GetEnv();
+  auto promise = promises().MakePromise<void>();
+  promise.RegisterForTask(env, AsyncFn::kFn, GetTask());
+  DeleteFirestore(TestFirestore());
+
+  auto future = promise.GetFuture();
+  EXPECT_EQ(future.status(), FutureStatus::kFutureStatusInvalid);
+}
+
 }  // namespace
 }  // namespace firestore
 }  // namespace firebase

--- a/firestore/integration_test_internal/src/android/promise_factory_android_test.cc
+++ b/firestore/integration_test_internal/src/android/promise_factory_android_test.cc
@@ -1,0 +1,132 @@
+// Copyright 2021 Google LLC
+
+#include "firestore/src/android/promise_factory_android.h"
+
+#include <utility>
+
+#include "android/firestore_integration_test_android.h"
+#include "android/task_completion_source.h"
+#include "firebase/future.h"
+#include "firestore/src/android/converter_android.h"
+#include "firestore/src/android/firestore_android.h"
+#include "firestore/src/jni/env.h"
+#include "firestore/src/jni/integer.h"
+#include "firestore/src/jni/ownership.h"
+#include "firestore/src/jni/task.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace firestore {
+namespace {
+
+using jni::Env;
+using jni::Integer;
+using jni::Local;
+using jni::Task;
+
+// Since `PromiseFactory` acts as a "constructor" of `Promise` objects, its
+// ability to create `Promise` objects is thoroughly tested in the unit tests
+// for `Promise` and therefore the tests here only cover the other aspects of
+// `PromiseFactory`, such as move semantics.
+
+class PromiseFactoryTest : public FirestoreAndroidIntegrationTest {
+ public:
+  // An enum of asynchronous functions to use in tests, as required by
+  // `FutureManager`.
+  enum class AsyncFn {
+    kFn,
+    kCount,  // Must be the last enum value.
+  };
+
+ protected:
+  void AssertCreatesValidFutures(Env& env,
+                                 PromiseFactory<AsyncFn>& promise_factory) {
+    Local<TaskCompletionSource> tcs = TaskCompletionSource::Create(env);
+    Local<Task> task = tcs.GetTask(env);
+    Future<void> future =
+        promise_factory.NewFuture<void>(env, AsyncFn::kFn, task);
+    EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
+    tcs.SetResult(env, jni::Integer::Create(env, 42));
+    Await(future);
+    EXPECT_EQ(future.status(), FutureStatus::kFutureStatusComplete);
+  }
+
+  void AssertCreatesInvalidFutures(Env& env,
+                                   PromiseFactory<AsyncFn>& promise_factory) {
+    Local<TaskCompletionSource> tcs = TaskCompletionSource::Create(env);
+    Local<Task> task = tcs.GetTask(env);
+    Future<void> future =
+        promise_factory.NewFuture<void>(env, AsyncFn::kFn, task);
+    EXPECT_EQ(future.status(), FutureStatus::kFutureStatusInvalid);
+  }
+};
+
+TEST_F(PromiseFactoryTest, CopyConstructor) {
+  Firestore* firestore = TestFirestore();
+  PromiseFactory<AsyncFn> promise_factory1(GetFirestoreInternal(firestore));
+
+  PromiseFactory<AsyncFn> promise_factory2(promise_factory1);
+
+  Env env;
+  {
+    SCOPED_TRACE("promise_factory1");
+    AssertCreatesValidFutures(env, promise_factory1);
+  }
+  {
+    SCOPED_TRACE("promise_factory2");
+    AssertCreatesValidFutures(env, promise_factory2);
+  }
+}
+
+TEST_F(PromiseFactoryTest, CopyConstructorWithDeletedFirestore) {
+  Firestore* firestore = TestFirestore();
+  PromiseFactory<AsyncFn> promise_factory1(GetFirestoreInternal(firestore));
+  DeleteFirestore(firestore);
+
+  PromiseFactory<AsyncFn> promise_factory2(promise_factory1);
+
+  Env env;
+  {
+    SCOPED_TRACE("promise_factory1");
+    AssertCreatesInvalidFutures(env, promise_factory1);
+  }
+  {
+    SCOPED_TRACE("promise_factory2");
+    AssertCreatesInvalidFutures(env, promise_factory2);
+  }
+}
+
+TEST_F(PromiseFactoryTest, MoveConstructor) {
+  Firestore* firestore = TestFirestore();
+  PromiseFactory<AsyncFn> promise_factory1(GetFirestoreInternal(firestore));
+
+  PromiseFactory<AsyncFn> promise_factory2(std::move(promise_factory1));
+
+  Env env;
+  AssertCreatesValidFutures(env, promise_factory2);
+}
+
+TEST_F(PromiseFactoryTest, MoveConstructorWithDeletedFirestore) {
+  Firestore* firestore = TestFirestore();
+  PromiseFactory<AsyncFn> promise_factory1(GetFirestoreInternal(firestore));
+  DeleteFirestore(firestore);
+
+  PromiseFactory<AsyncFn> promise_factory2(std::move(promise_factory1));
+
+  Env env;
+  AssertCreatesInvalidFutures(env, promise_factory2);
+}
+
+TEST_F(PromiseFactoryTest, ShouldCreateInvalidPromisesIfFirestoreIsDeleted) {
+  Firestore* firestore = TestFirestore();
+  PromiseFactory<AsyncFn> promise_factory(GetFirestoreInternal(firestore));
+  DeleteFirestore(firestore);
+  Env env;
+
+  AssertCreatesInvalidFutures(env, promise_factory);
+}
+
+}  // namespace
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/integration_test_internal/src/source_test.cc
+++ b/firestore/integration_test_internal/src/source_test.cc
@@ -15,12 +15,9 @@
 namespace firebase {
 namespace firestore {
 
-// TODO(b/187448376): Temporarily disabling all tests as they seem to time out
-// on Android.
-
 using SourceTest = FirestoreIntegrationTest;
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetDocumentWhileOnlineWithDefaultGetOptions) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -34,7 +31,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithDefaultGetOptions) {
   EXPECT_EQ(initial_data, snapshot.GetData());
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetCollectionWhileOnlineWithDefaultGetOptions) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -51,7 +48,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithDefaultGetOptions) {
   EXPECT_EQ(initial_docs, QuerySnapshotToMap(snapshot));
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetDocumentWhileOfflineWithDefaultGetOptions) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -68,7 +65,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithDefaultGetOptions) {
   EXPECT_EQ(initial_data, snapshot.GetData());
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetCollectionWhileOfflineWithDefaultGetOptions) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -102,7 +99,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithDefaultGetOptions) {
   EXPECT_EQ(new_data, QuerySnapshotToMap(snapshot));
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetDocumentWhileOnlineWithSourceEqualToCache) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -117,7 +114,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithSourceEqualToCache) {
   EXPECT_EQ(initial_data, snapshot.GetData());
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetCollectionWhileOnlineWithSourceEqualToCache) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -135,7 +132,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithSourceEqualToCache) {
   EXPECT_EQ(initial_docs, QuerySnapshotToMap(snapshot));
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetDocumentWhileOfflineWithSourceEqualToCache) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -151,7 +148,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithSourceEqualToCache) {
   EXPECT_EQ(initial_data, snapshot.GetData());
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetCollectionWhileOfflineWithSourceEqualToCache) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -185,7 +182,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithSourceEqualToCache) {
   EXPECT_EQ(new_data, QuerySnapshotToMap(snapshot));
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetDocumentWhileOnlineWithSourceEqualToServer) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -199,7 +196,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOnlineWithSourceEqualToServer) {
   EXPECT_EQ(initial_data, snapshot.GetData());
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetCollectionWhileOnlineWithSourceEqualToServer) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -216,7 +213,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOnlineWithSourceEqualToServer) {
   EXPECT_EQ(initial_docs, QuerySnapshotToMap(snapshot));
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetDocumentWhileOfflineWithSourceEqualToServer) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -229,7 +226,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithSourceEqualToServer) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetCollectionWhileOfflineWithSourceEqualToServer) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -245,7 +242,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithSourceEqualToServer) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithDifferentGetOptions) {
+TEST_F(SourceTest, GetDocumentWhileOfflineWithDifferentGetOptions) {
   MapFieldValue initial_data = {{"key", FieldValue::String("value")}};
   DocumentReference doc_ref = DocumentWithData(initial_data);
 
@@ -290,7 +287,7 @@ TEST_F(SourceTest, DISABLED_GetDocumentWhileOfflineWithDifferentGetOptions) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithDifferentGetOptions) {
+TEST_F(SourceTest, GetCollectionWhileOfflineWithDifferentGetOptions) {
   std::map<std::string, MapFieldValue> initial_docs = {
       {"doc1", {{"key1", FieldValue::String("value1")}}},
       {"doc2", {{"key2", FieldValue::String("value2")}}},
@@ -352,7 +349,7 @@ TEST_F(SourceTest, DISABLED_GetCollectionWhileOfflineWithDifferentGetOptions) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, DISABLED_GetNonExistingDocWhileOnlineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetNonExistingDocWhileOnlineWithDefaultGetOptions) {
   DocumentReference doc_ref = Document();
 
   Future<DocumentSnapshot> future = doc_ref.Get();
@@ -364,8 +361,7 @@ TEST_F(SourceTest, DISABLED_GetNonExistingDocWhileOnlineWithDefaultGetOptions) {
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOnlineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOnlineWithDefaultGetOptions) {
   CollectionReference col_ref = Collection();
 
   Future<QuerySnapshot> future = col_ref.Get();
@@ -378,8 +374,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingDocWhileOfflineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetNonExistingDocWhileOfflineWithDefaultGetOptions) {
   DocumentReference doc_ref = Document();
 
   DisableNetwork();
@@ -389,10 +384,11 @@ TEST_F(SourceTest,
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-// TODO(b/112267729): We should raise a fromCache=true event with a
-// nonexistent snapshot, but because the default source goes through a normal
-// listener, we do not.
-TEST_F(SourceTest, DISABLED_GetDeletedDocWhileOfflineWithDefaultGetOptions) {
+
+TEST_F(SourceTest, GetDeletedDocWhileOfflineWithDefaultGetOptions) {
+  GTEST_SKIP() << "b/112267729: We should raise a fromCache=true event with "
+               << "a nonexistent snapshot, but because the default source goes "
+               << "through a normal listener, we do not.";
   DocumentReference doc_ref = Document();
   Await(doc_ref.Delete());
 
@@ -407,8 +403,7 @@ TEST_F(SourceTest, DISABLED_GetDeletedDocWhileOfflineWithDefaultGetOptions) {
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOfflineWithDefaultGetOptions) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOfflineWithDefaultGetOptions) {
   CollectionReference col_ref = Collection();
 
   DisableNetwork();
@@ -422,8 +417,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingDocWhileOnlineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetNonExistingDocWhileOnlineWithSourceEqualToCache) {
   DocumentReference doc_ref = Document();
 
   // Attempt to get doc. This will fail since there's nothing in cache.
@@ -433,8 +427,7 @@ TEST_F(SourceTest,
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOnlineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOnlineWithSourceEqualToCache) {
   CollectionReference col_ref = Collection();
 
   Future<QuerySnapshot> future = col_ref.Get(Source::kCache);
@@ -447,8 +440,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingDocWhileOfflineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetNonExistingDocWhileOfflineWithSourceEqualToCache) {
   DocumentReference doc_ref = Document();
 
   DisableNetwork();
@@ -459,7 +451,7 @@ TEST_F(SourceTest,
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, DISABLED_GetDeletedDocWhileOfflineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetDeletedDocWhileOfflineWithSourceEqualToCache) {
   DocumentReference doc_ref = Document();
   Await(doc_ref.Delete());
 
@@ -474,8 +466,7 @@ TEST_F(SourceTest, DISABLED_GetDeletedDocWhileOfflineWithSourceEqualToCache) {
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOfflineWithSourceEqualToCache) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOfflineWithSourceEqualToCache) {
   CollectionReference col_ref = Collection();
 
   DisableNetwork();
@@ -489,8 +480,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingDocWhileOnlineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetNonExistingDocWhileOnlineWithSourceEqualToServer) {
   DocumentReference doc_ref = Document();
 
   Future<DocumentSnapshot> future = doc_ref.Get(Source::kServer);
@@ -502,8 +492,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOnlineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOnlineWithSourceEqualToServer) {
   CollectionReference col_ref = Collection();
 
   Future<QuerySnapshot> future = col_ref.Get(Source::kServer);
@@ -516,8 +505,7 @@ TEST_F(SourceTest,
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingDocWhileOfflineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetNonExistingDocWhileOfflineWithSourceEqualToServer) {
   DocumentReference doc_ref = Document();
 
   DisableNetwork();
@@ -528,8 +516,7 @@ TEST_F(SourceTest,
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest,
-       DISABLED_GetNonExistingCollectionWhileOfflineWithSourceEqualToServer) {
+TEST_F(SourceTest, GetNonExistingCollectionWhileOfflineWithSourceEqualToServer) {
   CollectionReference col_ref = Collection();
 
   DisableNetwork();

--- a/firestore/integration_test_internal/src/source_test.cc
+++ b/firestore/integration_test_internal/src/source_test.cc
@@ -384,7 +384,6 @@ TEST_F(SourceTest, GetNonExistingDocWhileOfflineWithDefaultGetOptions) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-
 TEST_F(SourceTest, GetDeletedDocWhileOfflineWithDefaultGetOptions) {
   GTEST_SKIP() << "b/112267729: We should raise a fromCache=true event with "
                << "a nonexistent snapshot, but because the default source goes "
@@ -516,7 +515,8 @@ TEST_F(SourceTest, GetNonExistingDocWhileOfflineWithSourceEqualToServer) {
   EXPECT_EQ(future.error(), Error::kErrorUnavailable);
 }
 
-TEST_F(SourceTest, GetNonExistingCollectionWhileOfflineWithSourceEqualToServer) {
+TEST_F(SourceTest,
+       GetNonExistingCollectionWhileOfflineWithSourceEqualToServer) {
   CollectionReference col_ref = Collection();
 
   DisableNetwork();

--- a/firestore/src/android/firestore_android.h
+++ b/firestore/src/android/firestore_android.h
@@ -250,8 +250,8 @@ class FirestoreInternalWeakReference {
    * deleted) for the duration of the callback's execution.
    *
    * If this method is invoked concurrently then calls will be serialized in
-   * an undefined order. Recursive calls of this method are allowed and will not
-   * block.
+   * an undefined order. Recursive calls of this method are allowed on the same
+   * thread and will not block.
    */
   template <typename CallbackT>
   auto Run(CallbackT callback) -> decltype(callback(this->firestore_)) {
@@ -263,10 +263,10 @@ class FirestoreInternalWeakReference {
    * Same as `Run()` except that it only invokes the given callback if the
    * `FirestoreInternal` pointer is non-null.
    */
-  void RunIfValid(std::function<void(FirestoreInternal*)> callback) {
+  void RunIfValid(const std::function<void(FirestoreInternal&)>& callback) {
     std::lock_guard<std::recursive_mutex> lock(mutex_);
     if (firestore_) {
-      callback(firestore_);
+      callback(*firestore_);
     }
   }
 };

--- a/firestore/src/android/promise_android.h
+++ b/firestore/src/android/promise_android.h
@@ -79,8 +79,13 @@ class Promise {
  private:
   // The constructor is intentionally private.
   // Create instances with `PromiseFactory`.
-  Promise(const FirestoreInternalWeakReference& firestore_ref, ReferenceCountedFutureImpl* impl, Completion* completion) : firestore_ref_(firestore_ref), completer_(make_unique<Completer<PublicType, InternalType>>(firestore_ref, impl, completion)), impl_(impl) {
-  }
+  Promise(const FirestoreInternalWeakReference& firestore_ref,
+          ReferenceCountedFutureImpl* impl,
+          Completion* completion)
+      : firestore_ref_(firestore_ref),
+        completer_(make_unique<Completer<PublicType, InternalType>>(
+            firestore_ref, impl, completion)),
+        impl_(impl) {}
 
   template <typename PublicT>
   class CompleterBase {
@@ -111,9 +116,10 @@ class Promise {
       jni::Object result(raw_result);
 
       if (result_code == ::firebase::util::kFutureResultSuccess) {
-        firestore_ref_.RunIfValid([this, &env, &result](FirestoreInternal* firestore) {
-          SucceedWithResult(env, result, firestore);
-        });
+        firestore_ref_.RunIfValid(
+            [this, &env, &result](FirestoreInternal* firestore) {
+              SucceedWithResult(env, result, firestore);
+            });
 
         delete this;
 

--- a/firestore/src/android/promise_android.h
+++ b/firestore/src/android/promise_android.h
@@ -117,7 +117,7 @@ class Promise {
 
       if (result_code == ::firebase::util::kFutureResultSuccess) {
         firestore_ref_.RunIfValid(
-            [this, &env, &result](FirestoreInternal* firestore) {
+            [this, &env, &result](FirestoreInternal& firestore) {
               SucceedWithResult(env, result, firestore);
             });
 
@@ -141,7 +141,7 @@ class Promise {
           break;
       }
       firestore_ref_.RunIfValid(
-          [this, error_code, status_message](FirestoreInternal* firestore) {
+          [this, error_code, status_message](FirestoreInternal& firestore) {
             impl_->Complete(handle_, error_code, status_message);
           });
       if (completion_ != nullptr) {
@@ -152,7 +152,7 @@ class Promise {
 
     virtual void SucceedWithResult(jni::Env& env,
                                    const jni::Object& result,
-                                   FirestoreInternal* firestore) = 0;
+                                   FirestoreInternal& firestore) = 0;
 
    private:
     FirestoreInternalWeakReference firestore_ref_;
@@ -173,9 +173,9 @@ class Promise {
 
     void SucceedWithResult(jni::Env& env,
                            const jni::Object& result,
-                           FirestoreInternal* firestore) override {
+                           FirestoreInternal& firestore) override {
       auto future_result =
-          MakePublic<PublicT, InternalT>(env, firestore, result);
+          MakePublic<PublicT, InternalT>(env, &firestore, result);
 
       this->impl_->CompleteWithResult(this->handle_, Error::kErrorOk,
                                       /*error_msg=*/"", future_result);
@@ -193,7 +193,7 @@ class Promise {
 
     void SucceedWithResult(jni::Env& env,
                            const jni::Object& result,
-                           FirestoreInternal*) override {
+                           FirestoreInternal&) override {
       this->impl_->Complete(this->handle_, Error::kErrorOk, /*error_msg=*/"");
       if (this->completion_ != nullptr) {
         this->completion_->CompleteWith(Error::kErrorOk, /*error_message*/ "",

--- a/firestore/src/android/promise_android.h
+++ b/firestore/src/android/promise_android.h
@@ -51,8 +51,6 @@ class Promise {
                               PublicType* result) = 0;
   };
 
-  ~Promise() {}
-
   Promise(const Promise&) = delete;
   Promise& operator=(const Promise&) = delete;
 
@@ -69,33 +67,39 @@ class Promise {
         env.get(), task.get(), ResultCallback, completer, kApiIdentifier);
   }
 
-  Future<PublicType> GetFuture() { return MakeFuture(impl_, handle_); }
+  Future<PublicType> GetFuture() {
+    return firestore_ref_.Run([this](FirestoreInternal* firestore) {
+      if (firestore == nullptr) {
+        return Future<PublicType>{};
+      }
+      return MakeFuture(impl_, handle_);
+    });
+  }
 
  private:
   // The constructor is intentionally private.
   // Create instances with `PromiseFactory`.
-  Promise(ReferenceCountedFutureImpl* impl,
-          FirestoreInternal* firestore,
-          Completion* completion)
-      : completer_(make_unique<Completer<PublicType, InternalType>>(
-            impl, firestore, completion)),
-        impl_(impl) {}
+  Promise(const FirestoreInternalWeakReference& firestore_ref, ReferenceCountedFutureImpl* impl, Completion* completion) : firestore_ref_(firestore_ref), completer_(make_unique<Completer<PublicType, InternalType>>(firestore_ref, impl, completion)), impl_(impl) {
+  }
 
   template <typename PublicT>
   class CompleterBase {
    public:
-    CompleterBase(ReferenceCountedFutureImpl* impl,
-                  FirestoreInternal* firestore,
+    CompleterBase(const FirestoreInternalWeakReference& firestore_ref,
+                  ReferenceCountedFutureImpl* impl,
                   Completion* completion)
-        : impl_{impl}, firestore_{firestore}, completion_(completion) {}
+        : firestore_ref_{firestore_ref}, impl_{impl}, completion_(completion) {}
 
     virtual ~CompleterBase() = default;
 
-    FirestoreInternal* firestore() { return firestore_; }
-
     SafeFutureHandle<PublicT> Alloc(int fn_index) {
-      handle_ = impl_->SafeAlloc<PublicT>(fn_index);
-      return handle_;
+      return firestore_ref_.Run([this, fn_index](FirestoreInternal* firestore) {
+        if (firestore == nullptr) {
+          return SafeFutureHandle<PublicT>{};
+        }
+        handle_ = impl_->SafeAlloc<PublicT>(fn_index);
+        return handle_;
+      });
     }
 
     virtual void CompleteWithResult(jobject raw_result,
@@ -107,8 +111,12 @@ class Promise {
       jni::Object result(raw_result);
 
       if (result_code == ::firebase::util::kFutureResultSuccess) {
-        // When succeeded, result is the resolved object of the Future.
-        SucceedWithResult(env, result);
+        firestore_ref_.RunIfValid([this, &env, &result](FirestoreInternal* firestore) {
+          SucceedWithResult(env, result, firestore);
+        });
+
+        delete this;
+
         return;
       }
 
@@ -126,20 +134,26 @@ class Promise {
                                   result_code);
           break;
       }
-      this->impl_->Complete(this->handle_, error_code, status_message);
-      if (this->completion_ != nullptr) {
-        this->completion_->CompleteWith(error_code, status_message, nullptr);
+      firestore_ref_.RunIfValid(
+          [this, error_code, status_message](FirestoreInternal* firestore) {
+            impl_->Complete(handle_, error_code, status_message);
+          });
+      if (completion_ != nullptr) {
+        completion_->CompleteWith(error_code, status_message, nullptr);
       }
       delete this;
     }
 
     virtual void SucceedWithResult(jni::Env& env,
-                                   const jni::Object& result) = 0;
+                                   const jni::Object& result,
+                                   FirestoreInternal* firestore) = 0;
+
+   private:
+    FirestoreInternalWeakReference firestore_ref_;
 
    protected:
     SafeFutureHandle<PublicT> handle_;
     ReferenceCountedFutureImpl* impl_;  // not owning
-    FirestoreInternal* firestore_;      // not owning
     Completion* completion_;            // not owning
   };
 
@@ -151,9 +165,11 @@ class Promise {
    public:
     using CompleterBase<PublicT>::CompleterBase;
 
-    void SucceedWithResult(jni::Env& env, const jni::Object& result) override {
+    void SucceedWithResult(jni::Env& env,
+                           const jni::Object& result,
+                           FirestoreInternal* firestore) override {
       auto future_result =
-          MakePublic<PublicT, InternalT>(env, this->firestore_, result);
+          MakePublic<PublicT, InternalT>(env, firestore, result);
 
       this->impl_->CompleteWithResult(this->handle_, Error::kErrorOk,
                                       /*error_msg=*/"", future_result);
@@ -161,7 +177,6 @@ class Promise {
         this->completion_->CompleteWith(Error::kErrorOk, /*error_message*/ "",
                                         &future_result);
       }
-      delete this;
     }
   };
 
@@ -170,13 +185,14 @@ class Promise {
    public:
     using CompleterBase<void>::CompleterBase;
 
-    void SucceedWithResult(jni::Env& env, const jni::Object& result) override {
+    void SucceedWithResult(jni::Env& env,
+                           const jni::Object& result,
+                           FirestoreInternal*) override {
       this->impl_->Complete(this->handle_, Error::kErrorOk, /*error_msg=*/"");
       if (this->completion_ != nullptr) {
         this->completion_->CompleteWith(Error::kErrorOk, /*error_message*/ "",
                                         nullptr);
       }
-      delete this;
     }
   };
 
@@ -191,6 +207,8 @@ class Promise {
       data->CompleteWithResult(result, result_code, status_message);
     }
   }
+
+  FirestoreInternalWeakReference firestore_ref_;
 
   std::unique_ptr<Completer<PublicType, InternalType>> completer_;
 

--- a/firestore/src/android/promise_factory_android.h
+++ b/firestore/src/android/promise_factory_android.h
@@ -19,28 +19,28 @@ class PromiseFactory {
  public:
   explicit PromiseFactory(FirestoreInternal* firestore)
       : firestore_ref_(firestore) {
-    firestore_ref_.RunIfValid([this](FirestoreInternal* firestore) {
-      firestore->future_manager().AllocFutureApi(this, ApiCount());
+    firestore_ref_.RunIfValid([this](FirestoreInternal& firestore) {
+      firestore.future_manager().AllocFutureApi(this, ApiCount());
     });
   }
 
   PromiseFactory(const PromiseFactory& rhs)
       : firestore_ref_(rhs.firestore_ref_) {
-    firestore_ref_.RunIfValid([this](FirestoreInternal* firestore) {
-      firestore->future_manager().AllocFutureApi(this, ApiCount());
+    firestore_ref_.RunIfValid([this](FirestoreInternal& firestore) {
+      firestore.future_manager().AllocFutureApi(this, ApiCount());
     });
   }
 
   PromiseFactory(PromiseFactory&& rhs)
       : firestore_ref_(Move(rhs.firestore_ref_)) {
-    firestore_ref_.RunIfValid([this, &rhs](FirestoreInternal* firestore) {
-      firestore->future_manager().MoveFutureApi(&rhs, this);
+    firestore_ref_.RunIfValid([this, &rhs](FirestoreInternal& firestore) {
+      firestore.future_manager().MoveFutureApi(&rhs, this);
     });
   }
 
   ~PromiseFactory() {
-    firestore_ref_.RunIfValid([this](FirestoreInternal* firestore) {
-      firestore->future_manager().ReleaseFutureApi(this);
+    firestore_ref_.RunIfValid([this](FirestoreInternal& firestore) {
+      firestore.future_manager().ReleaseFutureApi(this);
     });
   }
 


### PR DESCRIPTION
This fixes a crash on Android that occurs if the `Firestore` instance is deleted from an "OnCompletion" handler attached to a `Future` returned from `RunTransaction()`. The issue is that in the bowels on the code that manages `Future` objects it will end up using a deleted `FirestoreInternal` object when the completion completes. The fix is to null out the `FirestoreInternal` pointer when it is deleted and avoid using it thereafter.

This fix also fixes a crash that was occurring in `SourceTests`. Those tests are re-enabled by this PR.