### PR TITLE
Fix integration test check step

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -721,8 +721,8 @@ jobs:
           USE_EXPANDED_MATRIX=0
         fi
         if [[ "${{ github.event_name }}" == "schedule" ]]; then
-          # reuse flag --test_pull_request=sdk to generate report
-          generate_report=(-p test_pull_request sdk)
+          # reuse flag --test_pull_request=nightly-packaging to generate report
+          generate_report=(-p test_pull_request nightly-packaging)
         fi
         verbose_flag=
         if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -114,7 +114,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged == true }} ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -94,7 +94,7 @@ jobs:
               echo "::set-output name=github_ref::refs/pull/${{github.event.inputs.test_pull_request}}/merge"
               echo "::set-output name=pr_number::${{ github.event.inputs.test_pull_request }}"
             fi
-          elif [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then
+          elif [[ "${{ github.event.inputs.test_pull_request }}" == "nightly-packaging" ]]; then
             # Triggered by scheduled packaging SDK workflow.
             echo "::set-output name=trigger::scheduled_trigger"
             echo "::set-output name=github_ref::$GITHUB_SHA"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -76,7 +76,7 @@ jobs:
     - id: set_outputs
       run: |
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then 
-          if [[ "${{ github.event.inputs.test_pull_request }}" != "sdk" ]]; then
+          if [[ "${{ github.event.inputs.test_pull_request }}" != "nightly-packaging" ]]; then
             # Triggered manually
             echo "::set-output name=trigger::manual_trigger"
             if [[ "${{ github.event.inputs.use_expanded_matrix }}" == "1" ]]; then
@@ -1087,7 +1087,7 @@ jobs:
         if: needs.check_and_prepare.outputs.trigger == 'scheduled_trigger'
         shell: bash
         run: |
-          if [[ "${{ github.event.inputs.test_pull_request }}" == "sdk" ]]; then
+          if [[ "${{ github.event.inputs.test_pull_request }}" == "nightly-packaging" ]]; then
             additional_flags=(--build_against sdk)
           else
             additional_flags=(--build_against repo)


### PR DESCRIPTION
${{ github.event.pull_request.merged }}'s value could be: true, false, empty. When it's empty, there is an error.
fix bug: https://github.com/firebase/firebase-cpp-sdk/runs/3631754439?check_suite_focus=true#step:3:41

Also change the "sdk" flag value to more descriptive "nightly-packaging" 