### PR TITLE
Fix a data race that could manifest as null pointer dereference in FutureBase::Release()

### DIFF
--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -20,9 +20,9 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include <mutex>
 #include <utility>
 
-#include "app/src/mutex.h"
 #include "firebase/internal/common.h"
 
 #ifdef FIREBASE_USE_STD_FUNCTION
@@ -310,7 +310,7 @@ class FutureBase {
 
   /// Returns true if the two Futures reference the same result.
   bool operator==(const FutureBase& rhs) const {
-    MutexLock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return api_ == rhs.api_ && handle_ == rhs.handle_;
   }
 
@@ -320,7 +320,7 @@ class FutureBase {
 #if defined(INTERNAL_EXPERIMENTAL)
   /// Returns the API-specific handle. Should only be called by the API.
   FutureHandle GetHandle() const {
-    MutexLock lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     return handle_;
   }
 #endif  // defined(INTERNAL_EXPERIMENTAL)
@@ -328,7 +328,7 @@ class FutureBase {
  protected:
   /// @cond FIREBASE_APP_INTERNAL
 
-  mutable Mutex mutex_;
+  mutable std::mutex mutex_;
 
   /// Backpointer to the issuing API class.
   /// Set to nullptr when Future is invalidated.

--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -22,6 +22,7 @@
 
 #include <utility>
 
+#include "app/src/mutex.h"
 #include "firebase/internal/common.h"
 
 #ifdef FIREBASE_USE_STD_FUNCTION
@@ -309,6 +310,7 @@ class FutureBase {
 
   /// Returns true if the two Futures reference the same result.
   bool operator==(const FutureBase& rhs) const {
+    MutexLock lock(mutex_);
     return api_ == rhs.api_ && handle_ == rhs.handle_;
   }
 
@@ -317,11 +319,16 @@ class FutureBase {
 
 #if defined(INTERNAL_EXPERIMENTAL)
   /// Returns the API-specific handle. Should only be called by the API.
-  const FutureHandle& GetHandle() const { return handle_; }
+  FutureHandle GetHandle() const {
+    MutexLock lock(mutex_);
+    return handle_;
+  }
 #endif  // defined(INTERNAL_EXPERIMENTAL)
 
  protected:
   /// @cond FIREBASE_APP_INTERNAL
+
+  mutable Mutex mutex_;
 
   /// Backpointer to the issuing API class.
   /// Set to nullptr when Future is invalidated.

--- a/app/src/include/firebase/internal/future_impl.h
+++ b/app/src/include/firebase/internal/future_impl.h
@@ -255,9 +255,9 @@ inline FutureBase& FutureBase::operator=(FutureBase&& rhs) noexcept {
   {
     MutexLock lock(rhs.mutex_);
     detail::UnregisterForCleanup(rhs.api_, &rhs);
-    rhs.api_ = NULL;  // NOLINT
     new_api = rhs.api_;
     new_handle = rhs.handle_;
+    rhs.api_ = NULL;  // NOLINT
   }
 
   MutexLock lock(mutex_);

--- a/app/src/include/firebase/internal/future_impl.h
+++ b/app/src/include/firebase/internal/future_impl.h
@@ -207,7 +207,6 @@ inline FutureBase::FutureBase(const FutureBase& rhs)
     : api_(NULL)  // NOLINT
 {                 // NOLINT
   *this = rhs;
-  detail::RegisterForCleanup(api_, this);
 }
 
 inline FutureBase& FutureBase::operator=(const FutureBase& rhs) {
@@ -239,12 +238,7 @@ inline FutureBase& FutureBase::operator=(const FutureBase& rhs) {
 inline FutureBase::FutureBase(FutureBase&& rhs) noexcept
     : api_(NULL)  // NOLINT
 {
-  {
-    MutexLock lock(rhs.mutex_);
-    detail::UnregisterForCleanup(rhs.api_, &rhs);
-    *this = std::move(rhs);
-  }
-  detail::RegisterForCleanup(api_, this);
+  *this = std::move(rhs);
 }
 
 inline FutureBase& FutureBase::operator=(FutureBase&& rhs) noexcept {

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -569,8 +569,8 @@ code.
 ## Release Notes
 ### Next Release
 -   Changes
-    -   All Products (Android): Fixed a data race that could manifest as null
-        pointer dereference in FutureBase::Release().
+    -   General (Android): Fixed a data race that could manifest as null pointer
+        dereference in `FutureBase::Release()`.
         ([#747](https://github.com/firebase/firebase-cpp-sdk/pull/747))
     -   Auth (Desktop): Fixed a crash in `error_code()` when a request
         is cancelled or times out.

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -570,8 +570,8 @@ code.
 ### Next Release
 -   Changes
     -   All Products (Android): Fixed a data race that could manifest as null
-        pointer dereference in FutureBase::Release()
-        ([#NNN](https://github.com/firebase/firebase-cpp-sdk/issues/NNN))
+        pointer dereference in FutureBase::Release().
+        ([#747](https://github.com/firebase/firebase-cpp-sdk/pull/747))
     -   Auth (Desktop): Fixed a crash in `error_code()` when a request
         is cancelled or times out.
         ([#737](https://github.com/firebase/firebase-cpp-sdk/issues/737))

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -569,6 +569,9 @@ code.
 ## Release Notes
 ### Next Release
 -   Changes
+    -   All Products (Android): Fixed a data race that could manifest as null
+        pointer dereference in FutureBase::Release()
+        ([#NNN](https://github.com/firebase/firebase-cpp-sdk/issues/NNN))
     -   Auth (Desktop): Fixed a crash in `error_code()` when a request
         is cancelled or times out.
         ([#737](https://github.com/firebase/firebase-cpp-sdk/issues/737))


### PR DESCRIPTION
The `FutureBase` class has two data members that can be accessed concurrently from multiple threads without any synchronization: `api_` and `handle_`. This data race was detected by the thread sanitizer.

Although there are no known customer reports of crashes resulting from this data race, a recent continuous integration run crashed in Firestore with a null pointer dereference in the following stack trace:

```
firebase::FutureBase::Release()
firebase::FutureBase::~FutureBase()
firebase::Future<void>::~Future()
firebase::firestore::FirestoreIntegrationTest_FirestoreCanBeDeletedFromTransaction_Test::TestBody()
```

The test in question is `FirestoreCanBeDeletedFromTransaction`: https://github.com/firebase/firebase-cpp-sdk/blob/9efb188a6f3c69d26c0d298a1c8a5fd17ebff960/firestore/integration_test_internal/src/firestore_test.cc#L1528-L1544

This test deletes the `Firestore` instance from an auxiliary thread, which would cause all of the `Future` objects it owns to be "released" from that alternate thread. Therefore, in rare conditions, this would race with the deletion of the `Future` object from the test thread, and yield the null pointer dereference.

This PR fixes the data race by protecting those two members with a mutex.

Googlers can see b/183225305 and b/205966141 for more details.