### PR TITLE
Feature/admob 2021 stability in future usage

### DIFF
--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -795,6 +795,8 @@ TEST_F(FirebaseAdMobTest, TestBannerView) {
   // Set the listener.
   TestBoundingBoxListener bounding_box_listener;
   banner->SetBoundingBoxListener(&bounding_box_listener);
+  PauseForVisualInspectionAndCallbacks();
+
   int expected_num_bounding_box_changes = 0;
   EXPECT_EQ(expected_num_bounding_box_changes,
             bounding_box_listener.bounding_box_changes_.size());

--- a/admob/src/android/banner_view_internal_android.cc
+++ b/admob/src/android/banner_view_internal_android.cc
@@ -257,16 +257,18 @@ Future<void> BannerViewInternalAndroid::Initialize(AdParent parent,
   if (initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kBannerViewFnInitialize);
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorAlreadyInitialized,
                    kAdAlreadyInitializedErrorMessage, future_handle,
                    &future_data_);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
 
   initialized_ = true;
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kBannerViewFnSetPosition, &future_data_);
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = ::firebase::admob::GetJNI();
   FIREBASE_ASSERT(env);
@@ -281,8 +283,7 @@ Future<void> BannerViewInternalAndroid::Initialize(AdParent parent,
   call_data->callback_data = callback_data;
   util::RunOnMainThread(env, activity, InitializeBannerViewOnMainThread,
                         call_data);
-
-  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  return future;
 }
 
 // This function is run on the main thread and is called in the
