### PR TITLE
Add presubmit trigger with ccache in linux firestore

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -105,17 +105,17 @@ jobs:
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=github_ref::$GITHUB_SHA"
           echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
-          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
+          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == ${{ env.triggerLabelPrefix }}* ]]; then
             echo "::set-output name=trigger::label_trigger"
             if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
               echo "::set-output name=requested_tests::auto"
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}"]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }}]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=requested_tests::auto"
-          elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then
+          elif [[ "opened,reopened,synchronize" == *${{ github.event.action }}*  ]]; then
             echo "::set-output name=trigger::presubmit_trigger"
             echo "::set-output name=requested_tests::minimal"
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,7 +82,9 @@ jobs:
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then 
           if [[ "${{ github.event.inputs.test_pull_request }}" != "sdk" ]]; then
-            if [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
+            if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
+              echo "::set-output name=github_ref::$GITHUB_SHA"
+            elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
               # If specified as pr:commit_hash, split them.
               echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
               echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
@@ -112,7 +114,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && -n "${{ github.event.pull_request.merged }}" ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=requested_tests::auto"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -263,9 +263,9 @@ jobs:
         with:
           path: ccache_dir
           key: integration-test-ccache-${{ matrix.os }}
-      - name: List ccache files
-        run: |
-          ls ccache_dir
+#       - name: List ccache files
+#         run: |
+#           ls ccache_dir
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -123,15 +123,15 @@ jobs:
     ### If it's not a defined trigger, cancel workflow
     ### e.g. Triggered by non-"test-request" label; triggered by not merged PR close event.
     - name: Cancel workflow
-      if: steps.set_outputs.outputs.trigger == "" 
+      if: ${{ !steps.set_outputs.outputs.trigger }}
       uses: andymckay/cancel-action@0.2
     - name: Wait for workflow cancellation
-      if: steps.set_outputs.outputs.trigger == "" 
+      if: ${{ !steps.set_outputs.outputs.trigger }} 
       run: |
         sleep 300
         exit 1  # fail out if the cancellation above somehow failed.
     - name: Cancel previous runs on the same PR
-      if: steps.set_outputs.outputs.trigger == "presubmit_trigger" 
+      if: steps.set_outputs.outputs.trigger == 'presubmit_trigger' 
       uses: styfle/cancel-workflow-action@0.8.0
       with:
         access_token: ${{ github.token }}
@@ -1082,7 +1082,7 @@ jobs:
             --run_id ${{github.run_id}} \
             --new_token ${{steps.generate-token.outputs.token}}
       - name: Update Daily Report
-        if: ${{ needs.check_and_prepare.outputs.trigger == 'scheduled_trigger'}}
+        if: needs.check_and_prepare.outputs.trigger == 'scheduled_trigger'
         shell: bash
         run: |
           if [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -608,7 +608,7 @@ jobs:
     name: build-tvos-macos-latest
     needs: [check_and_prepare]
     runs-on: macos-latest
-    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -263,9 +263,6 @@ jobs:
         with:
           path: ccache_dir
           key: integration-test-ccache-${{ matrix.os }}
-#       - name: List ccache files
-#         run: |
-#           ls ccache_dir
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -339,7 +336,10 @@ jobs:
             ${additional_flags[*]}
       - name: Stats for ccache
         if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        run: ccache -s
+        run: |
+          ccache -s
+          ls ccache_dir
+          cat ccache_dir/ccache.conf
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -256,12 +256,12 @@ jobs:
           path: external/vcpkg/installed
           key: dev-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
       - name: Cache ccache files
-        if: startsWith(matrix.os, 'ubuntu')
+        if: startsWith(matrix.os, 'ubuntu') && matrix.ssl_variant == 'openssl'
         id: cache_ccache
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-${{ matrix.ssl_variant }}-${{ needs.prepare_matrix.outputs.apis }}-${{needs.prepare_matrix.outputs.github_ref}}
+          key: integration-test-ccache-linux-openssl-${{needs.prepare_matrix.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -152,7 +152,7 @@ jobs:
           TEST_MATRIX_PARAM=-e=1
           echo "::warning ::Running on the expanded matrix"
         elif [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "minimal" ]]; then 
-          TEST_MATRIX_PARAM=-m=1" >> $GITHUB_ENV
+          TEST_MATRIX_PARAM=-m=1
           echo "::warning ::Running on the minimal matrix"
         elif [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "auto" ]]; then 
           # auto-diff only apply when running in a PR. 
@@ -168,9 +168,9 @@ jobs:
 
         # To feed input into the job matrix, we first need to convert to a JSON
         # list. Then we can use fromJson to define the field in the matrix for the tests job.
-        apis=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
+        apis=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${TEST_MATRIX_PARAM} )
         echo "::set-output name=apis::${apis}"
-        echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis})"
+        echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} )"
         echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}")"
         # If building against a packaged SDK, only use boringssl.
         if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -50,17 +50,10 @@ env:
 
 jobs:
   check_and_prepare:
-    ### This job runs when the workflow was triggered by 1) PR getting labeled
-    ### 2) PR merged & closed 3) or manumlly triggered with Pull request #.
-    ### If triggered by label, then checks whether the label is a test-request
-    ### trigger (cancelling the workflow if not).
-    ### It sets outputs to control the build_* matrix (full or quick) and to tell
-    ### subsequent steps to update the labels as well.
     runs-on: ubuntu-latest
     outputs:
-      github_ref: ${{ steps.set_outputs.outputs.github_ref }}
       trigger: ${{ steps.set_outputs.outputs.trigger }}
-      requested_tests: ${{ steps.set_outputs.outputs.requested_tests }}
+      github_ref: ${{ steps.set_outputs.outputs.github_ref }}
       pr_number: ${{ steps.set_outputs.outputs.pr_number }}
       matrix_platform: ${{ steps.matrix_config.outputs.matrix_platform }}
       matrix_os: ${{ steps.matrix_config.outputs.matrix_os }}
@@ -78,45 +71,51 @@ jobs:
         permission: "admin"
       env:
         GITHUB_TOKEN: ${{ github.token }}
