### PR TITLE
Don't redeclare inherited state in CredentialsProviderDesktop

### DIFF
--- a/firestore/src/main/credentials_provider_desktop.cc
+++ b/firestore/src/main/credentials_provider_desktop.cc
@@ -188,11 +188,6 @@ void FirebaseCppCredentialsProvider::GetToken(
   }
 }
 
-void FirebaseCppCredentialsProvider::InvalidateToken() {
-  std::lock_guard<std::recursive_mutex> lock(contents_->mutex);
-  force_refresh_token_ = true;
-}
-
 void FirebaseCppCredentialsProvider::AddAuthStateListener() {
   App& app = contents_->app;
   auto callback = reinterpret_cast<void*>(OnAuthStateChanged);
@@ -234,8 +229,8 @@ void FirebaseCppCredentialsProvider::RequestToken(
   // can fail if there is a token change while the request is outstanding.
   int expected_generation = contents_->token_generation;
 
-  bool force_refresh = force_refresh_token_;
-  force_refresh_token_ = false;
+  bool force_refresh = force_refresh_;
+  force_refresh_ = false;
   auto future = GetAuthTokenAsync(contents_->app, force_refresh);
 
   std::weak_ptr<Contents> weak_contents(contents_);

--- a/firestore/src/main/credentials_provider_desktop.h
+++ b/firestore/src/main/credentials_provider_desktop.h
@@ -59,7 +59,6 @@ class FirebaseCppCredentialsProvider
   void GetToken(
       firestore::credentials::TokenListener<firestore::credentials::AuthToken>
           listener) override;
-  void InvalidateToken() override;
 
  private:
   void AddAuthStateListener();
@@ -109,14 +108,6 @@ class FirebaseCppCredentialsProvider
     int token_generation = 0;
   };
   std::shared_ptr<Contents> contents_;
-
-  // Affects the next `GetToken` request; if `true`, the token will be refreshed
-  // even if it hasn't expired yet.
-  bool force_refresh_token_ = false;
-
-  // Provided by the user code; may be an empty function.
-  firestore::credentials::CredentialChangeListener<firestore::credentials::User>
-      change_listener_;
 };
 
 }  // namespace firestore


### PR DESCRIPTION
FIxes https://github.com/firebase/firebase-cpp-sdk/issues/729