### PR TITLE
Update README to suggest Python3 versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The following prerequisites are required for all platforms.  Be sure to add any
 directories to your PATH as needed.
 
 - [CMake](https://cmake.org/), version 3.1, or newer
-- [Python](https://www.python.com/), version of 3.6, or newer
+- [Python](https://www.python.com/), version of 3.7, or newer
 - [Abseil-py](https://github.com/abseil/abseil-py)
 
 Note: Once python is installed you can use the following commands to install


### PR DESCRIPTION
As Python 2 is out of support, this updates the readme to suggest supported versions 3.6+. Python 2.7 should still work. I verified this works for firebase_analytics, perhaps 2.7 is needed for something else?

CI seems to be using Python 3.7 today. https://github.com/firebase/firebase-cpp-sdk/blob/196188e45b9e6615928f7cadd343a7dc41168bd0/.github/workflows/cpp-packaging.yml#L197