### PR TITLE
De-flake integration tests on Android devices

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -154,7 +154,7 @@ BUILD_CONFIGS = {
 
 TEST_DEVICES = {
   "android_min": {"type": "real", "model":"Nexus10", "version":"19"},
-  "android_target": {"type": "real", "model":"Pixel2", "version":"28"},
+  "android_target": {"type": "real", "model":"blueline", "version":"28"},
   "android_latest": {"type": "real", "model":"flame", "version":"29"},
   "emulator_min": {"type": "virtual", "image":"system-images;android-18;google_apis;x86"},
   "emulator_target": {"type": "virtual", "image":"system-images;android-28;google_apis;x86_64"},

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -549,8 +549,8 @@ def _create_and_boot_emulator(sdk_id):
   logging.info("Wait for emulator to boot: %s", " ".join(args))
   subprocess.run(args=args, check=True)
   if FLAGS.ci: 
-    # wait extra 90 seconds to ensure emulator booted.
-    time.sleep(90)
+    # wait extra 90 seconds to ensure emulator fully booted.
+    time.sleep(180)
   else:
     time.sleep(45)
 


### PR DESCRIPTION
Updated the FTL Android device. Now messaging pass the tests.
Wait longer for Android emulator booting. 
Test on Emulators all passed. (less flaky): 
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1243299829
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1243298994
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1243097033