### PR TITLE
Specify `targets` in `build.gradle` to improve build times of Firestore's integration tests on Android

### DIFF
--- a/firestore/integration_test/build.gradle
+++ b/firestore/integration_test/build.gradle
@@ -60,6 +60,7 @@ android {
     versionName '1.0'
     externalNativeBuild.cmake {
       arguments "-DFIREBASE_CPP_SDK_DIR=$gradle.firebase_cpp_sdk_dir"
+      targets 'firebase_firestore', 'firebase_auth', 'android_integration_test_main'
     }
     multiDexEnabled true
   }

--- a/firestore/integration_test_internal/build.gradle
+++ b/firestore/integration_test_internal/build.gradle
@@ -60,6 +60,7 @@ android {
     versionName '1.0'
     externalNativeBuild.cmake {
       arguments "-DFIREBASE_CPP_SDK_DIR=$gradle.firebase_cpp_sdk_dir"
+      targets 'firebase_firestore', 'firebase_auth', 'android_integration_test_main'
     }
     multiDexEnabled true
   }


### PR DESCRIPTION
Add the following line to the `build.gradle` files for Firestore's integration tests:

```
targets 'firebase_firestore', 'firebase_auth', 'android_integration_test_main'
```

This configures cmake to only build the necessary targets, instead of building all of the targets. This produces a meaningful build time improvement.