@@ -324,7 +325,7 @@ Future<AdResult> BannerViewInternalAndroid::LoadAd(const AdRequest& request) {
 
   FutureCallbackData<AdResult>* callback_data =
       CreateAdResultFutureCallbackData(kBannerViewFnLoadAd, &future_data_);
-  SafeFutureHandle<AdResult> future_handle = callback_data->future_handle;
+  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   LoadAdOnMainThreadData* call_data = new LoadAdOnMainThreadData();
   call_data->ad_request = request;
@@ -334,7 +335,7 @@ Future<AdResult> BannerViewInternalAndroid::LoadAd(const AdRequest& request) {
   jobject activity = ::firebase::admob::GetActivity();
   util::RunOnMainThread(env, activity, LoadAdOnMainThread, call_data);
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 BoundingBox BannerViewInternalAndroid::bounding_box() const {
@@ -398,13 +399,13 @@ Future<void> BannerViewInternalAndroid::SetPosition(int x, int y) {
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kBannerViewFnSetPosition, &future_data_);
-  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   ::firebase::admob::GetJNI()->CallVoidMethod(
       helper_, banner_view_helper::GetMethodId(banner_view_helper::kMoveToXY),
       reinterpret_cast<jlong>(callback_data), x, y);
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 Future<void> BannerViewInternalAndroid::SetPosition(
@@ -413,14 +414,14 @@ Future<void> BannerViewInternalAndroid::SetPosition(
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kBannerViewFnSetPosition, &future_data_);
-  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   ::firebase::admob::GetJNI()->CallVoidMethod(
       helper_,
       banner_view_helper::GetMethodId(banner_view_helper::kMoveToPosition),
       reinterpret_cast<jlong>(callback_data), static_cast<int>(position));
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 // This function is run on the main thread and is called in the
@@ -449,7 +450,7 @@ Future<void> BannerViewInternalAndroid::InvokeNullary(
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(fn, &future_data_);
-  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   NulleryInvocationOnMainThreadData* call_data =
       new NulleryInvocationOnMainThreadData();
@@ -459,7 +460,7 @@ Future<void> BannerViewInternalAndroid::InvokeNullary(
 
   util::RunOnMainThread(env, activity, InvokeNulleryOnMainThread, call_data);
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 }  // namespace internal

--- a/admob/src/android/banner_view_internal_android.h
+++ b/admob/src/android/banner_view_internal_android.h
@@ -35,7 +35,7 @@ namespace admob {
   X(Show, "show", "(J)V"),                                                     \
   X(Pause, "pause", "(J)V"),                                                   \
   X(Resume, "resume", "(J)V"),                                                 \
-  X(Destroy, "destroy", "(JZ)V"),                                               \
+  X(Destroy, "destroy", "(JZ)V"),                                              \
   X(MoveToPosition, "moveTo", "(JI)V"),                                        \
   X(MoveToXY, "moveTo", "(JII)V"),                                             \
   X(GetBoundingBox, "getBoundingBox", "()[I"),                                 \

--- a/admob/src/android/banner_view_internal_android.h
+++ b/admob/src/android/banner_view_internal_android.h
@@ -35,7 +35,7 @@ namespace admob {
   X(Show, "show", "(J)V"),                                                     \
   X(Pause, "pause", "(J)V"),                                                   \
   X(Resume, "resume", "(J)V"),                                                 \
-  X(Destroy, "destroy", "(J)V"),                                               \
+  X(Destroy, "destroy", "(JZ)V"),                                               \
   X(MoveToPosition, "moveTo", "(JI)V"),                                        \
   X(MoveToXY, "moveTo", "(JII)V"),                                             \
   X(GetBoundingBox, "getBoundingBox", "()[I"),                                 \

--- a/admob/src/android/interstitial_ad_internal_android.cc
+++ b/admob/src/android/interstitial_ad_internal_android.cc
@@ -76,10 +76,11 @@ Future<void> InterstitialAdInternalAndroid::Initialize(AdParent parent) {
   if (initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kInterstitialAdFnInitialize);
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);        
     CompleteFuture(kAdMobErrorAlreadyInitialized,
                    kAdAlreadyInitializedErrorMessage, future_handle,
                    &future_data_);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
 
   initialized_ = true;
@@ -88,11 +89,12 @@ Future<void> InterstitialAdInternalAndroid::Initialize(AdParent parent) {
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kInterstitialAdFnInitialize, &future_data_);
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
   env->CallVoidMethod(
       helper_,
       interstitial_ad_helper::GetMethodId(interstitial_ad_helper::kInitialize),
       reinterpret_cast<jlong>(callback_data), parent);
-  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  return future;
 }
 
 Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
@@ -100,11 +102,12 @@ Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
   firebase::MutexLock lock(mutex_);
 
   if (!initialized_) {
-    SafeFutureHandle<AdResult> handle =
+    SafeFutureHandle<AdResult> future_handle =
         CreateFuture<AdResult>(kInterstitialAdFnLoadAd, &future_data_);
+    Future<AdResult> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
-                   handle, &future_data_, AdResult());
-    return MakeFuture(&future_data_.future_impl, handle);
+                   future_handle, &future_data_, AdResult());
+    return future;
   }
 
   admob::AdMobError error = kAdMobErrorNone;
@@ -121,6 +124,7 @@ Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
   FIREBASE_ASSERT(env);
   FutureCallbackData<AdResult>* callback_data =
       CreateAdResultFutureCallbackData(kInterstitialAdFnLoadAd, &future_data_);
+  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   jstring j_ad_unit_str = env->NewStringUTF(ad_unit_id);
   ::firebase::admob::GetJNI()->CallVoidMethod(
@@ -129,8 +133,7 @@ Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
       reinterpret_cast<jlong>(callback_data), j_ad_unit_str, j_request);
   env->DeleteLocalRef(j_ad_unit_str);
   env->DeleteLocalRef(j_request);
-
-  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  return future;
 }
 
 Future<void> InterstitialAdInternalAndroid::Show() {
@@ -138,21 +141,22 @@ Future<void> InterstitialAdInternalAndroid::Show() {
   if (!initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kInterstitialAdFnShow);
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
                    future_handle, &future_data_);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kInterstitialAdFnShow, &future_data_);
-  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   ::firebase::admob::GetJNI()->CallVoidMethod(
       helper_,
       interstitial_ad_helper::GetMethodId(interstitial_ad_helper::kShow),
       reinterpret_cast<jlong>(callback_data));
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 }  // namespace internal

--- a/admob/src/android/interstitial_ad_internal_android.cc
+++ b/admob/src/android/interstitial_ad_internal_android.cc
@@ -76,7 +76,7 @@ Future<void> InterstitialAdInternalAndroid::Initialize(AdParent parent) {
   if (initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kInterstitialAdFnInitialize);
-    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);        
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorAlreadyInitialized,
                    kAdAlreadyInitializedErrorMessage, future_handle,
                    &future_data_);
@@ -89,7 +89,8 @@ Future<void> InterstitialAdInternalAndroid::Initialize(AdParent parent) {
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kInterstitialAdFnInitialize, &future_data_);
-  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<void> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
   env->CallVoidMethod(
       helper_,
       interstitial_ad_helper::GetMethodId(interstitial_ad_helper::kInitialize),
@@ -104,7 +105,8 @@ Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
   if (!initialized_) {
     SafeFutureHandle<AdResult> future_handle =
         CreateFuture<AdResult>(kInterstitialAdFnLoadAd, &future_data_);
-    Future<AdResult> future = MakeFuture(&future_data_.future_impl, future_handle);
+    Future<AdResult> future =
+        MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
                    future_handle, &future_data_, AdResult());
     return future;
@@ -124,7 +126,8 @@ Future<AdResult> InterstitialAdInternalAndroid::LoadAd(
   FIREBASE_ASSERT(env);
   FutureCallbackData<AdResult>* callback_data =
       CreateAdResultFutureCallbackData(kInterstitialAdFnLoadAd, &future_data_);
-  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<AdResult> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   jstring j_ad_unit_str = env->NewStringUTF(ad_unit_id);
   ::firebase::admob::GetJNI()->CallVoidMethod(
@@ -149,7 +152,8 @@ Future<void> InterstitialAdInternalAndroid::Show() {
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kInterstitialAdFnShow, &future_data_);
-  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<void> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   ::firebase::admob::GetJNI()->CallVoidMethod(
       helper_,

--- a/admob/src/android/rewarded_ad_internal_android.cc
+++ b/admob/src/android/rewarded_ad_internal_android.cc
@@ -89,7 +89,8 @@ Future<void> RewardedAdInternalAndroid::Initialize(AdParent parent) {
   initialized_ = true;
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kRewardedAdFnInitialize, &future_data_);
-  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<void> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = ::firebase::admob::GetJNI();
   FIREBASE_ASSERT(env);
@@ -107,7 +108,8 @@ Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
     SafeFutureHandle<AdResult> future_handle =
         future_data_.future_impl.SafeAlloc<AdResult>(kRewardedAdFnLoadAd,
                                                      AdResult());
-    Future<AdResult> future = MakeFuture(&future_data_.future_impl, future_handle); 
+    Future<AdResult> future =
+        MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
                    future_handle, &future_data_, AdResult());
     return future;
@@ -125,7 +127,8 @@ Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
   }
   FutureCallbackData<AdResult>* callback_data =
       CreateAdResultFutureCallbackData(kRewardedAdFnLoadAd, &future_data_);
-  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<AdResult> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = GetJNI();
   FIREBASE_ASSERT(env);
@@ -156,7 +159,8 @@ Future<void> RewardedAdInternalAndroid::Show(
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kRewardedAdFnShow, &future_data_);
-  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  Future<void> future =
+      MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = GetJNI();
   FIREBASE_ASSERT(env);

--- a/admob/src/android/rewarded_ad_internal_android.cc
+++ b/admob/src/android/rewarded_ad_internal_android.cc
@@ -79,15 +79,17 @@ Future<void> RewardedAdInternalAndroid::Initialize(AdParent parent) {
   if (initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kRewardedAdFnInitialize);
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorAlreadyInitialized,
                    kAdAlreadyInitializedErrorMessage, future_handle,
                    &future_data_);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
 
   initialized_ = true;
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kRewardedAdFnInitialize, &future_data_);
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = ::firebase::admob::GetJNI();
   FIREBASE_ASSERT(env);
@@ -95,19 +97,20 @@ Future<void> RewardedAdInternalAndroid::Initialize(AdParent parent) {
       helper_, rewarded_ad_helper::GetMethodId(rewarded_ad_helper::kInitialize),
       reinterpret_cast<jlong>(callback_data), parent);
   util::CheckAndClearJniExceptions(env);
-  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  return future;
 }
 
 Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
                                                    const AdRequest& request) {
   firebase::MutexLock lock(mutex_);
   if (!initialized_) {
-    SafeFutureHandle<AdResult> handle =
+    SafeFutureHandle<AdResult> future_handle =
         future_data_.future_impl.SafeAlloc<AdResult>(kRewardedAdFnLoadAd,
                                                      AdResult());
+    Future<AdResult> future = MakeFuture(&future_data_.future_impl, future_handle); 
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
-                   handle, &future_data_, AdResult());
-    return MakeFuture(&future_data_.future_impl, handle);
+                   future_handle, &future_data_, AdResult());
+    return future;
   }
 
   admob::AdMobError error = kAdMobErrorNone;
