### PR TITLE
RewardedAds for Android

### DIFF
--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -21,6 +21,7 @@ set(common_SRCS
     src/common/banner_view_internal.cc
     src/common/interstitial_ad.cc
     src/common/interstitial_ad_internal.cc
+    src/common/full_screen_ad_event_listener.cc
     src/common/rewarded_ad.cc
     src/common/rewarded_ad_internal.cc)
 

--- a/admob/CMakeLists.txt
+++ b/admob/CMakeLists.txt
@@ -20,7 +20,9 @@ set(common_SRCS
     src/common/banner_view.cc
     src/common/banner_view_internal.cc
     src/common/interstitial_ad.cc
-    src/common/interstitial_ad_internal.cc)
+    src/common/interstitial_ad_internal.cc
+    src/common/rewarded_ad.cc
+    src/common/rewarded_ad_internal.cc)
 
 # Define the resource build needed for Android
 firebase_cpp_gradle(":admob:admob_resources:generateDexJarRelease"
@@ -39,7 +41,8 @@ set(android_SRCS
     src/android/admob_android.cc
     src/android/banner_view_internal_android.cc
     src/android/interstitial_ad_internal_android.cc
-    src/android/response_info_android.cc)
+    src/android/response_info_android.cc
+    src/android/rewarded_ad_internal_android.cc)
 
 # Source files used by the iOS implementation.
 set(ios_SRCS
@@ -52,7 +55,8 @@ set(ios_SRCS
     src/ios/admob_ios.mm
     src/ios/banner_view_internal_ios.mm
     src/ios/interstitial_ad_internal_ios.mm
-    src/ios/response_info_ios.mm)
+    src/ios/response_info_ios.mm
+    src/ios/rewarded_ad_internal_ios.mm)
 
 # Source files used by the stub implementation.
 set(stub_SRCS

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -937,6 +937,9 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
             bounding_box_listener.bounding_box_changes_.size());
 
 #if defined(ANDROID) || TARGET_OS_IPHONE
+  // Simulators have varying aspect ratios.
+  TEST_REQUIRES_USER_INTERACTION;
+
   // As an extra check, all bounding boxes except the last should have the same
   // size aspect ratio that we requested. For example if you requested a 320x50
   // banner, you can get one with the size 960x150. Use EXPECT_NEAR because the

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -1233,6 +1233,7 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdErrorNotInitialized) {
 
 TEST_F(FirebaseAdMobTest, TesRewardedAdErrorAlreadyInitialized) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
 
   {
     firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -607,8 +607,8 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdLoad) {
 // Interactive test section.  These have been placed up front so that the
 // tester doesn't get bored waiting for them.
 TEST_F(FirebaseAdMobTest, TestBannerViewAdOpenedAdClosed) {
-  SKIP_TEST_ON_DESKTOP;
   TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
 
   const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
   firebase::admob::BannerView* banner = new firebase::admob::BannerView();
@@ -755,8 +755,8 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdLoadAndShow) {
   WaitForCompletion(rewarded->Show(&user_earned_reward_listener), "Show");
 
   LogDebug(
-      "Click the Install button in the ad, "
-      "return to the ad, and close the ad to continue");
+      "Wait for the Ad to finish playing, click the ad, return to the ad, "
+      "then close the ad to continue.");
 
   while (
       full_screen_content_listener.num_on_ad_dismissed_full_screen_content_ ==
@@ -785,8 +785,6 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdLoadAndShow) {
 // Other Banner View Tests
 
 TEST_F(FirebaseAdMobTest, TestBannerView) {
-  // AdMob cannot be tested on Firebase Test Lab, so disable tests on FTL.
-  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -1406,8 +1404,6 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdErrorBadExtrasClassName) {
 
 // Stress tests.  These take a while so run them near the end.
 TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
-  // AdMob cannot be tested on Firebase Test Lab, so disable tests on FTL.
-  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1426,7 +1422,6 @@ TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
 }
 
 TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
-  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1446,7 +1441,6 @@ TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
 }
 
 TEST_F(FirebaseAdMobTest, TestRewardedAdStress) {
-  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_IOS;
 

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -1405,6 +1405,7 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdErrorBadExtrasClassName) {
 
 // Stress tests.  These take a while so run them near the end.
 TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
+  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1423,6 +1424,7 @@ TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
 }
 
 TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
+  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1442,6 +1444,7 @@ TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
 }
 
 TEST_F(FirebaseAdMobTest, TestRewardedAdStress) {
+  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_IOS;
 

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -933,12 +933,12 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
   delete banner;
 
   PauseForVisualInspectionAndCallbacks();
-  EXPECT_EQ(++expected_num_bounding_box_changes,
-            bounding_box_listener.bounding_box_changes_.size());
-
 #if defined(ANDROID) || TARGET_OS_IPHONE
   // Simulators have varying aspect ratios.
   TEST_REQUIRES_USER_INTERACTION;
+
+  EXPECT_EQ(++expected_num_bounding_box_changes,
+            bounding_box_listener.bounding_box_changes_.size());
 
   // As an extra check, all bounding boxes except the last should have the same
   // size aspect ratio that we requested. For example if you requested a 320x50

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -696,6 +696,14 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdLoadAndShow) {
   firebase::admob::AdRequest request = GetAdRequest();
   WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request), "LoadAd");
 
+  firebase::admob::RewardedAd::ServerSideVerificationOptions options;
+  // We cannot programmatically verify that the AdMob phone SDKs marshal
+  // these values properly (there are no get methods). At least invoke the
+  // method to ensure least we can set them without any exceptions occurring.
+  options.custom_data = "custom data";
+  options.user_id = "123456";
+  rewarded->SetServerSideVerificationOptions(options);
+
   TestUserEarnedRewardListener user_earned_reward_listener;
   WaitForCompletion(rewarded->Show(&user_earned_reward_listener), "Show");
 

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -785,6 +785,7 @@ TEST_F(FirebaseAdMobTest, TestRewardedAdLoadAndShow) {
 // Other Banner View Tests
 
 TEST_F(FirebaseAdMobTest, TestBannerView) {
+  TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -934,9 +935,6 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
 
   PauseForVisualInspectionAndCallbacks();
 #if defined(ANDROID) || TARGET_OS_IPHONE
-  // Simulators have varying aspect ratios.
-  TEST_REQUIRES_USER_INTERACTION;
-
   EXPECT_EQ(++expected_num_bounding_box_changes,
             bounding_box_listener.bounding_box_changes_.size());
 

--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -65,9 +65,11 @@ const char* kAdMobAppID = "ca-app-pub-3940256099942544~1458002511";
 #if defined(__ANDROID__)
 const char* kBannerAdUnit = "ca-app-pub-3940256099942544/6300978111";
 const char* kInterstitialAdUnit = "ca-app-pub-3940256099942544/1033173712";
+const char* kRewardedAdUnit = "ca-app-pub-3940256099942544/5224354917";
 #else
 const char* kBannerAdUnit = "ca-app-pub-3940256099942544/2934735716";
 const char* kInterstitialAdUnit = "ca-app-pub-3940256099942544/4411468910";
+const char* kRewardedAdUnit = "ca-app-pub-3940256099942544/1712485313";
 #endif
 
 // Used in a test to send an errant ad unit id.
@@ -343,6 +345,21 @@ class TestFullScreenContentListener
   int num_on_ad_showed_full_screen_content_;
 };
 
+// A simple listener track UserEarnedReward events.
+class TestUserEarnedRewardListener
+    : public firebase::admob::UserEarnedRewardListener {
+ public:
+  TestUserEarnedRewardListener() : num_on_user_earned_reward_(0) {}
+
+  void OnUserEarnedReward(const firebase::admob::AdReward& reward) override {
+    ++num_on_user_earned_reward_;
+    EXPECT_EQ(reward.type(), "coins");
+    EXPECT_EQ(reward.amount(), 10);
+  }
+
+  int num_on_user_earned_reward_;
+};
+
 // A simple listener track ad pay events.
 class TestPaidEventListener : public firebase::admob::PaidEventListener {
  public:
@@ -488,6 +505,229 @@ TEST_F(FirebaseAdMobTest, TestRequestConfigurationSetGet) {
   EXPECT_TRUE(std::count(retrieved_configuration.test_device_ids.begin(),
                          retrieved_configuration.test_device_ids.end(), "3"));
 }
+
+// Simple Load Tests as a sanity check. These don't show the ad, just
+// ensure that we can load them before diving into the interactive tests.
+TEST_F(FirebaseAdMobTest, TestBannerViewLoadAd) {
+  SKIP_TEST_ON_DESKTOP;
+
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+  firebase::admob::BannerView* banner = new firebase::admob::BannerView();
+  WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
+                                       kBannerAdUnit, banner_ad_size),
+                    "Initialize");
+  WaitForCompletion(banner->LoadAd(GetAdRequest()), "LoadAd");
+  delete banner;
+}
+
+TEST_F(FirebaseAdMobTest, TestInterstitialAdLoad) {
+  SKIP_TEST_ON_DESKTOP;
+
+  // Note: while showing an ad requires user interaction (below),
+  // we test that we can simply load an ad first.
+
+  firebase::admob::InterstitialAd* interstitial =
+      new firebase::admob::InterstitialAd();
+
+  WaitForCompletion(interstitial->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // When the InterstitialAd is initialized, load an ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
+                    "LoadAd");
+  delete interstitial;
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdLoad) {
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  // Note: while showing an ad requires user interaction (below),
+  // we test that we can simply load an ad first.
+
+  firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // When the RewardedAd is initialized, load an ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request), "LoadAd");
+  delete rewarded;
+}
+
+// Interactive test section.  These have been placed up front so that the
+// tester doesn't get bored waiting for them.
+TEST_F(FirebaseAdMobTest, TestBannerViewAdOpenedAdClosed) {
+  SKIP_TEST_ON_DESKTOP;
+  TEST_REQUIRES_USER_INTERACTION;
+
+  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+  firebase::admob::BannerView* banner = new firebase::admob::BannerView();
+  WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
+                                       kBannerAdUnit, banner_ad_size),
+                    "Initialize");
+
+  // Set the listener.
+  TestAdListener ad_listener;
+  banner->SetAdListener(&ad_listener);
+
+  TestPaidEventListener paid_event_listener;
+  banner->SetPaidEventListener(&paid_event_listener);
+
+  // Load the banner ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  firebase::Future<firebase::admob::AdResult> load_ad_future =
+      banner->LoadAd(request);
+  WaitForCompletion(load_ad_future, "LoadAd");
+  WaitForCompletion(banner->Show(), "Show 0");
+
+  // Ad Events differ per platform. See the following for more info:
+  // https://www.googblogs.com/google-mobile-ads-sdk-a-note-on-ad-click-events/
+  // and https://groups.google.com/g/google-admob-ads-sdk/c/lzdt5szxSVU
+#if defined(ANDROID)
+  LogDebug("Click the Ad, and then close the ad to continue");
+
+  while (ad_listener.num_on_ad_opened_ == 0) {
+    app_framework::ProcessEvents(1000);
+  }
+
+  while (ad_listener.num_on_ad_closed_ == 0) {
+    app_framework::ProcessEvents(1000);
+  }
+
+  // Ensure all of the expected events were triggered on Android.
+  EXPECT_EQ(ad_listener.num_on_ad_clicked_, 1);
+  EXPECT_EQ(ad_listener.num_on_ad_impression_, 1);
+  EXPECT_EQ(ad_listener.num_on_ad_opened_, 1);
+  EXPECT_EQ(ad_listener.num_on_ad_closed_, 1);
+  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
+#else
+  LogDebug("Click the Ad, and then close the ad to continue");
+
+  while (ad_listener.num_on_ad_clicked_ == 0) {
+    app_framework::ProcessEvents(1000);
+  }
+
+  LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
+  app_framework::ProcessEvents(2000);
+
+  // Ensure all of the expected events were triggered on iOS.
+  EXPECT_EQ(ad_listener.num_on_ad_clicked_, 1);
+  EXPECT_EQ(ad_listener.num_on_ad_impression_, 1);
+  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
+  EXPECT_EQ(ad_listener.num_on_ad_opened_, 0);
+  EXPECT_EQ(ad_listener.num_on_ad_closed_, 0);
+#endif
+
+  load_ad_future.Release();
+  banner->SetAdListener(nullptr);
+  banner->SetPaidEventListener(nullptr);
+  WaitForCompletion(banner->Destroy(), "Destroy BannerView");
+  delete banner;
+}
+
+TEST_F(FirebaseAdMobTest, TestInterstitialAdLoadAndShow) {
+  TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
+
+  firebase::admob::InterstitialAd* interstitial =
+      new firebase::admob::InterstitialAd();
+
+  WaitForCompletion(interstitial->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  TestFullScreenContentListener full_screen_content_listener;
+  interstitial->SetFullScreenContentListener(&full_screen_content_listener);
+
+  TestPaidEventListener paid_event_listener;
+  interstitial->SetPaidEventListener(&paid_event_listener);
+
+  // When the InterstitialAd is initialized, load an ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
+                    "LoadAd");
+
+  WaitForCompletion(interstitial->Show(), "Show");
+
+  LogDebug("Click the Ad, and then return to the app to continue");
+
+  while (
+      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_ ==
+      0) {
+    app_framework::ProcessEvents(1000);
+  }
+
+  LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
+  app_framework::ProcessEvents(2000);
+
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_clicked_, 1);
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_showed_full_screen_content_,
+            1);
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_impression_, 1);
+  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
+  EXPECT_EQ(
+      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_, 1);
+
+  interstitial->SetFullScreenContentListener(nullptr);
+  interstitial->SetPaidEventListener(nullptr);
+
+  delete interstitial;
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdLoadAndShow) {
+  TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  TestFullScreenContentListener full_screen_content_listener;
+  rewarded->SetFullScreenContentListener(&full_screen_content_listener);
+
+  TestPaidEventListener paid_event_listener;
+  rewarded->SetPaidEventListener(&paid_event_listener);
+
+  // When the RewardedAd is initialized, load an ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request), "LoadAd");
+
+  TestUserEarnedRewardListener user_earned_reward_listener;
+  WaitForCompletion(rewarded->Show(&user_earned_reward_listener), "Show");
+
+  LogDebug(
+      "Click the Install button in the ad, "
+      "return to the ad, and close the ad to continue");
+
+  while (
+      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_ ==
+      0) {
+    app_framework::ProcessEvents(1000);
+  }
+
+  LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
+  app_framework::ProcessEvents(2000);
+
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_clicked_, 1);
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_showed_full_screen_content_,
+            1);
+  EXPECT_EQ(full_screen_content_listener.num_on_ad_impression_, 1);
+  EXPECT_EQ(
+      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_, 1);
+  EXPECT_EQ(user_earned_reward_listener.num_on_user_earned_reward_, 1);
+  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
+
+  rewarded->SetFullScreenContentListener(nullptr);
+  rewarded->SetPaidEventListener(nullptr);
+
+  delete rewarded;
+}
+
+// Other Banner View Tests
 
 TEST_F(FirebaseAdMobTest, TestBannerView) {
   // AdMob cannot be tested on Firebase Test Lab, so disable tests on FTL.
@@ -676,95 +916,6 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
 #endif
 }
 
-TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
-  // AdMob cannot be tested on Firebase Test Lab, so disable tests on FTL.
-  TEST_REQUIRES_USER_INTERACTION;
-  SKIP_TEST_ON_DESKTOP;
-
-  for (int i = 0; i < 10; ++i) {
-    const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
-    firebase::admob::BannerView* banner = new firebase::admob::BannerView();
-    WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
-                                         kBannerAdUnit, banner_ad_size),
-                      "TestBannerViewStress Initialize");
-
-    // Load the banner ad.
-    firebase::admob::AdRequest request = GetAdRequest();
-    WaitForCompletion(banner->LoadAd(request), "TestBannerViewStress LoadAd");
-    WaitForCompletion(banner->Destroy(), "Destroy BannerView");
-    delete banner;
-  }
-}
-
-TEST_F(FirebaseAdMobTest, TestBannerViewAdOpenedAdClosed) {
-  SKIP_TEST_ON_DESKTOP;
-  TEST_REQUIRES_USER_INTERACTION;
-
-  const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
-  firebase::admob::BannerView* banner = new firebase::admob::BannerView();
-  WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
-                                       kBannerAdUnit, banner_ad_size),
-                    "Initialize");
-
-  // Set the listener.
-  TestAdListener ad_listener;
-  banner->SetAdListener(&ad_listener);
-
-  TestPaidEventListener paid_event_listener;
-  banner->SetPaidEventListener(&paid_event_listener);
-
-  // Load the banner ad.
-  firebase::admob::AdRequest request = GetAdRequest();
-  firebase::Future<firebase::admob::AdResult> load_ad_future =
-      banner->LoadAd(request);
-  WaitForCompletion(load_ad_future, "LoadAd");
-  WaitForCompletion(banner->Show(), "Show 0");
-
-  // Ad Events differ per platform. See the following for more info:
-  // https://www.googblogs.com/google-mobile-ads-sdk-a-note-on-ad-click-events/
-  // and https://groups.google.com/g/google-admob-ads-sdk/c/lzdt5szxSVU
-#if defined(ANDROID)
-  LogDebug("Click the Ad, and then close the ad to continue");
-
-  while (ad_listener.num_on_ad_opened_ == 0) {
-    app_framework::ProcessEvents(1000);
-  }
-
-  while (ad_listener.num_on_ad_closed_ == 0) {
-    app_framework::ProcessEvents(1000);
-  }
-
-  // Ensure all of the expected events were triggered on Android.
-  EXPECT_EQ(ad_listener.num_on_ad_clicked_, 1);
-  EXPECT_EQ(ad_listener.num_on_ad_impression_, 1);
-  EXPECT_EQ(ad_listener.num_on_ad_opened_, 1);
-  EXPECT_EQ(ad_listener.num_on_ad_closed_, 1);
-  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
-#else
-  LogDebug("Click the Ad, and then close the ad to continue");
-
-  while (ad_listener.num_on_ad_clicked_ == 0) {
-    app_framework::ProcessEvents(1000);
-  }
-
-  LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
-  app_framework::ProcessEvents(2000);
-
-  // Ensure all of the expected events were triggered on iOS.
-  EXPECT_EQ(ad_listener.num_on_ad_clicked_, 1);
-  EXPECT_EQ(ad_listener.num_on_ad_impression_, 1);
-  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
-  EXPECT_EQ(ad_listener.num_on_ad_opened_, 0);
-  EXPECT_EQ(ad_listener.num_on_ad_closed_, 0);
-#endif
-
-  load_ad_future.Release();
-  banner->SetAdListener(nullptr);
-  banner->SetPaidEventListener(nullptr);
-  WaitForCompletion(banner->Destroy(), "Destroy BannerView");
-  delete banner;
-}
-
 TEST_F(FirebaseAdMobTest, TestBannerViewErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;
 
@@ -923,92 +1074,7 @@ TEST_F(FirebaseAdMobTest, TestBannerViewErrorBadExtrasClassName) {
   delete banner;
 }
 
-TEST_F(FirebaseAdMobTest, TestInterstitialAdLoad) {
-  SKIP_TEST_ON_DESKTOP;
-
-  // Note: while showing an ad requires user interaction (below),
-  // we test that we can simply load an ad first.
-
-  firebase::admob::InterstitialAd* interstitial =
-      new firebase::admob::InterstitialAd();
-
-  WaitForCompletion(interstitial->Initialize(app_framework::GetWindowContext()),
-                    "Initialize");
-
-  // When the InterstitialAd is initialized, load an ad.
-  firebase::admob::AdRequest request = GetAdRequest();
-  WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
-                    "LoadAd");
-  delete interstitial;
-}
-
-TEST_F(FirebaseAdMobTest, TestInterstitialAdLoadAndShow) {
-  TEST_REQUIRES_USER_INTERACTION;
-  SKIP_TEST_ON_DESKTOP;
-
-  firebase::admob::InterstitialAd* interstitial =
-      new firebase::admob::InterstitialAd();
-
-  WaitForCompletion(interstitial->Initialize(app_framework::GetWindowContext()),
-                    "Initialize");
-
-  TestFullScreenContentListener full_screen_content_listener;
-  interstitial->SetFullScreenContentListener(&full_screen_content_listener);
-
-  TestPaidEventListener paid_event_listener;
-  interstitial->SetPaidEventListener(&paid_event_listener);
-
-  // When the InterstitialAd is initialized, load an ad.
-  firebase::admob::AdRequest request = GetAdRequest();
-  WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
-                    "LoadAd");
-
-  WaitForCompletion(interstitial->Show(), "Show");
-
-  LogDebug("Click the Ad, and then return to the app to continue");
-
-  while (
-      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_ ==
-      0) {
-    app_framework::ProcessEvents(1000);
-  }
-
-  LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
-  app_framework::ProcessEvents(2000);
-
-  EXPECT_EQ(full_screen_content_listener.num_on_ad_clicked_, 1);
-  EXPECT_EQ(full_screen_content_listener.num_on_ad_showed_full_screen_content_,
-            1);
-  EXPECT_EQ(full_screen_content_listener.num_on_ad_impression_, 1);
-  EXPECT_EQ(paid_event_listener.num_on_paid_event_, 1);
-  EXPECT_EQ(
-      full_screen_content_listener.num_on_ad_dismissed_full_screen_content_, 1);
-
-  interstitial->SetFullScreenContentListener(nullptr);
-  interstitial->SetPaidEventListener(nullptr);
-
-  delete interstitial;
-}
-
-TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
-  TEST_REQUIRES_USER_INTERACTION;
-  SKIP_TEST_ON_DESKTOP;
-
-  for (int i = 0; i < 10; ++i) {
-    firebase::admob::InterstitialAd* interstitial =
-        new firebase::admob::InterstitialAd();
-
-    WaitForCompletion(
-        interstitial->Initialize(app_framework::GetWindowContext()),
-        "TestInterstitialAdStress Initialize");
-
-    // When the InterstitialAd is initialized, load an ad.
-    firebase::admob::AdRequest request = GetAdRequest();
-    WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
-                      "TestInterstitialAdStress LoadAd");
-    delete interstitial;
-  }
-}
+// Other InterstitialAd Tests
 
 TEST_F(FirebaseAdMobTest, TestInterstitialAdErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;
@@ -1146,6 +1212,200 @@ TEST_F(FirebaseAdMobTest, TestInterstitialAdErrorBadExtrasClassName) {
                     "LoadAd",
                     firebase::admob::kAdMobErrorAdNetworkClassLoadError);
   delete interstitial_ad;
+}
+
+// Other RewardedAd Tests.
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdErrorNotInitialized) {
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  firebase::admob::RewardedAd* rewarded_ad = new firebase::admob::RewardedAd();
+
+  firebase::admob::AdRequest request = GetAdRequest();
+  WaitForCompletion(rewarded_ad->LoadAd(kRewardedAdUnit, request), "LoadAd",
+                    firebase::admob::kAdMobErrorUninitialized);
+  WaitForCompletion(rewarded_ad->Show(/*listener=*/nullptr), "Show",
+                    firebase::admob::kAdMobErrorUninitialized);
+
+  delete rewarded_ad;
+}
+
+TEST_F(FirebaseAdMobTest, TesRewardedAdErrorAlreadyInitialized) {
+  SKIP_TEST_ON_DESKTOP;
+
+  {
+    firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+    firebase::Future<void> first_initialize =
+        rewarded->Initialize(app_framework::GetWindowContext());
+    firebase::Future<void> second_initialize =
+        rewarded->Initialize(app_framework::GetWindowContext());
+
+    WaitForCompletion(first_initialize, "First Initialize 1");
+    WaitForCompletion(second_initialize, "Second Initialize 1",
+                      firebase::admob::kAdMobErrorAlreadyInitialized);
+
+    first_initialize.Release();
+    second_initialize.Release();
+
+    delete rewarded;
+  }
+
+  // Reverse the order of the completion waits.
+  {
+    firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+    firebase::Future<void> first_initialize =
+        rewarded->Initialize(app_framework::GetWindowContext());
+    firebase::Future<void> second_initialize =
+        rewarded->Initialize(app_framework::GetWindowContext());
+
+    WaitForCompletion(second_initialize, "Second Initialize 1",
+                      firebase::admob::kAdMobErrorAlreadyInitialized);
+    WaitForCompletion(first_initialize, "First Initialize 1");
+
+    first_initialize.Release();
+    second_initialize.Release();
+
+    delete rewarded;
+  }
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdErrorLoadInProgress) {
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // Load the rewarded ad.
+  // Note potential flake: this test assumes the attempt to load an ad
+  // won't resolve immediately.  If it does then the result may be two
+  // successful ad loads instead of the expected
+  // kAdMobErrorLoadInProgress error.
+  firebase::admob::AdRequest request = GetAdRequest();
+  firebase::Future<firebase::admob::AdResult> first_load_ad =
+      rewarded->LoadAd(kRewardedAdUnit, request);
+  firebase::Future<firebase::admob::AdResult> second_load_ad =
+      rewarded->LoadAd(kRewardedAdUnit, request);
+
+  WaitForCompletion(second_load_ad, "Second LoadAd",
+                    firebase::admob::kAdMobErrorLoadInProgress);
+  WaitForCompletion(first_load_ad, "First LoadAd");
+
+  const firebase::admob::AdResult* result_ptr = second_load_ad.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_FALSE(result_ptr->is_successful());
+  EXPECT_EQ(result_ptr->code(), firebase::admob::kAdMobErrorLoadInProgress);
+  EXPECT_EQ(result_ptr->message(), "Ad is currently loading.");
+  EXPECT_EQ(result_ptr->domain(), "SDK");
+  const firebase::admob::ResponseInfo response_info =
+      result_ptr->response_info();
+  EXPECT_TRUE(response_info.adapter_responses().empty());
+  delete rewarded;
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdErrorBadAdUnitId) {
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // Load the rewarded ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  firebase::Future<firebase::admob::AdResult> load_ad =
+      rewarded->LoadAd(kBadAdUnit, request);
+  WaitForCompletion(load_ad, "LoadAd",
+                    firebase::admob::kAdMobErrorInvalidRequest);
+
+  const firebase::admob::AdResult* result_ptr = load_ad.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_FALSE(result_ptr->is_successful());
+  EXPECT_EQ(result_ptr->code(), firebase::admob::kAdMobErrorInvalidRequest);
+  EXPECT_FALSE(result_ptr->message().empty());
+  EXPECT_EQ(result_ptr->domain(), kErrorDomain);
+  const firebase::admob::ResponseInfo response_info =
+      result_ptr->response_info();
+  EXPECT_TRUE(response_info.adapter_responses().empty());
+  delete rewarded;
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdErrorBadExtrasClassName) {
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // Load the rewarded ad.
+  firebase::admob::AdRequest request = GetAdRequest();
+  request.add_extra(kAdNetworkExtrasInvalidClassName, "shouldnot", "work");
+  WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request), "LoadAd",
+                    firebase::admob::kAdMobErrorAdNetworkClassLoadError);
+  delete rewarded;
+}
+
+// Stress tests.  These take a while so run them near the end.
+TEST_F(FirebaseAdMobTest, TestBannerViewStress) {
+  // AdMob cannot be tested on Firebase Test Lab, so disable tests on FTL.
+  TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
+
+  for (int i = 0; i < 10; ++i) {
+    const firebase::admob::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+    firebase::admob::BannerView* banner = new firebase::admob::BannerView();
+    WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
+                                         kBannerAdUnit, banner_ad_size),
+                      "TestBannerViewStress Initialize");
+
+    // Load the banner ad.
+    firebase::admob::AdRequest request = GetAdRequest();
+    WaitForCompletion(banner->LoadAd(request), "TestBannerViewStress LoadAd");
+    WaitForCompletion(banner->Destroy(), "Destroy BannerView");
+    delete banner;
+  }
+}
+
+TEST_F(FirebaseAdMobTest, TestInterstitialAdStress) {
+  TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
+
+  for (int i = 0; i < 10; ++i) {
+    firebase::admob::InterstitialAd* interstitial =
+        new firebase::admob::InterstitialAd();
+
+    WaitForCompletion(
+        interstitial->Initialize(app_framework::GetWindowContext()),
+        "TestInterstitialAdStress Initialize");
+
+    // When the InterstitialAd is initialized, load an ad.
+    firebase::admob::AdRequest request = GetAdRequest();
+    WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
+                      "TestInterstitialAdStress LoadAd");
+    delete interstitial;
+  }
+}
+
+TEST_F(FirebaseAdMobTest, TestRewardedAdStress) {
+  TEST_REQUIRES_USER_INTERACTION;
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS;
+
+  for (int i = 0; i < 10; ++i) {
+    firebase::admob::RewardedAd* rewarded = new firebase::admob::RewardedAd();
+
+    WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                      "TestRewardedAdStress Initialize");
+
+    // When the RewardedAd is initialized, load an ad.
+    firebase::admob::AdRequest request = GetAdRequest();
+    WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request),
+                      "TestRewardedAdStress LoadAd");
+    delete rewarded;
+  }
 }
 
 #if defined(ANDROID) || (defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE)

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -539,102 +539,6 @@ void CompleteLoadAdInternalResult(FutureCallbackData<AdResult>* callback_data,
                          error_message);
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadedAd(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-
-  FutureCallbackData<AdResult>* callback_data =
-      reinterpret_cast<firebase::admob::FutureCallbackData<AdResult>*>(
-          data_ptr);
-
-  CompleteLoadAdInternalResult(callback_data, kAdMobErrorNone,
-                               /*error_message=*/"");
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadAdError(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_load_ad_error,
-    jint j_error_code, jstring j_error_message) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  FIREBASE_ASSERT(j_error_message);
-
-  const AdMobError error_code =
-      MapAndroidAdRequestErrorCodeToCPPErrorCode(j_error_code);
-
-  CompleteLoadAdAndroidErrorResult(env, data_ptr, j_load_ad_error, error_code,
-                                   j_error_message);
-}
-
-// Internal Errors use AdMobError codes.
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadAdInternalError(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint j_error_code,
-    jstring j_error_message) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  FIREBASE_ASSERT(j_error_message);
-
-  const AdMobError error_code =
-      static_cast<firebase::admob::AdMobError>(j_error_code);
-  CompleteLoadAdAndroidErrorResult(env, data_ptr, /*j_load_ad_error=*/nullptr,
-                                   error_code, j_error_message);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewFutureCallback(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint error_code,
-    jstring error_message) {
-  CompleteAdFutureCallback(env, clazz, data_ptr, error_code, error_message);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyBoundingBoxChanged(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfBoundingBoxChange(internal->bounding_box());
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdClicked(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-  internal->NotifyListenerAdClicked();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdClosed(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-  internal->NotifyListenerAdClosed();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdImpression(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-  internal->NotifyListenerAdImpression();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdOpened(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-  internal->NotifyListenerAdOpened();
-}
-
 AdValue::PrecisionType ConvertAndroidPrecisionTypeToCPPPrecisionType(
     const jint j_precision_type) {
   // Values taken from:
@@ -670,89 +574,76 @@ Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyPaidEvent(
   internal->NotifyListenerOfPaidEvent(ad_value);
 }
 
+// Common JNI methods
+//
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialAdFutureCallback(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint error_code,
-    jstring error_message) {
+JNI_completeAdFutureCallback(JNIEnv* env, jclass clazz, jlong data_ptr,
+                             jint error_code, jstring error_message) {
   CompleteAdFutureCallback(env, clazz, data_ptr, error_code, error_message);
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadedAd(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+extern "C" JNIEXPORT void JNICALL JNI_completeLoadedAd(JNIEnv* env,
+                                                       jclass clazz,
+                                                       jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
-
   FutureCallbackData<AdResult>* callback_data =
-      reinterpret_cast<firebase::admob::FutureCallbackData<AdResult>*>(
-          data_ptr);
-
+      reinterpret_cast<FutureCallbackData<AdResult>*>(data_ptr);
   CompleteLoadAdInternalResult(callback_data, kAdMobErrorNone,
                                /*error_message=*/"");
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadAdError(  // NOLINT
+extern "C" JNIEXPORT void JNICALL JNI_completeLoadAdError(
     JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_load_ad_error,
     jint j_error_code, jstring j_error_message) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_error_message);
-
   const AdMobError error_code =
       MapAndroidAdRequestErrorCodeToCPPErrorCode(j_error_code);
-
   CompleteLoadAdAndroidErrorResult(env, data_ptr, j_load_ad_error, error_code,
                                    j_error_message);
 }
 
 // Internal Errors use AdMobError codes.
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadAdInternalError(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint j_error_code,
-    jstring j_error_message) {
+JNI_completeLoadAdInternalError(JNIEnv* env, jclass clazz, jlong data_ptr,
+                                jint j_error_code, jstring j_error_message) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_error_message);
-
-  const AdMobError error_code =
-      static_cast<firebase::admob::AdMobError>(j_error_code);
-
+  const AdMobError error_code = static_cast<AdMobError>(j_error_code);
   CompleteLoadAdAndroidErrorResult(env, data_ptr, /*j_load_ad_error=*/nullptr,
                                    error_code, j_error_message);
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdClickedFullScreenContentEvent(  // NOLINT
+extern "C" JNIEXPORT void JNICALL JNI_notifyAdClickedFullScreenContentEvent(
     JNIEnv* env, jclass clazz, jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdClickedFullScreenContent();
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
+  listener->NotifyListenerOfAdClickedFullScreenContent();
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdDismissedFullScreenContentEvent(  // NOLINT
+extern "C" JNIEXPORT void JNICALL JNI_notifyAdDismissedFullScreenContentEvent(
     JNIEnv* env, jclass clazz, jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdDismissedFullScreenContent();
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
+  listener->NotifyListenerOfAdDismissedFullScreenContent();
 }
 
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdFailedToShowFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_ad_error) {
+JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
+                                               jlong data_ptr,
+                                               jobject j_ad_error) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_ad_error);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
-          data_ptr);
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
   AdResultInternal ad_result_internal;
   ad_result_internal.is_wrapper_error = false;
   ad_result_internal.is_successful = false;
@@ -762,39 +653,90 @@ Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdFailedT
   // Invoke AdMobInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.
   const AdResult& ad_result = AdMobInternal::CreateAdResult(ad_result_internal);
-  internal->NotifyListenerOfAdFailedToShowFullScreenContent(ad_result);
+  listener->NotifyListenerOfAdFailedToShowFullScreenContent(ad_result);
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdImpressionEvent(  // NOLINT
+extern "C" JNIEXPORT void JNICALL JNI_notifyAdImpressionEvent(JNIEnv* env,
+                                                              jclass clazz,
+                                                              jlong data_ptr) {
+  FIREBASE_ASSERT(env);
+  FIREBASE_ASSERT(data_ptr);
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
+  listener->NotifyListenerOfAdImpression();
+}
+
+extern "C" JNIEXPORT void JNICALL JNI_notifyAdShowedFullScreenContentEvent(
     JNIEnv* env, jclass clazz, jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdImpression();
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
+  listener->NotifyListenerOfAdShowedFullScreenContent();
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdShowedFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdShowedFullScreenContent();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyPaidEvent(  // NOLINT
+extern "C" JNIEXPORT void JNICALL JNI_notifyAdPaidEvent(
     JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
     jint j_precision_type, jlong j_value_micros) {
   FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::InterstitialAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::InterstitialAdInternal*>(
+  internal::FullScreenAdEventListener* listener =
+      reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
+
+  const char* currency_code = env->GetStringUTFChars(j_currency_code, nullptr);
+  const AdValue::PrecisionType precision_type =
+      ConvertAndroidPrecisionTypeToCPPPrecisionType(j_precision_type);
+  AdValue ad_value(currency_code, precision_type, (int64_t)j_value_micros);
+  listener->NotifyListenerOfPaidEvent(ad_value);
+}
+
+// JNI functions specific to BannerViews
+//
+extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyBoundingBoxChanged(
+    JNIEnv* env, jclass clazz, jlong data_ptr) {
+  firebase::admob::internal::BannerViewInternal* internal =
+      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
+  internal->NotifyListenerOfBoundingBoxChange(internal->bounding_box());
+}
+
+extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdClicked(
+    JNIEnv* env, jclass clazz, jlong data_ptr) {
+  firebase::admob::internal::BannerViewInternal* internal =
+      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
+          data_ptr);
+  internal->NotifyListenerAdClicked();
+}
+
+extern "C" JNIEXPORT void JNICALL
+JNI_BannerViewHelper_notifyAdClosed(JNIEnv* env, jclass clazz, jlong data_ptr) {
+  firebase::admob::internal::BannerViewInternal* internal =
+      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
+          data_ptr);
+  internal->NotifyListenerAdClosed();
+}
+
+extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdImpression(
+    JNIEnv* env, jclass clazz, jlong data_ptr) {
+  firebase::admob::internal::BannerViewInternal* internal =
+      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
+          data_ptr);
+  internal->NotifyListenerAdImpression();
+}
+
+extern "C" JNIEXPORT void JNICALL
+JNI_BannerViewHelper_notifyAdOpened(JNIEnv* env, jclass clazz, jlong data_ptr) {
+  firebase::admob::internal::BannerViewInternal* internal =
+      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
+          data_ptr);
+  internal->NotifyListenerAdOpened();
+}
+
+extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdPaidEvent(
+    JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
+    jint j_precision_type, jlong j_value_micros) {
+  FIREBASE_ASSERT(data_ptr);
+  internal::BannerViewInternal* internal =
+      reinterpret_cast<internal::BannerViewInternal*>(data_ptr);
 
   const char* currency_code = env->GetStringUTFChars(j_currency_code, nullptr);
   const AdValue::PrecisionType precision_type =
@@ -803,255 +745,95 @@ Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyPaidEvent
   internal->NotifyListenerOfPaidEvent(ad_value);
 }
 
-// Rewarded Ad
+// JNI functions specific to RewardedAds
+//
 extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedAdFutureCallback(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint error_code,
-    jstring error_message) {
-  CompleteAdFutureCallback(env, clazz, data_ptr, error_code, error_message);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadedAd(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+JNI_RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
+                                jstring reward_type, jint amount) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
-
-  FutureCallbackData<AdResult>* callback_data =
-      reinterpret_cast<firebase::admob::FutureCallbackData<AdResult>*>(
-          data_ptr);
-
-  CompleteLoadAdInternalResult(callback_data, kAdMobErrorNone,
-                               /*error_message=*/"");
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadAdError(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_load_ad_error,
-    jint j_error_code, jstring j_error_message) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  FIREBASE_ASSERT(j_error_message);
-
-  const AdMobError error_code =
-      MapAndroidAdRequestErrorCodeToCPPErrorCode(j_error_code);
-
-  CompleteLoadAdAndroidErrorResult(env, data_ptr, j_load_ad_error, error_code,
-                                   j_error_message);
-}
-
-// Internal Errors use AdMobError codes.
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadAdInternalError(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jint j_error_code,
-    jstring j_error_message) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  FIREBASE_ASSERT(j_error_message);
-
-  const AdMobError error_code =
-      static_cast<firebase::admob::AdMobError>(j_error_code);
-
-  CompleteLoadAdAndroidErrorResult(env, data_ptr, /*j_load_ad_error=*/nullptr,
-                                   error_code, j_error_message);
-}
-
-extern "C" JNIEXPORT void JNICALL
-RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
-                            jstring reward_type, jint amount) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
+  internal::RewardedAdInternal* internal =
+      reinterpret_cast<internal::RewardedAdInternal*>(data_ptr);
   internal->NotifyListenerOfUserEarnedReward(
       util::JStringToString(env, reward_type), (int64_t)amount);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdClickedFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdClickedFullScreenContent();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdDismissedFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdDismissedFullScreenContent();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdFailedToShowFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_ad_error) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  FIREBASE_ASSERT(j_ad_error);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-  AdResultInternal ad_result_internal;
-  ad_result_internal.is_wrapper_error = false;
-  ad_result_internal.is_successful = false;
-  ad_result_internal.j_ad_error = j_ad_error;
-
-  // Invoke AdMobInternal, a friend of AdResult, to have it access its
-  // protected constructor with the AdError data.
-  const AdResult& ad_result = AdMobInternal::CreateAdResult(ad_result_internal);
-  internal->NotifyListenerOfAdFailedToShowFullScreenContent(ad_result);
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdImpressionEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdImpression();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdShowedFullScreenContentEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
-  FIREBASE_ASSERT(env);
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-  internal->NotifyListenerOfAdShowedFullScreenContent();
-}
-
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdPaidEvent(  // NOLINT
-    JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
-    jint j_precision_type, jlong j_value_micros) {
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::RewardedAdInternal* internal =
-      reinterpret_cast<firebase::admob::internal::RewardedAdInternal*>(
-          data_ptr);
-
-  const char* currency_code = env->GetStringUTFChars(j_currency_code, nullptr);
-  const AdValue::PrecisionType precision_type =
-      ConvertAndroidPrecisionTypeToCPPPrecisionType(j_precision_type);
-  AdValue ad_value(currency_code, precision_type, (int64_t)j_value_micros);
-  internal->NotifyListenerOfPaidEvent(ad_value);
 }
 
 bool RegisterNatives() {
   static const JNINativeMethod kBannerMethods[] = {
       {"completeBannerViewFutureCallback", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewFutureCallback)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
       {"completeBannerViewLoadedAd", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadedAd)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadedAd)},
       {"completeBannerViewLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadAdError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdError)},
       {"completeBannerViewLoadAdInternalError", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_completeBannerViewLoadAdInternalError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdInternalError)},
       {"notifyBoundingBoxChanged", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyBoundingBoxChanged)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyBoundingBoxChanged)},
       {"notifyAdClicked", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdClicked)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdClicked)},
       {"notifyAdClosed", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdClosed)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdClosed)},
       {"notifyAdImpression", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdImpression)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdImpression)},
       {"notifyAdOpened", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyAdOpened)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdOpened)},
       {"notifyPaidEvent", "(JLjava/lang/String;IJ)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyPaidEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdPaidEvent)},
   };
   static const JNINativeMethod kInterstitialMethods[] = {
       {"completeInterstitialAdFutureCallback", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialAdFutureCallback)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
       {"completeInterstitialLoadedAd", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadedAd)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadedAd)},
       {"completeInterstitialLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadAdError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdError)},
       {"completeInterstitialLoadAdInternalError", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_completeInterstitialLoadAdInternalError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdInternalError)},
       {"notifyAdClickedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdClickedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdClickedFullScreenContentEvent)},
       {"notifyAdDismissedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdDismissedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdDismissedFullScreenContentEvent)},
       {"notifyAdFailedToShowFullScreenContentEvent",
        "(JLcom/google/android/gms/ads/AdError;)V",
        reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdFailedToShowFullScreenContentEvent)},  // NOLINT
+           &JNI_notifyAdFailedToShowFullScreenContentEvent)},
       {"notifyAdImpressionEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdImpressionEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdImpressionEvent)},
       {"notifyAdShowedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyAdShowedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdShowedFullScreenContentEvent)},
       {"notifyPaidEvent", "(JLjava/lang/String;IJ)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_InterstitialAdHelper_notifyPaidEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdPaidEvent)},
   };
 
   static const JNINativeMethod kRewardedAdMethods[] = {
       {"completeRewardedAdFutureCallback", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedAdFutureCallback)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
       {"completeRewardedLoadedAd", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadedAd)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadedAd)},
       {"completeRewardedLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadAdError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdError)},
       {"completeRewardedLoadAdInternalError", "(JILjava/lang/String;)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_completeRewardedLoadAdInternalError)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_completeLoadAdInternalError)},
       {"notifyUserEarnedRewardEvent", "(JLjava/lang/String;I)V",
-       reinterpret_cast<void*>(&RewardedAd_UserEarnedReward)},
+       reinterpret_cast<void*>(&JNI_RewardedAd_UserEarnedReward)},
       {"notifyAdClickedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdClickedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdClickedFullScreenContentEvent)},
       {"notifyAdDismissedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdDismissedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdDismissedFullScreenContentEvent)},
       {"notifyAdFailedToShowFullScreenContentEvent",
        "(JLcom/google/android/gms/ads/AdError;)V",
        reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdFailedToShowFullScreenContentEvent)},  // NOLINT
+           &JNI_notifyAdFailedToShowFullScreenContentEvent)},
       {"notifyAdImpressionEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdImpressionEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdImpressionEvent)},
       {"notifyAdShowedFullScreenContentEvent", "(J)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdShowedFullScreenContentEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdShowedFullScreenContentEvent)},
       {"notifyPaidEvent", "(JLjava/lang/String;IJ)V",
-       reinterpret_cast<void*>(
-           &Java_com_google_firebase_admob_internal_cpp_RewardedAdHelper_notifyRewardedAdPaidEvent)},  // NOLINT
+       reinterpret_cast<void*>(&JNI_notifyAdPaidEvent)},
   };
 
   JNIEnv* env = GetJNI();

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -781,33 +781,16 @@ static void JNICALL AdMobInitializationHelper_initializationCompleteCallback(
   }
 }
 