+    ### It sets "github_ref,trigger,pr_number,requested_tests" outputs to control the following jobs and steps
     - id: set_outputs
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then 
           if [[ "${{ github.event.inputs.test_pull_request }}" != "sdk" ]]; then
+            # Triggered manually
+            echo "::set-output name=trigger::manual_trigger"
+            if [[ "${{ github.event.inputs.use_expanded_matrix }}" == "1" ]]; then
+              echo "::set-output name=requested_tests::expanded"
+            fi
             if [[ -z "${{github.event.inputs.test_pull_request}}" ]]; then
+              # test_pull_request not specified
               echo "::set-output name=github_ref::$GITHUB_SHA"
             elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
               # If specified as pr:commit_hash, split them.
-              echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
               echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+              echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
             else
               # Just the PR specified, use refs/pull/<number>/merge as the ref.
-              echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
               echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+              echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
             fi
-            echo "::set-output name=trigger::manual_trigger"
           elif [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then
             # Triggered by scheduled packaging SDK workflow.
-            echo "::set-output name=github_ref::$GITHUB_SHA"
             echo "::set-output name=trigger::scheduled_trigger"
+            echo "::set-output name=github_ref::$GITHUB_SHA"
             echo "::set-output name=requested_tests::expanded"
           fi
         elif [[ "${{ github.event_name }}" == "schedule" ]]; then
-          echo "::set-output name=github_ref::$GITHUB_SHA"
           echo "::set-output name=trigger::scheduled_trigger"
+          echo "::set-output name=github_ref::$GITHUB_SHA"
           echo "::set-output name=requested_tests::expanded"
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=github_ref::$GITHUB_SHA"
-          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
-            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
+          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
             echo "::set-output name=trigger::label_trigger"
+            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
               echo "::set-output name=requested_tests::auto"
             else
               echo "::set-output name=requested_tests::expanded"
             fi
           elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
-            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=trigger::postsubmit_trigger"
+            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"
           elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then
             echo "::set-output name=trigger::presubmit_trigger"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -608,7 +608,7 @@ jobs:
     name: build-tvos-macos-latest
     needs: [check_and_prepare]
     runs-on: macos-latest
-    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,7 @@ env:
   statusCommentIdentifier: "integration-test-status-comment"
   pythonVersion: '3.7'
   artifactRetentionDays: 2
+  CCACHE_DIR: ${{ github.workspace }}/ccache_dir
 
 jobs:
   check_trigger:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -310,6 +310,8 @@ jobs:
           run_id: ${{ github.event.inputs.test_packaged_sdk }}
       - name: Build integration tests
         shell: bash
+        env: 
+          CCACHE_DIR: ${{ github.workspace }}/ccache_dir
         run: |
           declare -a additional_flags
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,7 +112,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }}]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=requested_tests::auto"
           elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -261,7 +261,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-${{needs.prepare_matrix.outputs.github_ref}}
+          key: integration-test-ccache-linux-$GITHUB_REF
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -261,7 +261,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-$GITHUB_REF
+          key: integration-test-ccache-linux-${{ github.ref }}
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -72,6 +72,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ github.token }}
     ### It sets "github_ref,trigger,pr_number,requested_tests" outputs to control the following jobs and steps
+    ### trigger value: manual_trigger, scheduled_trigger, label_trigger, postsubmit_trigger, presubmit_trigger
     - id: set_outputs
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then 
@@ -113,7 +114,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}" == "true" ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -310,8 +310,6 @@ jobs:
           run_id: ${{ github.event.inputs.test_packaged_sdk }}
       - name: Build integration tests
         shell: bash
-        env: 
-          CCACHE_DIR: ${{ github.workspace }}/ccache_dir
         run: |
           declare -a additional_flags
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -261,7 +261,8 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-${{ github.ref }}
+          key: integration-test-ccache-linux-${{ github.ref }}-${{ hashFiles('ccache_dir/ccache.conf') }}
+          restore-keys: integration-test-ccache-linux-${{ github.ref }}-
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1082,7 +1082,7 @@ jobs:
             --run_id ${{github.run_id}} \
             --new_token ${{steps.generate-token.outputs.token}}
       - name: Update Daily Report
