### PR TITLE
Fix Firestore build resulting from the rename of auth to credentials in the iOS SDK

### DIFF
--- a/admob/integration_test/Podfile
+++ b/admob/integration_test/Podfile
@@ -3,7 +3,7 @@ platform :ios, '10.0'
 # Firebase AdMob test application.
 
 target 'integration_test' do
-  pod 'Firebase/Analytics', '8.8.0'
+  pod 'Firebase/Analytics', '8.9.0'
   pod 'Google-Mobile-Ads-SDK', '7.69.0-cppsdk'
 end
 

--- a/analytics/integration_test/Podfile
+++ b/analytics/integration_test/Podfile
@@ -4,7 +4,7 @@ platform :ios, '10.0'
 # Firebase Analytics test application.
 
 target 'integration_test' do
-  pod 'Firebase/Analytics', '8.8.0'
+  pod 'Firebase/Analytics', '8.9.0'
 end
 
 post_install do |installer|

--- a/app/integration_test/Podfile
+++ b/app/integration_test/Podfile
@@ -4,7 +4,7 @@ platform :ios, '10.0'
 # Firebase App test application.
 
 target 'integration_test' do
-  pod 'Firebase/Analytics', '8.8.0'
+  pod 'Firebase/Analytics', '8.9.0'
 end
 
 post_install do |installer|

--- a/auth/integration_test/Podfile
+++ b/auth/integration_test/Podfile
@@ -4,12 +4,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'integration_test' do
   platform :ios, '10.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|

--- a/database/integration_test/Podfile
+++ b/database/integration_test/Podfile
@@ -4,14 +4,14 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'integration_test' do
   platform :ios, '10.0'
-  pod 'Firebase/Database', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Database', '8.9.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
-  pod 'Firebase/Database', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Database', '8.9.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|

--- a/dynamic_links/integration_test/Podfile
+++ b/dynamic_links/integration_test/Podfile
@@ -4,7 +4,7 @@ platform :ios, '10.0'
 # Firebase Dynamic Links test application.
 
 target 'integration_test' do
-  pod 'Firebase/DynamicLinks', '8.8.0'
+  pod 'Firebase/DynamicLinks', '8.9.0'
 end
 
 post_install do |installer|

--- a/firestore/integration_test/Podfile
+++ b/firestore/integration_test/Podfile
@@ -5,13 +5,13 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'integration_test' do
   platform :ios, '10.0'
   pod 'Firebase/Firestore', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
   pod 'Firebase/Firestore', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|

--- a/firestore/integration_test_internal/Podfile
+++ b/firestore/integration_test_internal/Podfile
@@ -5,13 +5,13 @@ platform :ios, '10.0'
 target 'integration_test' do
   platform :ios, '10.0'
   pod 'Firebase/Firestore', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
   pod 'Firebase/Firestore', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|

--- a/firestore/integration_test_internal/src/util/integration_test_util.cc
+++ b/firestore/integration_test_internal/src/util/integration_test_util.cc
@@ -17,7 +17,7 @@
 #include <chrono>  // NOLINT(build/c++11)
 #include <thread>  // NOLINT(build/c++11)
 
-#include "Firestore/core/src/auth/empty_credentials_provider.h"
+#include "Firestore/core/src/credentials/empty_credentials_provider.h"
 #include "absl/memory/memory.h"
 #include "app_framework.h"
 #include "firebase/app.h"
