### PR TITLE
Make pod header public so unity can build

### DIFF
--- a/ios_pod/CMakeLists.txt
+++ b/ios_pod/CMakeLists.txt
@@ -81,6 +81,8 @@ function(setup_pod_headers target_name)
       # Add pod name twice as some frameworks moved includes inside a folder with
       # the pod name
       target_include_directories(${target_name}
+        # Link the Pods publicly, so that dependent libraries can access the necessary header files as well.
+        # Same for the below workaround.
         PUBLIC
           ${FIREBASE_POD_HEADER_DIR}/${pod}
           ${FIREBASE_POD_HEADER_DIR}/${pod}/${pod}


### PR DESCRIPTION
### Description
Update the ios_pod/CMakeLists.txt, so in unity sdk firestore can build on ios
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

