### PR TITLE
Dummy change to firestore.h for testing GitHub Actions

### DIFF
--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -432,6 +432,8 @@ class Firestore {
   void DeleteInternal();
 
   mutable FirestoreInternal* internal_ = nullptr;
+ 
+  int dummy_change_ = 0;
 };
 
 }  // namespace firestore


### PR DESCRIPTION
DO NOT MERGE

This PR is merely to attempt to reproduce build errors from #710 in the `ubuntu-latest-Release-x86-static` ([link](https://github.com/firebase/firebase-cpp-sdk/runs/4330169860?check_suite_focus=true)) and `ubuntu-latest-Debug-x86-static` ([link](https://github.com/firebase/firebase-cpp-sdk/runs/4330169962?check_suite_focus=true)) workflows.

For convenience, the build error from `ubuntu-latest-Release-x86-static` is:

```
Traceback (most recent call last):
  File "scripts/gha/build_desktop.py", line 301, in <module>
    main()
  File "scripts/gha/build_desktop.py", line 257, in main
    cleanup=True, use_openssl=args.use_openssl)
  File "scripts/gha/build_desktop.py", line 137, in install_cpp_dependencies_with_vcpkg
    success = utils.verify_vcpkg_build(vcpkg_triplet, attempt_auto_fix=True)
  File "/home/runner/work/firebase-cpp-sdk/firebase-cpp-sdk/scripts/gha/utils.py", line 208, in verify_vcpkg_build
    "vcpkg installation.".format(installed_triplets_dir_path))
ValueError: Could not find directory containing installed packages by vcpkg: /home/runner/work/firebase-cpp-sdk/firebase-cpp-sdk/external/vcpkg/installed/x86-linux
Please check if there were errors during vcpkg installation.
```

and the build error from `ubuntu-latest-Debug-x86-static` is:

```
CMake Error at scripts/cmake/vcpkg_execute_required_process.cmake:127 (message):

Call Stack (most recent call first):
  scripts/cmake/vcpkg_configure_cmake.cmake:366 (vcpkg_execute_required_process)
  scripts/detect_compiler/portfile.cmake:18 (vcpkg_configure_cmake)
  scripts/ports.cmake:141 (include)


Error: vcpkg was unable to detect the active compiler's information. See above for the CMake failure output.
```