### PR TITLE
Messaging crash during initialization

### DIFF
--- a/messaging/src/android/cpp/messaging.cc
+++ b/messaging/src/android/cpp/messaging.cc
@@ -630,6 +630,8 @@ InitResult Initialize(const ::firebase::App& app, Listener* listener,
       pthread_create(&g_poll_thread, nullptr, MessageProcessingThread, nullptr);
   FIREBASE_ASSERT(result == 0);
 
+  FutureData::Create();
+
   if (g_registration_token_request_state !=
       kRegistrationTokenRequestStateNone) {
     // Calling this again, now that we're initialized.
@@ -646,8 +648,6 @@ InitResult Initialize(const ::firebase::App& app, Listener* listener,
         g_delivery_metrics_export_to_big_query_state ==
         kDeliveryMetricsExportToBigQueryEnable);
   }
-
-  FutureData::Create();
 
   // Supposedly App creation also creates a registration token, but this seems
   // to happen before the C++ listeners are able to capture it.

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -579,6 +579,7 @@ code.
         ([#739](https://github.com/firebase/firebase-cpp-sdk/pull/739))
         ([#745](https://github.com/firebase/firebase-cpp-sdk/pull/745))
     -   Messaging (Android): Fixed crash during initialization.
+        ([#760](https://github.com/firebase/firebase-cpp-sdk/pull/760))
 
 
 ### 8.7.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -578,6 +578,7 @@ code.
     -   Messaging (Android): Fixed crash during termination.
         ([#739](https://github.com/firebase/firebase-cpp-sdk/pull/739))
         ([#745](https://github.com/firebase/firebase-cpp-sdk/pull/745))
+    -   Messaging (Android): Fixed crash during initialization.
 
 
 ### 8.7.0


### PR DESCRIPTION
### Description
In the unity quick start forum there is a bug report about messaging also crashing during startup. https://github.com/firebase/firebase-unity-sdk/issues/73 . I have not been able to reproduce this but as it looked a lot like the shutdown crashes I thought I would have a quick look. 

During the initialisation() function it calls SetTokenRegistrationOnInitEnabled() which in turn trickles down to a GetToken() call and if the Task is quick enough (i.e if we don't have an internet connection maybe?) it will trigger the CompleteStringCallback before FutureData::Create has been called.


Creating the FutureData before calling SetTokenRegistrationOnInitEnabled() is a "potential" fix as I have not seen the actual crash myself.


[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