-        if: ${{ check_and_prepare.outputs.trigger == 'scheduled_trigger'}}
+        if: ${{ needs.check_and_prepare.outputs.trigger == 'scheduled_trigger'}}
         shell: bash
         run: |
           if [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -4,7 +4,7 @@ on:
   schedule:
     - cron: "0 9 * * *"  # 9am UTC = 1am PST / 2am PDT
   pull_request:
-    types: [ labeled, closed ]
+    types: [ labeled, closed, opened, reopened, synchronize ]
 
   workflow_dispatch:
     inputs:
@@ -49,7 +49,7 @@ env:
   artifactRetentionDays: 2
 
 jobs:
-  check_trigger:
+  check_and_prepare:
     ### This job runs when the workflow was triggered by 1) PR getting labeled
     ### 2) PR merged & closed 3) or manumlly triggered with Pull request #.
     ### If triggered by label, then checks whether the label is a test-request
@@ -57,48 +57,20 @@ jobs:
     ### It sets outputs to control the build_* matrix (full or quick) and to tell
     ### subsequent steps to update the labels as well.
     runs-on: ubuntu-latest
-    if: |
-      github.event_name == 'pull_request' || (github.event.inputs.test_pull_request != '' && github.event.inputs.test_pull_request != 'sdk')
     outputs:
-      should_update_pr: ${{ steps.set_outputs.outputs.should_update_pr }}
+      github_ref: ${{ steps.set_outputs.outputs.github_ref }}
+      trigger: ${{ steps.set_outputs.outputs.trigger }}
       requested_tests: ${{ steps.set_outputs.outputs.requested_tests }}
-      pr_number: ${{ steps.get_pr_number.outputs.pr_number }}
+      pr_number: ${{ steps.set_outputs.outputs.pr_number }}
+      matrix_platform: ${{ steps.matrix_config.outputs.matrix_platform }}
+      matrix_os: ${{ steps.matrix_config.outputs.matrix_os }}
+      matrix_ssl: ${{ steps.matrix_config.outputs.matrix_ssl }}
+      apis: ${{ steps.matrix_config.outputs.apis }}
+      mobile_test_on: ${{ steps.matrix_config.outputs.mobile_test_on }}
+      android_device: ${{ steps.matrix_config.outputs.android_device }}
+      ios_device: ${{ steps.matrix_config.outputs.ios_device }}
+      tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
     steps:
-    ### If the label isn't 1)the test-request triggers, 2) closed on merge trigger, cancel the workflow.
-    - name: Cancel workflow
-      if: (github.event.action == 'labeled' && !startsWith(github.event.label.name, env.triggerLabelPrefix)) || (github.event.action == 'closed' && github.event.pull_request.merged != true)
-      uses: andymckay/cancel-action@0.2
-    - name: Wait for above cancellation
-      if: (github.event.action == 'labeled' && !startsWith(github.event.label.name, env.triggerLabelPrefix)) || (github.event.action == 'closed' && github.event.pull_request.merged != true)
-      run: |
-        sleep 300
-        exit 1  # fail out if the cancellation above somehow failed.
-    - id: get_pr_number
-      run: |
-        # In this step, github_ref is only used for the status message below.
-        # It will be recalculated in prepare_matrix.
-        if [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
-          echo "::set-output name=github_ref::$GITHUB_SHA"
-        elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
-          # If specified as pr:commit_hash, split them.
-          echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
-          echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
-        else
-          # Just a PR number.
-          echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
-          echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
-        fi
-    - name: Cancel previous runs on the same PR
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
-    - name: Remove triggering label
-      uses: actions-ecosystem/action-remove-labels@v1
-      with:
-        github_token: ${{ github.token }}
-        number: "${{ steps.get_pr_number.outputs.pr_number }}"
-        labels: "${{ github.event.label.name }}"
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
       uses: lannonbr/repo-permission-check-action@2.0.0
@@ -108,130 +80,138 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
     - id: set_outputs
       run: |
-        echo "::set-output name=should_update_pr::1"
-        if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelFull }}" ]]; then
-          echo "::set-output name=requested_tests::full"
-        elif [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
-          echo "::set-output name=requested_tests::auto"
-        else
-          # For manual PR testing, use auto mode.
-          echo "::set-output name=requested_tests::auto"
+        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then 
+          if [[ "${{ github.event.inputs.test_pull_request }}" != "sdk" ]]; then
+            if [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
+              # If specified as pr:commit_hash, split them.
+              echo "::set-output name=pr_number::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1)"
+              echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
+            else
+              # Just the PR specified, use refs/pull/<number>/merge as the ref.
+              echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
+              echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
+            fi
+            echo "::set-output name=trigger::manual_trigger"
+          elif [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then
+            # Triggered by scheduled packaging SDK workflow.
+            echo "::set-output name=github_ref::$GITHUB_SHA"
+            echo "::set-output name=trigger::scheduled_trigger"
+            echo "::set-output name=requested_tests::expanded"
+          fi
+        elif [[ "${{ github.event_name }}" == "schedule" ]]; then
+          echo "::set-output name=github_ref::$GITHUB_SHA"
+          echo "::set-output name=trigger::scheduled_trigger"
+          echo "::set-output name=requested_tests::expanded"
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "::set-output name=github_ref::$GITHUB_SHA"
+          echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
+          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
+            echo "::set-output name=trigger::label_trigger"
+            if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
+              echo "::set-output name=requested_tests::auto"
+            else
+              echo "::set-output name=requested_tests::expanded"
+            fi
+          elif [[ "${{ github.event.action }}" == "closed" && "${{ github.event.pull_request.merged }}"]]; then
+            echo "::set-output name=trigger::postsubmit_trigger"
+            echo "::set-output name=requested_tests::auto"
+          elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then
+            echo "::set-output name=trigger::presubmit_trigger"
+            echo "::set-output name=requested_tests::minimal"
+          fi
         fi
-    ### Add the in-progress label and remove any previous success/fail labels.
+    ### If it's not a defined trigger, cancel workflow
+    ### e.g. Triggered by non-"test-request" label; triggered by not merged PR close event.
+    - name: Cancel workflow
+      if: steps.set_outputs.outputs.trigger == "" 
+      uses: andymckay/cancel-action@0.2
+    - name: Wait for workflow cancellation
+      if: steps.set_outputs.outputs.trigger == "" 
+      run: |
+        sleep 300
+        exit 1  # fail out if the cancellation above somehow failed.
+    - name: Cancel previous runs on the same PR
+      if: steps.set_outputs.outputs.trigger == "presubmit_trigger" 
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
       with:
-        ref: ${{steps.get_pr_number.outputs.github_ref}}
+        ref: ${{steps.set_outputs.outputs.github_ref}}
+        fetch-depth: 0
+        submodules: false
     - name: Setup python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ env.pythonVersion }}
     - name: Install python deps
       run: pip install -r scripts/gha/requirements.txt
-    - name: Update PR label and comment
+    - id: matrix_config
       run: |
+        if [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "expanded" ]]; then 
+          TEST_MATRIX_PARAM=-e=1
+          echo "::warning ::Running on the expanded matrix"
+        elif [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "minimal" ]]; then 
+          TEST_MATRIX_PARAM=-m=1" >> $GITHUB_ENV
+          echo "::warning ::Running on the minimal matrix"
+        elif [[ "${{ steps.set_outputs.outputs.requested_tests }}" == "auto" ]]; then 
+          # auto-diff only apply when running in a PR. 
+          # diff against the PR's base. "git merge-base main branch_name" will give the common ancestor of both branches.
+          MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
+          # If origin/<branch> is no longer valid, then just run all tests.
+          if [[ -n "${MERGE_BASE}" ]]; then
+            echo "::warning ::Auto-diff origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}"
+            git diff --name-only origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}
+            TEST_MATRIX_PARAM="--auto_diff origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}"
+          fi
+        fi
+
+        # To feed input into the job matrix, we first need to convert to a JSON
+        # list. Then we can use fromJson to define the field in the matrix for the tests job.
+        apis=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
+        echo "::set-output name=apis::${apis}"
+        echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis})"
+        echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}")"
+        # If building against a packaged SDK, only use boringssl.
+        if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
+          echo "::warning ::Downloading SDK package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
+          # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here. It won't actually matter later.
+          echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ssl_lib -o openssl )"
+        else
+          echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
+        fi
+        mobile_test_on=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k mobile_test_on -o "${{github.event.inputs.mobile_test_on}}")
+        echo "::set-output name=mobile_test_on::${mobile_test_on}"
+        echo "::set-output name=android_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k android_device -t ${mobile_test_on} )"
+        echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ios_device -t ${mobile_test_on} )"
+        echo "::set-output name=tvos_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k tvos_device -t ${mobile_test_on} )"
+    - name: Update PR label and comment
+      if: steps.set_outputs.outputs.pr_number
+      run: |
+        #Add the in-progress label and remove any previous labels.
         python scripts/gha/it_workflow.py --stage start \
           --token ${{github.token}} \