@@ -33,13 +33,13 @@
 namespace firebase {
 namespace firestore {
 
-using auth::EmptyCredentialsProvider;
+using credentials::EmptyAuthCredentialsProvider;
 
 struct TestFriend {
   static FirestoreInternal* CreateTestFirestoreInternal(App* app) {
 #if !defined(__ANDROID__)
-    return new FirestoreInternal(app,
-                                 absl::make_unique<EmptyCredentialsProvider>());
+    return new FirestoreInternal(
+        app, absl::make_unique<EmptyAuthCredentialsProvider>());
 #else
     return new FirestoreInternal(app);
 #endif  // !defined(__ANDROID__)

--- a/firestore/src/main/create_credentials_provider.h
+++ b/firestore/src/main/create_credentials_provider.h
@@ -19,7 +19,7 @@
 
 #include <memory>
 
-#include "Firestore/core/src/auth/credentials_provider.h"
+#include "Firestore/core/src/credentials/credentials_fwd.h"
 
 #if defined(__ANDROID__)
 #error "This header should not be used on Android."
@@ -31,7 +31,8 @@ class App;
 
 namespace firestore {
 
-std::unique_ptr<auth::CredentialsProvider> CreateCredentialsProvider(App& app);
+std::unique_ptr<credentials::AuthCredentialsProvider> CreateCredentialsProvider(
+    App& app);
 
 }  // namespace firestore
 }  // namespace firebase

--- a/firestore/src/main/create_credentials_provider_desktop.cc
+++ b/firestore/src/main/create_credentials_provider_desktop.cc
@@ -22,10 +22,10 @@
 namespace firebase {
 namespace firestore {
 
-using auth::CredentialsProvider;
+using credentials::AuthCredentialsProvider;
 using firebase::auth::Auth;
 
-std::unique_ptr<CredentialsProvider> CreateCredentialsProvider(App& app) {
+std::unique_ptr<AuthCredentialsProvider> CreateCredentialsProvider(App& app) {
   return absl::make_unique<FirebaseCppCredentialsProvider>(app);
 }
 

--- a/firestore/src/main/create_credentials_provider_ios.mm
+++ b/firestore/src/main/create_credentials_provider_ios.mm
@@ -21,18 +21,18 @@
 
 #include "app/src/include/firebase/app.h"
 #include "absl/memory/memory.h"
-#include "Firestore/core/src/auth/firebase_credentials_provider_apple.h"
+#include "Firestore/core/src/credentials/firebase_auth_credentials_provider_apple.h"
 
 namespace firebase {
 namespace firestore {
 
-using auth::CredentialsProvider;
-using auth::FirebaseCredentialsProvider;
+using credentials::AuthCredentialsProvider;
+using credentials::FirebaseAuthCredentialsProvider;
 
-std::unique_ptr<CredentialsProvider> CreateCredentialsProvider(App& app) {
+std::unique_ptr<AuthCredentialsProvider> CreateCredentialsProvider(App& app) {
   FIRApp* ios_app = app.GetPlatformApp();
   auto ios_auth = FIR_COMPONENT(FIRAuthInterop, ios_app.container);
-  return absl::make_unique<FirebaseCredentialsProvider>(ios_app, ios_auth);
+  return absl::make_unique<FirebaseAuthCredentialsProvider>(ios_app, ios_auth);
 }
 
 }  // namespace firestore

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -24,7 +24,7 @@
 #include <unordered_set>
 
 #include "Firestore/core/src/api/firestore.h"
-#include "Firestore/core/src/auth/credentials_provider.h"
+#include "Firestore/core/src/credentials/credentials_provider.h"
 #include "Firestore/core/src/model/database_id.h"
 #include "app/src/cleanup_notifier.h"
 #include "app/src/future_manager.h"
@@ -147,11 +147,13 @@ class FirestoreInternal {
     kCount,
   };
 
-  FirestoreInternal(App* app,
-                    std::unique_ptr<auth::CredentialsProvider> credentials);
+  FirestoreInternal(
+      App* app,
+      std::unique_ptr<credentials::AuthCredentialsProvider> credentials);
 
   std::shared_ptr<api::Firestore> CreateFirestore(
-      App* app, std::unique_ptr<auth::CredentialsProvider> credentials);
+      App* app,
+      std::unique_ptr<credentials::AuthCredentialsProvider> credentials);
 
   // Gets the reference-counted Future implementation of this instance, which
   // can be used to create a Future.

--- a/functions/integration_test/Podfile
+++ b/functions/integration_test/Podfile
@@ -5,13 +5,13 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'integration_test' do
   platform :ios, '10.0'
   pod 'Firebase/Functions', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
   pod 'Firebase/Functions', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|

--- a/installations/integration_test/Podfile
+++ b/installations/integration_test/Podfile
@@ -4,8 +4,8 @@ platform :ios, '10.0'
 # Firebase Installations test application.
 
 target 'integration_test' do
-  pod 'Firebase/Analytics', '8.8.0'
-  pod 'Firebase/Installations', '8.8.0'
+  pod 'Firebase/Analytics', '8.9.0'
+  pod 'Firebase/Installations', '8.9.0'
 end
 
 post_install do |installer|

--- a/ios_pod/Podfile
+++ b/ios_pod/Podfile
@@ -2,19 +2,19 @@ source 'https://github.com/CocoaPods/Specs.git'
 platform :ios, '10.0'
 
 target 'GetPods' do
-  pod 'Firebase/Core', '8.8.0'
+  pod 'Firebase/Core', '8.9.0'
 
   pod 'Google-Mobile-Ads-SDK', '7.69.0-cppsdk'
-  pod 'Firebase/Analytics', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
-  pod 'Firebase/Crashlytics', '8.8.0'
-  pod 'Firebase/Database', '8.8.0'
-  pod 'Firebase/DynamicLinks', '8.8.0'
+  pod 'Firebase/Analytics', '8.9.0'
+  pod 'Firebase/Auth', '8.9.0'
+  pod 'Firebase/Crashlytics', '8.9.0'
+  pod 'Firebase/Database', '8.9.0'
+  pod 'Firebase/DynamicLinks', '8.9.0'
   pod 'Firebase/Firestore', '8.8.0'
   pod 'Firebase/Functions', '8.8.0'
-  pod 'Firebase/Installations', '8.8.0'
+  pod 'Firebase/Installations', '8.9.0'
   pod 'Firebase/Messaging', '8.8.0'
-  pod 'Firebase/RemoteConfig', '8.8.0'
+  pod 'Firebase/RemoteConfig', '8.9.0'
   pod 'Firebase/Storage', '8.8.0'
 
 end

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -180,46 +180,46 @@ Feature                    | Required Frameworks and Cocoapods
 -------------------------- | ---------------------------------------
 Firebase AdMob             | firebase_admob.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/Analytics Cocoapod (8.8.0)
+|                          | Firebase/Analytics Cocoapod (8.9.0)
 |                          | Google-Mobile-Ads-SDK Cocoapod (7.69.0-cppsdk)
 Firebase Analytics         | firebase_analytics.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/Analytics Cocoapod (8.8.0)
+|                          | Firebase/Analytics Cocoapod (8.9.0)
 Firebase Authentication    | firebase_auth.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Dynamic Links     | firebase_dynamic_links.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/DynamicLinks Cocoapod (8.8.0)
+|                          | Firebase/DynamicLinks Cocoapod (8.9.0)
 Cloud Firestore            | firebase_firestore.xcframework
 |                          | firebase_auth.xcframework
 |                          | firebase.xcframework
 |                          | Firebase/Firestore Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Functions         | firebase_functions.xcframework
 |                          | firebase_auth.xcframework (optional)
 |                          | firebase.xcframework
 |                          | Firebase/Functions Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Installations     | firebase_installations.xcframework
 |                          | firebase.xcframework
-|                          | FirebaseInstallations Cocoapod (8.8.0)
+|                          | FirebaseInstallations Cocoapod (8.9.0)
 Firebase Cloud Messaging   | firebase_messaging.xcframework
 |                          | firebase.xcframework
 |                          | Firebase/Messaging Cocoapod (8.8.0)
 Firebase Realtime Database | firebase_database.xcframework
 |                          | firebase_auth.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/Database Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Database Cocoapod (8.9.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Remote Config     | firebase_remote_config.xcframework
 |                          | firebase.xcframework
-|                          | Firebase/RemoteConfig Cocoapod (8.8.0)
+|                          | Firebase/RemoteConfig Cocoapod (8.9.0)
 Firebase Storage           | firebase_storage.xcframework
 |                          | firebase_auth.xcframework
 |                          | firebase.xcframework
 |                          | Firebase/Storage Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 
 Important: Each version of the Firebase C++ SDK supports a specific version of
 the Firebase iOS SDK. Please ensure that you reference the Cocoapod versions
@@ -240,46 +240,46 @@ Feature                    | Required Libraries and Cocoapods
 -------------------------- | -----------------------------------------
 Firebase AdMob             | libfirebase_admob.a
 |                          | libfirebase_app.a
-|                          | Firebase/Analytics Cocoapod (8.8.0)
+|                          | Firebase/Analytics Cocoapod (8.9.0)
 |                          | Google-Mobile-Ads-SDK Cocoapod (7.69.0-cppsdk)
 Firebase Analytics         | libfirebase_analytics.a
 |                          | libfirebase_app.a
-|                          | Firebase/Analytics Cocoapod (8.8.0)
+|                          | Firebase/Analytics Cocoapod (8.9.0)
 Firebase Authentication    | libfirebase_auth.a
 |                          | libfirebase_app.a
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Dynamic Links     | libfirebase_dynamic_links.a
 |                          | libfirebase_app.a
-|                          | Firebase/DynamicLinks Cocoapod (8.8.0)
+|                          | Firebase/DynamicLinks Cocoapod (8.9.0)
 Cloud Firestore            | libfirebase_firestore.a
 |                          | libfirebase_app.a
 |                          | libfirebase_auth.a
 |                          | Firebase/Firestore Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Functions         | libfirebase_functions.a
 |                          | libfirebase_app.a
 |                          | libfirebase_auth.a (optional)
 |                          | Firebase/Functions Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Installations     | libfirebase_installations.a
 |                          | libfirebase_app.a
-|                          | FirebaseInstallations Cocoapod (8.8.0)
+|                          | FirebaseInstallations Cocoapod (8.9.0)
 Firebase Cloud Messaging   | libfirebase_messaging.a
 |                          | libfirebase_app.a
 |                          | Firebase/CloudMessaging Cocoapod (8.1.1)
 Firebase Realtime Database | libfirebase_database.a
 |                          | libfirebase_app.a
 |                          | libfirebase_auth.a
-|                          | Firebase/Database Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Database Cocoapod (8.9.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 Firebase Remote Config     | libfirebase_remote_config.a
 |                          | libfirebase_app.a
-|                          | Firebase/RemoteConfig Cocoapod (8.8.0)
+|                          | Firebase/RemoteConfig Cocoapod (8.9.0)
 Firebase Storage           | libfirebase_storage.a
 |                          | libfirebase_app.a
 |                          | libfirebase_auth.a
 |                          | Firebase/Storage Cocoapod (8.8.0)
-|                          | Firebase/Auth Cocoapod (8.8.0)
+|                          | Firebase/Auth Cocoapod (8.9.0)
 
 Important: Each version of the Firebase C++ SDK supports a specific version of
 the Firebase iOS SDK. Please ensure that you reference the Cocoapod versions

--- a/remote_config/integration_test/Podfile
+++ b/remote_config/integration_test/Podfile
@@ -4,12 +4,12 @@ source 'https://github.com/CocoaPods/Specs.git'
 
 target 'integration_test' do
   platform :ios, '10.0'
-  pod 'Firebase/RemoteConfig', '8.8.0'
+  pod 'Firebase/RemoteConfig', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
-  pod 'Firebase/RemoteConfig', '8.8.0'
+  pod 'Firebase/RemoteConfig', '8.9.0'
 end
 
 post_install do |installer|

--- a/storage/integration_test/Podfile
+++ b/storage/integration_test/Podfile
@@ -5,13 +5,13 @@ source 'https://github.com/CocoaPods/Specs.git'
 target 'integration_test' do
   platform :ios, '10.0'
   pod 'Firebase/Storage', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 target 'integration_test_tvos' do
   platform :tvos, '10.0'
   pod 'Firebase/Storage', '8.8.0'
-  pod 'Firebase/Auth', '8.8.0'
+  pod 'Firebase/Auth', '8.9.0'
 end
 
 post_install do |installer|


### PR DESCRIPTION
Note that this PR will not build until the iOS dependencies are updated to 8.9.0 (currently they are 8.8.0). This PR will not be merged; instead, it will be merged into the branch that updates the iOS dependencies to 8.9.0.

I tested this locally on Mac and Linux desktop and on iOS simulator.