### PR TITLE
Add copyright line when importing Analytics iOS headers, if missing

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -109,7 +109,7 @@ jobs:
                 # Each file in this directory matches a file in the Analytics iOS SDK.
                 cp -vf "${podtmp}/${header_dir}/${ios_header}" .
                 # Add a note to each file about its source.
-                sed -i~ 's|^/// @file|\n// Copied from Firebase Analytics iOS SDK '"${analytics_version}"'.\n\n/// @file|' "${ios_header}"
+                sed -i~ 's|^/// @file|// Copyright '"$(date +%Y)"' Google LLC\n\n// Copied from Firebase Analytics iOS SDK '"${analytics_version}"'.\n\n/// @file|' "${ios_header}"
                 rm -f "${ios_header}~" # remove backup file that sed generated
                 python ../../scripts/format_code.py --f "${ios_header}"
               done

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -108,8 +108,14 @@ jobs:
               for ios_header in *.h; do
                 # Each file in this directory matches a file in the Analytics iOS SDK.
                 cp -vf "${podtmp}/${header_dir}/${ios_header}" .
+                # If the file doesn't have a Google copyright, add one.
+                if ! grep -q '^// Copyright ' "${ios_header}"; then
+                  copyright_line="// Copyright $(date +%Y) Google LLC\n"
+                else
+                  copyright_line=
+                fi
                 # Add a note to each file about its source.
-                sed -i~ 's|^/// @file|// Copyright '"$(date +%Y)"' Google LLC\n\n// Copied from Firebase Analytics iOS SDK '"${analytics_version}"'.\n\n/// @file|' "${ios_header}"
+                sed -i~ "s|^/// @file|${copyright_line}\n// Copied from Firebase Analytics iOS SDK ${analytics_version}.\n\n/// @file|" "${ios_header}"
                 rm -f "${ios_header}~" # remove backup file that sed generated
                 python ../../scripts/format_code.py --f "${ios_header}"
               done

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -109,7 +109,7 @@ jobs:
                 # Each file in this directory matches a file in the Analytics iOS SDK.
                 cp -vf "${podtmp}/${header_dir}/${ios_header}" .
                 # If the file doesn't have a Google copyright, add one.
-                if ! grep -q '^// Copyright ' "${ios_header}"; then
+                if ! grep -q "^// Copyright [0-9]* Google LLC" "${ios_header}"; then
                   copyright_line="// Copyright $(date +%Y) Google LLC\n"
                 else
                   copyright_line=


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The header files in the Analytics iOS SDK that we copy over into our SDK don't have a copyright line. Add one.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Run "Update Dependencies" workflow, which generated #781.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