-          --issue_number ${{steps.get_pr_number.outputs.pr_number}} \
+          --issue_number ${{steps.set_outputs.outputs.pr_number}} \
           --actor ${{github.actor}} \
-          --commit ${{steps.get_pr_number.outputs.github_ref}} \
+          --commit ${{steps.set_outputs.outputs.github_ref}} \
           --run_id ${{github.run_id}}
-
-  # To feed input into the job matrix, we first need to convert to a JSON
-  # list. Then we can use fromJson to define the field in the matrix for the tests job.
-  prepare_matrix:
-    runs-on: ubuntu-latest
-    needs: check_trigger
-    if: ${{ !cancelled() && !failure() }}  # Run even if check_trigger was skipped.
-    outputs:
-      matrix_platform: ${{ steps.export-result.outputs.matrix_platform }}
-      matrix_os: ${{ steps.export-result.outputs.matrix_os }}
-      matrix_ssl: ${{ steps.export-result.outputs.matrix_ssl }}
-      apis: ${{ steps.export-result.outputs.apis }}
-      mobile_test_on: ${{ steps.export-result.outputs.mobile_test_on }}
-      android_device: ${{ steps.export-result.outputs.android_device }}
-      ios_device: ${{ steps.export-result.outputs.ios_device }}
-      tvos_device: ${{ steps.export-result.outputs.tvos_device }}
-      github_ref: ${{ steps.export-result.outputs.github_ref }}
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-          submodules: false
-      - name: Use expanded matrix
-        if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1' || needs.check_trigger.outputs.requested_tests == 'full'
-        run: |
-          echo "EXPANDED_MATRIX_PARAM=-e=1" >> $GITHUB_ENV
-          echo "::warning ::Running on the expanded matrix"
-      - name: Set auto-diff option if specified.
-        if: needs.check_trigger.outputs.requested_tests == 'auto'
-        run: |
-          echo "Autodetecting which tests to run."
-          if [[ -n "${{github.event.inputs.test_pull_request}}" || "${{github.event.inputs.test_pull_request}}" == "sdk" ]]; then
-            # If running this manually, diff against our common ancestor with main.
-            MERGE_BASE=$(git merge-base HEAD origin/main)
-            echo "::warning ::Auto-diff HEAD..${MERGE_BASE}"
-            git diff --name-only HEAD..${MERGE_BASE}
-            echo "AUTO_DIFF_PARAM=--auto_diff HEAD..${MERGE_BASE}" >> $GITHUB_ENV
-          else
-            # If running in a PR, diff against the PR's base.
-            # "git merge-base main branch_name" will give the common ancestor of both branches.
-            MERGE_BASE=$(git merge-base origin/${{github.event.pull_request.head.ref}} origin/${{github.event.pull_request.base.ref}} || true)
-            # If origin/<branch> is no longer valid, then just run all tests.
-            if [[ -n "${MERGE_BASE}" ]]; then
-              echo "::warning ::Auto-diff origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}"
-              git diff --name-only origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}
-              echo "AUTO_DIFF_PARAM=--auto_diff origin/${{github.event.pull_request.head.ref}}..${MERGE_BASE}" >> $GITHUB_ENV
-            fi
-          fi
-      - id: export-result
-        # e.g. 'ubuntu-latest,macos-latest' -> '["ubuntu-latest","macos-latest"]'
-        run: |
-          apis=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k apis -o "${{github.event.inputs.apis}}" ${AUTO_DIFF_PARAM})
-          echo "::set-output name=apis::${apis}"
-          echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} ${AUTO_DIFF_PARAM})"
-          echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}" ${AUTO_DIFF_PARAM})"
-          # If building against a packaged SDK, only use boringssl.
-          if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
-            echo "::warning ::Downloading SDK package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
-            # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here. It won't actually matter later.
-            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o openssl )"
-          else
-            echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
-          fi
-          mobile_test_on=$( python scripts/gha/print_matrix_configuration.py -c -w integration_tests -k mobile_test_on -o "${{github.event.inputs.mobile_test_on}}")
-          echo "::set-output name=mobile_test_on::${mobile_test_on}"
-          echo "::set-output name=android_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k android_device -t ${mobile_test_on} )"
-          echo "::set-output name=ios_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k ios_device -t ${mobile_test_on} )"
-          echo "::set-output name=tvos_device::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${EXPANDED_MATRIX_PARAM} -k tvos_device -t ${mobile_test_on} )"
-          if [[ -z "${{github.event.inputs.test_pull_request}}" || "${{github.event.inputs.test_pull_request}}" == "sdk" ]]; then
-            echo "::warning ::Running on https://github.com/${{github.repository}}/commits/$GITHUB_SHA"
-            echo "::set-output name=github_ref::$GITHUB_SHA"
-          elif [[ "${{github.event.inputs.test_pull_request}}" == *:* ]]; then
-            # If specified as pr:commit_hash, split them to get the exact hash.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f1) on commit https://github.com/${{github.repository}}/commit/$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
-            echo "::set-output name=github_ref::$(echo ${{ github.event.inputs.test_pull_request }} | cut -d: -f2)"
-          else
-            # Just the PR specified, use refs/pull/<number>/merge as the ref.
-            echo "::warning ::Running on https://github.com/${{github.repository}}/pull/${{github.event.inputs.test_pull_request}}"
-            echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
-          fi
 
   build_desktop:
     name: build-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-    needs: [check_trigger, prepare_matrix]
