### PR TITLE
Admob - AdSize and AdRequest updates

### DIFF
--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -40,6 +40,7 @@ set(android_SRCS
 
 # Source files used by the iOS implementation.
 set(ios_SRCS
+    src/ios/FADAdSize.mm
     src/ios/FADBannerView.mm
     src/ios/FADInterstitialDelegate.mm
     src/ios/FADRequest.mm

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -90,6 +90,10 @@ static const char* kAdNetworkExtrasClassName =
 static const char* kAdNetworkExtrasClassName = "GADExtras";
 #endif
 
+// Used to detect kAdMobErrorAdNetworkClassLoadErrors when loading
+// ads.
+static const char* kAdNetworkExtrasInvalidClassName = "abc123321cba";
+
 static const char* kContentUrl = "http://www.firebase.com";
 
 using app_framework::LogDebug;
@@ -610,6 +614,26 @@ TEST_F(FirebaseAdMobTest, TestBannerViewAlreadyInitialized) {
                       firebase::admob::kAdMobErrorAlreadyInitialized);
     delete banner;
   }
+}
+
+TEST_F(FirebaseAdMobTest, TestBannerViewWithBadExtrasClassName) {
+  SKIP_TEST_ON_DESKTOP;
+
+  static const int kBannerWidth = 320;
+  static const int kBannerHeight = 50;
+
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+  firebase::admob::BannerView* banner = new firebase::admob::BannerView();
+  WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
+                                       kBannerAdUnit, banner_ad_size),
+                    "Initialize");
+
+  // Load the banner ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  request.add_extra(kAdNetworkExtrasInvalidClassName, "shouldnot", "work");
+  WaitForCompletion(banner->LoadAd(request), "LoadAd",
+                    firebase::admob::kAdMobErrorAdNetworkClassLoadError);
+  delete banner;
 }
 
 // A simple listener to help test changes to a InterstitialAd.

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -90,7 +90,7 @@ static const char* kAdNetworkExtrasClassName =
 static const char* kAdNetworkExtrasClassName = "GADExtras";
 #endif
 
-static const std::string kContentUrl = "http://www.firebase.com";
+static const char* kContentUrl = "http://www.firebase.com";
 
 using app_framework::LogDebug;
 using app_framework::ProcessEvents;
@@ -197,7 +197,7 @@ firebase::admob::AdRequest FirebaseAdMobTest::GetAdRequest() {
                       extras_iter->second.c_str());
   }
 
-  request.set_content_url(kContentUrl.c_str());
+  request.set_content_url(kContentUrl);
 
   return request;
 }
