### PR TITLE
Properly convert milliseconds to seconds

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -581,7 +581,7 @@ code.
     -   Messaging (Android): Fixed crash during initialization.
         ([#760](https://github.com/firebase/firebase-cpp-sdk/pull/760))
     - Remote config (Desktop): Fixed cache expiration time value used by
-      FetchAndActivate().
+      `RemoteConfig::FetchAndActivate()`.
       ([#767](https://github.com/firebase/firebase-cpp-sdk/pull/767))
 
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -580,6 +580,9 @@ code.
         ([#745](https://github.com/firebase/firebase-cpp-sdk/pull/745))
     -   Messaging (Android): Fixed crash during initialization.
         ([#760](https://github.com/firebase/firebase-cpp-sdk/pull/760))
+    - Remote config (Desktop): Fixed cache expiration time value used by
+      FetchAndActivate().
+      ([#767](https://github.com/firebase/firebase-cpp-sdk/pull/767))
 
 
 ### 8.7.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -580,7 +580,7 @@ code.
         ([#745](https://github.com/firebase/firebase-cpp-sdk/pull/745))
     -   Messaging (Android): Fixed crash during initialization.
         ([#760](https://github.com/firebase/firebase-cpp-sdk/pull/760))
-    -   Remote config (Desktop): Fixed cache expiration time value used by
+    -   Remote Config (Desktop): Fixed cache expiration time value used by
         `RemoteConfig::FetchAndActivate()`.
         ([#767](https://github.com/firebase/firebase-cpp-sdk/pull/767))
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -580,10 +580,9 @@ code.
         ([#745](https://github.com/firebase/firebase-cpp-sdk/pull/745))
     -   Messaging (Android): Fixed crash during initialization.
         ([#760](https://github.com/firebase/firebase-cpp-sdk/pull/760))
-    - Remote config (Desktop): Fixed cache expiration time value used by
-      `RemoteConfig::FetchAndActivate()`.
-      ([#767](https://github.com/firebase/firebase-cpp-sdk/pull/767))
-
+    -   Remote config (Desktop): Fixed cache expiration time value used by
+        `RemoteConfig::FetchAndActivate()`.
+        ([#767](https://github.com/firebase/firebase-cpp-sdk/pull/767))
 
 ### 8.7.0
 -   Changes

--- a/remote_config/src/desktop/remote_config_desktop.cc
+++ b/remote_config/src/desktop/remote_config_desktop.cc
@@ -140,7 +140,8 @@ Future<bool> RemoteConfigInternal::FetchAndActivate() {
       future_impl_.SafeAlloc<bool>(kRemoteConfigFnFetchAndActivate);
 
   cache_expiration_in_seconds_ =
-      config_settings_.minimum_fetch_interval_in_milliseconds;
+      config_settings_.minimum_fetch_interval_in_milliseconds /
+      ::firebase::internal::kMillisecondsPerSecond;
 
   uint64_t milliseconds_since_epoch =
       std::chrono::duration_cast<std::chrono::milliseconds>(


### PR DESCRIPTION
Currently, a value expressed in milliseconds is directly assigned to a variable
which is supposed to store seconds and it's later converted to mills again.
Thus, convert properly upon assignment

### Description
> Provide details of the change, and generalize the change in the PR title above.

Currently, a value expressed in milliseconds is directly assigned to a variable
which is supposed to store seconds and it's later converted to mills again.
Thus, convert properly upon assignment

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Setting different timeouts via RemoteConfig::SetConfigSettings(), calling RemoteConfig::FetchAndActivate() and verifying if an expected update was indeed fetched or cached config was used.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