+    needs: [check_and_prepare]
     runs-on: ${{ matrix.os }}
     # Skip this if there is an empty matrix (which can happen if "auto" was set above).
     # But check cancelled() && !failure() so it runs even if check_trigger was skipped.
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'Desktop') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
-        ssl_variant: ${{ fromJson(needs.prepare_matrix.outputs.matrix_ssl) }}
+        os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
+        ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
       - name: Set env vars (Linux)
         if: startsWith(matrix.os, 'ubuntu')
@@ -261,7 +241,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-openssl-${{needs.prepare_matrix.outputs.github_ref}}
+          key: integration-test-ccache-linux-openssl
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -329,7 +309,7 @@ jobs:
             fi
           fi
           python scripts/gha/build_testapps.py --p Desktop \
-            --t ${{ needs.prepare_matrix.outputs.apis }} \
+            --t ${{ needs.check_and_prepare.outputs.apis }} \
             --output_directory "${{ github.workspace }}" \
             --artifact_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}" \
             --noadd_timestamp \
@@ -374,21 +354,21 @@ jobs:
         run: |
           python scripts/gha/gcs_uploader.py --testapp_dir ta --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
         shell: bash
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           pushd ${{env.GCS_UPLOAD_DIR}}
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize build results
         if: ${{ !cancelled() }}
@@ -401,17 +381,17 @@ jobs:
 
   build_android:
     name: build-android-${{ matrix.os }}
-    needs: [check_trigger, prepare_matrix]
+    needs: [check_and_prepare]
     runs-on: ${{ matrix.os }}
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'Android') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'Android') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
+        os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
       - name: Add msbuild to PATH (Windows)
         if: startsWith(matrix.os, 'windows')
@@ -465,7 +445,7 @@ jobs:
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           fi
           python scripts/gha/build_testapps.py --p Android \
-            --t ${{ needs.prepare_matrix.outputs.apis }}  \
+            --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
             --artifact_name "android-${{ matrix.os }}" \
             --noadd_timestamp \
@@ -493,19 +473,19 @@ jobs:
           path: build-results-android-${{ matrix.os }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize build results
         if: ${{ !cancelled() }}
@@ -518,15 +498,15 @@ jobs:
 
   build_ios:
     name: build-ios-macos-latest
-    needs: [check_trigger, prepare_matrix]
+    needs: [check_and_prepare]
     runs-on: macos-latest
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'iOS') && contains(needs.prepare_matrix.outputs.matrix_os, 'macos-latest') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
       - name: Setup python
         uses: actions/setup-python@v2
@@ -569,9 +549,9 @@ jobs:
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           fi
           python scripts/gha/build_testapps.py --p iOS \
-            --t ${{ needs.prepare_matrix.outputs.apis }}  \
+            --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
-            --ios_sdk ${{ needs.prepare_matrix.outputs.mobile_test_on }} \
+            --ios_sdk ${{ needs.check_and_prepare.outputs.mobile_test_on }} \
             --artifact_name "ios-macos-latest" \
             --noadd_timestamp \
             --short_output_paths \
@@ -598,19 +578,19 @@ jobs:
           path: build-results-ios-macos-latest*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize build results
         if: ${{ !cancelled() }}
@@ -623,15 +603,15 @@ jobs:
 
   build_tvos:
     name: build-tvos-macos-latest
-    needs: [check_trigger, prepare_matrix]
+    needs: [check_and_prepare]
     runs-on: macos-latest
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'tvOS') && contains(needs.prepare_matrix.outputs.matrix_os, 'macos-latest') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') && needs.prepare_matrix.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
       - name: Setup python
         uses: actions/setup-python@v2
@@ -674,7 +654,7 @@ jobs:
             additional_flags+=(--packaged_sdk downloaded_sdk/firebase_cpp_sdk)
           fi
           python scripts/gha/build_testapps.py --p tvOS \
-            --t ${{ needs.prepare_matrix.outputs.apis }}  \
+            --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
             --artifact_name "tvos-macos-latest" \
             --noadd_timestamp \
@@ -702,19 +682,19 @@ jobs:
           path: build-results-tvos-macos-latest*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize build results
         if: ${{ !cancelled() }}
@@ -727,18 +707,18 @@ jobs:
 
   test_desktop:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-    needs: [check_trigger, prepare_matrix, build_desktop]
+    needs: [check_and_prepare, build_desktop]
     runs-on: ${{ matrix.os }}
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'Desktop') && needs.prepare_matrix.outputs.apis != '' && !cancelled()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
-        ssl_variant: ${{ fromJson(needs.prepare_matrix.outputs.matrix_ssl) }}
+        os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
+        ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Desktop integration tests artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -778,19 +758,19 @@ jobs:
           path: testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize test results
         if: ${{ !cancelled() }}
@@ -803,18 +783,18 @@ jobs:
 
   test_android:
     name: test-android-${{ matrix.build_os }}-${{ matrix.android_device }}
-    needs: [check_trigger, prepare_matrix, build_android]
+    needs: [check_and_prepare, build_android]
     runs-on: macos-latest
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'Android') && needs.prepare_matrix.outputs.apis != '' && !cancelled()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'Android') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
       matrix:
