### PR TITLE
firestore.cmake: point to the HEAD of the NanopbNoPackedStructsCmakeFix branch in the iOS repository

### DIFF
--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -22,7 +22,7 @@ ExternalProject_Add(
   firestore
 
   GIT_REPOSITORY https://github.com/firebase/firebase-ios-sdk
-  GIT_TAG 9aa0c85b1817684a601c21dcabe8bfe8e74c3692
+  GIT_TAG 03e174c4b75fb127a81fde78692cc0d963c75069
 
   PREFIX ${PROJECT_BINARY_DIR}
 

--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -18,12 +18,11 @@ if(TARGET firestore)
   return()
 endif()
 
-set(version CocoaPods-8.9.1)
 ExternalProject_Add(
   firestore
 
-  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  URL https://github.com/firebase/firebase-ios-sdk/archive/${version}.tar.gz
+  GIT_REPOSITORY https://github.com/firebase/firebase-ios-sdk
+  GIT_TAG 9aa0c85b1817684a601c21dcabe8bfe8e74c3692
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
DO NOT MERGE

This is a temporary branch that picks up https://github.com/firebase/firebase-ios-sdk/pull/8923 (CMakeLists.txt: add -DPB_NO_PACKED_STRUCTS=1 to the nanopb compiler flags) from the iOS SDK. With this, I'm going to create a custom build of the C++ SDK so that the customer can test to see if it fixes https://github.com/firebase/firebase-cpp-sdk/issues/712 ([Bug] Firestore fails to link for desktop on macOS Monterey because of unaligned pointers).