### PR TITLE
Add a delay to the Analytics test app.

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -43,6 +43,7 @@
 
 namespace firebase_testapp_automated {
 
+using app_framework::ProcessEvents;
 using firebase_test_framework::FirebaseTest;
 
 class FirebaseAnalyticsTest : public FirebaseTest {

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -70,6 +70,13 @@ void FirebaseAnalyticsTest::TearDownTestSuite() {
   firebase::analytics::Terminate();
   delete shared_app_;
   shared_app_ = nullptr;
+
+  // The Analytics integration test is too fast for FTL, so pause a few seconds here.
+  ProcessEvents(1000);
+  ProcessEvents(1000);
+  ProcessEvents(1000);
+  ProcessEvents(1000);
+  ProcessEvents(1000);
 }
 
 TEST_F(FirebaseAnalyticsTest, TestSetCollectionEnabled) {

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -72,7 +72,8 @@ void FirebaseAnalyticsTest::TearDownTestSuite() {
   delete shared_app_;
   shared_app_ = nullptr;
 
-  // The Analytics integration test is too fast for FTL, so pause a few seconds here.
+  // The Analytics integration test is too fast for FTL, so pause a few seconds
+  // here.
   ProcessEvents(1000);
   ProcessEvents(1000);
   ProcessEvents(1000);


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.


Since updating to Firebase iOS 8.10.0, the Analytics integration test finishes too quickly for FTL. This adds a delay to the end of the app.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Integration tests run.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