-        build_os: ${{ fromJson(needs.prepare_matrix.outputs.matrix_os) }}
-        android_device: ${{ fromJson(needs.prepare_matrix.outputs.android_device) }}
+        build_os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
+        android_device: ${{ fromJson(needs.check_and_prepare.outputs.android_device) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Android integration tests artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -873,19 +853,19 @@ jobs:
           path: testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize test results
         if: ${{ !cancelled() }}
@@ -898,17 +878,17 @@ jobs:
 
   test_ios:
     name: test-ios-macos-latest-${{ matrix.ios_device }}
-    needs: [check_trigger, prepare_matrix, build_ios]
+    needs: [check_and_prepare, build_ios]
     runs-on: macos-latest
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'iOS') && needs.prepare_matrix.outputs.apis != '' && !cancelled()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
       matrix:
-        ios_device: ${{ fromJson(needs.prepare_matrix.outputs.ios_device) }}
+        ios_device: ${{ fromJson(needs.check_and_prepare.outputs.ios_device) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download iOS integration tests artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -967,19 +947,19 @@ jobs:
           path: testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize test results
         if: ${{ !cancelled() }}
@@ -992,17 +972,17 @@ jobs:
 
   test_tvos:
     name: test-tvos-macos-latest-${{ matrix.tvos_device }}
-    needs: [check_trigger, prepare_matrix, build_tvos]
+    needs: [check_and_prepare, build_tvos]
     runs-on: macos-latest
-    if: contains(needs.prepare_matrix.outputs.matrix_platform, 'tvOS') && needs.prepare_matrix.outputs.apis != '' && !cancelled()
+    if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
       matrix:
-        tvos_device: ${{ fromJson(needs.prepare_matrix.outputs.tvos_device) }}
+        tvos_device: ${{ fromJson(needs.check_and_prepare.outputs.tvos_device) }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download tvOS integration tests artifact
         uses: actions/download-artifact@v2.0.8
         with:
@@ -1040,19 +1020,19 @@ jobs:
           path: testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize test results
         if: ${{ !cancelled() }}
@@ -1065,13 +1045,13 @@ jobs:
 
   summarize_results:
     name: "summarize-results"
-    needs: [check_trigger, prepare_matrix, test_desktop, test_android, test_ios, test_tvos]
+    needs: [check_and_prepare, test_desktop, test_android, test_ios, test_tvos]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:
       - uses: actions/checkout@v2
         with:
-          ref: ${{needs.prepare_matrix.outputs.github_ref}}
+          ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1092,17 +1072,17 @@ jobs:
           app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
           private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
       - name: Update PR label and comment
-        if: ${{ needs.check_trigger.outputs.should_update_pr }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number }}
         run: |
           python scripts/gha/it_workflow.py --stage end \
             --token ${{github.token}} \
-            --issue_number ${{needs.check_trigger.outputs.pr_number}}\
+            --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}} \
             --new_token ${{steps.generate-token.outputs.token}}
       - name: Update Daily Report
-        if: ${{ github.event_name == 'schedule' || github.event.inputs.test_pull_request == 'sdk'}}
+        if: ${{ check_and_prepare.outputs.trigger == 'scheduled_trigger'}}
         shell: bash
         run: |
           if [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then
@@ -1113,7 +1093,7 @@ jobs:
           python scripts/gha/it_workflow.py --stage report \
             --token ${{github.token}} \
             --actor ${{github.actor}} \
-            --commit ${{needs.prepare_matrix.outputs.github_ref}} \
+            --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}} \
             ${additional_flags[*]}
       - name: Summarize results into GitHub log

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,7 +47,6 @@ env:
   statusCommentIdentifier: "integration-test-status-comment"
   pythonVersion: '3.7'
   artifactRetentionDays: 2
-  CCACHE_DIR: ${{ github.workspace }}/ccache_dir
 
 jobs:
   check_trigger:
@@ -262,7 +261,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-${{ matrix.os }}
+          key: integration-test-ccache-linux-${{needs.prepare_matrix.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -311,6 +310,8 @@ jobs:
           run_id: ${{ github.event.inputs.test_packaged_sdk }}
       - name: Build integration tests
         shell: bash
+        env: 
+          CCACHE_DIR: ${{ github.workspace }}/ccache_dir
         run: |
           declare -a additional_flags
           if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
@@ -334,12 +335,6 @@ jobs:
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
-      - name: Stats for ccache
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
-        run: |
-          ccache -s
-          ls ccache_dir
-          cat ccache_dir/ccache.conf
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -104,15 +104,16 @@ jobs:
           echo "::set-output name=requested_tests::expanded"
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=github_ref::$GITHUB_SHA"
-          echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
           if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
+            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=trigger::label_trigger"
             if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
               echo "::set-output name=requested_tests::auto"
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && -n "${{ github.event.pull_request.merged }}" ]]; then
+            echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=requested_tests::auto"
           elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -105,7 +105,7 @@ jobs:
         elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
           echo "::set-output name=github_ref::$GITHUB_SHA"
           echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
-          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == ${{ env.triggerLabelPrefix }}* ]]; then
+          if [[ "${{ github.event.action }}" == "labeled" && "${{ github.event.action }}" && "${{ github.event.label.name }}" == "${{ env.triggerLabelPrefix }}"* ]]; then
             echo "::set-output name=trigger::label_trigger"
             if [[ "${{ github.event.label.name }}" == "${{ env.triggerLabelQuick }}" ]]; then
               echo "::set-output name=requested_tests::auto"
@@ -115,7 +115,7 @@ jobs:
           elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }}]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=requested_tests::auto"
-          elif [[ "opened,reopened,synchronize" == *${{ github.event.action }}*  ]]; then
+          elif [[ "opened,reopened,synchronize" == *"${{ github.event.action }}"*  ]]; then
             echo "::set-output name=trigger::presubmit_trigger"
             echo "::set-output name=requested_tests::minimal"
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -337,6 +337,9 @@ jobs:
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
+      - name: Stats for ccache
+        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+        run: ccache -s
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -255,6 +255,16 @@ jobs:
         with:
           path: external/vcpkg/installed
           key: dev-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
+      - name: Cache ccache files
+        if: startsWith(matrix.os, 'ubuntu')
+        id: cache_ccache
+        uses: actions/cache@v2
+        with:
+          path: ccache_dir
+          key: integration-test-ccache-${{ matrix.os }}
+      - name: List ccache files
+        run: |
+          ls ccache_dir
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -239,12 +239,11 @@ jobs:
           path: external/vcpkg/installed
           key: dev-vcpkg-${{ env.VCPKG_TRIPLET }}-${{ hashFiles(format('{0}', env.VCPKG_RESPONSE_FILE)) }}-${{ hashFiles('.git/modules/external/vcpkg/HEAD') }}
       - name: Cache ccache files
