### PR TITLE
Replace ThrowInvalidArgument with SimpleThrowInvalidArgument to fix iOS absl linker error in Unity SDK

### DIFF
--- a/firestore/src/main/firestore_main.cc
+++ b/firestore/src/main/firestore_main.cc
@@ -35,6 +35,7 @@
 #include "app/src/include/firebase/future.h"
 #include "app/src/reference_counted_future_impl.h"
 #include "firebase/firestore/firestore_version.h"
+#include "firestore/src/common/exception_common.h"
 #include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/common/macros.h"
 #include "firestore/src/common/util.h"
@@ -55,7 +56,6 @@ using model::DatabaseId;
 using util::AsyncQueue;
 using util::Executor;
 using util::Status;
-using util::ThrowInvalidArgument;
 
 std::shared_ptr<AsyncQueue> CreateWorkerQueue() {
   auto executor = Executor::CreateSerial("com.google.firebase.firestore");
@@ -86,8 +86,12 @@ LoadBundleTaskProgress ToApiProgress(
 
 void ValidateDoubleSlash(const char* path) {
   if (std::strstr(path, "//") != nullptr) {
-    ThrowInvalidArgument(
-        "Invalid path (%s). Paths must not contain // in them.", path);
+    // TODO(b/147444199): use string formatting.
+    // ThrowInvalidArgument(
+    //     "Invalid path (%s). Paths must not contain // in them.", path);
+    auto message = std::string("Invalid path (") + path +
+                   "). Paths must not contain // in them.";
+    SimpleThrowInvalidArgument(message);
   }
 }
 
@@ -138,10 +142,14 @@ DocumentReference FirestoreInternal::Document(const char* document_path) const {
 
 Query FirestoreInternal::CollectionGroup(const char* collection_id) const {
   if (std::strchr(collection_id, '/') != nullptr) {
-    ThrowInvalidArgument(
-        "Invalid collection ID (%s). Collection IDs must not contain / in "
-        "them.",
-        collection_id);
+    // TODO(b/147444199): use string formatting.
+    // ThrowInvalidArgument(
+    //     "Invalid collection ID (%s). Collection IDs must not contain / in "
+    //     "them.",
+    //     collection_id);
+    auto message = std::string("Invalid collection ID (") + collection_id +
+                   "). Collection IDs must not contain / in them.";
+    SimpleThrowInvalidArgument(message);
   }
 
   core::Query core_query = firestore_core_->GetCollectionGroup(collection_id);

--- a/firestore/src/main/transaction_main.cc
+++ b/firestore/src/main/transaction_main.cc
@@ -28,6 +28,7 @@
 #include "Firestore/core/src/util/status.h"
 #include "Firestore/core/src/util/statusor.h"
 #include "absl/types/optional.h"
+#include "firestore/src/common/exception_common.h"
 #include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/main/converter_main.h"
 #include "firestore/src/main/document_reference_main.h"
@@ -45,7 +46,6 @@ using core::ParsedUpdateData;
 using model::Document;
 using util::Status;
 using util::StatusOr;
-using util::ThrowInvalidArgument;
 
 const model::DocumentKey& GetKey(const DocumentReference& document) {
   return GetInternal(&document)->key();
@@ -183,7 +183,7 @@ void TransactionInternal::ValidateReference(const DocumentReference& document) {
   SIMPLE_HARD_ASSERT(internal_doc, "Invalid document reference provided.");
 
   if (internal_doc->firestore() != firestore()) {
-    ThrowInvalidArgument(
+    SimpleThrowInvalidArgument(
         "Provided document reference is from a different Cloud Firestore "
         "instance.");
   }


### PR DESCRIPTION
This a follow-up fix to #616 which additionally replaces `ThrowInvalidArgument` with `SimpleThrowInvalidArgument` to avoid absl-related linker errors in the Unity SDK for iOS.

The "style" of the changes made in this PR were based on those made in other files, such as:

https://github.com/firebase/firebase-cpp-sdk/blob/cebf363f7b25a7c8f200d1381159784df7ee52b3/firestore/src/main/query_main.cc#L196-L206

Googlers can see cl/289114361 for the introduction of `SimpleThrowInvalidArgument` for context.