### PR TITLE
Add firestore/CPPLINT.cfg

### DIFF
--- a/firestore/CPPLINT.cfg
+++ b/firestore/CPPLINT.cfg
@@ -1,0 +1,1 @@
+filter=-runtime/references,-build/c++11


### PR DESCRIPTION
The new `CPPLINT.cfg` just disables some noisy checks:

* `runtime/references` - This category produces warnings like `Is this a non-const reference? If so, make const or use a pointer: TestData& test_data`
* `build/c++11` - This category produces warnings like `<mutex> is an unapproved C++11 header.`