### PR TITLE
Define new error codes for passthrough errors.

### DIFF
--- a/auth/src/android/common_android.cc
+++ b/auth/src/android/common_android.cc
@@ -115,7 +115,10 @@ static const ErrorCodeMapping kFirebaseAuthCodes[] = {
     {"ERROR_UNSUPPORTED_FIRST_FACTOR", kAuthErrorUnsupportedFirstFactor},
     {"ERROR_EMAIL_CHANGE_NEEDS_VERIFICATION",
      kAuthErrorEmailChangeNeedsVerification},
-    {"ERROR_USER_CANCELLED", kAuthErrorMissingOrInvalidNonce},
+    {"ERROR_USER_CANCELLED", kAuthErrorUserCancelled},
+    {"ERROR_UNSUPPORTED_PASSTHROUGH_OPERATION",
+     kAuthErrorUnsupportedPassthroughOperation},
+    {"ERROR_TOKEN_REFRESH_UNAVAILABLE", kAuthErrorTokenRefreshUnavailable},
     {nullptr},
 };
 

--- a/auth/src/android/common_android.cc
+++ b/auth/src/android/common_android.cc
@@ -115,6 +115,7 @@ static const ErrorCodeMapping kFirebaseAuthCodes[] = {
     {"ERROR_UNSUPPORTED_FIRST_FACTOR", kAuthErrorUnsupportedFirstFactor},
     {"ERROR_EMAIL_CHANGE_NEEDS_VERIFICATION",
      kAuthErrorEmailChangeNeedsVerification},
+    {"ERROR_MISSING_OR_INVALID_NONCE", kAuthErrorMissingOrInvalidNonce},
     {"ERROR_USER_CANCELLED", kAuthErrorUserCancelled},
     {"ERROR_UNSUPPORTED_PASSTHROUGH_OPERATION",
      kAuthErrorUnsupportedPassthroughOperation},

--- a/auth/src/include/firebase/auth/types.h
+++ b/auth/src/include/firebase/auth/types.h
@@ -419,6 +419,14 @@ enum AuthError {
   /// IDP sign-in.
   kAuthErrorUserCancelled,
 
+  /// Indicates that a request was made to an unsupported backend endpoint in
+  /// passthrough mode.
+  kAuthErrorUnsupportedPassthroughOperation,
+
+  /// Indicates that a token refresh was requested, but neither a refresh token
+  /// nor a custom token provider is available.
+  kAuthErrorTokenRefreshUnavailable,
+
 #endif  // INTERNAL_EXEPERIMENTAL
 };
 


### PR DESCRIPTION
Add `ERROR_UNSUPPORTED_PASSTHROUGH_OPERATION` and `ERROR_TOKEN_REFRESH_UNAVAILABLE` error codes.

Note: Also fixed a typo in the C++ error code mapping for `ERROR_USER_CANCELLED`.

Corresponding Android change in cl/385610798.