### PR TITLE
Add a comment field, for when update-dependencies is triggered by others.

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -93,6 +93,7 @@ jobs:
         run: |
           touch update_log.txt
           touch update_log_processed.txt
+          echo >> ios_pod/Podfile
           if true; then #! git update-index --refresh; then
             # Do a bit of post-processing on the update log to split it by platform.
             UPDATE_LOGFILE_PROCESSED=update_log_processed.txt

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -112,13 +112,16 @@ jobs:
 
             date_str=$(date "+%a %b %d %Y")
             commit_title="Update ${CHOSEN_DEPS} dependencies - ${date_str}"
-            commit_body="$(cat ${UPDATE_LOGFILE_PROCESSED})
+            commit_body=
+            if [[ -n '${{ github.event.inputs.comment }}' ]]; then
+              # If a comment was provided, start with that instead of blank.
+              commit_body='${{ github.event.inputs.comment }}
+
+            '
+            fi
+            commit_body="${commit_body}$(cat ${UPDATE_LOGFILE_PROCESSED})
 
           > Created by [${{github.workflow}} workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
-            if [[ -n '${{ github.event.inputs.comment }}' ]]; then
-              commit_body="${commit_body}
-          > "'${{ github.event.inputs.comment }}'
-            fi
             git config user.email "firebase-workflow-trigger-bot@google.com"
             git config user.name "firebase-workflow-trigger-bot"
             git config core.commentChar "%"  # so we can use # in git commit messages

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -91,10 +91,7 @@ jobs:
       - name: Push branch if there are changes
         id: push-branch
         run: |
-          touch update_log.txt
-          touch update_log_processed.txt
-          echo >> ios_pod/Podfile
-          if true; then #! git update-index --refresh; then
+          if ! git update-index --refresh; then
             # Do a bit of post-processing on the update log to split it by platform.
             UPDATE_LOGFILE_PROCESSED=update_log_processed.txt
             if grep -q ^Android: "${UPDATE_LOGFILE}"; then

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -91,6 +91,8 @@ jobs:
       - name: Push branch if there are changes
         id: push-branch
         run: |
+          touch update_log.txt
+          touch update_log_processed.txt
           if true; then #! git update-index --refresh; then
             # Do a bit of post-processing on the update log to split it by platform.
             UPDATE_LOGFILE_PROCESSED=update_log_processed.txt

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,6 +14,9 @@ on:
       baseBranch:
         description: 'create the new branch from this base'
         default: 'main'
+      comment:
+        description: 'extra comment for PR'
+        default: ''
 
 env:
   branchPrefix: "workflow/auto-update-deps-"
@@ -109,6 +112,11 @@ jobs:
             commit_body="$(cat ${UPDATE_LOGFILE_PROCESSED})
 
           > Created by [${{github.workflow}} workflow]($GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID)."
+            if [[ -n '${{ github.event.inputs.comment }}' ]]; then
+              commit_body="${commit_body}
+          > "'${{ github.event.inputs.comment }}'
+              commit_title="${commit_title} "'(${{ github.event.inputs.comment }})'
+            fi
             git config user.email "firebase-workflow-trigger-bot@google.com"
             git config user.name "firebase-workflow-trigger-bot"
             git config core.commentChar "%"  # so we can use # in git commit messages

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -118,7 +118,6 @@ jobs:
             if [[ -n '${{ github.event.inputs.comment }}' ]]; then
               commit_body="${commit_body}
           > "'${{ github.event.inputs.comment }}'
-              commit_title="${commit_title} "'(${{ github.event.inputs.comment }})'
             fi
             git config user.email "firebase-workflow-trigger-bot@google.com"
             git config user.name "firebase-workflow-trigger-bot"

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -15,7 +15,7 @@ on:
         description: 'create the new branch from this base'
         default: 'main'
       comment:
-        description: 'extra comment for PR'
+        description: 'optional comment to add to PR'
         default: ''
 
 env:
@@ -91,7 +91,7 @@ jobs:
       - name: Push branch if there are changes
         id: push-branch
         run: |
-          if ! git update-index --refresh; then
+          if true; then #! git update-index --refresh; then
             # Do a bit of post-processing on the update log to split it by platform.
             UPDATE_LOGFILE_PROCESSED=update_log_processed.txt
             if grep -q ^Android: "${UPDATE_LOGFILE}"; then


### PR DESCRIPTION
update-dependencies will be triggered by other projects (e.g. firebase-ios-sdk once https://github.com/firebase/firebase-ios-sdk/pull/8654 goes in). This adds an optional comment that will be included in the created PR, to make it clear what triggered the update.