### PR TITLE
Replace HARD_ASSERT with SIMPLE_HARD_ASSERT to fix absl linker breakage.

### DIFF
--- a/firestore/src/main/transaction_main.cc
+++ b/firestore/src/main/transaction_main.cc
@@ -180,7 +180,7 @@ void TransactionInternal::MarkPermanentlyFailed() {
 
 void TransactionInternal::ValidateReference(const DocumentReference& document) {
   auto* internal_doc = GetInternal(&document);
-  HARD_ASSERT(internal_doc, "Invalid document reference provided.");
+  SIMPLE_HARD_ASSERT(internal_doc, "Invalid document reference provided.");
 
   if (internal_doc->firestore() != firestore()) {
     ThrowInvalidArgument(


### PR DESCRIPTION
Fix the following build error in the downstream Unity SDK builds for iOS:

```
Undefined symbols for architecture arm64:
  "firebase::firestore::util::internal::StringFormatPieces(char const*, std::initializer_list<absl::string_view>)", referenced from:
      std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> > firebase::firestore::util::StringFormat<char const*>(char const*, char const* const&) in libFirebaseCppFirestore.a(firestore_main.o)
      firebase::firestore::TransactionInternal::ValidateReference(firebase::firestore::DocumentReference const&) in libFirebaseCppFirestore.a(transaction_main.o)
      void firebase::firestore::util::ThrowInvalidArgument<>(char const*) in libFirebaseCppFirestore.a(transaction_main.o)
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```