@@ -122,6 +125,7 @@ Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
   }
   FutureCallbackData<AdResult>* callback_data =
       CreateAdResultFutureCallbackData(kRewardedAdFnLoadAd, &future_data_);
+  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = GetJNI();
   FIREBASE_ASSERT(env);
@@ -133,7 +137,7 @@ Future<AdResult> RewardedAdInternalAndroid::LoadAd(const char* ad_unit_id,
   env->DeleteLocalRef(j_ad_unit_str);
   env->DeleteLocalRef(j_request);
 
-  return MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+  return future;
 }
 
 Future<void> RewardedAdInternalAndroid::Show(
@@ -142,16 +146,17 @@ Future<void> RewardedAdInternalAndroid::Show(
   if (!initialized_) {
     const SafeFutureHandle<void> future_handle =
         future_data_.future_impl.SafeAlloc<void>(kRewardedAdFnShow);
+    Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
     CompleteFuture(kAdMobErrorUninitialized, kAdUninitializedErrorMessage,
                    future_handle, &future_data_);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
 
   user_earned_reward_listener_ = listener;
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kRewardedAdFnShow, &future_data_);
-  SafeFutureHandle<void> future_handle = callback_data->future_handle;
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   JNIEnv* env = GetJNI();
   FIREBASE_ASSERT(env);
@@ -167,7 +172,7 @@ Future<void> RewardedAdInternalAndroid::Show(
   env->DeleteLocalRef(j_verification_custom_data);
   env->DeleteLocalRef(j_verification_user_id);
 
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 }  // namespace internal

--- a/admob/src/common/admob_common.cc
+++ b/admob/src/common/admob_common.cc
@@ -227,7 +227,9 @@ const char* GetRequestAgentString() {
 // Mark a future as complete.
 void CompleteFuture(int error, const char* error_msg,
                     SafeFutureHandle<void> handle, FutureData* future_data) {
-  future_data->future_impl.Complete(handle, error, error_msg);
+  if (future_data->future_impl.ValidFuture(handle)) {
+    future_data->future_impl.Complete(handle, error, error_msg);
+  }
 }
 
 // For calls that aren't asynchronous, we can create and complete at the

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -44,6 +44,7 @@ Future<void> BannerViewInternalIOS::Initialize(AdParent parent,
   firebase::MutexLock lock(mutex_);
   const SafeFutureHandle<void> future_handle =
     future_data_.future_impl.SafeAlloc<void>(kBannerViewFnInitialize);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
   if(initialized_) {
     CompleteFuture(kAdMobErrorAlreadyInitialized,
@@ -58,7 +59,7 @@ Future<void> BannerViewInternalIOS::Initialize(AdParent parent,
     CompleteFuture(kAdMobErrorNone, nullptr, future_handle, &future_data_);
     });
   }
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 Future<AdResult> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
@@ -66,12 +67,13 @@ Future<AdResult> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
   FutureCallbackData<AdResult>* callback_data =
     CreateAdResultFutureCallbackData(kBannerViewFnLoadAd,
                                      &future_data_);
-  SafeFutureHandle<AdResult> future_handle = callback_data->future_handle;
+  Future<AdResult> future = MakeFuture(&future_data_.future_impl,
+    callback_data->future_handle);
 
   if (ad_load_callback_data_ != nil) {
     CompleteLoadAdInternalResult(callback_data, kAdMobErrorLoadInProgress,
       kAdLoadInProgressErrorMessage);
-    return MakeFuture(&future_data_.future_impl, future_handle);
+    return future;
   }
   // Persist a pointer to the callback data so that we may use it after the iOS
   // SDK returns the AdResult.
@@ -97,13 +99,15 @@ Future<AdResult> BannerViewInternalIOS::LoadAd(const AdRequest& request) {
       [banner_view_ loadRequest:ad_request];
     }
   });
-  return MakeFuture(&future_data_.future_impl, future_handle);
+  return future;
 }
 
 Future<void> BannerViewInternalIOS::SetPosition(int x, int y) {
   firebase::MutexLock lock(mutex_);
-  const firebase::SafeFutureHandle<void> handle =
+  const firebase::SafeFutureHandle<void> future_handle =
     future_data_.future_impl.SafeAlloc<void>(kBannerViewFnSetPosition);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
+
   dispatch_async(dispatch_get_main_queue(), ^{
     AdMobError error = kAdMobErrorUninitialized;
     const char* error_msg = kAdUninitializedErrorMessage;
@@ -112,15 +116,17 @@ Future<void> BannerViewInternalIOS::SetPosition(int x, int y) {
       error = kAdMobErrorNone;
       error_msg = nullptr;
     }
-    CompleteFuture(error, error_msg, handle, &future_data_);
+    CompleteFuture(error, error_msg, future_handle, &future_data_);
   });
-  return MakeFuture(&future_data_.future_impl, handle);
+  return future;
 }
 
 Future<void> BannerViewInternalIOS::SetPosition(BannerView::Position position) {
   firebase::MutexLock lock(mutex_);
-  const firebase::SafeFutureHandle<void> handle =
+  const firebase::SafeFutureHandle<void> future_handle =
     future_data_.future_impl.SafeAlloc<void>(kBannerViewFnSetPosition);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
+
   dispatch_async(dispatch_get_main_queue(), ^{
     AdMobError error = kAdMobErrorUninitialized;
     const char* error_msg = kAdUninitializedErrorMessage;
@@ -129,31 +135,35 @@ Future<void> BannerViewInternalIOS::SetPosition(BannerView::Position position) {
       error = kAdMobErrorNone;
       error_msg = nullptr;
     }
-    CompleteFuture(error, error_msg, handle, &future_data_);
+    CompleteFuture(error, error_msg, future_handle, &future_data_);
   });
-  return MakeFuture(&future_data_.future_impl, handle);
+  return future;
 }
 
 Future<void> BannerViewInternalIOS::Hide() {
   firebase::MutexLock lock(mutex_);
-  const SafeFutureHandle<void> handle =
+  const SafeFutureHandle<void> future_handle =
     future_data_.future_impl.SafeAlloc<void>(kBannerViewFnHide);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [banner_view_ hide];
-    CompleteFuture(kAdMobErrorNone, nullptr, handle, &future_data_);
+    CompleteFuture(kAdMobErrorNone, nullptr, future_handle, &future_data_);
   });