-        if: startsWith(matrix.os, 'ubuntu') && matrix.ssl_variant == 'openssl'
-        id: cache_ccache
+        if: needs.check_and_prepare.outputs.trigger == 'presubmit_trigger'
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-openssl
+          key: presubmit-integration-test-ccache
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -261,8 +261,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ccache_dir
-          key: integration-test-ccache-linux-${{ github.ref }}-${{ hashFiles('ccache_dir/ccache.conf') }}
-          restore-keys: integration-test-ccache-linux-${{ github.ref }}-
+          key: integration-test-ccache-linux-${{ matrix.ssl_variant }}-${{ needs.prepare_matrix.outputs.apis }}-${{needs.prepare_matrix.outputs.github_ref}}
       - name: Setup python
         uses: actions/setup-python@v2
         with:

--- a/scripts/gha/it_workflow.py
+++ b/scripts/gha/it_workflow.py
@@ -53,6 +53,8 @@ import summarize_test_results as summarize
 _REPORT_LABEL = "nightly-testing"
 _REPORT_TITLE = "Nightly Integration Testing Report"
 
+_LABEL_TRIGGER_FULL = "tests-requested: full"
+_LABEL_TRIGGER_QUICK = "tests-requested: quick"
 _LABEL_PROGRESS = "tests: in-progress"
 _LABEL_FAILED = "tests: failed"
 _LABEL_SUCCEED = "tests: succeeded"