@@ -211,7 +211,7 @@ TEST_F(FirebaseAdMobTest, TestGetAdRequestValues) {
   const firebase::admob::AdRequest request = GetAdRequest();
 
   // Content URL.
-  EXPECT_TRUE(request.content_url() == kContentUrl);
+  EXPECT_TRUE(request.content_url() == std::string(kContentUrl));
 
   // Extras.
   std::map<std::string, std::map<std::string, std::string> > configured_extras =

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -19,10 +19,12 @@
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <map>
 #include <vector>
 
 #include "app_framework.h"  // NOLINT
 #include "firebase/admob.h"
+#include "firebase/admob/types.h"
 #include "firebase/app.h"
 #include "firebase/util.h"
 #include "firebase_test_framework.h"  // NOLINT
@@ -72,6 +74,24 @@ const char* kInterstitialAdUnit = "ca-app-pub-3940256099942544/4411468910";
 const std::vector<std::string> kTestDeviceIDs = {
     "2077ef9a63d2b398840261c8221a0c9b", "098fe087d987c9a878965454a65654d7"};
 
+// Sample keywords to use in making the request.
+static const std::vector<std::string> kKeywords({"AdMob", "C++", "Fun"});
+
+// "Extra" key value pairs can be added to the request as well. Typically
+// these are used when testing new features.
+static const std::map<std::string, std::string> kAdMobAdapterExtras = {
+    {"the_name_of_an_extra", "the_value_for_that_extra"},
+    {"heres", "a second example"}};
+
+#if defined(__ANDROID__)
+static const char* kAdNetworkExtrasClassName =
+    "com/google/ads/mediation/admob/AdMobAdapter";
+#else
+static const char* kAdNetworkExtrasClassName = "GADExtras";
+#endif
+
+static const std::string kContentUrl = "http://www.firebase.com";
+
 using app_framework::LogDebug;
 using app_framework::ProcessEvents;
 
@@ -95,6 +115,8 @@ class FirebaseAdMobTest : public FirebaseTest {
 };
 
 firebase::App* FirebaseAdMobTest::shared_app_ = nullptr;
+
+void BrieflyPauseForVisualInspection() { app_framework::ProcessEvents(100); }
 
 void FirebaseAdMobTest::SetUpTestSuite() {
   LogDebug("Initialize Firebase App.");
@@ -161,27 +183,71 @@ void FirebaseAdMobTest::SetUp() {
 void FirebaseAdMobTest::TearDown() { FirebaseTest::TearDown(); }
 
 firebase::admob::AdRequest FirebaseAdMobTest::GetAdRequest() {
-  // Sample keywords to use in making the request.
-  static const char* kKeywords[] = {"AdMob", "C++", "Fun"};
-
   firebase::admob::AdRequest request;
 
   // Additional keywords to be used in targeting.
-  request.keyword_count = sizeof(kKeywords) / sizeof(kKeywords[0]);
-  request.keywords = kKeywords;
+  for (auto keyword_iter = kKeywords.begin(); keyword_iter != kKeywords.end();
+       ++keyword_iter) {
+    request.add_keyword((*keyword_iter).c_str());
+  }
 
-  // "Extra" key value pairs can be added to the request as well. Typically
-  // these are used when testing new features.
-  static const firebase::admob::KeyValuePair kRequestExtras[] = {
-      {"the_name_of_an_extra", "the_value_for_that_extra"}};
-  request.extras_count = sizeof(kRequestExtras) / sizeof(kRequestExtras[0]);
-  request.extras = kRequestExtras;
+  for (auto extras_iter = kAdMobAdapterExtras.begin();
+       extras_iter != kAdMobAdapterExtras.end(); ++extras_iter) {
+    request.add_extra(kAdNetworkExtrasClassName, extras_iter->first.c_str(),
+                      extras_iter->second.c_str());
+  }
+
+  request.set_content_url(kContentUrl.c_str());
 
   return request;
 }
 
 // Test cases below.
 TEST_F(FirebaseAdMobTest, TestGetAdRequest) { GetAdRequest(); }
+
+TEST_F(FirebaseAdMobTest, TestGetAdRequestValues) {
+  SKIP_TEST_ON_DESKTOP;
+
+  const firebase::admob::AdRequest request = GetAdRequest();
+
+  // Content URL.
+  EXPECT_TRUE(request.content_url() == kContentUrl);
+
+  // Extras.
+  std::map<std::string, std::map<std::string, std::string> > configured_extras =
+      request.extras();
+
+  EXPECT_EQ(configured_extras.size(), 1);
+  for (auto extras_name_iter = configured_extras.begin();
+       extras_name_iter != configured_extras.end(); ++extras_name_iter) {
+    // Confirm class name.
+    const std::string class_name = extras_name_iter->first;
+    EXPECT_EQ(class_name, kAdNetworkExtrasClassName);
+
+    // Grab the extras.
+    const std::map<std::string, std::string>& configured_extras =
+        extras_name_iter->second;
+    EXPECT_EQ(configured_extras.size(), kAdMobAdapterExtras.size());
+
+    // Check the extra key value pairs.
+    for (auto constant_extras_iter = kAdMobAdapterExtras.begin();
+         constant_extras_iter != kAdMobAdapterExtras.end();
+         ++constant_extras_iter) {
+      // Ensure the configured value matches the constant for the same key.
+      EXPECT_EQ(configured_extras.at(constant_extras_iter->first),
+                constant_extras_iter->second);
+    }
+  }
+
+  const std::unordered_set<std::string> configured_keywords =
+      request.keywords();
+  EXPECT_EQ(configured_keywords.size(), kKeywords.size());
+  for (auto keyword_iter = kKeywords.begin(); keyword_iter != kKeywords.end();
+       ++keyword_iter) {
+    EXPECT_TRUE(configured_keywords.find(*keyword_iter) !=
+                configured_keywords.end());
+  }
+}
 
 // A simple listener to help test changes to a BannerView.
 class TestBannerViewListener : public firebase::admob::BannerView::Listener {
@@ -199,6 +265,71 @@ class TestBannerViewListener : public firebase::admob::BannerView::Listener {
       presentation_states_;
   std::vector<firebase::admob::BoundingBox> bounding_box_changes_;
 };
+
+TEST_F(FirebaseAdMobTest, TestAdSize) {
+  uint32_t kWidth = 50;
+  uint32_t kHeight = 10;
+
+  using firebase::admob::AdSize;
+
+  const AdSize adaptive_landscape =
+      AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(kWidth);
+  EXPECT_EQ(adaptive_landscape.width(), kWidth);
+  EXPECT_EQ(adaptive_landscape.height(), 0);
+  EXPECT_EQ(adaptive_landscape.type(), AdSize::kTypeAnchoredAdaptive);
+  EXPECT_EQ(adaptive_landscape.orientation(), AdSize::kOrientationLandscape);
+
+  const AdSize adaptive_portrait =
+      AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(kWidth);
+  EXPECT_EQ(adaptive_portrait.width(), kWidth);
+  EXPECT_EQ(adaptive_portrait.height(), 0);
+  EXPECT_EQ(adaptive_portrait.type(), AdSize::kTypeAnchoredAdaptive);
+  EXPECT_EQ(adaptive_portrait.orientation(), AdSize::kOrientationPortrait);
+
+  EXPECT_FALSE(adaptive_portrait == adaptive_landscape);
+  EXPECT_TRUE(adaptive_portrait != adaptive_landscape);
+
+  const firebase::admob::AdSize adaptive_current =
+      AdSize::GetCurrentOrientationAnchoredAdaptiveBannerAdSize(kWidth);
+  EXPECT_EQ(adaptive_current.width(), kWidth);
+  EXPECT_EQ(adaptive_current.height(), 0);
+  EXPECT_EQ(adaptive_current.type(), AdSize::kTypeAnchoredAdaptive);
+  EXPECT_EQ(adaptive_current.orientation(), AdSize::kOrientationCurrent);
+
+  const firebase::admob::AdSize custom_ad_size(kWidth, kHeight);
+  EXPECT_EQ(custom_ad_size.width(), kWidth);
+  EXPECT_EQ(custom_ad_size.height(), kHeight);
+  EXPECT_EQ(custom_ad_size.type(), AdSize::kTypeStandard);
+  EXPECT_EQ(custom_ad_size.orientation(), AdSize::kOrientationCurrent);
+
+  const AdSize custom_ad_size_2(kWidth, kHeight);
+  EXPECT_TRUE(custom_ad_size == custom_ad_size_2);
+  EXPECT_FALSE(custom_ad_size != custom_ad_size_2);
+
+  const AdSize banner = AdSize::kBanner;
+  EXPECT_EQ(banner.width(), 320);
+  EXPECT_EQ(banner.height(), 50);
+  EXPECT_EQ(banner.type(), AdSize::kTypeStandard);
+  EXPECT_EQ(banner.orientation(), AdSize::kOrientationCurrent);
+
+  const AdSize fullbanner = AdSize::kFullBanner;
+  EXPECT_EQ(fullbanner.width(), 468);
+  EXPECT_EQ(fullbanner.height(), 60);
+  EXPECT_EQ(fullbanner.type(), AdSize::kTypeStandard);
+  EXPECT_EQ(fullbanner.orientation(), AdSize::kOrientationCurrent);
+
+  const AdSize leaderboard = AdSize::kLeaderBoard;
+  EXPECT_EQ(leaderboard.width(), 728);
+  EXPECT_EQ(leaderboard.height(), 90);
+  EXPECT_EQ(leaderboard.type(), AdSize::kTypeStandard);
+  EXPECT_EQ(leaderboard.orientation(), AdSize::kOrientationCurrent);
+
+  const AdSize medium_rectangle = AdSize::kMediumRectangle;
+  EXPECT_EQ(medium_rectangle.width(), 300);
+  EXPECT_EQ(medium_rectangle.height(), 250);
+  EXPECT_EQ(medium_rectangle.type(), AdSize::kTypeStandard);
+  EXPECT_EQ(medium_rectangle.orientation(), AdSize::kOrientationCurrent);
+}
 
 TEST_F(FirebaseAdMobTest, TestRequestConfigurationSetGetEmptyConfig) {
   SKIP_TEST_ON_DESKTOP;
@@ -273,11 +404,7 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
   static const int kBannerWidth = 320;
   static const int kBannerHeight = 50;
 
-  firebase::admob::AdSize banner_ad_size;
-  banner_ad_size.ad_size_type = firebase::admob::kAdSizeStandard;
-  banner_ad_size.width = kBannerWidth;
-  banner_ad_size.height = kBannerHeight;
-
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
   firebase::admob::BannerView* banner = new firebase::admob::BannerView();
   WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
                                        kBannerAdUnit, banner_ad_size),
@@ -301,13 +428,16 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
-  // Move to each of the six pre-defined positions.
+  BrieflyPauseForVisualInspection();
 
+  // Move to each of the six pre-defined positions.
   WaitForCompletion(banner->MoveTo(firebase::admob::BannerView::kPositionTop),
                     "MoveTo(Top)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   WaitForCompletion(
       banner->MoveTo(firebase::admob::BannerView::kPositionTopLeft),
@@ -316,12 +446,16 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
+  BrieflyPauseForVisualInspection();
+
   WaitForCompletion(
       banner->MoveTo(firebase::admob::BannerView::kPositionTopRight),
       "MoveTo(TopRight)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   WaitForCompletion(
       banner->MoveTo(firebase::admob::BannerView::kPositionBottom),
@@ -330,12 +464,16 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
+  BrieflyPauseForVisualInspection();
+
   WaitForCompletion(
       banner->MoveTo(firebase::admob::BannerView::kPositionBottomLeft),
       "MoveTo(BottomLeft)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   WaitForCompletion(
       banner->MoveTo(firebase::admob::BannerView::kPositionBottomRight),
@@ -344,26 +482,36 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
+  BrieflyPauseForVisualInspection();
+
   // Move to some coordinates.
   WaitForCompletion(banner->MoveTo(100, 300), "MoveTo(x0, y0)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
+  BrieflyPauseForVisualInspection();
+
   WaitForCompletion(banner->MoveTo(100, 400), "MoveTo(x1, y1)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   // Try hiding and showing the BannerView.
   WaitForCompletion(banner->Hide(), "Hide 1");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateHidden);
 
+  BrieflyPauseForVisualInspection();
+
   WaitForCompletion(banner->Show(), "Show 1");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   // Move again after hiding/showing.
   WaitForCompletion(banner->MoveTo(100, 300), "MoveTo(x2, y2)");
@@ -371,10 +519,14 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
 
+  BrieflyPauseForVisualInspection();
+
   WaitForCompletion(banner->MoveTo(100, 400), "Moveto(x3, y3)");
   expected_presentation_states.push_back(
       firebase::admob::BannerView::kPresentationStateVisibleWithAd);
   expected_num_bounding_box_changes++;
+
+  BrieflyPauseForVisualInspection();
 
   WaitForCompletion(banner->Hide(), "Hide 2");
   expected_presentation_states.push_back(
@@ -429,11 +581,7 @@ TEST_F(FirebaseAdMobTest, TestBannerViewAlreadyInitialized) {
   static const int kBannerWidth = 320;
   static const int kBannerHeight = 50;
 
-  firebase::admob::AdSize banner_ad_size;
-  banner_ad_size.ad_size_type = firebase::admob::kAdSizeStandard;
-  banner_ad_size.width = kBannerWidth;
-  banner_ad_size.height = kBannerHeight;
-
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
   firebase::admob::BannerView* banner = new firebase::admob::BannerView();
 
   {
@@ -543,10 +691,7 @@ TEST_F(FirebaseAdMobTest, TestBannerViewMultithreadDeletion) {
   static const int kBannerWidth = 320;
   static const int kBannerHeight = 50;
 
-  firebase::admob::AdSize banner_ad_size;
-  banner_ad_size.ad_size_type = firebase::admob::kAdSizeStandard;
-  banner_ad_size.width = kBannerWidth;
-  banner_ad_size.height = kBannerHeight;
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
 
   for (int i = 0; i < 5; ++i) {
     firebase::admob::BannerView* banner = new firebase::admob::BannerView();

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -43,8 +43,9 @@ METHOD_LOOKUP_DEFINITION(ad_request_builder,
                          ADREQUESTBUILDER_METHODS);
 
 jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
-                                         admob::AdMobError& error) {
-  error = kAdMobErrorNone;
+                                         admob::AdMobError* error) {
+  FIREBASE_ASSERT(error);
+  *error = kAdMobErrorNone;
 
   JNIEnv* env = ::firebase::admob::GetJNI();
   jobject builder = env->NewObject(
@@ -64,7 +65,7 @@ jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
           "Failed to resolve extras class. Check that \"%s\""
           " is present in your APK.",
           adapter_name.c_str());
-      error = kAdMobErrorAdNetworkClassLoadError;
+      *error = kAdMobErrorAdNetworkClassLoadError;
       env->DeleteLocalRef(builder);
       return nullptr;
     }

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -53,6 +53,9 @@ jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
       ad_request_builder::GetMethodId(ad_request_builder::kConstructor));
 
   // Network Extras.
+  // The map associates class names of mediation adapters with a 
+  // key value pairs, the extras, to send to those medation adapters.
+  // e.g. Mediation_Map < class name, Extras_Map < key, value > >
   const std::map<std::string, std::map<std::string, std::string>>& extras =
       request.extras();
   for (auto adapter_iter = extras.begin(); adapter_iter != extras.end();

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -21,6 +21,7 @@
 
 #include <cstdarg>
 #include <cstddef>
+#include <map>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -22,6 +22,7 @@
 #include <cstdarg>
 #include <cstddef>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "admob/admob_resources.h"
@@ -35,23 +36,21 @@
 namespace firebase {
 namespace admob {
 
-static const char* kAdMobAdapterClassName =
-    "com/google/ads/mediation/admob/AdMobAdapter";
-
 METHOD_LOOKUP_DEFINITION(ad_request_builder,
                          PROGUARD_KEEP_CLASS
                          "com/google/android/gms/ads/AdRequest$Builder",
                          ADREQUESTBUILDER_METHODS);
 
-AdRequestConverter::AdRequestConverter(AdRequest request) {
+AdRequestConverter::AdRequestConverter(const AdRequest& request) {
   JNIEnv* env = ::firebase::admob::GetJNI();
   jobject builder = env->NewObject(
       ad_request_builder::GetClass(),
       ad_request_builder::GetMethodId(ad_request_builder::kConstructor));
 
   // Keywords.
-  for (int i = 0; i < request.keyword_count; i++) {
-    jstring keyword_str = env->NewStringUTF(request.keywords[i]);
+  const std::unordered_set<std::string>& keywords = request.keywords();
+  for (auto keyword = keywords.begin(); keyword != keywords.end(); ++keyword) {
+    jstring keyword_str = env->NewStringUTF((*keyword).c_str());
     builder = util::ContinueBuilder(
         env, builder,
         env->CallObjectMethod(
@@ -62,14 +61,29 @@ AdRequestConverter::AdRequestConverter(AdRequest request) {
   }
 
   // Network Extras.
-  if (request.extras_count > 0) {
+  const std::map<std::string, std::map<std::string, std::string>>& extras =
+      request.extras();
+  for (auto adapter_iter = extras.begin(); adapter_iter != extras.end();
+       ++adapter_iter) {
+    std::string adapter_name = adapter_iter->first;
+
+    jclass adapter_class = util::FindClass(env, adapter_name.c_str());
+    if (adapter_class == nullptr) {
+      LogError(
+          "Failed to resolve extras class. Check that \"%s\""
+          " is present in your APK.",
+          adapter_name.c_str());
+      continue;
+    }
+
     jobject extras_bundle =
         env->NewObject(util::bundle::GetClass(),
                        util::bundle::GetMethodId(util::bundle::kConstructor));
 
-    for (int i = 0; i < request.extras_count; i++) {
-      jstring extra_key_str = env->NewStringUTF(request.extras[i].key);
-      jstring extra_value_str = env->NewStringUTF(request.extras[i].value);
+    for (auto extra_iter = adapter_iter->second.begin();
+         extra_iter != adapter_iter->second.end(); ++extra_iter) {
+      jstring extra_key_str = env->NewStringUTF(extra_iter->first.c_str());
+      jstring extra_value_str = env->NewStringUTF(extra_iter->second.c_str());
       env->CallVoidMethod(extras_bundle,
                           util::bundle::GetMethodId(util::bundle::kPutString),
                           extra_key_str, extra_value_str);
@@ -77,28 +91,27 @@ AdRequestConverter::AdRequestConverter(AdRequest request) {
       env->DeleteLocalRef(extra_key_str);
     }
 
-    jclass admob_adapter_class =
-        util::FindClass(env, admob::GetActivity(), kAdMobAdapterClassName);
-
-    // If the adapter wasn't found correctly, the app has a serious problem.
-    FIREBASE_ASSERT_MESSAGE(
-        admob_adapter_class,
-        "Failed to locate the AdMobAdapter class for extras. Check that "
-        "com.google.ads.mediation.admob.AdMobAdapter is present in your APK.");
-    if (!admob_adapter_class) {
-      env->DeleteLocalRef(extras_bundle);
-      return;
-    }
-
     builder = util::ContinueBuilder(
         env, builder,
         env->CallObjectMethod(builder,
                               ad_request_builder::GetMethodId(
                                   ad_request_builder::kAddNetworkExtrasBundle),
-                              admob_adapter_class, extras_bundle));
+                              adapter_class, extras_bundle));
 
     env->DeleteLocalRef(extras_bundle);
-    env->DeleteLocalRef(admob_adapter_class);
+    env->DeleteLocalRef(adapter_class);
+  }
+
+  // Content URL
+  if (!request.content_url().empty()) {
+    jstring content_url = env->NewStringUTF(request.content_url().c_str());
+    builder = util::ContinueBuilder(
+        env, builder,
+        env->CallObjectMethod(
+            builder,
+            ad_request_builder::GetMethodId(ad_request_builder::kSetContentUrl),
+            content_url));
+    env->DeleteLocalRef(content_url);
   }
 
   // Set the request agent string so requests originating from this library can

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -53,7 +53,7 @@ jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
       ad_request_builder::GetMethodId(ad_request_builder::kConstructor));
 
   // Network Extras.
-  // The map associates class names of mediation adapters with a 
+  // The map associates class names of mediation adapters with a
   // key value pairs, the extras, to send to those medation adapters.
   // e.g. Mediation_Map < class name, Extras_Map < key, value > >
   const std::map<std::string, std::map<std::string, std::string>>& extras =

--- a/admob/src/android/ad_request_converter.h
+++ b/admob/src/android/ad_request_converter.h
@@ -32,7 +32,7 @@ class AdRequestConverter {
   /// Constructor.
   ///
   /// @param request The AdRequest struct to be converted into a Java AdRequest.
-  AdRequestConverter(AdRequest request);
+  AdRequestConverter(const AdRequest& request);
 
   /// Destructor.
   ~AdRequestConverter();

--- a/admob/src/android/ad_request_converter.h
+++ b/admob/src/android/ad_request_converter.h
@@ -35,7 +35,7 @@ namespace admob {
 /// @return On succes, a local reference to an Android object representing the
 /// AdRequest, or nullptr on error.
 jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
-                                         admob::AdMobError& error);
+                                         admob::AdMobError* error);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/android/ad_request_converter.h
+++ b/admob/src/android/ad_request_converter.h
@@ -32,7 +32,7 @@ class AdRequestConverter {
   /// Constructor.
   ///
   /// @param request The AdRequest struct to be converted into a Java AdRequest.
-  AdRequestConverter(const AdRequest& request);
+  explicit AdRequestConverter(const AdRequest& request);
 
   /// Destructor.
   ~AdRequestConverter();

--- a/admob/src/android/ad_request_converter.h
+++ b/admob/src/android/ad_request_converter.h
@@ -27,24 +27,15 @@ namespace admob {
 
 /// Converts instances of the AdRequest struct used by the C++ wrapper to
 /// jobject references to Mobile Ads SDK AdRequest objects.
-class AdRequestConverter {
- public:
-  /// Constructor.
-  ///
-  /// @param request The AdRequest struct to be converted into a Java AdRequest.
-  explicit AdRequestConverter(const AdRequest& request);
-
-  /// Destructor.
-  ~AdRequestConverter();
-
-  /// Retrieves the Java AdRequest associated with this object.
-  ///
-  /// @return a jobject AdRequest reference.
-  jobject GetJavaRequestObject();
-
- private:
-  jobject java_request_;
-};
+///
+/// @param[in] request The AdRequest struct to be converted into a Java
+/// AdRequest.
+/// @param[out] error kAdMobErrorNone on success, or another error if
+/// problems occurred.
+/// @return On succes, a local reference to an Android object representing the
+/// AdRequest, or nullptr on error.
+jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
+                                         admob::AdMobError& error);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -44,6 +44,20 @@ METHOD_LOOKUP_DEFINITION(mobile_ads,
                          PROGUARD_KEEP_CLASS
                          "com/google/android/gms/ads/MobileAds",
                          MOBILEADS_METHODS);
+METHOD_LOOKUP_DEFINITION(ad_size,
+                         PROGUARD_KEEP_CLASS
+                         "com/google/android/gms/ads/AdSize",
+                         ADSIZE_METHODS);
+METHOD_LOOKUP_DEFINITION(request_config,
+                         PROGUARD_KEEP_CLASS
+                         "com/google/android/gms/ads/RequestConfiguration",
+                         REQUESTCONFIGURATION_METHODS);
+
+METHOD_LOOKUP_DEFINITION(
+    request_config_builder,
+    PROGUARD_KEEP_CLASS
+    "com/google/android/gms/ads/RequestConfiguration$Builder",
+    REQUESTCONFIGURATIONBUILDER_METHODS);
 
 METHOD_LOOKUP_DEFINITION(request_config,
                          PROGUARD_KEEP_CLASS
@@ -528,6 +542,53 @@ bool RegisterNatives() {
          interstitial_ad_helper::RegisterNatives(
              env, kInterstitialMethods,
              FIREBASE_ARRAYSIZE(kInterstitialMethods));
+}
+
+jobject CreateJavaAdSize(JNIEnv* env, jobject j_activity,
+                         const AdSize& adsize) {
+  FIREBASE_ASSERT(env);
+  FIREBASE_ASSERT(j_activity);
+
+  jobject j_ad_size = nullptr;
+  switch (adsize.type()) {
+    case AdSize::kTypeAnchoredAdaptive:
+      switch (adsize.orientation()) {
+        case AdSize::kOrientationLandscape:
+          j_ad_size = env->CallStaticObjectMethod(
+              ad_size::GetClass(),
+              ad_size::GetMethodId(
+                  ad_size::kGetCurrentOrientationAnchoredAdaptiveBannerAdSize),
+              j_activity, adsize.width());
+          break;
+        case AdSize::kOrientationPortrait:
+          j_ad_size = env->CallStaticObjectMethod(
+              ad_size::GetClass(),
+              ad_size::GetMethodId(
+                  ad_size::kGetLandscapeAnchoredAdaptiveBannerAdSize),
+              j_activity, adsize.width());
+          break;
+        case AdSize::kOrientationCurrent:
+          j_ad_size = env->CallStaticObjectMethod(
+              ad_size::GetClass(),
+              ad_size::GetMethodId(
+                  ad_size::kGetCurrentOrientationAnchoredAdaptiveBannerAdSize),
+              j_activity, adsize.width());
+
+        default:
+          FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Orientation");
+      }
+    case AdSize::kTypeStandard:
+      j_ad_size = env->NewObject(ad_size::GetClass(),
+                                 ad_size::GetMethodId(ad_size::kConstructor),
+                                 adsize.width(), adsize.height());
+      break;
+    default:
+      FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Type");
+  }
+  bool jni_exception = util::CheckAndClearJniExceptions(env);
+  FIREBASE_ASSERT(!jni_exception);
+  FIREBASE_ASSERT(j_ad_size);
+  return j_ad_size;
 }
 
 }  // namespace admob

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -59,17 +59,6 @@ METHOD_LOOKUP_DEFINITION(
     "com/google/android/gms/ads/RequestConfiguration$Builder",
     REQUESTCONFIGURATIONBUILDER_METHODS);
 
-METHOD_LOOKUP_DEFINITION(request_config,
-                         PROGUARD_KEEP_CLASS
-                         "com/google/android/gms/ads/RequestConfiguration",
-                         REQUESTCONFIGURATION_METHODS);
-
-METHOD_LOOKUP_DEFINITION(
-    request_config_builder,
-    PROGUARD_KEEP_CLASS
-    "com/google/android/gms/ads/RequestConfiguration$Builder",
-    REQUESTCONFIGURATIONBUILDER_METHODS);
-
 static JavaVM* g_java_vm = nullptr;
 static const ::firebase::App* g_app = nullptr;
 static jobject g_activity;

--- a/admob/src/android/admob_android.h
+++ b/admob/src/android/admob_android.h
@@ -24,6 +24,8 @@
 namespace firebase {
 namespace admob {
 
+class AdSize;
+
 // Used to setup the cache of AdRequestBuilder class method IDs to reduce
 // time spent looking up methods by string.
 // clang-format off
@@ -32,11 +34,31 @@ namespace admob {
   X(Build, "build", "()Lcom/google/android/gms/ads/AdRequest;"),             \
   X(AddKeyword, "addKeyword",                                                \
       "(Ljava/lang/String;)Lcom/google/android/gms/ads/AdRequest$Builder;"), \
-  X(SetRequestAgent, "setRequestAgent",                                      \
-      "(Ljava/lang/String;)Lcom/google/android/gms/ads/AdRequest$Builder;"), \
   X(AddNetworkExtrasBundle, "addNetworkExtrasBundle",                        \
       "(Ljava/lang/Class;Landroid/os/Bundle;)"                               \
-      "Lcom/google/android/gms/ads/AdRequest$Builder;")
+      "Lcom/google/android/gms/ads/AdRequest$Builder;"),                     \
+  X(SetContentUrl, "setContentUrl",                                          \
+      "(Ljava/lang/String;)Lcom/google/android/gms/ads/AdRequest$Builder;"), \
+  X(SetRequestAgent, "setRequestAgent",                                      \
+      "(Ljava/lang/String;)Lcom/google/android/gms/ads/AdRequest$Builder;")
+// clang-format on
+
+// clang-format off
+#define ADSIZE_METHODS(X)                                                    \
+  X(Constructor, "<init>", "(II)V"),                                         \
+  X(GetCurrentOrientationAnchoredAdaptiveBannerAdSize,                       \
+    "getCurrentOrientationAnchoredAdaptiveBannerAdSize",                     \
+    "(Landroid/content/Context;I)Lcom/google/android/gms/ads/AdSize;",       \
+    util::kMethodTypeStatic),                                                \
+  X(GetLandscapeAnchoredAdaptiveBannerAdSize,                                \
+    "getLandscapeAnchoredAdaptiveBannerAdSize",                              \
+    "(Landroid/content/Context;I)Lcom/google/android/gms/ads/AdSize;",       \
+    util::kMethodTypeStatic),                                                \
+  X(GetPortraitAnchoredAdaptiveBannerAdSize,                                 \
+    "getPortraitAnchoredAdaptiveBannerAdSize",                               \
+    "(Landroid/content/Context;I)Lcom/google/android/gms/ads/AdSize;",       \
+    util::kMethodTypeStatic)
+
 // clang-format on
 
 // clang-format off
@@ -84,6 +106,7 @@ METHOD_LOOKUP_DECLARATION(request_config,
                           REQUESTCONFIGURATION_METHODS);
 METHOD_LOOKUP_DECLARATION(request_config_builder,
                           REQUESTCONFIGURATIONBUILDER_METHODS);
+METHOD_LOOKUP_DECLARATION(ad_size, ADSIZE_METHODS);
 
 // Change codes used when receiving state change callbacks from the Java
 // BannerViewHelperHelper object.
@@ -106,6 +129,11 @@ bool RegisterNatives();
 
 // Release classes registered by this module.
 void ReleaseClasses(JNIEnv* env);
+
+// Constructs a com.google.android.gms.ads.AdSize object from a C++ AdSize
+// counterpart.
+jobject CreateJavaAdSize(JNIEnv* env, jobject activity,
+                         const AdSize& an_ad_size);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/android/banner_view_internal_android.cc
+++ b/admob/src/android/banner_view_internal_android.cc
@@ -51,9 +51,6 @@ METHOD_LOOKUP_DEFINITION(
 METHOD_LOOKUP_DEFINITION(ad_view, "com/google/android/gms/ads/AdView",
                          AD_VIEW_METHODS);
 
-METHOD_LOOKUP_DEFINITION(ad_size, "com/google/android/gms/ads/AdSize",
-                         AD_SIZE_METHODS);
-
 namespace internal {
 
 BannerViewInternalAndroid::BannerViewInternalAndroid(BannerView* base)
@@ -120,7 +117,8 @@ struct BannerViewInternalInitializeData {
   BannerViewInternalInitializeData()
       : activity_global(nullptr),
         ad_view(nullptr),
-        banner_view_helper(nullptr) {}
+        banner_view_helper(nullptr),
+        ad_size(0, 0) {}
   ~BannerViewInternalInitializeData() {
     JNIEnv* env = GetJNI();
     env->DeleteGlobalRef(activity_global);
@@ -159,29 +157,23 @@ void InitializeBannerViewOnMainThread(void* data) {
   env->CallVoidMethod(call_data->ad_view,
                       ad_view::GetMethodId(ad_view::kSetAdUnitId),
                       ad_unit_id_str);
-  env->DeleteLocalRef(ad_unit_id_str);
-
   bool jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);
+  env->DeleteLocalRef(ad_unit_id_str);
 
-  jobject ad_size = env->NewObject(
-      ad_size::GetClass(), ad_size::GetMethodId(ad_size::kConstructor),
-      call_data->ad_size.width, call_data->ad_size.height);
-
-  jni_exception = util::CheckAndClearJniExceptions(env);
-  FIREBASE_ASSERT(!jni_exception);
-
+  jobject ad_size =
+      CreateJavaAdSize(env, call_data->activity_global, call_data->ad_size);
+  FIREBASE_ASSERT(ad_size);
   env->CallVoidMethod(call_data->ad_view,
                       ad_view::GetMethodId(ad_view::kSetAdSize), ad_size);
-
   jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);
+  env->DeleteLocalRef(ad_size);
 
   env->CallVoidMethod(
       call_data->banner_view_helper,
       banner_view_helper::GetMethodId(banner_view_helper::kInitialize),
       call_data->activity_global);
-
   jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);
 
@@ -191,17 +183,14 @@ void InitializeBannerViewOnMainThread(void* data) {
                      banner_view_helper_ad_view_listener::GetMethodId(
                          banner_view_helper_ad_view_listener::kConstructor),
                      call_data->banner_view_helper);
-
   jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);
 
   env->CallVoidMethod(call_data->ad_view,
                       ad_view::GetMethodId(ad_view::kSetAdListener),
                       ad_listener);
-
   jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);
-
   env->DeleteLocalRef(ad_listener);
 
   CompleteFuture(kAdMobErrorNone, "", call_data->callback_data->future_handle,
@@ -212,7 +201,7 @@ void InitializeBannerViewOnMainThread(void* data) {
 
 Future<void> BannerViewInternalAndroid::Initialize(AdParent parent,
                                                    const char* ad_unit_id,
-                                                   AdSize size) {
+                                                   const AdSize& size) {
   FutureCallbackData* callback_data =
       CreateFutureCallbackData(&future_data_, kBannerViewFnInitialize);
 

--- a/admob/src/android/banner_view_internal_android.cc
+++ b/admob/src/android/banner_view_internal_android.cc
@@ -237,7 +237,7 @@ Future<void> BannerViewInternalAndroid::LoadAd(const AdRequest& request) {
       CreateFutureCallbackData(&future_data_, kBannerViewFnLoadAd);
 
   admob::AdMobError error = kAdMobErrorNone;
-  jobject request_ref = GetJavaAdRequestFromCPPAdRequest(request, error);
+  jobject request_ref = GetJavaAdRequestFromCPPAdRequest(request, &error);
 
   if (request_ref == nullptr) {
     if (error == kAdMobErrorNone) {

--- a/admob/src/android/banner_view_internal_android.h
+++ b/admob/src/android/banner_view_internal_android.h
@@ -62,13 +62,6 @@ METHOD_LOOKUP_DECLARATION(banner_view_helper_ad_view_listener,
 
 METHOD_LOOKUP_DECLARATION(ad_view, AD_VIEW_METHODS);
 
-// clang-format off
-#define AD_SIZE_METHODS(X)                                            \
-  X(Constructor, "<init>", "(II)V")
-// clang-format on
-
-METHOD_LOOKUP_DECLARATION(ad_size, AD_SIZE_METHODS);
-
 namespace internal {
 
 class BannerViewInternalAndroid : public BannerViewInternal {
@@ -77,7 +70,7 @@ class BannerViewInternalAndroid : public BannerViewInternal {
   ~BannerViewInternalAndroid() override;
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id,
-                          AdSize size) override;
+                          const AdSize& size) override;
   Future<void> LoadAd(const AdRequest& request) override;
   Future<void> Hide() override;
   Future<void> Show() override;

--- a/admob/src/android/interstitial_ad_internal_android.cc
+++ b/admob/src/android/interstitial_ad_internal_android.cc
@@ -89,7 +89,7 @@ Future<void> InterstitialAdInternalAndroid::LoadAd(const AdRequest& request) {
       CreateFutureCallbackData(&future_data_, kInterstitialAdFnLoadAd);
 
   admob::AdMobError error = kAdMobErrorNone;
-  jobject request_ref = GetJavaAdRequestFromCPPAdRequest(request, error);
+  jobject request_ref = GetJavaAdRequestFromCPPAdRequest(request, &error);
 
   if (request_ref == nullptr) {
     if (error == kAdMobErrorNone) {

--- a/admob/src/android/interstitial_ad_internal_android.cc
+++ b/admob/src/android/interstitial_ad_internal_android.cc
@@ -88,14 +88,24 @@ Future<void> InterstitialAdInternalAndroid::LoadAd(const AdRequest& request) {
   FutureCallbackData* callback_data =
       CreateFutureCallbackData(&future_data_, kInterstitialAdFnLoadAd);
 
-  AdRequestConverter converter(request);
-  jobject request_ref = converter.GetJavaRequestObject();
+  admob::AdMobError error = kAdMobErrorNone;
+  jobject request_ref = GetJavaAdRequestFromCPPAdRequest(request, error);
 
-  ::firebase::admob::GetJNI()->CallVoidMethod(
-      helper_,
-      interstitial_ad_helper::GetMethodId(interstitial_ad_helper::kLoadAd),
-      reinterpret_cast<jlong>(callback_data), request_ref);
-  return GetLastResult(kInterstitialAdFnLoadAd);
+  if (request_ref == nullptr) {
+    if (error == kAdMobErrorNone) {
+      error = kAdMobErrorInternalError;
+    }
+    CompleteFuture(error, "", callback_data->future_handle,
+                   callback_data->future_data);
+  } else {
+    ::firebase::admob::GetJNI()->CallVoidMethod(
+        helper_,
+        interstitial_ad_helper::GetMethodId(interstitial_ad_helper::kLoadAd),
+        reinterpret_cast<jlong>(callback_data), request_ref);
+    ::firebase::admob::GetJNI()->DeleteLocalRef(request_ref);
+  }
+  return Future<void>(&callback_data->future_data->future_impl,
+                      callback_data->future_handle);
 }
 
 Future<void> InterstitialAdInternalAndroid::Show() {

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -51,6 +51,10 @@ DEFINE_FIREBASE_VERSION_STRING(FirebaseAdMob);
 static CleanupNotifier* g_cleanup_notifier = nullptr;
 const char kAdMobModuleName[] = "admob";
 
+// Hardcoded values are from publicly available documentation:
+// https://developers.google.com/android/reference/com/google/android/gms/ads/AdSize
+// A dynamic resolution of thes values creates a lot of Android code,
+// and these are standards that are not likely to change.
 const AdSize AdSize::kBanner(/*width=*/320, /*height=*/50);
 const AdSize AdSize::kFullBanner(468, 60);
 const AdSize AdSize::kLargeBanner(320, 100);

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -50,6 +50,77 @@ DEFINE_FIREBASE_VERSION_STRING(FirebaseAdMob);
 static CleanupNotifier* g_cleanup_notifier = nullptr;
 const char kAdMobModuleName[] = "admob";
 
+const AdSize AdSize::kBanner(/*width=*/320, /*height=*/50);
+const AdSize AdSize::kFullBanner(468, 60);
+const AdSize AdSize::kLargeBanner(320, 100);
+const AdSize AdSize::kLeaderBoard(728, 90);
+const AdSize AdSize::kMediumRectangle(300, 250);
+
+AdSize::AdSize(uint32_t width, uint32_t height)
+    : width_(width),
+      height_(height),
+      type_(AdSize::kTypeStandard),
+      orientation_(AdSize::kOrientationCurrent) {}
+
+AdSize AdSize::GetAnchoredAdaptiveBannerAdSize(uint32_t width,
+                                               Orientation orientation) {
+  AdSize ad_size(width, 0);
+  ad_size.type_ = AdSize::kTypeAnchoredAdaptive;
+  ad_size.orientation_ = orientation;
+  return ad_size;
+}
+
+AdSize AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(uint32_t width) {
+  return GetAnchoredAdaptiveBannerAdSize(width, AdSize::kOrientationLandscape);
+}
+
+AdSize AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(uint32_t width) {
+  return GetAnchoredAdaptiveBannerAdSize(width, AdSize::kOrientationPortrait);
+}
+
+AdSize AdSize::GetCurrentOrientationAnchoredAdaptiveBannerAdSize(
+    uint32_t width) {
+  return GetAnchoredAdaptiveBannerAdSize(width, AdSize::kOrientationCurrent);
+}
+
+bool AdSize::is_equal(const AdSize& ad_size) const {
+  return (type_ == ad_size.type_) && (width_ == ad_size.width_) &&
+         (height_ == ad_size.height_) && (orientation_ == ad_size.orientation_);
+}
+
+bool AdSize::operator==(const AdSize& rhs) const { return is_equal(rhs); }
+
+bool AdSize::operator!=(const AdSize& rhs) const { return !is_equal(rhs); }
+
+AdRequest::AdRequest() {}
+AdRequest::~AdRequest() {}
+
+AdRequest::AdRequest(const char* content_url) { set_content_url(content_url); }
+
+void AdRequest::add_extra(const char* ad_network, const char* extra_key,
+                          const char* extra_value) {
+  if (ad_network != nullptr && extra_key != nullptr && extra_value != nullptr) {
+    extras_[std::string(ad_network)][std::string(extra_key)] =
+        std::string(extra_value);
+  }
+}
+
+void AdRequest::add_keyword(const char* keyword) {
+  if (keyword != nullptr) {
+    keywords_.insert(std::string(keyword));
+  }
+}
+
+void AdRequest::set_content_url(const char* content_url) {
+  if (content_url == nullptr) {
+    return;
+  }
+  std::string url(content_url);
+  if (url.size() <= 512) {
+    content_url_ = url;
+  }
+}
+
 void RegisterTerminateOnDefaultAppDestroy() {
   if (!AppCallback::GetEnabledByName(kAdMobModuleName)) {
     // It's possible to initialize AdMob without firebase::App so only register

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -18,6 +18,7 @@
 
 #include <assert.h>
 
+#include <string>
 #include <vector>
 
 #include "admob/src/include/firebase/admob.h"

--- a/admob/src/common/banner_view.cc
+++ b/admob/src/common/banner_view.cc
@@ -56,7 +56,7 @@ static bool CheckIsInitialized(internal::BannerViewInternal* internal) {
 }
 
 Future<void> BannerView::Initialize(AdParent parent, const char* ad_unit_id,
-                                    AdSize size) {
+                                    const AdSize& size) {
   return internal_->Initialize(parent, ad_unit_id, size);
 }
 

--- a/admob/src/common/banner_view_internal.h
+++ b/admob/src/common/banner_view_internal.h
@@ -51,7 +51,7 @@ class BannerViewInternal {
 
   // Initializes this object and any platform-specific helpers that it uses.
   virtual Future<void> Initialize(AdParent parent, const char* ad_unit_id,
-                                  AdSize size) = 0;
+                                  const AdSize& size) = 0;
 
   // Initiates an ad request.
   virtual Future<void> LoadAd(const AdRequest& request) = 0;

--- a/admob/src/include/firebase/admob/banner_view.h
+++ b/admob/src/include/firebase/admob/banner_view.h
@@ -144,7 +144,7 @@ class BannerView {
   /// @param[in] parent The platform-specific UI element that will host the ad.
   /// @param[in] ad_unit_id The ad unit ID to use when requesting ads.
   /// @param[in] size The desired ad size for the banner.
-  Future<void> Initialize(AdParent parent, const char* ad_unit_id, AdSize size);
+  Future<void> Initialize(AdParent parent, const char* ad_unit_id, const AdSize& size);
 
   /// Returns a @ref Future that has the status of the last call to
   /// @ref Initialize.

--- a/admob/src/include/firebase/admob/banner_view.h
+++ b/admob/src/include/firebase/admob/banner_view.h
@@ -144,7 +144,8 @@ class BannerView {
   /// @param[in] parent The platform-specific UI element that will host the ad.
   /// @param[in] ad_unit_id The ad unit ID to use when requesting ads.
   /// @param[in] size The desired ad size for the banner.
-  Future<void> Initialize(AdParent parent, const char* ad_unit_id, const AdSize& size);
+  Future<void> Initialize(AdParent parent, const char* ad_unit_id,
+                          const AdSize& size);
 
   /// Returns a @ref Future that has the status of the last call to
   /// @ref Initialize.

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -223,6 +223,7 @@ struct KeyValuePair {
   const char *value;
 };
 
+/// Contains targeting information used to fetch an ad.
 class AdRequest {
  public:
   /// Creates an @ref AdRequest with no custom configuration.
@@ -236,7 +237,7 @@ class AdRequest {
   /// The URL is ignored if null or the number of characters exceeds 512.
   ///
   /// @param[in] content_url the url of the content being viewed.
-  AdRequest(const char *content_url);
+  explicit AdRequest(const char *content_url);
 
   ~AdRequest();
 
@@ -265,7 +266,7 @@ class AdRequest {
   /// @param[in] ad_network the ad network for which to add the extra.
   /// @param[in] extra_key a key which will be passed to the corresponding ad
   /// network adapter.
-  /// @param[in] extra_value the value associated with @ref extra_key.
+  /// @param[in] extra_value the value associated with extra_key.
   void add_extra(const char *ad_network, const char *extra_key,
                  const char *extra_value);
 
@@ -273,7 +274,7 @@ class AdRequest {
   ///
   /// Multiple keywords may be added via repeated invocations of this method.
   ///
-  /// @param[in] a string that Admob will use to aid in targeting ads.
+  /// @param[in] keyword a string that Admob will use to aid in targeting ads.
   void add_keyword(const char *keyword);
 
   /// When requesting an ad, apps may pass the URL of the content they are

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -17,7 +17,9 @@
 #ifndef FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_TYPES_H_
 #define FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_TYPES_H_
 
+#include <map>
 #include <string>
+#include <unordered_set>
 #include <vector>
 
 #include "firebase/internal/platform.h"
@@ -84,17 +86,132 @@ enum AdMobError {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
-/// @brief Types of ad sizes.
-enum AdSizeType { kAdSizeStandard = 0 };
+/// The size of a banner ad.
+class AdSize {
+ public:
+  ///  Denotes the orientation of the AdSize.
+  enum Orientation {
+    /// AdSize should reflect the current orientation of the device.
+    kOrientationCurrent = 0,
 
-/// @brief An ad size value to be used in requesting ads.
-struct AdSize {
-  /// The type of ad size.
-  AdSizeType ad_size_type;
-  /// Height of the ad (in points or dp).
-  int height;
-  /// Width of the ad (in points or dp).
-  int width;
+    /// AdSize will be adaptively formatted in Landscape mode.
+    kOrientationLandscape,
+
+    /// AdSize will be adaptively formatted in Portrait mode.
+    kOrientationPortrait
+  };
+
+  /// Denotes the type size object that the @ref AdSize represents.
+  enum Type {
+    /// The standard AdSize type of a set height and width.
+    kTypeStandard = 0,
+
+    /// An adaptive size anchored to a portion of the screen.
+    kTypeAnchoredAdaptive,
+  };
+
+  /// Mobile Marketing Association (MMA) banner ad size (320x50
+  /// density-independent pixels).
+  static const AdSize kBanner;
+
+  /// Interactive Advertising Bureau (IAB) full banner ad size
+  /// (468x60 density-independent pixels).
+  static const AdSize kFullBanner;
+
+  /// Taller version of kGADAdSizeBanner. Typically 320x100.
+  static const AdSize kLargeBanner;
+
+  /// Interactive Advertising Bureau (IAB) leaderboard ad size
+  /// (728x90 density-independent pixels).
+  static const AdSize kLeaderBoard;
+
+  /// Interactive Advertising Bureau (IAB) medium rectangle ad size
+  /// (300x250 density-independent pixels).
+  static const AdSize kMediumRectangle;
+
+  /// Creates a new AdSize.
+  ///
+  /// @param[in] width The width of the ad in density-independent pixels.
+  /// @param[in] height The height of the ad in density-independent pixels.
+  AdSize(uint32_t width, uint32_t height);
+
+  /// @brief Creates an AdSize with the given width and a Google-optimized
+  /// height to create a banner ad in landscape mode.
+  ///
+  /// @param[in] width The width of the ad in density-independent pixels.
+  ///
+  /// @return an AdSize with the given width and a Google-optimized height
+  /// to create a banner ad. The size returned will have an aspect ratio
+  /// similar to BANNER, suitable for anchoring near the top or bottom of
+  /// your app.
+  static AdSize GetLandscapeAnchoredAdaptiveBannerAdSize(uint32_t width);
+
+  /// @brief Creates an AdSize with the given width and a Google-optimized
+  /// height to create a banner ad in portrait mode.
+  ///
+  /// @param[in] width The width of the ad in density-independent pixels.
+  ///
+  /// @return an AdSize with the given width and a Google-optimized height
+  /// to create a banner ad. The size returned will have an aspect ratio
+  /// similar to BANNER, suitable for anchoring near the top or bottom
+  /// of your app.
+  static AdSize GetPortraitAnchoredAdaptiveBannerAdSize(uint32_t width);
+
+  /// @brief Creates an AdSize with the given width and a Google-optimized
+  /// height to create a banner ad given the current orientation.
+  ///
+  /// @param[in] width The width of the ad in density-independent pixels.
+  ///
+  /// @return an AdSize with the given width and a Google-optimized height
+  /// to create a banner ad. The size returned will have an aspect ratio
+  /// similar to AdSize, suitable for anchoring near the top or bottom of
+  /// your app.
+  static AdSize GetCurrentOrientationAnchoredAdaptiveBannerAdSize(
+      uint32_t width);
+
+  /// Comparison operator.
+  ///
+  /// @return true if `rhs` refers to the same AdSize as `this`.
+  bool operator==(const AdSize &rhs) const;
+
+  /// Comparison operator.
+  ///
+  /// @returns true if `rhs` refers to a different AdSize as `this`.
+  bool operator!=(const AdSize &rhs) const;
+
+  /// The width of the region represented by this AdSize.  Value is in
+  /// density-independent pixels.
+  uint32_t width() const { return width_; }
+
+  /// The height of the region represented by this AdSize. Value is in
+  /// density-independent pixels.
+  uint32_t height() const { return height_; }
+
+  /// The AdSize orientation.
+  Orientation orientation() const { return orientation_; }
+
+  /// The AdSize type, either standard size or adaptive.
+  Type type() const { return type_; }
+
+ private:
+  /// Returns an Anchor Adpative AdSize Object given a width and orientation.
+  static AdSize GetAnchoredAdaptiveBannerAdSize(uint32_t width,
+                                                Orientation orientation);
+
+  /// Returns true if the AdSize parameter is equivalient to this AdSize object.
+  bool is_equal(const AdSize &ad_size) const;
+
+  /// Denotes the orientation for anchored adaptive AdSize objects.
+  Orientation orientation_;
+
+  /// Advertisement width in platform-indepenent pixels.
+  uint32_t width_;
+
+  /// Advertisement width in platform-indepenent pixels.
+  uint32_t height_;
+
+  /// The type of AdSize (standard or adaptive)
+  Type type_;
 };
 
 /// @brief Generic Key-Value container used for the "extras" values in an
@@ -106,18 +223,71 @@ struct KeyValuePair {
   const char *value;
 };
 
-/// @brief The information needed to request an ad.
-struct AdRequest {
-  /// An array of keywords or phrases describing the current user activity, such
-  /// as "Sports Scores" or "Football."
-  const char **keywords;
-  /// The number of entries in the array referenced by keywords.
-  unsigned int keyword_count;
-  /// A @ref KeyValuePair specifying additional parameters accepted by an ad
-  /// network.
-  const KeyValuePair *extras;
-  /// The number of entries in the array referenced by extras.
-  unsigned int extras_count;
+class AdRequest {
+ public:
+  /// Creates an @ref AdRequest with no custom configuration.
+  AdRequest();
+
+  /// Creates an @ref AdRequest with the optional content URL.
+  ///
+  /// When requesting an ad, apps may pass the URL of the content they are
+  /// serving. This enables keyword targeting to match the ad with the content.
+  ///
+  /// The URL is ignored if null or the number of characters exceeds 512.
+  ///
+  /// @param[in] content_url the url of the content being viewed.
+  AdRequest(const char *content_url);
+
+  ~AdRequest();
+
+  /// The content URL targeting information.
+  ///
+  /// @return the content URL for the @ref AdRequest. The string will be empty
+  /// if no content URL has been configured.
+  const std::string &content_url() const { return content_url_; }
+
+  /// A Map of ad network adapters to their collection of extra parameters, as
+  /// configured via @ref add_extra.
+  const std::map<std::string, std::map<std::string, std::string> > &extras()
+      const {
+    return extras_;
+  }
+
+  /// Keywords which will help Admob to provide targeted ads, as added by
+  /// @ref add_keyword.
+  const std::unordered_set<std::string> &keywords() const { return keywords_; }
+
+  /// Add a network extra for the associated ad_network.
+  ///
+  /// Appends an extra to the corresponding list of extras for the ad_network.
+  /// Each ad network can have multiple extra strings.
+  ///
+  /// @param[in] ad_network the ad network for which to add the extra.
+  /// @param[in] extra_key a key which will be passed to the corresponding ad
+  /// network adapter.
+  /// @param[in] extra_value the value associated with @ref extra_key.
+  void add_extra(const char *ad_network, const char *extra_key,
+                 const char *extra_value);
+
+  /// Adds a keyword for targeting purposes.
+  ///
+  /// Multiple keywords may be added via repeated invocations of this method.
+  ///
+  /// @param[in] a string that Admob will use to aid in targeting ads.
+  void add_keyword(const char *keyword);
+
+  /// When requesting an ad, apps may pass the URL of the content they are
+  /// serving. This enables keyword targeting to match the ad with the content.
+  ///
+  /// The URL is ignored if null or the number of characters exceeds 512.
+  ///
+  /// @param[in] content_url the url of the content being viewed.
+  void set_content_url(const char *content_url);
+
+ private:
+  std::string content_url_;
+  std::map<std::string, std::map<std::string, std::string> > extras_;
+  std::unordered_set<std::string> keywords_;
 };
 
 /// @brief The screen location and dimensions of an ad view once it has been

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -79,6 +79,9 @@ enum AdMobError {
   /// An attempt has been made to show an ad on an Android Activity that has
   /// no window token (such as one that's not done initializing).
   kAdMobErrorNoWindowToken,
+  /// An attempt to load an Ad Network extras class for an ad request has
+  /// failed.
+  kAdMobErrorAdNetworkClassLoadError,
   /// Fallback error for any unidentified cases.
   kAdMobErrorUnknown,
 };

--- a/admob/src/ios/FADAdSize.h
+++ b/admob/src/ios/FADAdSize.h
@@ -1,5 +1,5 @@
 /*
- * Copyright 2016 Google LLC
+ * Copyright 2021 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 namespace firebase {
 namespace admob {
 
-/// Returns a GADRequest from an admob::AdRequest.
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest);
+/// Returns a GADAdSize from an admob::AdSize.
+GADAdSize GADSizeFromCppAdSize(const AdSize& ad_size);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADAdSize.mm
+++ b/admob/src/ios/FADAdSize.mm
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#import "admob/src/ios/FADAdSize.h"
+
+#include "admob/src/common/admob_common.h"
+
+namespace firebase {
+namespace admob {
+
+GADAdSize GADSizeFromCppAdSize(const AdSize& ad_size) {
+  switch (ad_size.type()) {
+    case AdSize::kTypeAnchoredAdaptive:
+      switch (ad_size.orientation()) {
+        case AdSize::kOrientationLandscape:
+          return GADLandscapeAnchoredAdaptiveBannerAdSizeWithWidth(ad_size.width());
+          break;
+        case AdSize::kOrientationPortrait:
+          return GADPortraitAnchoredAdaptiveBannerAdSizeWithWidth(ad_size.width());
+          break;
+        case AdSize::kOrientationCurrent:
+          return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(ad_size.width());
+          break;
+        default:
+          FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Orientation");
+      }
+    case AdSize::kTypeStandard:
+      return GADAdSizeFromCGSize(CGSizeMake(ad_size.width(), ad_size.height()));
+      break;
+    default:
+      FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Type");
+  }
+}
+
+}
+}

--- a/admob/src/ios/FADBannerView.mm
+++ b/admob/src/ios/FADBannerView.mm
@@ -16,6 +16,8 @@
 
 #include "admob/src/ios/FADBannerView.h"
 
+#import "admob/src/ios/FADAdSize.h"
+
 namespace admob = firebase::admob;
 
 @interface FADBannerView () <GADBannerViewDelegate> {
@@ -35,7 +37,7 @@ namespace admob = firebase::admob;
   NSString *_adUnitID;
 
   /// The banner view's ad size.
-  admob::AdSize _adSize;
+  GADAdSize _adSize;
 
   /// The BannerViewInternalIOS object.
   admob::internal::BannerViewInternalIOS *_cppBannerView;
@@ -52,14 +54,15 @@ namespace admob = firebase::admob;
 
 - (instancetype)initWithView:(UIView *)view
                     adUnitID:(NSString *)adUnitID
-                      adSize:(admob::AdSize)adSize
+                      adSize:(firebase::admob::AdSize)adSize
           internalBannerView:(firebase::admob::internal::BannerViewInternalIOS *)cppBannerView {
-  CGRect frame = CGRectMake(0, 0, adSize.width, adSize.height);
+  GADAdSize gadsize = GADSizeFromCppAdSize(adSize);
+  CGRect frame = CGRectMake(0, 0, gadsize.size.width, gadsize.size.height);
   self = [super initWithFrame:frame];
   if (self) {
     _parentView = view;
     _adUnitID = [adUnitID copy];
-    _adSize = adSize;
+    _adSize = gadsize;
     _cppBannerView = cppBannerView;
     _presentationState = admob::BannerView::kPresentationStateHidden;
     [self setUpBannerView];
@@ -69,8 +72,7 @@ namespace admob = firebase::admob;
 
 /// Called from the designated initializer. Sets up a banner view.
 - (void)setUpBannerView {
-  GADAdSize size = GADAdSizeFromCGSize(CGSizeMake(_adSize.width, _adSize.height));
-  _bannerView = [[GADBannerView alloc] initWithAdSize:size];
+  _bannerView = [[GADBannerView alloc] initWithAdSize:_adSize];
   _bannerView.adUnitID = _adUnitID;
   _bannerView.delegate = self;
 

--- a/admob/src/ios/FADRequest.h
+++ b/admob/src/ios/FADRequest.h
@@ -32,10 +32,13 @@ namespace admob {
 /// GAdRequest.
 /// @param[out] error kAdMobErrorNone on success, or another error if
 /// problems occurred.
+/// @param[out] error_message a string representation of any error that
+/// occurs.
 /// @return On succes, a pointer to a GADRequest object representing the
 /// AdRequest, or nullptr on error.
 GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
-                                       admob::AdMobError* error);
+                                       admob::AdMobError* error, 
+                                       std::string& error_message);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADRequest.h
+++ b/admob/src/ios/FADRequest.h
@@ -17,6 +17,8 @@
 #import <Foundation/Foundation.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
+#include <string>
+
 #include "admob/src/include/firebase/admob/types.h"
 
 NS_ASSUME_NONNULL_BEGIN
@@ -37,8 +39,8 @@ namespace admob {
 /// @return On succes, a pointer to a GADRequest object representing the
 /// AdRequest, or nullptr on error.
 GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
-                                       admob::AdMobError* error, 
-                                       std::string& error_message);
+                                       admob::AdMobError* error,
+                                       std::string* error_message);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADRequest.h
+++ b/admob/src/ios/FADRequest.h
@@ -25,7 +25,7 @@ namespace firebase {
 namespace admob {
 
 /// Returns a GADRequest from an admob::AdRequest.
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest);
+GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobError& error);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADRequest.h
+++ b/admob/src/ios/FADRequest.h
@@ -25,7 +25,17 @@ namespace firebase {
 namespace admob {
 
 /// Returns a GADRequest from an admob::AdRequest.
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobError& error);
+/// Converts instances of the AdRequest struct used by the C++ wrapper to
+/// to Mobile Ads SDK GADRequest objects.
+///
+/// @param[in] request The AdRequest struct to be converted into a
+/// GAdRequest.
+/// @param[out] error kAdMobErrorNone on success, or another error if
+/// problems occurred.
+/// @return On succes, a pointer to a GADRequest object representing the
+/// AdRequest, or nullptr on error.
+GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
+                                       admob::AdMobError* error);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -17,40 +17,76 @@
 #import "admob/src/ios/FADRequest.h"
 
 #include "admob/src/common/admob_common.h"
+#include "app/src/util_ios.h"
+
+#include "app/src/log.h"
 
 namespace firebase {
 namespace admob {
 
-GADRequest *GADRequestFromCppAdRequest(AdRequest adRequest) {
+GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest) {
   // Create the GADRequest.
-  GADRequest *request = [GADRequest request];
+  GADRequest *gadRequest = [GADRequest request];
+
   // Keywords.
-  if (adRequest.keyword_count > 0) {
-    NSMutableArray *keywords = [[NSMutableArray alloc] init];
-    for (int i = 0; i < adRequest.keyword_count; i++) {
-      [keywords addObject:@(adRequest.keywords[i])];
+  const std::unordered_set<std::string>& keywords = adRequest.keywords();
+  if( keywords.size() > 0 ) {
+    NSMutableArray *gadKeywords = [[NSMutableArray alloc] init];
+    for (auto keyword = keywords.begin(); keyword != keywords.end(); ++keyword) {
+      [gadKeywords addObject: util::StringToNSString(*keyword)];
     }
-    request.keywords = keywords;
+    gadRequest.keywords = gadKeywords;
+  }
+  
+  // Extras.
+  const std::map<std::string, std::map<std::string, std::string>>& extras =
+      adRequest.extras();
+  for (auto adapter_iter = extras.begin(); adapter_iter != extras.end(); 
+       ++adapter_iter) {
+    const std::string adapterClassName = adapter_iter->first;
+    // Attempt to resolve the custom class.
+    Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
+    if (extrasClass == nil ) {
+      LogError("Failed to resolve extras class: \"%s\"", adapterClassName.c_str());
+      continue;
+    }
+
+    // Attempt allocate a object of the class, and check to see if it's
+    // of an expected type.
+    id gadExtrasId = [[extrasClass alloc] init];
+    if (![gadExtrasId isKindOfClass:[GADExtras class]]) {
+      LogError("Failed to load extras class inherited from GADExtras: \"%s\"",
+          adapterClassName.c_str());
+      continue;
+    }
+
+    // Add the key/value dictionary to the object.
+    // adpter_iter->second is a std::map of the key/value pairs.
+    if (!adapter_iter->second.empty()) {
+      NSMutableDictionary *additionalParameters = [[NSMutableDictionary alloc] init];
+      for (auto extra_iter = adapter_iter->second.begin();
+           extra_iter != adapter_iter->second.end(); ++extra_iter) {
+        NSString *key = util::StringToNSString(extra_iter->first);
+        NSString *value = util::StringToNSString(extra_iter->second);
+        additionalParameters[key] = value;
+      }
+      
+      GADExtras* gadExtras = (GADExtras*)gadExtrasId;
+      gadExtras.additionalParameters = additionalParameters;
+      [gadRequest registerAdNetworkExtras:gadExtras];
+    }
   }
 
-  // Extras.
-  if (adRequest.extras_count > 0) {
-    NSMutableDictionary *additionalParameters = [[NSMutableDictionary alloc] init];
-    for (int i = 0; i < adRequest.extras_count; i++) {
-      NSString *key = @(adRequest.extras[i].key);
-      NSString *value = @(adRequest.extras[i].value);
-      additionalParameters[key] = value;
-    }
-    GADExtras *extras = [[GADExtras alloc] init];
-    extras.additionalParameters = additionalParameters;
-    [request registerAdNetworkExtras:extras];
+  // Content URL
+  if (!adRequest.content_url().empty()) {
+    gadRequest.contentURL = util::StringToNSString(adRequest.content_url());
   }
 
   // Set the request agent string so requests originating from this library can
   // be tracked and reported on as a group.
-  request.requestAgent = @(GetRequestAgentString());
+  gadRequest.requestAgent = @(GetRequestAgentString());
 
-  return request;
+  return gadRequest;
 }
 
 }

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -24,8 +24,10 @@
 namespace firebase {
 namespace admob {
 
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobError& error) {
-  error = kAdMobErrorNone;
+GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, 
+                                      admob::AdMobError* error) {
+  FIREBASE_ASSERT(error);
+  *error = kAdMobErrorNone;
 
   // Create the GADRequest.
   GADRequest *gadRequest = [GADRequest request];
@@ -50,7 +52,7 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobE
     Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
     if (extrasClass == nil ) {
       LogError("Failed to resolve extras class: \"%s\"", adapterClassName.c_str());
-      error = kAdMobErrorAdNetworkClassLoadError;
+      *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }
 
@@ -60,7 +62,7 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobE
     if (![gadExtrasId isKindOfClass:[GADExtras class]]) {
       LogError("Failed to load extras class inherited from GADExtras: \"%s\"",
           adapterClassName.c_str());
-      error = kAdMobErrorAdNetworkClassLoadError;
+      *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }
 

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -25,7 +25,8 @@ namespace firebase {
 namespace admob {
 
 GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, 
-                                      admob::AdMobError* error) {
+                                      admob::AdMobError* error, 
+                                      std::string& error_message) {
   FIREBASE_ASSERT(error);
   *error = kAdMobErrorNone;
 
@@ -51,7 +52,9 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
     // Attempt to resolve the custom class.
     Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
     if (extrasClass == nil ) {
-      LogError("Failed to resolve extras class: \"%s\"", adapterClassName.c_str());
+      error_message = "Failed to resolve extras class: ";
+      error_message.append(adapterClassName);
+      LogError(error_message.c_str());
       *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }
@@ -60,8 +63,9 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
     // of an expected type.
     id gadExtrasId = [[extrasClass alloc] init];
     if (![gadExtrasId isKindOfClass:[GADExtras class]]) {
-      LogError("Failed to load extras class inherited from GADExtras: \"%s\"",
-          adapterClassName.c_str());
+      error_message = "Failed to load extras class inherited from GADExtras: ";
+      error_message.append(adapterClassName);
+      LogError(error_message.c_str());
       *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -24,7 +24,9 @@
 namespace firebase {
 namespace admob {
 
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest) {
+GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, admob::AdMobError& error) {
+  error = kAdMobErrorNone;
+
   // Create the GADRequest.
   GADRequest *gadRequest = [GADRequest request];
 
@@ -48,7 +50,8 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest) {
     Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
     if (extrasClass == nil ) {
       LogError("Failed to resolve extras class: \"%s\"", adapterClassName.c_str());
-      continue;
+      error = kAdMobErrorAdNetworkClassLoadError;
+      return nullptr;
     }
 
     // Attempt allocate a object of the class, and check to see if it's
@@ -57,7 +60,8 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest) {
     if (![gadExtrasId isKindOfClass:[GADExtras class]]) {
       LogError("Failed to load extras class inherited from GADExtras: \"%s\"",
           adapterClassName.c_str());
-      continue;
+      error = kAdMobErrorAdNetworkClassLoadError;
+      return nullptr;
     }
 
     // Add the key/value dictionary to the object.

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -26,8 +26,9 @@ namespace admob {
 
 GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, 
                                       admob::AdMobError* error, 
-                                      std::string& error_message) {
+                                      std::string* error_message) {
   FIREBASE_ASSERT(error);
+  FIREBASE_ASSERT(error_message);
   *error = kAdMobErrorNone;
 
   // Create the GADRequest.
@@ -52,9 +53,9 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
     // Attempt to resolve the custom class.
     Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
     if (extrasClass == nil ) {
-      error_message = "Failed to resolve extras class: ";
-      error_message.append(adapterClassName);
-      LogError(error_message.c_str());
+      *error_message = "Failed to resolve extras class: ";
+      error_message->append(adapterClassName);
+      LogError(error_message->c_str());
       *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }
@@ -63,9 +64,9 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
     // of an expected type.
     id gadExtrasId = [[extrasClass alloc] init];
     if (![gadExtrasId isKindOfClass:[GADExtras class]]) {
-      error_message = "Failed to load extras class inherited from GADExtras: ";
-      error_message.append(adapterClassName);
-      LogError(error_message.c_str());
+      *error_message = "Failed to load extras class inherited from GADExtras: ";
+      error_message->append(adapterClassName);
+      LogError(error_message->c_str());
       *error = kAdMobErrorAdNetworkClassLoadError;
       return nullptr;
     }

--- a/admob/src/ios/banner_view_internal_ios.h
+++ b/admob/src/ios/banner_view_internal_ios.h
@@ -33,7 +33,7 @@ class BannerViewInternalIOS : public BannerViewInternal {
   ~BannerViewInternalIOS();
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id,
-                          AdSize size) override;
+                          const AdSize& size) override;
   Future<void> LoadAd(const AdRequest& request) override;
   Future<void> Hide() override;
   Future<void> Show() override;

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -39,7 +39,7 @@ BannerViewInternalIOS::~BannerViewInternalIOS() {
 }
 
 Future<void> BannerViewInternalIOS::Initialize(AdParent parent, const char* ad_unit_id,
-                                               AdSize size) {
+                                               const AdSize& size) {
   FutureCallbackData* callback_data =
       CreateFutureCallbackData(&future_data_, kBannerViewFnInitialize);
   if(initialized_) {

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -81,7 +81,7 @@ Future<void> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an admob::AdRequest.
     AdMobError error = kAdMobErrorNone;
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, error);
+    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, &error);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -81,13 +81,18 @@ Future<void> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an admob::AdRequest.
     AdMobError error = kAdMobErrorNone;
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, &error);
+    std::string error_message;
+    GADRequest *ad_request =
+     GADRequestFromCppAdRequest(*request_copy, &error, error_message);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {
         error = kAdMobErrorInternalError;
+        CompleteLoadFuture(error, 
+          "Internal error attempting to create GADRequest.");
+      } else {
+        CompleteLoadFuture(error, error_message.c_str());
       }
-      CompleteLoadFuture(error, "");
     } else {
       // Make the banner view ad request.
       [banner_view_ loadRequest:ad_request];

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -83,7 +83,7 @@ Future<void> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
     AdMobError error = kAdMobErrorNone;
     std::string error_message;
     GADRequest *ad_request =
-     GADRequestFromCppAdRequest(*request_copy, &error, error_message);
+     GADRequestFromCppAdRequest(*request_copy, &error, &error_message);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -79,11 +79,19 @@ Future<void> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
   AdRequest *request_copy = new AdRequest;
   *request_copy = request;
   dispatch_async(dispatch_get_main_queue(), ^{
-    // A GADRequest from an admob::AdRequest.
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy);
+    // Create a GADRequest from an admob::AdRequest.
+    AdMobError error = kAdMobErrorNone;
+    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, error);
     delete request_copy;
-    // Make the banner view ad request.
-    [banner_view_ loadRequest:ad_request];
+    if(ad_request==nullptr) {
+      if(error==kAdMobErrorNone) {
+        error = kAdMobErrorInternalError;
+      }
+      CompleteLoadFuture(error, "");
+    } else {
+      // Make the banner view ad request.
+      [banner_view_ loadRequest:ad_request];
+    }
   });
   return GetLastResult(kBannerViewFnLoadAd);
 }

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -79,7 +79,7 @@ Future<void> InterstitialAdInternalIOS::LoadAd(const AdRequest& request) {
     AdMobError error = kAdMobErrorNone;
     std::string error_message;
     GADRequest *ad_request =
-     GADRequestFromCppAdRequest(*request_copy, &error, error_message);
+     GADRequestFromCppAdRequest(*request_copy, &error, &error_message);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -75,12 +75,21 @@ Future<void> InterstitialAdInternalIOS::LoadAd(const AdRequest& request) {
   AdRequest *request_copy = new AdRequest;
   *request_copy = request;
   dispatch_async(dispatch_get_main_queue(), ^{
-    // A GADRequest from an admob::AdRequest.
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy);
+    // Create a GADRequest from an admob::AdRequest.
+    AdMobError error = kAdMobErrorNone;
+    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, error);
     delete request_copy;
-    // Make the interstitial ad request.
-    [interstitial_ loadRequest:ad_request];
+    if(ad_request==nullptr) {
+      if(error==kAdMobErrorNone) {
+        error = kAdMobErrorInternalError;
+      }
+      CompleteLoadFuture(error, "");
+    } else {
+      // Make the interstitial ad request.
+      [interstitial_ loadRequest:ad_request];
+    }
   });
+
   return GetLastResult(kInterstitialAdFnLoadAd);
 }
 

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -77,15 +77,20 @@ Future<void> InterstitialAdInternalIOS::LoadAd(const AdRequest& request) {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an admob::AdRequest.
     AdMobError error = kAdMobErrorNone;
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, &error);
+    std::string error_message;
+    GADRequest *ad_request =
+     GADRequestFromCppAdRequest(*request_copy, &error, error_message);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {
         error = kAdMobErrorInternalError;
+        CompleteLoadFuture(error, 
+          "Internal error attempting to create GADRequest.");
+      } else {
+        CompleteLoadFuture(error, error_message.c_str());
       }
-      CompleteLoadFuture(error, "");
     } else {
-      // Make the interstitial ad request.
+  // Make the interstitial ad request.
       [interstitial_ loadRequest:ad_request];
     }
   });

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -77,7 +77,7 @@ Future<void> InterstitialAdInternalIOS::LoadAd(const AdRequest& request) {
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an admob::AdRequest.
     AdMobError error = kAdMobErrorNone;
-    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, error);
+    GADRequest *ad_request = GADRequestFromCppAdRequest(*request_copy, &error);
     delete request_copy;
     if(ad_request==nullptr) {
       if(error==kAdMobErrorNone) {

--- a/admob/src/stub/banner_view_internal_stub.h
+++ b/admob/src/stub/banner_view_internal_stub.h
@@ -34,7 +34,7 @@ class BannerViewInternalStub : public BannerViewInternal {
   ~BannerViewInternalStub() override {}
 
   Future<void> Initialize(AdParent parent, const char* ad_unit_id,
-                          AdSize size) override {
+                          const AdSize& size) override {
     return CreateAndCompleteFutureStub(kBannerViewFnInitialize);
   }
 


### PR DESCRIPTION
Updated the AdSize and AdRequest structures:
 - Converted them to classes.
 - AdRequest now has methods to manipulate the content url, keywords and network extras.  
 - Extras are are now collections with mediation class names keys.  The class names now dynamically resolved to jclasses on on Android and GADSize objects on iOS, as these objects are required as part of the Admob phone SDK API when setting extras.
 - AdSize now provides methods for Adaptive sizes, and includes constants for common ad sizes.
 
Banner and Interstitial ads were updated to use these new structures.

Updated Itests
 - Some unit testing is done on these structures.
 - Added pauses between banner ad move commands as they were moving too quickly for Android phones to properly render them (they flashed as blank black boxes.)

[iTest execution](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1271413043)
[Packaging execution 1](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1293182830) [Packaging execution 2, expanded](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1295146882) - builds fine, some test failures in unrelated storage and messaging code.