### PR TITLE
Remove "Android" tag from the release notes entry for #747

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -569,7 +569,7 @@ code.
 ## Release Notes
 ### Next Release
 -   Changes
-    -   General (Android): Fixed a data race that could manifest as null pointer
+    -   General: Fixed a data race that could manifest as null pointer
         dereference in `FutureBase::Release()`.
         ([#747](https://github.com/firebase/firebase-cpp-sdk/pull/747))
     -   Auth (Desktop): Fixed a crash in `error_code()` when a request


### PR DESCRIPTION
I had originally thought that the issue was specific to Android, because the bug only surfaced on Android; however, it indeed affects all platforms.