@@ -122,7 +124,7 @@ flags.DEFINE_string(
 def test_start(token, issue_number, actor, commit, run_id):
   """In PR, when start testing, add comment and label \"tests: in-progress\""""
   github.add_label(token, issue_number, _LABEL_PROGRESS)
-  for label in [_LABEL_FAILED, _LABEL_SUCCEED]:
+  for label in [_LABEL_TRIGGER_FULL, _LABEL_TRIGGER_QUICK, _LABEL_FAILED, _LABEL_SUCCEED]:
     github.delete_label(token, issue_number, label)
 
   comment = (_COMMENT_TITLE_PROGESS +

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -200,20 +200,13 @@ def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
   search_blocks = []
 
   parm_type_key = "config" if config_parms_only else "matrix"
-  default_workflow_block = PARAMETERS.get(DEFAULT_WORKFLOW)
-  default_workflow_parm_block = default_workflow_block.get(parm_type_key)
-  search_blocks.insert(0, default_workflow_parm_block)
-  if test_matrix and test_matrix in default_workflow_parm_block:
-    search_blocks.insert(0, default_workflow_parm_block[test_matrix])
-
-  if workflow != DEFAULT_WORKFLOW:
-    workflow_block = PARAMETERS.get(workflow)
-    if workflow_block:
-      workflow_parm_block = workflow_block.get(parm_type_key)
-      if workflow_parm_block:
-        search_blocks.insert(0, workflow_parm_block)
-        if test_matrix and test_matrix in workflow_parm_block:
-          search_blocks.insert(0, workflow_parm_block[test_matrix])
+  workflow_block = PARAMETERS.get(workflow)
+  if workflow_block:
+    workflow_parm_block = workflow_block.get(parm_type_key)
+    if workflow_parm_block:
+      search_blocks.insert(0, workflow_parm_block)
+      if test_matrix and test_matrix in workflow_parm_block:
+        search_blocks.insert(0, workflow_parm_block[test_matrix])
 
   for search_block in search_blocks:
     if parm_key in search_block:

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -120,7 +120,7 @@ PARAMETERS = {
       MINIMAL_KEY: {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
-        "apis": ["firestore"]
+        "apis": "firestore"
       },
 
       EXPANDED_KEY: {
@@ -196,7 +196,6 @@ def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
   """
   # Search for a given key happens in the following sequential order
   # Minimal/Expanded block (if test_matrix) -> Standard block
-  search_blocks = []
 
   parm_type_key = "config" if config_parms_only else "matrix"
   workflow_block = PARAMETERS.get(workflow)

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -375,6 +375,8 @@ def main():
     test_matrix = EXPANDED_KEY
   elif args.minimal:
     test_matrix = MINIMAL_KEY
+  else:
+    test_matrix = ""
   value = get_value(args.workflow, test_matrix, args.parm_key, args.config)
   if args.workflow == "integration_tests" and (args.parm_key == "android_device" or args.parm_key == "ios_device"):
     value = filter_devices(value, args.device_type)

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -195,22 +195,17 @@ def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
       (str|list): Matched value for the given key.
   """
   # Search for a given key happens in the following sequential order
-  # Expanded block (if use_expanded) -> Standard block
-  # -> Expanded default block (if_use_expanded) -> Default standard block
+  # Minimal/Expanded block (if test_matrix) -> Standard block
   search_blocks = []
 
   parm_type_key = "config" if config_parms_only else "matrix"
   workflow_block = PARAMETERS.get(workflow)
   if workflow_block:
-    workflow_parm_block = workflow_block.get(parm_type_key)
-    if workflow_parm_block:
-      search_blocks.insert(0, workflow_parm_block)
-      if test_matrix and test_matrix in workflow_parm_block:
-        search_blocks.insert(0, workflow_parm_block[test_matrix])
-
-  for search_block in search_blocks:
-    if parm_key in search_block:
-      return search_block[parm_key]
+    if test_matrix and test_matrix in workflow_block["matrix"]:
+      if parm_key in workflow_block["matrix"][test_matrix]:
+        return workflow_block["matrix"][test_matrix][parm_key]
+    
+    return workflow_block[parm_type_key][parm_key]
 
   else:
     raise KeyError("Parameter key: '{0}' of type '{1}' not found "\

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -203,7 +203,7 @@ def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
   default_workflow_block = PARAMETERS.get(DEFAULT_WORKFLOW)
   default_workflow_parm_block = default_workflow_block.get(parm_type_key)
   search_blocks.insert(0, default_workflow_parm_block)
-  if test_matrix in default_workflow_parm_block:
+  if test_matrix and test_matrix in default_workflow_parm_block:
     search_blocks.insert(0, default_workflow_parm_block[test_matrix])
 
   if workflow != DEFAULT_WORKFLOW:
@@ -212,7 +212,7 @@ def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
       workflow_parm_block = workflow_block.get(parm_type_key)
       if workflow_parm_block:
         search_blocks.insert(0, workflow_parm_block)
-        if test_matrix in workflow_parm_block:
+        if test_matrix and test_matrix in workflow_parm_block:
           search_blocks.insert(0, workflow_parm_block[test_matrix])
 
   for search_block in search_blocks:

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -67,6 +67,7 @@ from integration_testing import config_reader
 # if there is no direct match for a key.
 DEFAULT_WORKFLOW = "desktop"
 EXPANDED_KEY = "expanded"
+MINIMAL_KEY = "minimal"
 
 PARAMETERS = {
   "desktop": {
@@ -115,6 +116,12 @@ PARAMETERS = {
       "ndk_version": ["r22b"],
       "platform_version": ["28"],
       "build_tools_version": ["28.0.3"],
+
+      MINIMAL_KEY: {
+        "os": ["ubuntu-latest"],
+        "platform": ["Desktop"],
+        "apis": ["firestore"]
+      },
 
       EXPANDED_KEY: {
         "ssl_lib": ["openssl", "boringssl"],
@@ -171,12 +178,12 @@ TEST_DEVICES = {
  
 
 
-def get_value(workflow, use_expanded, parm_key, config_parms_only=False):
+def get_value(workflow, test_matrix, parm_key, config_parms_only=False):
   """ Fetch value from configuration
 
   Args:
       workflow (str): Key corresponding to the github workflow.
-      use_expanded (bool): Use expanded configuration for the workflow?
+      test_matrix (str): Use EXPANDED_KEY or MINIMAL_KEY configuration for the workflow?
       parm_key (str): Exact key name to fetch from configuration.
       config_parms_only (bool): Search in config blocks if True, else matrix
                                 blocks.
@@ -196,8 +203,8 @@ def get_value(workflow, use_expanded, parm_key, config_parms_only=False):
   default_workflow_block = PARAMETERS.get(DEFAULT_WORKFLOW)
   default_workflow_parm_block = default_workflow_block.get(parm_type_key)
   search_blocks.insert(0, default_workflow_parm_block)
-  if use_expanded and EXPANDED_KEY in default_workflow_parm_block:
-    search_blocks.insert(0, default_workflow_parm_block[EXPANDED_KEY])
+  if test_matrix in default_workflow_parm_block:
+    search_blocks.insert(0, default_workflow_parm_block[test_matrix])
 
   if workflow != DEFAULT_WORKFLOW:
     workflow_block = PARAMETERS.get(workflow)
@@ -205,8 +212,8 @@ def get_value(workflow, use_expanded, parm_key, config_parms_only=False):
       workflow_parm_block = workflow_block.get(parm_type_key)
       if workflow_parm_block:
         search_blocks.insert(0, workflow_parm_block)
-        if use_expanded and EXPANDED_KEY in workflow_parm_block:
-          search_blocks.insert(0, workflow_parm_block[EXPANDED_KEY])
+        if test_matrix in workflow_parm_block:
+          search_blocks.insert(0, workflow_parm_block[test_matrix])
 
   for search_block in search_blocks:
     if parm_key in search_block:
@@ -214,10 +221,10 @@ def get_value(workflow, use_expanded, parm_key, config_parms_only=False):
 
   else:
     raise KeyError("Parameter key: '{0}' of type '{1}' not found "\
-                   "for workflow '{2}' (expanded = {3}) .".format(parm_key,
+                   "for workflow '{2}' (test_matrix = {3}) .".format(parm_key,
                                                                 parm_type_key,
                                                                 workflow,
-                                                                use_expanded))
+                                                                test_matrix))
 
 
 def filter_devices(devices, device_type):
@@ -364,7 +371,11 @@ def main():
     print(TEST_DEVICES.get(args.parm_key).get("type"))
     return 
 
-  value = get_value(args.workflow, args.expanded, args.parm_key, args.config)
+  if args.expanded:
+    test_matrix = EXPANDED_KEY
+  elif args.minimal:
+    test_matrix = MINIMAL_KEY
+  value = get_value(args.workflow, test_matrix, args.parm_key, args.config)
   if args.workflow == "integration_tests" and (args.parm_key == "android_device" or args.parm_key == "ios_device"):
     value = filter_devices(value, args.device_type)
   if args.auto_diff:
@@ -376,6 +387,7 @@ def parse_cmdline_args():
   parser = argparse.ArgumentParser(description='Query matrix and config parameters used in Github workflows.')
   parser.add_argument('-c', '--config', action='store_true', help='Query parameter used for Github workflow/dispatch configurations.')
   parser.add_argument('-w', '--workflow', default=DEFAULT_WORKFLOW, help='Config key for Github workflow.')
+  parser.add_argument('-m', '--minimal', type=bool, default=False, help='Use minimal matrix')
   parser.add_argument('-e', '--expanded', type=bool, default=False, help='Use expanded matrix')
   parser.add_argument('-k', '--parm_key', required=True, help='Print the value of specified key from matrix or config maps.')
   parser.add_argument('-a', '--auto_diff', metavar='BRANCH', help='Compare with specified base branch to automatically set matrix options')


### PR DESCRIPTION
Combined "check_trigger" job and "prepare_matrix" job into "check_and_prepare" job.
Added "trigger" env variable. Apply "expanded_matrix, minimal_matrix, auto_diff" with different triggers accordingly.
Removed "auto_diff" from manual trigger, because the logic doesn't work. (Always override by inputs.)
Add presubmit(push) trigger, which run linux firestore with ccache. 
presubmit check: [without ccache](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1236217489) 35 mins vs [with ccache](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1236567562) 18 mins
To understand different [triggers](https://g3doc.corp.google.com/firebase/testing/g3doc/sdk/games-cpp.md?cl=head#ci-triggers).

TODO: Will add branch_protection_rules "build-desktop-ubuntu-latest-openssl" and "test-desktop-ubuntu-latest-openssl" after this PR get merged.
Will have a cache system which enable ccache in more cases.

