### PR TITLE
Fix test on emulator workflow failures

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -829,7 +829,7 @@ jobs:
           npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run Android integration tests on Emulator locally
-        timeout-minutes: 60
+        timeout-minutes: 90
         if: steps.get-device-type.outputs.device_type == 'virtual'
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \

--- a/scripts/gha/integration_testing/gameloop_android/build.gradle
+++ b/scripts/gha/integration_testing/gameloop_android/build.gradle
@@ -23,7 +23,7 @@ allprojects {
 
 ext {
     compileSdk = 28
-    buildTools = '28.0.3'
+    buildTools = '29.0.2'
     minSdk = 16
     targetSdk = 28
 }

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -513,7 +513,14 @@ def _setup_android(platform_version, build_tool_version, sdk_id, retry=1):
 
   command = "yes | sdkmanager --licenses"
   logging.info("Accept all licenses: %s", command)
-  subprocess.run(command, shell=True, check=False)
+  if retry > 1:
+    try:
+      subprocess.run(command, shell=True, check=False, timeout=_CMD_TIMEOUT)
+    except:
+      _setup_android(platform_version, build_tool_version, sdk_id, retry-1)
+      return
+  else:
+    subprocess.run(command, shell=True, check=False, timeout=_CMD_TIMEOUT)
 
   args = ["sdkmanager", sdk_id]
   logging.info("Download an emulator: %s", " ".join(args))
@@ -524,12 +531,18 @@ def _setup_android(platform_version, build_tool_version, sdk_id, retry=1):
       _setup_android(platform_version, build_tool_version, sdk_id, retry-1)
       return
   else:
-      subprocess.run(args=args, check=True, timeout=_CMD_TIMEOUT)
+    subprocess.run(args=args, check=True, timeout=_CMD_TIMEOUT)
 
   args = ["sdkmanager", "--update"]
   logging.info("Update all installed packages: %s", " ".join(args))
-  subprocess.run(args=args, check=False)
-
+  if retry > 1:
+    try:
+      subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
+    except:
+      _setup_android(platform_version, build_tool_version, sdk_id, retry-1)
+      return
+  else:
+    subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
 
 def _shutdown_emulator():
   command = "adb devices | grep emulator | cut -f1 | while read line; do adb -s $line emu kill; done"

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -657,7 +657,16 @@ def _install_android_gameloop_app(gameloop_project, retry=1):
     subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
   args = ["./gradlew", "clean"]
   logging.info("Clean game-loop cache: %s", " ".join(args))
-  subprocess.run(args=args, check=False)
+  if retry > 1:
+    try:
+      subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
+    except:
+      logging.info("Clean game-loop cache timeout, Reset Emualtor now... Remaining retry: %s", retry-1)
+      _reset_emulator_on_error()
+      _install_android_gameloop_app(gameloop_project, retry-1)
+      return
+  else:
+    subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
   args = ["./gradlew", "installDebug", "installDebugAndroidTest"]
   logging.info("Installing game-loop app and test: %s", " ".join(args))
   if retry > 1:

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -549,8 +549,8 @@ def _create_and_boot_emulator(sdk_id):
   logging.info("Wait for emulator to boot: %s", " ".join(args))
   subprocess.run(args=args, check=True)
   if FLAGS.ci: 
-    # wait extra 180 seconds to ensure emulator fully booted.
-    time.sleep(180)
+    # wait extra 210 seconds to ensure emulator fully booted.
+    time.sleep(210)
   else:
     time.sleep(45)
 
@@ -564,8 +564,8 @@ def _reset_emulator_on_error():
   logging.info("Wait for emulator to boot: %s", " ".join(args))
   subprocess.run(args=args, check=True)
   if FLAGS.ci: 
-    # wait extra 180 seconds to ensure emulator booted.
-    time.sleep(180)
+    # wait extra 210 seconds to ensure emulator booted.
+    time.sleep(210)
   else:
     time.sleep(45)
 

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -580,7 +580,6 @@ def _reset_emulator_on_error(type=_RESET_TYPE_REBOOT):
     args = ["adb", "shell", "recovery", "--wipe_data"]
     logging.info("Erase my Emulator: %s", " ".join(args))
     subprocess.run(args=args, check=True)
-    _reset_emulator_on_error()
 
   # reboot emulator: _RESET_TYPE_WIPE_REBOOT, _RESET_TYPE_REBOOT
   logging.info("game-loop test error!!! reboot emualtor...")

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -59,12 +59,12 @@ available tools with the following commands:
 Device Information is stored in TEST_DEVICES in print_matrix_configuration.py
 Example:
 sdk id "system-images;android-29;google_apis;x86":
-  --android_sdk "system-images;android-29;google_apis;x86" --build_tools_version "28.0.3"
+  --android_sdk "system-images;android-29;google_apis;x86" --build_tools_version "29.0.2"
 
 Alternatively, to set an Android device, use the one of the values below:
 [emulator_min, emulator_target, emulator_latest]
 Example:
-  --android_device "emulator_target" --build_tools_version "28.0.3"
+  --android_device "emulator_target" --build_tools_version "29.0.2"
 
 Returns:
    1: No iOS/Android integration_test apps found
@@ -129,7 +129,7 @@ flags.DEFINE_string(
     "android_sdk", "system-images;android-29;google_apis;x86",
     "See module docstring for details on how to set and get this id.")
 flags.DEFINE_string(
-    "build_tools_version", "28.0.3",
+    "build_tools_version", "29.0.2",
     "android build_tools_version")
 flags.DEFINE_string(
     "logfile_name", "simulator-test",

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -618,9 +618,8 @@ def _uninstall_android_app(package_name, retry=1):
   """Uninstall integration_test app from the emulator."""
   args = ["adb", "uninstall", package_name]
   logging.info("Uninstall testapp: %s", " ".join(args))
-  check = (retry <= 1)
-  result = subprocess.run(args=args, check=check, timeout=_CMD_TIMEOUT)
-  if result.returncode != 0:
+  result = subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
+  if retry > 1 and result.returncode != 0:
     logging.info("Uninstall testapp %s failed, Reset Emualtor now... Remaining retry: %s", package_name, retry-1)
     _reset_emulator_on_error()
     _uninstall_android_app(package_name, retry-1)

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -644,7 +644,17 @@ def _uninstall_android_app(package_name, retry=1):
 def _install_android_gameloop_app(gameloop_project, retry=1):
   os.chdir(gameloop_project)
   logging.info("cd to gameloop_project: %s", gameloop_project)
-  _uninstall_android_app("com.google.firebase.gameloop")
+  args = ["adb", "uninstall", "com.google.firebase.gameloop"]
+  if retry > 1:
+    try:
+      subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
+    except:
+      logging.info("Uninstall gameloop_project timeout, Reset Emualtor now... Remaining retry: %s", retry-1)
+      _reset_emulator_on_error()
+      _install_android_gameloop_app(gameloop_project, retry-1)
+      return
+  else:
+    subprocess.run(args=args, check=False, timeout=_CMD_TIMEOUT)
   args = ["./gradlew", "clean"]
   logging.info("Clean game-loop cache: %s", " ".join(args))
   subprocess.run(args=args, check=False)


### PR DESCRIPTION
### Description
Test on Emualtor sometimes failed when install Android app. https://github.com/firebase/firebase-cpp-sdk/runs/4078767834?check_suite_focus=true
```
Install testapp: adb install /Users/runner/work/firebase-cpp-sdk/firebase-cpp-sdk/testapps/firestore/iti-debug.apk
cmd: Failure calling service package: Broken pipe (32)
adb: failed to install /Users/runner/work/firebase-cpp-sdk/firebase-cpp-sdk/testapps/firestore/iti-debug.apk: cmd: Failure calling service package: Broken pipe (32)
Performing Streamed Install
```
This article suggests delete the old emulator and create a new one :
https://medium.com/@aedwin905/solved-failure-calling-service-package-broken-pipe-32-3b860c7e04bb

Also saw some errors when downloading emulator, uninstalling apps.

Thus, I made the following changes:
1. For critical steps, I added 5 minutes timeout and 3 times retry. 
2. Before retry the step, I also reset and reboot the emulator. 
3. Test on emulator timeout in 90 minutes.
4. Updated the build-tool version to 29.0.2 

***
### Testing
See the testing result in the comment
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