-extern "C" JNIEXPORT void JNICALL
-Java_com_google_firebase_admob_internal_cpp_BannerViewHelper_notifyPaidEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
-    jint j_precision_type, jlong j_value_micros) {
-  FIREBASE_ASSERT(data_ptr);
-  firebase::admob::internal::BannerViewInternal* internal =
-      reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
-          data_ptr);
-
-  const char* currency_code = env->GetStringUTFChars(j_currency_code, nullptr);
-  const AdValue::PrecisionType precision_type =
-      ConvertAndroidPrecisionTypeToCPPPrecisionType(j_precision_type);
-  AdValue ad_value(currency_code, precision_type, (int64_t)j_value_micros);
-  internal->NotifyListenerOfPaidEvent(ad_value);
-}
+namespace {
 
 // Common JNI methods
 //
-extern "C" JNIEXPORT void JNICALL
-JNI_completeAdFutureCallback(JNIEnv* env, jclass clazz, jlong data_ptr,
-                             jint error_code, jstring error_message) {
+void JNI_completeAdFutureCallback(JNIEnv* env, jclass clazz, jlong data_ptr,
+                                  jint error_code, jstring error_message) {
   CompleteAdFutureCallback(env, clazz, data_ptr, error_code, error_message);
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_completeLoadedAd(JNIEnv* env,
-                                                       jclass clazz,
-                                                       jlong data_ptr) {
+void JNI_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FutureCallbackData<AdResult>* callback_data =
@@ -816,9 +799,9 @@ extern "C" JNIEXPORT void JNICALL JNI_completeLoadedAd(JNIEnv* env,
                                /*error_message=*/"");
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_completeLoadAdError(
-    JNIEnv* env, jclass clazz, jlong data_ptr, jobject j_load_ad_error,
-    jint j_error_code, jstring j_error_message) {
+void JNI_completeLoadAdError(JNIEnv* env, jclass clazz, jlong data_ptr,
+                             jobject j_load_ad_error, jint j_error_code,
+                             jstring j_error_message) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_error_message);
@@ -829,9 +812,9 @@ extern "C" JNIEXPORT void JNICALL JNI_completeLoadAdError(
 }
 
 // Internal Errors use AdMobError codes.
-extern "C" JNIEXPORT void JNICALL
-JNI_completeLoadAdInternalError(JNIEnv* env, jclass clazz, jlong data_ptr,
-                                jint j_error_code, jstring j_error_message) {
+void JNI_completeLoadAdInternalError(JNIEnv* env, jclass clazz, jlong data_ptr,
+                                     jint j_error_code,
+                                     jstring j_error_message) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_error_message);
@@ -840,8 +823,8 @@ JNI_completeLoadAdInternalError(JNIEnv* env, jclass clazz, jlong data_ptr,
                                    error_code, j_error_message);
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_notifyAdClickedFullScreenContentEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_notifyAdClickedFullScreenContentEvent(JNIEnv* env, jclass clazz,
+                                               jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   internal::FullScreenAdEventListener* listener =
@@ -849,8 +832,8 @@ extern "C" JNIEXPORT void JNICALL JNI_notifyAdClickedFullScreenContentEvent(
   listener->NotifyListenerOfAdClickedFullScreenContent();
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_notifyAdDismissedFullScreenContentEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_notifyAdDismissedFullScreenContentEvent(JNIEnv* env, jclass clazz,
+                                                 jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   internal::FullScreenAdEventListener* listener =
@@ -858,10 +841,9 @@ extern "C" JNIEXPORT void JNICALL JNI_notifyAdDismissedFullScreenContentEvent(
   listener->NotifyListenerOfAdDismissedFullScreenContent();
 }
 
-extern "C" JNIEXPORT void JNICALL
-JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
-                                               jlong data_ptr,
-                                               jobject j_ad_error) {
+void JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
+                                                    jlong data_ptr,
+                                                    jobject j_ad_error) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(j_ad_error);
@@ -879,9 +861,7 @@ JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
   listener->NotifyListenerOfAdFailedToShowFullScreenContent(ad_result);
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_notifyAdImpressionEvent(JNIEnv* env,
-                                                              jclass clazz,
-                                                              jlong data_ptr) {
+void JNI_notifyAdImpressionEvent(JNIEnv* env, jclass clazz, jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   internal::FullScreenAdEventListener* listener =
@@ -889,8 +869,8 @@ extern "C" JNIEXPORT void JNICALL JNI_notifyAdImpressionEvent(JNIEnv* env,
   listener->NotifyListenerOfAdImpression();
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_notifyAdShowedFullScreenContentEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_notifyAdShowedFullScreenContentEvent(JNIEnv* env, jclass clazz,
+                                              jlong data_ptr) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   internal::FullScreenAdEventListener* listener =
@@ -898,9 +878,9 @@ extern "C" JNIEXPORT void JNICALL JNI_notifyAdShowedFullScreenContentEvent(
   listener->NotifyListenerOfAdShowedFullScreenContent();
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_notifyAdPaidEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
-    jint j_precision_type, jlong j_value_micros) {
+void JNI_notifyAdPaidEvent(JNIEnv* env, jclass clazz, jlong data_ptr,
+                           jstring j_currency_code, jint j_precision_type,
+                           jlong j_value_micros) {
   FIREBASE_ASSERT(data_ptr);
   internal::FullScreenAdEventListener* listener =
       reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
@@ -914,49 +894,51 @@ extern "C" JNIEXPORT void JNICALL JNI_notifyAdPaidEvent(
 
 // JNI functions specific to BannerViews
 //
-extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyBoundingBoxChanged(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_BannerViewHelper_notifyBoundingBoxChanged(JNIEnv* env, jclass clazz,
+                                                   jlong data_ptr) {
   firebase::admob::internal::BannerViewInternal* internal =
       reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
   internal->NotifyListenerOfBoundingBoxChange(internal->bounding_box());
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdClicked(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_BannerViewHelper_notifyAdClicked(JNIEnv* env, jclass clazz,
+                                          jlong data_ptr) {
   firebase::admob::internal::BannerViewInternal* internal =
       reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
   internal->NotifyListenerAdClicked();
 }
 
-extern "C" JNIEXPORT void JNICALL
-JNI_BannerViewHelper_notifyAdClosed(JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_BannerViewHelper_notifyAdClosed(JNIEnv* env, jclass clazz,
+                                         jlong data_ptr) {
   firebase::admob::internal::BannerViewInternal* internal =
       reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
   internal->NotifyListenerAdClosed();
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdImpression(
-    JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_BannerViewHelper_notifyAdImpression(JNIEnv* env, jclass clazz,
+                                             jlong data_ptr) {
   firebase::admob::internal::BannerViewInternal* internal =
       reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
   internal->NotifyListenerAdImpression();
 }
 
-extern "C" JNIEXPORT void JNICALL
-JNI_BannerViewHelper_notifyAdOpened(JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_BannerViewHelper_notifyAdOpened(JNIEnv* env, jclass clazz,
+                                         jlong data_ptr) {
   firebase::admob::internal::BannerViewInternal* internal =
       reinterpret_cast<firebase::admob::internal::BannerViewInternal*>(
           data_ptr);
   internal->NotifyListenerAdOpened();
 }
 
-extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdPaidEvent(
-    JNIEnv* env, jclass clazz, jlong data_ptr, jstring j_currency_code,
-    jint j_precision_type, jlong j_value_micros) {
+void JNI_BannerViewHelper_notifyAdPaidEvent(JNIEnv* env, jclass clazz,
+                                            jlong data_ptr,
+                                            jstring j_currency_code,
+                                            jint j_precision_type,
+                                            jlong j_value_micros) {
   FIREBASE_ASSERT(data_ptr);
   internal::BannerViewInternal* internal =
       reinterpret_cast<internal::BannerViewInternal*>(data_ptr);
@@ -970,9 +952,8 @@ extern "C" JNIEXPORT void JNICALL JNI_BannerViewHelper_notifyAdPaidEvent(
 
 // JNI functions specific to RewardedAds
 //
-extern "C" JNIEXPORT void JNICALL
-JNI_RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
-                                jstring reward_type, jint amount) {
+void JNI_RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
+                                     jstring reward_type, jint amount) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   internal::RewardedAdInternal* internal =
@@ -980,6 +961,8 @@ JNI_RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
   internal->NotifyListenerOfUserEarnedReward(
       util::JStringToString(env, reward_type), (int64_t)amount);
 }
+
+}  // namespace
 
 bool RegisterNatives() {
   static const JNINativeMethod kBannerMethods[] = {

--- a/admob/src/android/rewarded_ad_internal_android.cc
+++ b/admob/src/android/rewarded_ad_internal_android.cc
@@ -1,0 +1,163 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "admob/src/android/rewarded_ad_internal_android.h"
+
+#include <assert.h>
+#include <jni.h>
+
+#include <cstdarg>
+#include <cstddef>
+
+#include "admob/admob_resources.h"
+#include "admob/src/android/ad_request_converter.h"
+#include "admob/src/android/admob_android.h"
+#include "admob/src/common/admob_common.h"
+#include "admob/src/include/firebase/admob.h"
+#include "admob/src/include/firebase/admob/types.h"
+#include "app/src/assert.h"
+#include "app/src/util_android.h"
+
+namespace firebase {
+namespace admob {
+
+METHOD_LOOKUP_DEFINITION(
+    rewarded_ad_helper,
+    "com/google/firebase/admob/internal/cpp/RewardedAdHelper",
+    REWARDEDADHELPER_METHODS);
+
+namespace internal {
+
+RewardedAdInternalAndroid::RewardedAdInternalAndroid(RewardedAd* base)
+    : RewardedAdInternal(base), helper_(nullptr), initialized_(false) {
+  firebase::MutexLock lock(mutex_);
+  JNIEnv* env = ::firebase::admob::GetJNI();
+  jobject helper_ref = env->NewObject(
+      rewarded_ad_helper::GetClass(),
+      rewarded_ad_helper::GetMethodId(rewarded_ad_helper::kConstructor),
+      reinterpret_cast<jlong>(this));
+
+  FIREBASE_ASSERT(helper_ref);
+  helper_ = env->NewGlobalRef(helper_ref);
+  FIREBASE_ASSERT(helper_);
+  env->DeleteLocalRef(helper_ref);
+}
+
+RewardedAdInternalAndroid::~RewardedAdInternalAndroid() {
+  firebase::MutexLock lock(mutex_);
+  JNIEnv* env = ::firebase::admob::GetJNI();
+  // Since it's currently not possible to destroy the rewarded ad, just
+  // disconnect from it so the listener doesn't initiate callbacks with stale
+  // data.
+  env->CallVoidMethod(helper_, rewarded_ad_helper::GetMethodId(
+                                   rewarded_ad_helper::kDisconnect));
+  env->DeleteGlobalRef(helper_);
+
+  helper_ = nullptr;
+  full_screen_content_listener_ = nullptr;
+  paid_event_listener_ = nullptr;
+  user_earned_reward_listener_ = nullptr;
+}
+
+Future<void> RewardedAdInternalAndroid::Initialize(AdParent parent) {
+  firebase::MutexLock lock(mutex_);
+
+  if (initialized_) {
+    const SafeFutureHandle<void> future_handle =
+        future_data_.future_impl.SafeAlloc<void>(kRewardedAdFnInitialize);
+    CompleteFuture(kAdMobErrorAlreadyInitialized,
+                   kAdAlreadyInitializedErrorMessage, future_handle,
+                   &future_data_);
+    return MakeFuture(&future_data_.future_impl, future_handle);
+  }
+
+  initialized_ = true;
+  JNIEnv* env = ::firebase::admob::GetJNI();
+  FIREBASE_ASSERT(env);
+
+  FutureCallbackData<void>* callback_data =
+      CreateVoidFutureCallbackData(kRewardedAdFnInitialize, &future_data_);
+  env->CallVoidMethod(
+      helper_, rewarded_ad_helper::GetMethodId(rewarded_ad_helper::kInitialize),
+      reinterpret_cast<jlong>(callback_data), parent);
+  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+}
+
+Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
+                                                   const AdRequest& request) {
+  firebase::MutexLock lock(mutex_);
+
+  if (!initialized_) {
+    SafeFutureHandle<AdResult> handle =
+        future_data_.future_impl.SafeAlloc<AdResult>(kRewardedAdFnLoadAd,
+                                                     AdResult());
+    CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
+                   handle, &future_data_, AdResult());
+    return MakeFuture(&future_data_.future_impl, handle);
+  }
+
+  admob::AdMobError error = kAdMobErrorNone;
+  jobject j_request = GetJavaAdRequestFromCPPAdRequest(request, &error);
+  if (j_request == nullptr) {
+    if (error == kAdMobErrorNone) {
+      error = kAdMobErrorInternalError;
+    }
+    return CreateAndCompleteFutureWithResult(
+        kRewardedAdFnLoadAd, error, kAdCouldNotParseAdRequestErrorMessage,
+        &future_data_, AdResult());
+  }
+  JNIEnv* env = GetJNI();
+  FIREBASE_ASSERT(env);
+  FutureCallbackData<AdResult>* callback_data =
+      CreateAdResultFutureCallbackData(kRewardedAdFnLoadAd, &future_data_);
+
+  jstring j_ad_unit_str = env->NewStringUTF(ad_unit_id);
+  ::firebase::admob::GetJNI()->CallVoidMethod(
+      helper_, rewarded_ad_helper::GetMethodId(rewarded_ad_helper::kLoadAd),
+      reinterpret_cast<jlong>(callback_data), j_ad_unit_str, j_request);
+  env->DeleteLocalRef(j_ad_unit_str);
+  env->DeleteLocalRef(j_request);
+
+  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+}
+
+Future<void> RewardedAdInternalAndroid::Show(
+    UserEarnedRewardListener* listener) {
+  firebase::MutexLock lock(mutex_);
+  if (!initialized_) {
+    const SafeFutureHandle<void> future_handle =
+        future_data_.future_impl.SafeAlloc<void>(kRewardedAdFnShow);
+    CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
+                   future_handle, &future_data_);
+    return MakeFuture(&future_data_.future_impl, future_handle);
+  }
+
+  user_earned_reward_listener_ = listener;
+
+  FutureCallbackData<void>* callback_data =
+      CreateVoidFutureCallbackData(kRewardedAdFnShow, &future_data_);
+  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+
+  ::firebase::admob::GetJNI()->CallVoidMethod(
+      helper_, rewarded_ad_helper::GetMethodId(rewarded_ad_helper::kShow),
+      reinterpret_cast<jlong>(callback_data));
+
+  return MakeFuture(&future_data_.future_impl, future_handle);
+}
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/android/rewarded_ad_internal_android.h
+++ b/admob/src/android/rewarded_ad_internal_android.h
@@ -30,7 +30,7 @@ namespace admob {
 #define REWARDEDADHELPER_METHODS(X)                                            \
   X(Constructor, "<init>", "(J)V"),                                            \
   X(Initialize, "initialize", "(JLandroid/app/Activity;)V"),                   \
-  X(Show, "show", "(J)V"),                                                     \
+  X(Show, "show", "(JLjava/lang/String;Ljava/lang/String;)V"),                 \
   X(LoadAd, "loadAd",                                                          \
     "(JLjava/lang/String;Lcom/google/android/gms/ads/AdRequest;)V"),           \
   X(Disconnect, "disconnect", "()V")

--- a/admob/src/android/rewarded_ad_internal_android.h
+++ b/admob/src/android/rewarded_ad_internal_android.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_ANDROID_REWARDED_AD_INTERNAL_ANDROID_H_
+#define FIREBASE_ADMOB_SRC_ANDROID_REWARDED_AD_INTERNAL_ANDROID_H_
+
+#include "admob/src/common/rewarded_ad_internal.h"
+#include "app/src/mutex.h"
+#include "app/src/util_android.h"
+
+namespace firebase {
+namespace admob {
+
+// Used to set up the cache of RewardedAdHelper class method IDs to reduce
+// time spent looking up methods by string.
+// clang-format off
+#define REWARDEDADHELPER_METHODS(X)                                        \
+  X(Constructor, "<init>", "(J)V"),                                            \
+  X(Initialize, "initialize", "(JLandroid/app/Activity;)V"),                   \
+  X(Show, "show", "(J)V"),                                                     \
+  X(LoadAd, "loadAd",                                                          \
+    "(JLjava/lang/String;Lcom/google/android/gms/ads/AdRequest;)V"),           \
+  X(Disconnect, "disconnect", "()V")
+// clang-format on
+
+METHOD_LOOKUP_DECLARATION(rewarded_ad_helper, REWARDEDADHELPER_METHODS);
+
+namespace internal {
+
+class RewardedAdInternalAndroid : public RewardedAdInternal {
+ public:
+  explicit RewardedAdInternalAndroid(RewardedAd* base);
+  ~RewardedAdInternalAndroid() override;
+
+  Future<void> Initialize(AdParent parent) override;
+  Future<AdResult> LoadAd(const char* ad_unit_id,
+                          const AdRequest& request) override;
+  Future<void> Show(UserEarnedRewardListener* listener) override;
+  bool is_initialized() const override { return initialized_; }
+
+ private:
+  // Reference to the Java helper object used to interact with the Mobile Ads
+  // SDK.
+  jobject helper_;
+
+  // Tracks if this Rewarded Ad has been initialized.
+  bool initialized_;
+
+  // Mutex to guard against concurrent operations;
+  Mutex mutex_;
+};
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_ANDROID_REWARDED_AD_INTERNAL_ANDROID_H_

--- a/admob/src/android/rewarded_ad_internal_android.h
+++ b/admob/src/android/rewarded_ad_internal_android.h
@@ -27,7 +27,7 @@ namespace admob {
 // Used to set up the cache of RewardedAdHelper class method IDs to reduce
 // time spent looking up methods by string.
 // clang-format off
-#define REWARDEDADHELPER_METHODS(X)                                        \
+#define REWARDEDADHELPER_METHODS(X)                                            \
   X(Constructor, "<init>", "(J)V"),                                            \
   X(Initialize, "initialize", "(JLandroid/app/Activity;)V"),                   \
   X(Show, "show", "(J)V"),                                                     \

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -24,6 +24,7 @@
 #include "admob/src/include/firebase/admob.h"
 #include "admob/src/include/firebase/admob/banner_view.h"
 #include "admob/src/include/firebase/admob/interstitial_ad.h"
+#include "admob/src/include/firebase/admob/rewarded_ad.h"
 #include "admob/src/include/firebase/admob/types.h"
 #include "app/src/cleanup_notifier.h"
 #include "app/src/include/firebase/version.h"
@@ -58,15 +59,6 @@ const char* kAdCouldNotParseAdRequestErrorMessage =
     "Could Not Parse AdRequest.";
 const char* kAdLoadInProgressErrorMessage = "Ad is currently loading.";
 const char* kAdUninitializedErrorMessage = "Ad has not been fully initialized.";
-
-// AdListener
-// Default no-op implementation for each listener method so that applications
-// need only implement the methods they're interested in.
-AdListener::~AdListener() {}
-void AdListener::OnAdClicked() {}
-void AdListener::OnAdClosed() {}
-void AdListener::OnAdImpression() {}
-void AdListener::OnAdOpened() {}
 
 // AdMobInternal
 void AdMobInternal::CompleteLoadAdFuture(
@@ -174,24 +166,14 @@ void AdView::SetPaidEventListener(PaidEventListener* listener) {
   paid_event_listener_ = listener;
 }
 
-// FullScreenContentListener
-// Default no-op implementation for each listener method so that applications
-// need only implement the methods they're interested in.
-FullScreenContentListener::~FullScreenContentListener() {}
-void FullScreenContentListener::OnAdClicked() {}
-void FullScreenContentListener::OnAdDismissedFullScreenContent() {}
-void FullScreenContentListener::OnAdFailedToShowFullScreenContent(
-    const AdResult& ad_result) {}
-void FullScreenContentListener::OnAdImpression() {}
-void FullScreenContentListener::OnAdShowedFullScreenContent() {}
-
-// Misc - other default destructors, and application helpers.
-
-// Non-inline implementation of the Listeners' virtual destructors, to prevent
+// Non-inline implementation of the virtual destructors, to prevent
 // their vtables from being emitted in each translation unit.
+AdListener::~AdListener() {}
 AdView::~AdView() {}
 AdViewBoundingBoxListener::~AdViewBoundingBoxListener() {}
+FullScreenContentListener::~FullScreenContentListener() {}
 PaidEventListener::~PaidEventListener() {}
+UserEarnedRewardListener::~UserEarnedRewardListener() {}
 
 void RegisterTerminateOnDefaultAppDestroy() {
   if (!AppCallback::GetEnabledByName(kAdMobModuleName)) {

--- a/admob/src/common/banner_view.cc
+++ b/admob/src/common/banner_view.cc
@@ -31,8 +31,7 @@ BannerView::BannerView() {
   FIREBASE_ASSERT(admob::IsInitialized());
   internal_ = internal::BannerViewInternal::CreateInstance(this);
   GetOrCreateCleanupNotifier()->RegisterObject(this, [](void* object) {
-    FIREBASE_ASSERT_MESSAGE(
-        false, "BannerView must be deleted before admob::Terminate.");
+    LogWarning("BannerView must be deleted before admob::Terminate.");
     BannerView* banner_view = reinterpret_cast<BannerView*>(object);
     delete banner_view->internal_;
     banner_view->internal_ = nullptr;

--- a/admob/src/common/full_screen_ad_event_listener.cc
+++ b/admob/src/common/full_screen_ad_event_listener.cc
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2016 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "admob/src/common/full_screen_ad_event_listener.h"
+
+#include "app/src/mutex.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+void FullScreenAdEventListener::SetFullScreenContentListener(
+    FullScreenContentListener* listener) {
+  MutexLock lock(listener_mutex_);
+  full_screen_content_listener_ = listener;
+}
+
+void FullScreenAdEventListener::SetPaidEventListener(
+    PaidEventListener* listener) {
+  MutexLock lock(listener_mutex_);
+  paid_event_listener_ = listener;
+}
+
+void FullScreenAdEventListener::NotifyListenerOfAdClickedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdClicked();
+  }
+}
+
+void FullScreenAdEventListener::NotifyListenerOfAdDismissedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdDismissedFullScreenContent();
+  }
+}
+
+void FullScreenAdEventListener::NotifyListenerOfAdFailedToShowFullScreenContent(
+    const AdResult& ad_result) {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdFailedToShowFullScreenContent(ad_result);
+  }
+}
+
+void FullScreenAdEventListener::NotifyListenerOfAdImpression() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdImpression();
+  }
+}
+
+void FullScreenAdEventListener::NotifyListenerOfAdShowedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdShowedFullScreenContent();
+  }
+}
+
+void FullScreenAdEventListener::NotifyListenerOfPaidEvent(
+    const AdValue& ad_value) {
+  MutexLock lock(listener_mutex_);
+  if (paid_event_listener_ != nullptr) {
+    paid_event_listener_->OnPaidEvent(ad_value);
+  }
+}
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/common/full_screen_ad_event_listener.h
+++ b/admob/src/common/full_screen_ad_event_listener.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_COMMON_FULL_SCREEN_AD_EVENT_LISTENER_H_
+#define FIREBASE_ADMOB_SRC_COMMON_FULL_SCREEN_AD_EVENT_LISTENER_H_
+
+#include "admob/src/common/admob_common.h"
+#include "app/src/mutex.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+// Listener class used by both InterstitialAds and RewardedAds.
+class FullScreenAdEventListener {
+ public:
+  FullScreenAdEventListener()
+      : full_screen_content_listener_(nullptr), paid_event_listener_(nullptr) {}
+
+  // Sets the @ref FullScreenContentListener to receive events about UI
+  // and presentation state.
+  void SetFullScreenContentListener(FullScreenContentListener* listener);
+
+  // Sets the @ref PaidEventListener to receive information about paid events.
+  void SetPaidEventListener(PaidEventListener* listener);
+
+  // Notifies the FullScreenContentListener (if one exists) that an event has
+  // occurred.
+  virtual void NotifyListenerOfAdClickedFullScreenContent();
+  virtual void NotifyListenerOfAdDismissedFullScreenContent();
+  virtual void NotifyListenerOfAdFailedToShowFullScreenContent(
+      const AdResult& ad_result);
+  virtual void NotifyListenerOfAdImpression();
+  virtual void NotifyListenerOfAdShowedFullScreenContent();
+
+  // Notify the PaidEventListener (if one exists) that a paid event has
+  // occurred.
+  virtual void NotifyListenerOfPaidEvent(const AdValue& ad_value);
+
+ protected:
+  // Reference to the listener to which this object sends full screen event
+  // callbacks.
+  FullScreenContentListener* full_screen_content_listener_;
+
+  // Reference to the listener to which this object sends ad payout
+  // event callbacks.
+  PaidEventListener* paid_event_listener_;
+
+  // Lock object for accessing listener_.
+  Mutex listener_mutex_;
+};
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_COMMON_FULL_SCREEN_AD_EVENT_LISTENER_H_

--- a/admob/src/common/interstitial_ad.cc
+++ b/admob/src/common/interstitial_ad.cc
@@ -32,8 +32,7 @@ InterstitialAd::InterstitialAd() {
   internal_ = internal::InterstitialAdInternal::CreateInstance(this);
 
   GetOrCreateCleanupNotifier()->RegisterObject(this, [](void* object) {
-    FIREBASE_ASSERT_MESSAGE(
-        false, "InterstitialAd must be deleted before admob::Terminate.");
+    LogWarning("InterstitialAd must be deleted before admob::Terminate.");
     InterstitialAd* interstitial_ad = reinterpret_cast<InterstitialAd*>(object);
     delete interstitial_ad->internal_;
     interstitial_ad->internal_ = nullptr;

--- a/admob/src/common/interstitial_ad_internal.cc
+++ b/admob/src/common/interstitial_ad_internal.cc
@@ -36,10 +36,7 @@ namespace admob {
 namespace internal {
 
 InterstitialAdInternal::InterstitialAdInternal(InterstitialAd* base)
-    : base_(base),
-      future_data_(kInterstitialAdFnCount),
-      full_screen_content_listener_(nullptr),
-      paid_event_listener_(nullptr) {}
+    : base_(base), future_data_(kInterstitialAdFnCount) {}
 
 InterstitialAdInternal* InterstitialAdInternal::CreateInstance(
     InterstitialAd* base) {
@@ -51,61 +48,6 @@ InterstitialAdInternal* InterstitialAdInternal::CreateInstance(
   return new InterstitialAdInternalStub(base);
 #endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
         // FIREBASE_PLATFORM_TVOS
-}
-
-void InterstitialAdInternal::SetFullScreenContentListener(
-    FullScreenContentListener* listener) {
-  MutexLock lock(listener_mutex_);
-  full_screen_content_listener_ = listener;
-}
-
-void InterstitialAdInternal::SetPaidEventListener(PaidEventListener* listener) {
-  MutexLock lock(listener_mutex_);
-  paid_event_listener_ = listener;
-}
-
-void InterstitialAdInternal::NotifyListenerOfAdClickedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdClicked();
-  }
-}
-
-void InterstitialAdInternal::NotifyListenerOfAdDismissedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdDismissedFullScreenContent();
-  }
-}
-
-void InterstitialAdInternal::NotifyListenerOfAdFailedToShowFullScreenContent(
-    const AdResult& ad_result) {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdFailedToShowFullScreenContent(ad_result);
-  }
-}
-
-void InterstitialAdInternal::NotifyListenerOfAdImpression() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdImpression();
-  }
-}
-
-void InterstitialAdInternal::NotifyListenerOfAdShowedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdShowedFullScreenContent();
-  }
-}
-
-void InterstitialAdInternal::NotifyListenerOfPaidEvent(
-    const AdValue& ad_value) {
-  MutexLock lock(listener_mutex_);
-  if (paid_event_listener_ != nullptr) {
-    paid_event_listener_->OnPaidEvent(ad_value);
-  }
 }
 
 Future<void> InterstitialAdInternal::GetLastResult(InterstitialAdFn fn) {

--- a/admob/src/common/interstitial_ad_internal.h
+++ b/admob/src/common/interstitial_ad_internal.h
@@ -18,6 +18,7 @@
 #define FIREBASE_ADMOB_SRC_COMMON_INTERSTITIAL_AD_INTERNAL_H_
 
 #include "admob/src/common/admob_common.h"
+#include "admob/src/common/full_screen_ad_event_listener.h"
 #include "admob/src/include/firebase/admob/interstitial_ad.h"
 #include "app/src/include/firebase/future.h"
 #include "app/src/mutex.h"
@@ -34,7 +35,7 @@ enum InterstitialAdFn {
   kInterstitialAdFnCount
 };
 
-class InterstitialAdInternal {
+class InterstitialAdInternal : public FullScreenAdEventListener {
  public:
   // Create an instance of whichever subclass of InterstitialAdInternal is
   // appropriate for the current platform.
@@ -52,26 +53,6 @@ class InterstitialAdInternal {
 
   // Displays an interstitial ad.
   virtual Future<void> Show() = 0;
-
-  /// Sets the @ref FullScreenContentListener to receive events about UI
-  // and presentation state.
-  void SetFullScreenContentListener(FullScreenContentListener* listener);
-
-  /// Sets the @ref PaidEventListener to receive information about paid events.
-  void SetPaidEventListener(PaidEventListener* listener);
-
-  // Notifies the FullScreenContentListener (if one exists) that an event has
-  // occurred.
-  void NotifyListenerOfAdClickedFullScreenContent();
-  void NotifyListenerOfAdDismissedFullScreenContent();
-  void NotifyListenerOfAdFailedToShowFullScreenContent(
-      const AdResult& ad_result);
-  void NotifyListenerOfAdImpression();
-  void NotifyListenerOfAdShowedFullScreenContent();
-
-  // Notifies the PaidEventListener (if one exists) that a paid event has
-  // occurred.
-  void NotifyListenerOfPaidEvent(const AdValue& ad_value);
 
   // Retrieves the most recent Future for a given function.
   Future<void> GetLastResult(InterstitialAdFn fn);
@@ -94,17 +75,6 @@ class InterstitialAdInternal {
 
   // Future data used to synchronize asynchronous calls.
   FutureData future_data_;
-
-  // Reference to the listener to which this object sends full screen event
-  // callbacks.
-  FullScreenContentListener* full_screen_content_listener_;
-
-  // Reference to the listener to which this object sends ad payout
-  // event callbacks.
-  PaidEventListener* paid_event_listener_;
-
-  // Lock object for accessing listener_.
-  Mutex listener_mutex_;
 };
 
 }  // namespace internal

--- a/admob/src/common/rewarded_ad.cc
+++ b/admob/src/common/rewarded_ad.cc
@@ -68,7 +68,6 @@ Future<AdResult> RewardedAd::LoadAd(const char* ad_unit_id,
         kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
         &internal_->future_data_, AdResult());
   }
-
   return internal_->LoadAd(ad_unit_id, request);
 }
 

--- a/admob/src/common/rewarded_ad.cc
+++ b/admob/src/common/rewarded_ad.cc
@@ -32,8 +32,7 @@ RewardedAd::RewardedAd() {
   internal_ = internal::RewardedAdInternal::CreateInstance(this);
 
   GetOrCreateCleanupNotifier()->RegisterObject(this, [](void* object) {
-    FIREBASE_ASSERT_MESSAGE(
-        false, "RewardedAd must be deleted before admob::Terminate.");
+    LogWarning("RewardedAd must be deleted before admob::Terminate.");
     RewardedAd* rewarded_ad = reinterpret_cast<RewardedAd*>(object);
     delete rewarded_ad->internal_;
     rewarded_ad->internal_ = nullptr;

--- a/admob/src/common/rewarded_ad.cc
+++ b/admob/src/common/rewarded_ad.cc
@@ -108,5 +108,10 @@ void RewardedAd::SetPaidEventListener(PaidEventListener* listener) {
   internal_->SetPaidEventListener(listener);
 }
 
+void RewardedAd::SetServerSideVerificationOptions(
+    const ServerSideVerificationOptions& options) {
+  internal_->SetServerSideVerificationOptions(options);
+}
+
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/common/rewarded_ad.cc
+++ b/admob/src/common/rewarded_ad.cc
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "admob/src/include/firebase/admob/rewarded_ad.h"
+
+#include "admob/src/common/admob_common.h"
+#include "admob/src/common/rewarded_ad_internal.h"
+#include "app/src/assert.h"
+#include "app/src/include/firebase/future.h"
+
+namespace firebase {
+namespace admob {
+
+const char kUninitializedError[] =
+    "Initialize() must be called before this method.";
+
+RewardedAd::RewardedAd() {
+  FIREBASE_ASSERT(admob::IsInitialized());
+  internal_ = internal::RewardedAdInternal::CreateInstance(this);
+
+  GetOrCreateCleanupNotifier()->RegisterObject(this, [](void* object) {
+    FIREBASE_ASSERT_MESSAGE(
+        false, "RewardedAd must be deleted before admob::Terminate.");
+    RewardedAd* rewarded_ad = reinterpret_cast<RewardedAd*>(object);
+    delete rewarded_ad->internal_;
+    rewarded_ad->internal_ = nullptr;
+  });
+}
+
+RewardedAd::~RewardedAd() {
+  GetOrCreateCleanupNotifier()->UnregisterObject(this);
+  delete internal_;
+}
+
+// Initialize must be called before any other methods in the namespace. This
+// method asserts that Initialize() has been invoked and allowed to complete.
+static bool CheckIsInitialized(internal::RewardedAdInternal* internal) {
+  FIREBASE_ASSERT(internal);
+  return internal->is_initialized();
+}
+
+Future<void> RewardedAd::Initialize(AdParent parent) {
+  return internal_->Initialize(parent);
+}
+
+Future<void> RewardedAd::InitializeLastResult() const {
+  return internal_->GetLastResult(internal::kRewardedAdFnInitialize);
+}
+
+Future<AdResult> RewardedAd::LoadAd(const char* ad_unit_id,
+                                    const AdRequest& request) {
+  if (!CheckIsInitialized(internal_)) {
+    return CreateAndCompleteFutureWithResult(
+        firebase::admob::internal::kRewardedAdFnLoadAd,
+        kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
+        &internal_->future_data_, AdResult());
+  }
+
+  return internal_->LoadAd(ad_unit_id, request);
+}
+
+Future<AdResult> RewardedAd::LoadAdLastResult() const {
+  if (!CheckIsInitialized(internal_)) {
+    return CreateAndCompleteFutureWithResult(
+        firebase::admob::internal::kRewardedAdFnLoadAd,
+        kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
+        &internal_->future_data_, AdResult());
+  }
+  return internal_->GetLoadAdLastResult();
+}
+
+Future<void> RewardedAd::Show(UserEarnedRewardListener* listener) {
+  if (!CheckIsInitialized(internal_)) {
+    return CreateAndCompleteFuture(
+        firebase::admob::internal::kRewardedAdFnShow, kAdMobErrorUninitialized,
+        kAdUninitializedErrorMessage, &internal_->future_data_);
+  }
+  return internal_->Show(listener);
+}
+
+Future<void> RewardedAd::ShowLastResult() const {
+  if (!CheckIsInitialized(internal_)) {
+    return CreateAndCompleteFuture(
+        firebase::admob::internal::kRewardedAdFnShow, kAdMobErrorUninitialized,
+        kAdUninitializedErrorMessage, &internal_->future_data_);
+  }
+  return internal_->GetLastResult(internal::kRewardedAdFnShow);
+}
+
+void RewardedAd::SetFullScreenContentListener(
+    FullScreenContentListener* listener) {
+  internal_->SetFullScreenContentListener(listener);
+}
+
+void RewardedAd::SetPaidEventListener(PaidEventListener* listener) {
+  internal_->SetPaidEventListener(listener);
+}
+
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/common/rewarded_ad_internal.cc
+++ b/admob/src/common/rewarded_ad_internal.cc
@@ -31,6 +31,8 @@
 #endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
         // FIREBASE_PLATFORM_TVOS
 
+#include <string>
+
 namespace firebase {
 namespace admob {
 namespace internal {
@@ -38,8 +40,6 @@ namespace internal {
 RewardedAdInternal::RewardedAdInternal(RewardedAd* base)
     : base_(base),
       future_data_(kRewardedAdFnCount),
-      full_screen_content_listener_(nullptr),
-      paid_event_listener_(nullptr),
       user_earned_reward_listener_(nullptr) {}
 
 RewardedAdInternal* RewardedAdInternal::CreateInstance(RewardedAd* base) {
@@ -53,65 +53,11 @@ RewardedAdInternal* RewardedAdInternal::CreateInstance(RewardedAd* base) {
         // FIREBASE_PLATFORM_TVOS
 }
 
-void RewardedAdInternal::SetFullScreenContentListener(
-    FullScreenContentListener* listener) {
-  MutexLock lock(listener_mutex_);
-  full_screen_content_listener_ = listener;
-}
-
-void RewardedAdInternal::SetPaidEventListener(PaidEventListener* listener) {
-  MutexLock lock(listener_mutex_);
-  paid_event_listener_ = listener;
-}
-
 void RewardedAdInternal::NotifyListenerOfUserEarnedReward(
     const std::string& type, int64_t amount) {
   MutexLock lock(listener_mutex_);
   if (user_earned_reward_listener_ != nullptr) {
     user_earned_reward_listener_->OnUserEarnedReward(AdReward(type, amount));
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfAdClickedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdClicked();
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfAdDismissedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdDismissedFullScreenContent();
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfAdFailedToShowFullScreenContent(
-    const AdResult& ad_result) {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdFailedToShowFullScreenContent(ad_result);
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfAdImpression() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdImpression();
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfAdShowedFullScreenContent() {
-  MutexLock lock(listener_mutex_);
-  if (full_screen_content_listener_ != nullptr) {
-    full_screen_content_listener_->OnAdShowedFullScreenContent();
-  }
-}
-
-void RewardedAdInternal::NotifyListenerOfPaidEvent(const AdValue& ad_value) {
-  MutexLock lock(listener_mutex_);
-  if (paid_event_listener_ != nullptr) {
-    paid_event_listener_->OnPaidEvent(ad_value);
   }
 }
 

--- a/admob/src/common/rewarded_ad_internal.cc
+++ b/admob/src/common/rewarded_ad_internal.cc
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "admob/src/common/rewarded_ad_internal.h"
+
+#include "admob/src/include/firebase/admob/rewarded_ad.h"
+#include "app/src/include/firebase/future.h"
+#include "app/src/include/firebase/internal/platform.h"
+#include "app/src/mutex.h"
+#include "app/src/reference_counted_future_impl.h"
+
+#if FIREBASE_PLATFORM_ANDROID
+#include "admob/src/android/rewarded_ad_internal_android.h"
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+#include "admob/src/ios/rewarded_ad_internal_ios.h"
+#else
+#include "admob/src/stub/rewarded_ad_internal_stub.h"
+#endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
+        // FIREBASE_PLATFORM_TVOS
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+RewardedAdInternal::RewardedAdInternal(RewardedAd* base)
+    : base_(base),
+      future_data_(kRewardedAdFnCount),
+      full_screen_content_listener_(nullptr),
+      paid_event_listener_(nullptr),
+      user_earned_reward_listener_(nullptr) {}
+
+RewardedAdInternal* RewardedAdInternal::CreateInstance(RewardedAd* base) {
+#if FIREBASE_PLATFORM_ANDROID
+  return new RewardedAdInternalAndroid(base);
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+  return new RewardedAdInternalIOS(base);
+#else
+  return new RewardedAdInternalStub(base);
+#endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
+        // FIREBASE_PLATFORM_TVOS
+}
+
+void RewardedAdInternal::SetFullScreenContentListener(
+    FullScreenContentListener* listener) {
+  MutexLock lock(listener_mutex_);
+  full_screen_content_listener_ = listener;
+}
+
+void RewardedAdInternal::SetPaidEventListener(PaidEventListener* listener) {
+  MutexLock lock(listener_mutex_);
+  paid_event_listener_ = listener;
+}
+
+void RewardedAdInternal::NotifyListenerOfUserEarnedReward(
+    const std::string& type, int64_t amount) {
+  MutexLock lock(listener_mutex_);
+  if (user_earned_reward_listener_ != nullptr) {
+    user_earned_reward_listener_->OnUserEarnedReward(AdReward(type, amount));
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfAdClickedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdClicked();
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfAdDismissedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdDismissedFullScreenContent();
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfAdFailedToShowFullScreenContent(
+    const AdResult& ad_result) {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdFailedToShowFullScreenContent(ad_result);
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfAdImpression() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdImpression();
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfAdShowedFullScreenContent() {
+  MutexLock lock(listener_mutex_);
+  if (full_screen_content_listener_ != nullptr) {
+    full_screen_content_listener_->OnAdShowedFullScreenContent();
+  }
+}
+
+void RewardedAdInternal::NotifyListenerOfPaidEvent(const AdValue& ad_value) {
+  MutexLock lock(listener_mutex_);
+  if (paid_event_listener_ != nullptr) {
+    paid_event_listener_->OnPaidEvent(ad_value);
+  }
+}
+
+Future<void> RewardedAdInternal::GetLastResult(RewardedAdFn fn) {
+  return static_cast<const Future<void>&>(
+      future_data_.future_impl.LastResult(fn));
+}
+
+Future<AdResult> RewardedAdInternal::GetLoadAdLastResult() {
+  return static_cast<const Future<AdResult>&>(
+      future_data_.future_impl.LastResult(kRewardedAdFnLoadAd));
+}
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/common/rewarded_ad_internal.cc
+++ b/admob/src/common/rewarded_ad_internal.cc
@@ -71,6 +71,12 @@ Future<AdResult> RewardedAdInternal::GetLoadAdLastResult() {
       future_data_.future_impl.LastResult(kRewardedAdFnLoadAd));
 }
 
+void RewardedAdInternal::SetServerSideVerificationOptions(
+    const RewardedAd::ServerSideVerificationOptions&
+        serverSideVerificationOptions) {
+  serverSideVerificationOptions_ = serverSideVerificationOptions;
+}
+
 }  // namespace internal
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/common/rewarded_ad_internal.h
+++ b/admob/src/common/rewarded_ad_internal.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_COMMON_REWARDED_AD_INTERNAL_H_
+#define FIREBASE_ADMOB_SRC_COMMON_REWARDED_AD_INTERNAL_H_
+
+#include "admob/src/common/admob_common.h"
+#include "admob/src/include/firebase/admob/rewarded_ad.h"
+#include "app/src/include/firebase/future.h"
+#include "app/src/mutex.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+// Constants representing each RewardedAd function that returns a Future.
+enum RewardedAdFn {
+  kRewardedAdFnInitialize,
+  kRewardedAdFnLoadAd,
+  kRewardedAdFnShow,
+  kRewardedAdFnCount
+};
+
+class RewardedAdInternal {
+ public:
+  // Create an instance of whichever subclass of RewardedAdInternal is
+  // appropriate for the current platform.
+  static RewardedAdInternal* CreateInstance(RewardedAd* base);
+
+  // Virtual destructor is required.
+  virtual ~RewardedAdInternal() = default;
+
+  // Initializes this object and any platform-specific helpers that it uses.
+  virtual Future<void> Initialize(AdParent parent) = 0;
+
+  // Initiates an ad request.
+  virtual Future<AdResult> LoadAd(const char* ad_unit_id,
+                                  const AdRequest& request) = 0;
+
+  // Displays an interstitial ad.
+  virtual Future<void> Show(UserEarnedRewardListener* listener) = 0;
+
+  /// Sets the @ref FullScreenContentListener to receive events about UI
+  // and presentation state.
+  void SetFullScreenContentListener(FullScreenContentListener* listener);
+
+  /// Sets the @ref PaidEventListener to receive information about paid events.
+  void SetPaidEventListener(PaidEventListener* listener);
+
+  /// Notifies the UserEarnedRewardListener (if one exists) than a reward
+  /// event has occurred.
+  void NotifyListenerOfUserEarnedReward(const std::string& type,
+                                        int64_t amount);
+
+  // Notifies the FullScreenContentListener (if one exists) that an event has
+  // occurred.
+  void NotifyListenerOfAdClickedFullScreenContent();
+  void NotifyListenerOfAdDismissedFullScreenContent();
+  void NotifyListenerOfAdFailedToShowFullScreenContent(
+      const AdResult& ad_result);
+  void NotifyListenerOfAdImpression();
+  void NotifyListenerOfAdShowedFullScreenContent();
+
+  // Notifies the PaidEventListener (if one exists) that a paid event has
+  // occurred.
+  void NotifyListenerOfPaidEvent(const AdValue& ad_value);
+
+  // Retrieves the most recent Future for a given function.
+  Future<void> GetLastResult(RewardedAdFn fn);
+
+  // Retrieves the most recent AdResult future for the LoadAd function.
+  Future<AdResult> GetLoadAdLastResult();
+
+  // Returns true if the RewardedAd has been initialized.
+  virtual bool is_initialized() const = 0;
+
+ protected:
+  friend class firebase::admob::RewardedAd;
+
+  // Used by CreateInstance() to create an appropriate one for the current
+  // platform.
+  explicit RewardedAdInternal(RewardedAd* base);
+
+  // A pointer back to the RewardedAd class that created us.
+  RewardedAd* base_;
+
+  // Future data used to synchronize asynchronous calls.
+  FutureData future_data_;
+
+  // Reference to the listener to which this object sends full screen event
+  // callbacks.
+  FullScreenContentListener* full_screen_content_listener_;
+
+  // Reference to the listener to which this object sends ad payout
+  // event callbacks.
+  PaidEventListener* paid_event_listener_;
+
+  // Reference to the listener to which this object sends user earned
+  // reward event callbacks.
+  UserEarnedRewardListener* user_earned_reward_listener_;
+
+  // Lock object for accessing listener_.
+  Mutex listener_mutex_;
+};
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_COMMON_REWARDED_AD_INTERNAL_H_

--- a/admob/src/common/rewarded_ad_internal.h
+++ b/admob/src/common/rewarded_ad_internal.h
@@ -17,10 +17,12 @@
 #ifndef FIREBASE_ADMOB_SRC_COMMON_REWARDED_AD_INTERNAL_H_
 #define FIREBASE_ADMOB_SRC_COMMON_REWARDED_AD_INTERNAL_H_
 
+#include <string>
+
 #include "admob/src/common/admob_common.h"
+#include "admob/src/common/full_screen_ad_event_listener.h"
 #include "admob/src/include/firebase/admob/rewarded_ad.h"
 #include "app/src/include/firebase/future.h"
-#include "app/src/mutex.h"
 
 namespace firebase {
 namespace admob {
@@ -34,7 +36,7 @@ enum RewardedAdFn {
   kRewardedAdFnCount
 };
 
-class RewardedAdInternal {
+class RewardedAdInternal : public FullScreenAdEventListener {
  public:
   // Create an instance of whichever subclass of RewardedAdInternal is
   // appropriate for the current platform.
@@ -53,30 +55,10 @@ class RewardedAdInternal {
   // Displays an interstitial ad.
   virtual Future<void> Show(UserEarnedRewardListener* listener) = 0;
 
-  /// Sets the @ref FullScreenContentListener to receive events about UI
-  // and presentation state.
-  void SetFullScreenContentListener(FullScreenContentListener* listener);
-
-  /// Sets the @ref PaidEventListener to receive information about paid events.
-  void SetPaidEventListener(PaidEventListener* listener);
-
   /// Notifies the UserEarnedRewardListener (if one exists) than a reward
   /// event has occurred.
   void NotifyListenerOfUserEarnedReward(const std::string& type,
                                         int64_t amount);
-
-  // Notifies the FullScreenContentListener (if one exists) that an event has
-  // occurred.
-  void NotifyListenerOfAdClickedFullScreenContent();
-  void NotifyListenerOfAdDismissedFullScreenContent();
-  void NotifyListenerOfAdFailedToShowFullScreenContent(
-      const AdResult& ad_result);
-  void NotifyListenerOfAdImpression();
-  void NotifyListenerOfAdShowedFullScreenContent();
-
-  // Notifies the PaidEventListener (if one exists) that a paid event has
-  // occurred.
-  void NotifyListenerOfPaidEvent(const AdValue& ad_value);
 
   // Retrieves the most recent Future for a given function.
   Future<void> GetLastResult(RewardedAdFn fn);
@@ -100,20 +82,9 @@ class RewardedAdInternal {
   // Future data used to synchronize asynchronous calls.
   FutureData future_data_;
 
-  // Reference to the listener to which this object sends full screen event
-  // callbacks.
-  FullScreenContentListener* full_screen_content_listener_;
-
-  // Reference to the listener to which this object sends ad payout
-  // event callbacks.
-  PaidEventListener* paid_event_listener_;
-
   // Reference to the listener to which this object sends user earned
   // reward event callbacks.
   UserEarnedRewardListener* user_earned_reward_listener_;
-
-  // Lock object for accessing listener_.
-  Mutex listener_mutex_;
 };
 
 }  // namespace internal

--- a/admob/src/common/rewarded_ad_internal.h
+++ b/admob/src/common/rewarded_ad_internal.h
@@ -69,6 +69,11 @@ class RewardedAdInternal : public FullScreenAdEventListener {
   // Returns true if the RewardedAd has been initialized.
   virtual bool is_initialized() const = 0;
 
+  /// Sets the server side verification options.
+  void SetServerSideVerificationOptions(
+      const RewardedAd::ServerSideVerificationOptions&
+          serverSideVerificationOptions);
+
  protected:
   friend class firebase::admob::RewardedAd;
 
@@ -85,6 +90,9 @@ class RewardedAdInternal : public FullScreenAdEventListener {
   // Reference to the listener to which this object sends user earned
   // reward event callbacks.
   UserEarnedRewardListener* user_earned_reward_listener_;
+
+  // Options for RewardedAd server-side verification callbacks.
+  RewardedAd::ServerSideVerificationOptions serverSideVerificationOptions_;
 };
 
 }  // namespace internal

--- a/admob/src/include/firebase/admob.h
+++ b/admob/src/include/firebase/admob.h
@@ -27,6 +27,7 @@
 
 #include "firebase/admob/banner_view.h"
 #include "firebase/admob/interstitial_ad.h"
+#include "firebase/admob/rewarded_ad.h"
 #include "firebase/admob/types.h"
 #include "firebase/app.h"
 #include "firebase/internal/common.h"

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -21,6 +21,8 @@
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 
+#include <string>
+
 namespace firebase {
 namespace admob {
 

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -128,4 +128,4 @@ class RewardedAd {
 }  // namespace admob
 }  // namespace firebase
 
-#endif  // FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_INTERSTITIAL_AD_H_
+#endif  // FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_REWARDED_AD_H_

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_REWARDED_AD_H_
+#define FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_REWARDED_AD_H_
+
+#include "firebase/admob/types.h"
+#include "firebase/future.h"
+#include "firebase/internal/common.h"
+
+namespace firebase {
+namespace admob {
+
+namespace internal {
+// Forward declaration for platform-specific data, implemented in each library.
+class RewardedAdInternal;
+}  // namespace internal
+
+/// @brief Loads and displays AdMob rewarded ads.
+///
+/// @ref RewardedAd is a single-use object that can load and show a
+/// single AdMob rewarded ad.
+///
+/// RewardedAd objects provide information about their current state
+/// through Futures. @ref Initialize, @ref LoadAd, and @ref Show each have a
+/// corresponding @ref Future from which you can determine result of the
+/// previous call.
+///
+/// Here's how one might initialize, load, and show an rewarded ad while
+/// checking against the result of the previous action at each step:
+///
+/// @code
+/// namespace admob = ::firebase::admob;
+/// admob::RewardedAd* rewarded = new admob::RewardedAd();
+/// rewarded->Initialize(ad_parent);
+/// @endcode
+///
+/// Then, later:
+///
+/// @code
+/// if (rewarded->InitializeLastResult().status() ==
+///     ::firebase::kFutureStatusComplete &&
+///     rewarded->InitializeLastResult().error() ==
+///     firebase::admob::kAdMobErrorNone) {
+///   rewarded->LoadAd( "YOUR_AD_UNIT_ID", my_ad_request);
+/// }
+/// @endcode
+///
+/// And after that:
+///
+/// @code
+/// if (rewarded->LoadAdLastResult().status() ==
+///     ::firebase::kFutureStatusComplete &&
+///     rewarded->LoadAdLastResult().error() ==
+///     firebase::admob::kAdMobErrorNone)) {
+///   rewarded->Show();
+/// }
+/// @endcode
+class RewardedAd {
+ public:
+  /// Creates an uninitialized @ref RewardedAd object.
+  /// @ref Initialize must be called before the object is used.
+  RewardedAd();
+
+  ~RewardedAd();
+
+  /// Initialize the @ref RewardedAd object.
+  /// @param[in] parent The platform-specific UI element that will host the ad.
+  Future<void> Initialize(AdParent parent);
+
+  /// Returns a @ref Future containing the status of the last call to
+  /// @ref Initialize.
+  Future<void> InitializeLastResult() const;
+
+  /// Begins an asynchronous request for an ad.
+  ///
+  /// @param[in] ad_unit_id The ad unit ID to use in loading the ad.
+  /// @param[in] request An AdRequest struct with information about the request
+  ///                    to be made (such as targeting info).
+  Future<AdResult> LoadAd(const char* ad_unit_id, const AdRequest& request);
+
+  /// Returns a @ref Future containing the status of the last call to
+  /// @ref LoadAd.
+  Future<AdResult> LoadAdLastResult() const;
+
+  /// Shows the @ref RewardedAd. This should not be called unless an ad has
+  /// already been loaded.
+  ///
+  /// param[in] listener The @ref UserEarnedRewardListener to be notified when
+  /// user earns a reward.
+  Future<void> Show(UserEarnedRewardListener* listener);
+
+  /// Returns a @ref Future containing the status of the last call to
+  /// @ref Show.
+  Future<void> ShowLastResult() const;
+
+  /// Sets the @ref FullScreenContentListener for this @ref RewardedAd.
+  ///
+  /// @param[in] listener A valid @ref FullScreenContentListener to receive
+  ///                     callbacks.
+  void SetFullScreenContentListener(FullScreenContentListener* listener);
+
+  /// Registers a callback to be invoked when this ad is estimated to have
+  /// earned money
+  ///
+  /// @param[in] listener A valid @ref PaidEventListener to receive callbacks.
+  void SetPaidEventListener(PaidEventListener* listener);
+
+ private:
+  // An internal, platform-specific implementation object that this class uses
+  // to interact with the Google Mobile Ads SDKs for iOS and Android.
+  internal::RewardedAdInternal* internal_;
+};
+
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_INTERSTITIAL_AD_H_

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -71,6 +71,16 @@ class RewardedAdInternal;
 /// @endcode
 class RewardedAd {
  public:
+  /// Options for RewardedAd server-side verification callbacks. Set options on
+  /// a RewardedAd object using the SetServerSideVerificationOptions.
+  struct ServerSideVerificationOptions {
+    /// Custom data to be included in server-side verification callbacks.
+    std::string custom_data;
+
+    /// User id to be used in server-to-server reward callbacks.
+    std::string user_id;
+  };
+
   /// Creates an uninitialized @ref RewardedAd object.
   /// @ref Initialize must be called before the object is used.
   RewardedAd();
@@ -118,6 +128,14 @@ class RewardedAd {
   ///
   /// @param[in] listener A valid @ref PaidEventListener to receive callbacks.
   void SetPaidEventListener(PaidEventListener* listener);
+
+  /// Sets the server side verification options.
+  ///
+  /// @param[in] serverSideVerificationOptions A @ref
+  /// ServerSideVerificationOptions object containing custom data and a user
+  /// Id.
+  void SetServerSideVerificationOptions(
+      const ServerSideVerificationOptions &serverSideVerificationOptions);
 
  private:
   // An internal, platform-specific implementation object that this class uses

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -17,11 +17,11 @@
 #ifndef FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_REWARDED_AD_H_
 #define FIREBASE_ADMOB_SRC_INCLUDE_FIREBASE_ADMOB_REWARDED_AD_H_
 
+#include <string>
+
 #include "firebase/admob/types.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
-
-#include <string>
 
 namespace firebase {
 namespace admob {

--- a/admob/src/include/firebase/admob/rewarded_ad.h
+++ b/admob/src/include/firebase/admob/rewarded_ad.h
@@ -66,7 +66,7 @@ class RewardedAdInternal;
 ///     ::firebase::kFutureStatusComplete &&
 ///     rewarded->LoadAdLastResult().error() ==
 ///     firebase::admob::kAdMobErrorNone)) {
-///   rewarded->Show();
+///   rewarded->Show(&my_user_earned_reward_listener);
 /// }
 /// @endcode
 class RewardedAd {

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -142,17 +142,17 @@ class AdListener {
   virtual ~AdListener();
 
   /// Called when a click is recorded for an ad.
-  virtual void OnAdClicked();
+  virtual void OnAdClicked() {}
 
   /// Called when the user is about to return to the application after clicking
   /// on an ad.
-  virtual void OnAdClosed();
+  virtual void OnAdClosed() {}
 
   /// Called when an impression is recorded for an ad.
-  virtual void OnAdImpression();
+  virtual void OnAdImpression() {}
 
   /// Called when an ad opens an overlay that covers the screen.
-  virtual void OnAdOpened();
+  virtual void OnAdOpened() {}
 };
 
 /// Information about why an ad operation failed.
@@ -454,6 +454,24 @@ class AdRequest {
   std::unordered_set<std::string> keywords_;
 };
 
+/// Describes a reward credited to a user for interacting with a RewardedAd.
+class AdReward {
+ public:
+  /// Creates an @ref AdReward.
+  AdReward(const std::string& type, int64_t amount)
+      : type_(type), amount_(amount) {}
+
+  /// Returns the reward amount.
+  int64_t amount() const { return amount_; }
+
+  /// Returns the type of the reward.
+  const std::string& type() const { return type_; }
+
+ private:
+  const int64_t amount_;
+  const std::string type_;
+};
+
 /// The monetary value earned from an ad.
 class AdValue {
  public:
@@ -660,22 +678,22 @@ class FullScreenContentListener {
   virtual ~FullScreenContentListener();
 
   /// Called when the user clicked the ad.
-  virtual void OnAdClicked();
+  virtual void OnAdClicked() {}
 
   /// Called when the ad dismissed full screen content.
-  virtual void OnAdDismissedFullScreenContent();
+  virtual void OnAdDismissedFullScreenContent() {}
 
   /// Called when the ad failed to show full screen content.
   ///
   /// param[in] ad_result An object containing detailed information
   /// about the error.
-  virtual void OnAdFailedToShowFullScreenContent(const AdResult& ad_result);
+  virtual void OnAdFailedToShowFullScreenContent(const AdResult& ad_result) {}
 
   /// Called when an impression is recorded for an ad.
-  virtual void OnAdImpression();
+  virtual void OnAdImpression() {}
 
   /// Called when the ad showed the full screen content.
-  virtual void OnAdShowedFullScreenContent();
+  virtual void OnAdShowedFullScreenContent() {}
 };
 
 /// Listener to be invoked when ads have been estimated to earn money.
@@ -684,7 +702,7 @@ class PaidEventListener {
   virtual ~PaidEventListener();
 
   /// Called when an ad is estimated to have earned money.
-  virtual void OnPaidEvent(const AdValue& value) = 0;
+  virtual void OnPaidEvent(const AdValue& value) {}
 };
 
 /// Information about an ad response.
@@ -851,6 +869,17 @@ struct RequestConfiguration {
   /// Sets a list of test device IDs corresponding to test devices which will
   /// always request test ads.
   std::vector<std::string> test_device_ids;
+};
+
+/// Listener to be invoked when the user earned a reward.
+class UserEarnedRewardListener {
+ public:
+  virtual ~UserEarnedRewardListener();
+  /// Called when the user earned a reward. The app is responsible for
+  /// crediting the user with the reward.
+  ///
+  /// param[in] reward the @ref AdReward that should be granted to the user.
+  virtual void OnUserEarnedReward(const AdReward& reward) {}
 };
 
 }  // namespace admob

--- a/admob/src/ios/rewarded_ad_internal_ios.h
+++ b/admob/src/ios/rewarded_ad_internal_ios.h
@@ -67,4 +67,4 @@ class RewardedAdInternalIOS : public RewardedAdInternal {
 }  // namespace admob
 }  // namespace firebase
 
-#endif  // FIREBASE_ADMOB_SRC_IOS_INTERSTITIAL_AD_INTERNAL_IOS_H_
+#endif  // FIREBASE_ADMOB_SRC_IOS_REWARDED_AD_INTERNAL_IOS_H_

--- a/admob/src/ios/rewarded_ad_internal_ios.h
+++ b/admob/src/ios/rewarded_ad_internal_ios.h
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_IOS_REWARDED_AD_INTERNAL_IOS_H_
+#define FIREBASE_ADMOB_SRC_IOS_REWARDED_AD_INTERNAL_IOS_H_
+
+extern "C" {
+#include <objc/objc.h>
+}  // extern "C"
+
+#include "admob/src/common/rewarded_ad_internal.h"
+#include "app/src/mutex.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+class RewardedAdInternalIOS : public RewardedAdInternal {
+ public:
+  explicit RewardedAdInternalIOS(RewardedAd* base);
+  ~RewardedAdInternalIOS();
+
+  Future<void> Initialize(AdParent parent) override;
+  Future<AdResult> LoadAd(const char* ad_unit_id,
+                          const AdRequest& request) override;
+  Future<void> Show(UserEarnedRewardListener* listener) override;
+  bool is_initialized() const override { return initialized_; }
+
+ private:
+  /// Prevents duplicate invocations of initailize on the Interstitial Ad.
+  bool initialized_;
+
+  /// Contains information to asynchronously complete the LoadAd Future.
+  FutureCallbackData<AdResult>* ad_load_callback_data_;
+
+  /// The GADRewardedAd object. Declared as an "id" type to avoid
+  /// referencing an Objective-C class in this header.
+  id rewarded_ad_;
+
+  /// The publisher-provided view (UIView) that's the parent view of the
+  /// rewarded ad. Declared as an "id" type to avoid referencing an
+  /// Objective-C class in this header.
+  id parent_view_;
+
+  /// The delegate object to listen for callbacks. Declared as an "id"
+  /// type to avoid referencing an Objective-C++ class in this header.
+  id rewarded_ad_delegate_;
+
+  // Mutex to guard against concurrent operations;
+  Mutex mutex_;
+};
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_IOS_INTERSTITIAL_AD_INTERNAL_IOS_H_

--- a/admob/src/ios/rewarded_ad_internal_ios.mm
+++ b/admob/src/ios/rewarded_ad_internal_ios.mm
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "admob/src/ios/rewarded_ad_internal_ios.h"
+
+#import "admob/src/ios/FADRequest.h"
+
+#import "admob/src/ios/admob_ios.h"
+#include "app/src/util_ios.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+RewardedAdInternalIOS::RewardedAdInternalIOS(RewardedAd* base)
+    : RewardedAdInternal(base), initialized_(false),
+    ad_load_callback_data_(nil), rewarded_ad_(nil),
+    parent_view_(nil), rewarded_ad_delegate_(nil) {}
+
+RewardedAdInternalIOS::~RewardedAdInternalIOS() { }
+
+Future<void> RewardedAdInternalIOS::Initialize(AdParent parent) {
+  firebase::MutexLock lock(mutex_);
+  return CreateAndCompleteFuture(
+        kRewardedAdFnInitialize, kAdMobErrorNone, nullptr, &future_data_);
+}
+
+Future<AdResult> RewardedAdInternalIOS::LoadAd(
+    const char* ad_unit_id, const AdRequest& request) {
+  return CreateAndCompleteFutureWithResult(
+    kRewardedAdFnLoadAd, kAdMobErrorNone, nullptr, &future_data_, AdResult());
+}
+
+Future<void> RewardedAdInternalIOS::Show(UserEarnedRewardListener* listener) {
+   return CreateAndCompleteFuture(
+        kRewardedAdFnShow, kAdMobErrorNone, nullptr, &future_data_);
+}
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/stub/rewarded_ad_internal_stub.h
+++ b/admob/src/stub/rewarded_ad_internal_stub.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_ADMOB_SRC_STUB_REWARDED_AD_INTERNAL_STUB_H_
+#define FIREBASE_ADMOB_SRC_STUB_REWARDED_AD_INTERNAL_STUB_H_
+
+#include "admob/src/common/rewarded_ad_internal.h"
+
+namespace firebase {
+namespace admob {
+namespace internal {
+
+/// Stub version of RewardedAdInternal, for use on desktop platforms. AdMob
+/// is forbidden on desktop, so this version creates and immediately completes
+/// the Future for each method.
+class RewardedAdInternalStub : public RewardedAdInternal {
+ public:
+  explicit RewardedAdInternalStub(RewardedAd* base)
+      : RewardedAdInternal(base) {}
+
+  ~RewardedAdInternalStub() override {}
+
+  Future<void> Initialize(AdParent parent) override {
+    return CreateAndCompleteFutureStub(kRewardedAdFnInitialize);
+  }
+
+  Future<AdResult> LoadAd(const char* ad_unit_id,
+                          const AdRequest& request) override {
+    return CreateAndCompleteAdResultFutureStub(kRewardedAdFnLoadAd);
+  }
+
+  virtual Future<void> Show(UserEarnedRewardListener* listener) {
+    return CreateAndCompleteFutureStub(kRewardedAdFnShow);
+  }
+
+  bool is_initialized() const override { return true; }
+
+ private:
+  Future<void> CreateAndCompleteFutureStub(RewardedAdFn fn) {
+    CreateAndCompleteFuture(fn, kAdMobErrorNone, nullptr, &future_data_);
+    return GetLastResult(fn);
+  }
+
+  Future<AdResult> CreateAndCompleteAdResultFutureStub(RewardedAdFn fn) {
+    return CreateAndCompleteFutureWithResult(fn, kAdMobErrorNone, nullptr,
+                                             &future_data_, AdResult());
+  }
+};
+
+}  // namespace internal
+}  // namespace admob
+}  // namespace firebase
+
+#endif  // FIREBASE_ADMOB_SRC_STUB_INTERSTITIAL_AD_INTERNAL_STUB_H_

--- a/admob/src/stub/rewarded_ad_internal_stub.h
+++ b/admob/src/stub/rewarded_ad_internal_stub.h
@@ -64,4 +64,4 @@ class RewardedAdInternalStub : public RewardedAdInternal {
 }  // namespace admob
 }  // namespace firebase
 
-#endif  // FIREBASE_ADMOB_SRC_STUB_INTERSTITIAL_AD_INTERNAL_STUB_H_
+#endif  // FIREBASE_ADMOB_SRC_STUB_REWARDED_AD_INTERNAL_STUB_H_

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java
@@ -24,7 +24,6 @@ public final class ConstantsHelper {
   /**
    * Error codes used in completing futures. These match the AdMobError enumeration in the C++ API.
    */
-  // LINT.IfChange
   public static final int CALLBACK_ERROR_NONE = 0;
 
   public static final int CALLBACK_ERROR_UNINITIALIZED = 1;
@@ -44,13 +43,11 @@ public final class ConstantsHelper {
   public static final int CALLBACK_ERROR_NO_WINDOW_TOKEN = 8;
 
   public static final int CALLBACK_ERROR_UNKNOWN = 9;
-  // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src/include/firebase/admob/types.h)
 
   /**
    * Error messages used for completing futures. These match the error codes in the AdMobError
    * enumeration in the C++ API.
    */
-  // LINT.IfChange
   public static final String CALLBACK_ERROR_MESSAGE_NONE = "";
 
   public static final String CALLBACK_ERROR_MESSAGE_UNINITIALIZED =
@@ -74,38 +71,11 @@ public final class ConstantsHelper {
       "Android Activity does not have a window token.";
 
   public static final String CALLBACK_ERROR_MESSAGE_UNKNOWN = "Unknown error occurred.";
-  // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src/include/firebase/admob/types.h)
 
-  /**
-   * Types of notifications to send back to the C++ side for listeners updates.
-   */
-  // LINT.IfChange
-  public static final int AD_VIEW_CHANGED_PRESENTATION_STATE = 0;
-
-  public static final int AD_VIEW_CHANGED_BOUNDING_BOX = 1;
-  // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java,
-  // //depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/NativeExpressAdViewHelper.java)
-
-  /**
-   * Presentation states (matches the BannerView::PresentationState and
-   * NativeExpressAdView::PresentationState enumerations in the public C++ API).
-   */
-  // LINT.IfChange
-  public static final int AD_VIEW_PRESENTATION_STATE_HIDDEN = 0;
-
-  public static final int AD_VIEW_PRESENTATION_STATE_VISIBLE_WITHOUT_AD = 1;
-
-  public static final int AD_VIEW_PRESENTATION_STATE_VISIBLE_WITH_AD = 2;
-
-  public static final int AD_VIEW_PRESENTATION_STATE_OPENED_PARTIAL_OVERLAY = 3;
-
-  public static final int AD_VIEW_PRESENTATION_STATE_COVERING_UI = 4;
-  // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src/include/firebase/admob/banner_view.h)
   /**
    * Ad view positions (matches the BannerView::Position and NativeExpressAdView::Position
    * enumerations in the public C++ API).
    */
-  // LINT.IfChange
   public static final int AD_VIEW_POSITION_UNDEFINED = -1;
 
   public static final int AD_VIEW_POSITION_TOP = 0;
@@ -119,5 +89,4 @@ public final class ConstantsHelper {
   public static final int AD_VIEW_POSITION_BOTTOM_LEFT = 4;
 
   public static final int AD_VIEW_POSITION_BOTTOM_RIGHT = 5;
-  // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src/include/firebase/admob/types.h)
 }

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/InterstitialAdHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/InterstitialAdHelper.java
@@ -32,8 +32,7 @@ import android.util.Log;
 /**
  * Helper class to make interactions between the AdMob C++ wrapper and Java {@link InterstitialAd}
  * objects cleaner. It's designed to wrap and adapt a single instance of {@link InterstitialAd},
- * translate calls coming from C++ into their (typically more complicated) Java equivalents, and
- * convert the Java listener patterns into game engine-friendly state machine polling.
+ * translate calls coming from C++ into their (typically more complicated) Java equivalents.
  */
 public class InterstitialAdHelper {
 

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/RewardedAdHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/RewardedAdHelper.java
@@ -25,6 +25,7 @@ import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnPaidEventListener;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
+import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
 import com.google.android.gms.ads.rewarded.RewardItem;
@@ -190,7 +191,8 @@ public class RewardedAdHelper {
   /**
    * Shows a previously loaded ad.
    */
-  public void show(final long callbackDataPtr) {
+  public void show(final long callbackDataPtr, final String verificationCustomData,
+                   final String verificationUserId) {
     mActivity.runOnUiThread(
         new Runnable() {
           @Override
@@ -207,6 +209,13 @@ public class RewardedAdHelper {
               } else {
                 errorCode = ConstantsHelper.CALLBACK_ERROR_NONE;
                 errorMessage = ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE;
+                if (!verificationCustomData.isEmpty() || !verificationUserId.isEmpty()) {
+                  ServerSideVerificationOptions options =
+                      new ServerSideVerificationOptions.Builder()
+                          .setCustomData(verificationCustomData)
+                          .setUserId(verificationUserId).build();
+                  mRewarded.setServerSideVerificationOptions(options);
+                }
                 mRewarded.show(
                     mActivity,
                     new UserEarnedRewardListener());

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/RewardedAdHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/RewardedAdHelper.java
@@ -34,8 +34,7 @@ import android.util.Log;
 /**
  * Helper class to make interactions between the AdMob C++ wrapper and Java {@link RewardedAd}
  * objects cleaner. It's designed to wrap and adapt a single instance of {@link RewardedAd},
- * translate calls coming from C++ into their (typically more complicated) Java equivalents, and
- * convert the Java listener patterns into game engine-friendly state machine polling.
+ * translate calls coming from C++ into their (typically more complicated) Java equivalents.
  */
 public class RewardedAdHelper {
 

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -409,6 +409,7 @@ if (IOS)
     ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob.h
     ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/banner_view.h
     ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/interstitial_ad.h
+    ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/rewarded_ad.h
     ${FIREBASE_SOURCE_DIR}/admob/src/include/firebase/admob/types.h)
 
   # Generate the analytics header file


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

- Implemented RewardedAd on Android, and created stubs for iOS and Desktop builds.
- Revamped C++ JNI function signatures to have much shorter names, and to reuse functions common to interstitial and rewarded ads.
- Created a new internal base class for full screen event listeners to share its implementation across RewardedAds and InsterstitialAds.  This allows us to reuse some JNI callback functions.
- Grouped those integration tests which require user interaction so that they execute one after the next, and front load them to the start of the itest flow (after a few quick sanity checks).  This should make running the manual tests easier.

***
### Testing
**[iTest Run](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1467851369)**
Expanded AdMob integration tests.
Executed tests manually on Android  phones.
Validated (via logs) that the SetServerSideVerificationOption strings are properly reaching the Android SDK space.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***