### PR TITLE
Fix app build for Android against prebuilt version

### DIFF
--- a/app/src/include/google_play_services/availability.h
+++ b/app/src/include/google_play_services/availability.h
@@ -22,7 +22,7 @@
 #if !defined(SWIG_BUILD)
 #include <jni.h>
 #endif
-#include "app/src/include/firebase/future.h"
+#include "firebase/future.h"
 
 /// @brief Google Play services APIs included with the Firebase C++ SDK.
 /// These APIs are Android-specific.


### PR DESCRIPTION
### Description
Fix app build for ```Android``` against prebuilt Firebase C++ SDK.

Android NDK 21 says: ```fatal error: 'app/src/include/firebase/future.h' file not found```

### Testing
Building was tested on my local computer.

### Type of Change
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.

#### Notes
Look at the files in ```app/src/include/firebase/``` directory.
File doesn't contain ```app/src/include/``` prefix inside ```#include``` paths.
Also removing the prefix ```app/src/include/``` from line ```25``` of ```app/src/include/google_play_services/availability.h``` has solved my build problem.