### PR TITLE
Fix crash in Messaging on Android when Terminate is called while tasks are still pending.

### DIFF
--- a/messaging/src/android/cpp/messaging.cc
+++ b/messaging/src/android/cpp/messaging.cc
@@ -704,8 +704,8 @@ void Terminate() {
   g_firebase_messaging = nullptr;
   SetListener(nullptr);
   ReleaseClasses(env);
-  FutureData::Destroy();
   util::Terminate(env);
+  FutureData::Destroy();
 }
 
 // Start a service which will communicate with the Firebase Cloud Messaging

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -572,6 +572,8 @@ code.
     -   Auth (Desktop): Fixed a crash in `error_code()` when a request
         is cancelled or times out.
         ([#737](https://github.com/firebase/firebase-cpp-sdk/issues/737))
+    -   Messaging (Android): Fixed crash during termination.
+        ([#739](https://github.com/firebase/firebase-cpp-sdk/pull/739))
 
 ### 8.7.0
 -   Changes


### PR DESCRIPTION
When firebase::messaging::Terminate is called while there are still pending tasks left a null pointer exception is causing an ANR on Andriod.

FutureData is destroyed before calling util::Terminate which in turn will try to cancel all pending callbacks. This will call cancel() in JniResultCallback.java which will lock a mutex and callback into C++ using the JniResultCallback_nativeResult function. Depending on the task canceled it will call into different callbacks in messaging.cc and some of them as for example CompleteStringCallback are using FutureData which has already been destroyed. This will cause the thread to stop and the mutex in JniResultCallbak.java to remain locked. The next message that either completes or fails will now end up in a dead lock causing an ANR.

The proposed fix is to not destroy FutureData until after the tasks have been canceled.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