-  return MakeFuture(&future_data_.future_impl, handle);
+  return future;
 }
 
 Future<void> BannerViewInternalIOS::Show() {
   firebase::MutexLock lock(mutex_);
-  const firebase::SafeFutureHandle<void> handle =
+  const firebase::SafeFutureHandle<void> future_handle =
     future_data_.future_impl.SafeAlloc<void>(kBannerViewFnShow);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [banner_view_ show];
-    CompleteFuture(kAdMobErrorNone, nullptr, handle, &future_data_);
+    CompleteFuture(kAdMobErrorNone, nullptr, future_handle, &future_data_);
   });
-  return MakeFuture(&future_data_.future_impl, handle);
+  return future;
 }
 
 /// This method is part of the C++ interface and is used only on Android.
@@ -175,8 +185,9 @@ Future<void> BannerViewInternalIOS::Resume() {
 /// Cleans up any resources created in BannerViewInternalIOS.
 Future<void> BannerViewInternalIOS::Destroy() {
   firebase::MutexLock lock(mutex_);
-  const firebase::SafeFutureHandle<void> handle =
+  const firebase::SafeFutureHandle<void> future_handle =
      future_data_.future_impl.SafeAlloc<void>(kBannerViewFnDestroy);
+  Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
   destroy_mutex_.Acquire();
   void (^destroyBlock)() = ^{
     [banner_view_ destroy];
@@ -196,11 +207,11 @@ Future<void> BannerViewInternalIOS::Destroy() {
       delete ad_load_callback_data_;
       ad_load_callback_data_ = nil;
     }
-    CompleteFuture(kAdMobErrorNone, nullptr, handle, &future_data_);
+    CompleteFuture(kAdMobErrorNone, nullptr, future_handle, &future_data_);
     destroy_mutex_.Release();
   };
   util::DispatchAsyncSafeMainQueue(destroyBlock);
-  return MakeFuture(&future_data_.future_impl, handle);
+  return future;
 }
 
 BoundingBox BannerViewInternalIOS::bounding_box() const {

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -32,23 +32,13 @@ InterstitialAdInternalIOS::InterstitialAdInternalIOS(InterstitialAd* base)
 
 InterstitialAdInternalIOS::~InterstitialAdInternalIOS() {
   firebase::MutexLock lock(mutex_);
-  // Clean up any resources created in InterstitialAdInternalIOS.
-  Mutex mutex(Mutex::kModeNonRecursive);
-  __block Mutex *mutex_in_block = &mutex;
-  mutex.Acquire();
-  void (^destroyBlock)() = ^{
-    ((GADInterstitialAd*)interstitial_).fullScreenContentDelegate = nil;
-    interstitial_delegate_ = nil;
-    interstitial_ = nil;
-    if(ad_load_callback_data_ != nil) {
-      delete ad_load_callback_data_;
-      ad_load_callback_data_ = nil;
-    }
-    mutex_in_block->Release();
-  };
-  util::DispatchAsyncSafeMainQueue(destroyBlock);
-  mutex.Acquire();
-  mutex.Release();
+  ((GADInterstitialAd*)interstitial_).fullScreenContentDelegate = nil;
+  interstitial_delegate_ = nil;
+  interstitial_ = nil;
+  if(ad_load_callback_data_ != nil) {
+    delete ad_load_callback_data_;
+    ad_load_callback_data_ = nil;
+  }
 }
 
 Future<void> InterstitialAdInternalIOS::Initialize(AdParent parent) {

--- a/admob/src/ios/rewarded_ad_internal_ios.mm
+++ b/admob/src/ios/rewarded_ad_internal_ios.mm
@@ -33,22 +33,13 @@ RewardedAdInternalIOS::RewardedAdInternalIOS(RewardedAd* base)
 RewardedAdInternalIOS::~RewardedAdInternalIOS() {
   firebase::MutexLock lock(mutex_);
   // Clean up any resources created in RewardedAdInternalIOS.
-  Mutex mutex(Mutex::kModeNonRecursive);
-  __block Mutex *mutex_in_block = &mutex;
-  mutex.Acquire();
-  void (^destroyBlock)() = ^{
-    ((GADRewardedAd*)rewarded_ad_).fullScreenContentDelegate = nil;
-    rewarded_ad_delegate_ = nil;
-    rewarded_ad_ = nil;
-    if(ad_load_callback_data_ != nil) {
-      delete ad_load_callback_data_;
-      ad_load_callback_data_ = nil;
-    }
-    mutex_in_block->Release();
-  };
-  util::DispatchAsyncSafeMainQueue(destroyBlock);
-  mutex.Acquire();
-  mutex.Release();
+  ((GADRewardedAd*)rewarded_ad_).fullScreenContentDelegate = nil;
+  rewarded_ad_delegate_ = nil;
+  rewarded_ad_ = nil;
+  if(ad_load_callback_data_ != nil) {
+    delete ad_load_callback_data_;
+    ad_load_callback_data_ = nil;
+  }
 }
 
 Future<void> RewardedAdInternalIOS::Initialize(AdParent parent) {

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -142,7 +142,7 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
   /**
    * Destroy/deallocate the {@link PopupWindow} and {@link AdView}.
    */
-  public void destroy(final long callbackDataPtr) {
+  public void destroy(final long callbackDataPtr, final boolean destructor_invocation) {
     // If the Activity isn't initialized, or already Destroyed, then there's
     // nothing to destroy.
     if (mActivity != null) {
@@ -169,7 +169,9 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
                 }
               }
               synchronized (mBannerViewLock) {
-                notifyBoundingBoxChanged(mBannerViewInternalPtr);
+                if(destructor_invocation == false) {
+                  notifyBoundingBoxChanged(mBannerViewInternalPtr);
+                }
                 mBannerViewInternalPtr = CPP_NULLPTR;
               }
               mActivity = null;

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-    package com.google.firebase.admob.internal.cpp;
+package com.google.firebase.admob.internal.cpp;
 
 import android.app.Activity;
 import android.graphics.drawable.ColorDrawable;
@@ -169,7 +169,7 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
                 }
               }
               synchronized (mBannerViewLock) {
-                if(destructor_invocation == false) {
+                if (destructor_invocation == false) {
                   notifyBoundingBoxChanged(mBannerViewInternalPtr);
                 }
                 mBannerViewInternalPtr = CPP_NULLPTR;
@@ -179,22 +179,24 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
               // BannerView's C++ destructor does not pass a future
               // to callback and complete, since that would cause the destructor
               // to block.
-              if(callbackDataPtr != CPP_NULLPTR) {
+              if (callbackDataPtr != CPP_NULLPTR) {
                 completeBannerViewFutureCallback(callbackDataPtr,
-                  ConstantsHelper.CALLBACK_ERROR_NONE,
-                  ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
+                    ConstantsHelper.CALLBACK_ERROR_NONE,
+                    ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
               }
             }
           });
     } else {
-      if(callbackDataPtr !=CPP_NULLPTR) {
+      if (callbackDataPtr != CPP_NULLPTR) {
         completeBannerViewFutureCallback(callbackDataPtr,
-          ConstantsHelper.CALLBACK_ERROR_NONE,
-          ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
+            ConstantsHelper.CALLBACK_ERROR_NONE,
+            ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
       }
     }
   }
-  
+
+  a
+
 
   /**
    * Loads an ad for the underlying AdView object.

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -1,4 +1,4 @@
-`/*
+/*
  * Copyright 2016 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -179,16 +179,22 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
               // BannerView's C++ destructor does not pass a future
               // to callback and complete, since that would cause the destructor
               // to block.
-              if(callbackDataPtr !=CPP_NULLPTR)
-              {
+              if(callbackDataPtr != CPP_NULLPTR) {
                 completeBannerViewFutureCallback(callbackDataPtr,
                   ConstantsHelper.CALLBACK_ERROR_NONE,
                   ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
               }
             }
           });
+    } else {
+      if(callbackDataPtr !=CPP_NULLPTR) {
+        completeBannerViewFutureCallback(callbackDataPtr,
+          ConstantsHelper.CALLBACK_ERROR_NONE,
+          ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
+      }
     }
   }
+  
 
   /**
    * Loads an ad for the underlying AdView object.

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -195,9 +195,6 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
     }
   }
 
-  a
-
-
   /**
    * Loads an ad for the underlying AdView object.
    */

--- a/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
+++ b/admob/src_java/com/google/firebase/admob/internal/cpp/BannerViewHelper.java
@@ -173,17 +173,16 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
                 mBannerViewInternalPtr = CPP_NULLPTR;
               }
               mActivity = null;
-            }
 
-            // BannerView's C++ destructor does not pass a future
-            // to callback and complete, since that would cause the destructor
-            // to block.
-        if(callbackDataPtr !=CPP_NULLPTR)
-
-            {
-              completeBannerViewFutureCallback(callbackDataPtr,
+              // BannerView's C++ destructor does not pass a future
+              // to callback and complete, since that would cause the destructor
+              // to block.
+              if(callbackDataPtr !=CPP_NULLPTR)
+              {
+                completeBannerViewFutureCallback(callbackDataPtr,
                   ConstantsHelper.CALLBACK_ERROR_NONE,
                   ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
+              }
             }
           });
     }
@@ -651,4 +650,3 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
   public static native void notifyPaidEvent(long nativeInternalPtr, String currencyCode,
                                             int precisionType, long valueMicros);
 }
-`


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fixes stability issues regarding race conditions in the AdMob SDK:
 - Ensure that future objects are fully created before launching async operations which use their handles.
 - Remove the blocking destructor of BannerView on Android. 
   - There was a race condition where the the future might be destroyed before the destroy method returns from Android causing an assertion in the Future implementation.
 - Remove the blocking destructors of Interstitial and Rewarded Ads on iOS.
   - These implementations don't invoke AdMob objects and so don't need to be run on the main thread.
 
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


FTL testing.  Local Testing. [Integration CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1516389819)
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
