### PR TITLE
AdMob 2021 return FullScreenContent errors

### DIFF
--- a/admob/integration_test/src/integration_test.cc
+++ b/admob/integration_test/src/integration_test.cc
@@ -130,6 +130,7 @@ using firebase_test_framework::FirebaseTest;
 
 using testing::AnyOf;
 using testing::Contains;
+using testing::ElementsAre;
 using testing::HasSubstr;
 using testing::Pair;
 using testing::Property;
@@ -763,7 +764,7 @@ TEST_F(FirebaseAdMobTest, TestInterstitialAdLoadAndShow) {
   WaitForCompletion(interstitial->Show(), "Show");
   app_framework::ProcessEvents(5000);
   EXPECT_THAT(content_listener.failure_codes(),
-              testing::ElementsAre(firebase::admob::kAdMobErrorAdAlreadyUsed));
+              ElementsAre(firebase::admob::kAdMobErrorAdAlreadyUsed));
 #endif
 
   interstitial->SetFullScreenContentListener(nullptr);

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -191,7 +191,7 @@ AdMobError MapAndroidFullScreenContentErrorCodeToCPPErrorCode(
     case 0:  // ERROR_CODE_INTERNAL_ERROR
       return kAdMobErrorInternalError;
     case 1:  // ERROR_CODE_AD_REUSED
-      return kAdMobErrorAdReused;
+      return kAdMobErrorAdAlreadyUsed;
     case 2:  // ERROR_CODE_NOT_READY
       return kAdMobErrorAdNotReady;
     case 3:  // ERROR_CODE_APP_NOT_FOREGROUND

--- a/admob/src/android/ad_request_converter.cc
+++ b/admob/src/android/ad_request_converter.cc
@@ -183,5 +183,25 @@ AdMobError MapAndroidAdRequestErrorCodeToCPPErrorCode(jint j_error_code) {
   }
 }
 
+AdMobError MapAndroidFullScreenContentErrorCodeToCPPErrorCode(
+    jint j_error_code) {
+  // Android error code sourced from
+  // https://developers.google.com/android/reference/com/google/android/gms/ads/FullScreenContentCallback
+  switch (j_error_code) {
+    case 0:  // ERROR_CODE_INTERNAL_ERROR
+      return kAdMobErrorInternalError;
+    case 1:  // ERROR_CODE_AD_REUSED
+      return kAdMobErrorAdReused;
+    case 2:  // ERROR_CODE_NOT_READY
+      return kAdMobErrorAdNotReady;
+    case 3:  // ERROR_CODE_APP_NOT_FOREGROUND
+      return kAdMobErrorAppNotInForeground;
+    case 4:  // ERROR_CODE_MEDIATION_SHOW_ERROR
+      return kAdMobErrorMediationShowError;
+    default:
+      return kAdMobErrorUnknown;
+  }
+}
+
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/android/ad_request_converter.h
+++ b/admob/src/android/ad_request_converter.h
@@ -41,6 +41,11 @@ jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
 // platform-independent error codes defined in AdMobError.
 AdMobError MapAndroidAdRequestErrorCodeToCPPErrorCode(jint j_error_code);
 
+// Converts the Android FullScreenContentCallback error codes to the CPP
+// platform-independent error codes defined in AdMobError.
+AdMobError MapAndroidFullScreenContentErrorCodeToCPPErrorCode(
+    jint j_error_code);
+
 }  // namespace admob
 }  // namespace firebase
 

--- a/admob/src/android/ad_result_android.h
+++ b/admob/src/android/ad_result_android.h
@@ -19,6 +19,7 @@
 
 #include <string>
 
+#include "admob/src/common/ad_result_internal.h"
 #include "admob/src/include/firebase/admob/types.h"
 #include "app/src/mutex.h"
 #include "app/src/util_android.h"
@@ -46,52 +47,6 @@ namespace admob {
 
 METHOD_LOOKUP_DECLARATION(ad_error, ADERROR_METHODS);
 METHOD_LOOKUP_DECLARATION(load_ad_error, LOADADERROR_METHODS);
-
-struct AdResultInternal {
-  // The type of AdResult, based on the operation that was requested.
-  enum AdResultInternalType {
-    // Standard AdResult type for most Ad operations.
-    kAdResultInternalStandard = 0,
-    // AdResult represents an error the GMA SDK wrapper.
-    kAdResultInternalWrapperError,
-    // AdResult resulting from a LoadAd operation.
-    kAdResultInternalLoadAdError,
-    // ADResult resulting from an attempt to show a full screen ad.
-    kAdResultInternalFullScreenContentError,
-  };
-
-  // Default constructor.
-  AdResultInternal() {
-    ad_result_type = kAdResultInternalStandard;
-    code = kAdMobErrorNone;
-    j_ad_error = nullptr;
-  }
-
-  // The type of AdResult, based on the operation that was requested.
-  AdResultInternalType ad_result_type;
-
-  // True if this was a successful result.
-  bool is_successful;
-
-  // An error code.
-  AdMobError code;
-
-  // A cached value of com.google.android.gms.ads.AdError.domain.
-  std::string domain;
-
-  // A cached value of com.google.android.gms.ads.AdError.message.
-  std::string message;
-
-  // A cached result from invoking com.google.android.gms.ads.AdError.ToString.
-  std::string to_string;
-
-  // If this is not a successful result, or if it's a wrapper error, then
-  // j_ad_error is a reference to a com.google.android.gms.ads.AdError produced
-  // by the Admob Android SDK.
-  jobject j_ad_error;
-
-  Mutex mutex;
-};
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/android/ad_result_android.h
+++ b/admob/src/android/ad_result_android.h
@@ -48,15 +48,30 @@ METHOD_LOOKUP_DECLARATION(ad_error, ADERROR_METHODS);
 METHOD_LOOKUP_DECLARATION(load_ad_error, LOADADERROR_METHODS);
 
 struct AdResultInternal {
-  // True if the result contains an error originating from C++/Java wrapper
-  // code. If false, then an Admob Android AdError has occurred.
-  bool is_wrapper_error;
+  // The type of AdResult, based on the operation that was requested.
+  enum AdResultInternalType {
+    // Standard AdResult type for most Ad operations.
+    kAdResultInternalStandard = 0,
+    // AdResult represents an error the GMA SDK wrapper.
+    kAdResultInternalWrapperError,
+    // AdResult resulting from a LoadAd operation.
+    kAdResultInternalLoadAdError,
+    // ADResult resulting from an attempt to show a full screen ad.
+    kAdResultInternalFullScreenContentError,
+  };
+
+  // Default constructor.
+  AdResultInternal() {
+    ad_result_type = kAdResultInternalStandard;
+    code = kAdMobErrorNone;
+    j_ad_error = nullptr;
+  }
+
+  // The type of AdResult, based on the operation that was requested.
+  AdResultInternalType ad_result_type;
 
   // True if this was a successful result.
   bool is_successful;
-
-  // True if this error data represents a result from a LoadAd request.
-  bool is_load_ad_error;
 
   // An error code.
   AdMobError code;

--- a/admob/src/android/adapter_response_info_android.cc
+++ b/admob/src/android/adapter_response_info_android.cc
@@ -44,12 +44,12 @@ AdapterResponseInfo::AdapterResponseInfo(
 
   // Construct an AdResultInternal from the AdError in the AdapterResponseInfo.
   AdResultInternal ad_result_internal;
-  ad_result_internal.j_ad_error = env->CallObjectMethod(
+  ad_result_internal.native_ad_error = env->CallObjectMethod(
       j_adapter_response_info,
       adapter_response_info::GetMethodId(adapter_response_info::kGetAdError));
-  FIREBASE_ASSERT(ad_result_internal.j_ad_error);
+  FIREBASE_ASSERT(ad_result_internal.native_ad_error);
   ad_result_ = AdResult(ad_result_internal);
-  env->DeleteLocalRef(ad_result_internal.j_ad_error);
+  env->DeleteLocalRef(ad_result_internal.native_ad_error);
 
   // The class name of the adapter.
   const jobject j_adapter_class_name =

--- a/admob/src/android/adapter_response_info_android.cc
+++ b/admob/src/android/adapter_response_info_android.cc
@@ -44,7 +44,6 @@ AdapterResponseInfo::AdapterResponseInfo(
 
   // Construct an AdResultInternal from the AdError in the AdapterResponseInfo.
   AdResultInternal ad_result_internal;
-  ad_result_internal.is_load_ad_error = false;
   ad_result_internal.j_ad_error = env->CallObjectMethod(
       j_adapter_response_info,
       adapter_response_info::GetMethodId(adapter_response_info::kGetAdError));

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -687,9 +687,8 @@ void CompleteLoadAdCallback(FutureCallbackData<AdResult>* callback_data,
   AdResultInternal ad_result_internal;
 
   ad_result_internal.j_ad_error = j_load_ad_error;
-  ad_result_internal.is_load_ad_error = true;
+  ad_result_internal.ad_result_type = AdResultInternal::kAdResultInternalLoadAdError;
   ad_result_internal.is_successful = true;  // assume until proven otherwise.
-  ad_result_internal.is_wrapper_error = false;
   ad_result_internal.code = error_code;
 
   // Further result configuration is based on success/failure.
@@ -699,7 +698,8 @@ void CompleteLoadAdCallback(FutureCallbackData<AdResult>* callback_data,
     ad_result_internal.is_successful = false;
   } else if (ad_result_internal.code != kAdMobErrorNone) {
     // C++ SDK Android AdMob Wrapper encountered an error.
-    ad_result_internal.is_wrapper_error = true;
+    ad_result_internal.ad_result_type =
+        AdResultInternal::kAdResultInternalWrapperError;
     ad_result_internal.is_successful = false;
     ad_result_internal.message = error_message;
     ad_result_internal.domain = "SDK";
@@ -850,9 +850,8 @@ void JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
   internal::FullScreenAdEventListener* listener =
       reinterpret_cast<internal::FullScreenAdEventListener*>(data_ptr);
   AdResultInternal ad_result_internal;
-  ad_result_internal.is_wrapper_error = false;
-  ad_result_internal.is_successful = false;
-  ad_result_internal.is_load_ad_error = false;
+  ad_result_internal.ad_result_type =
+      AdResultInternal::kAdResultInternalFullScreenContentError;
   ad_result_internal.j_ad_error = j_ad_error;
 
   // Invoke AdMobInternal, a friend of AdResult, to have it access its

--- a/admob/src/android/admob_android.cc
+++ b/admob/src/android/admob_android.cc
@@ -686,14 +686,15 @@ void CompleteLoadAdCallback(FutureCallbackData<AdResult>* callback_data,
   std::string future_error_message;
   AdResultInternal ad_result_internal;
 
-  ad_result_internal.j_ad_error = j_load_ad_error;
-  ad_result_internal.ad_result_type = AdResultInternal::kAdResultInternalLoadAdError;
+  ad_result_internal.native_ad_error = j_load_ad_error;
+  ad_result_internal.ad_result_type =
+      AdResultInternal::kAdResultInternalLoadAdError;
   ad_result_internal.is_successful = true;  // assume until proven otherwise.
   ad_result_internal.code = error_code;
 
   // Further result configuration is based on success/failure.
   if (j_load_ad_error != nullptr) {
-    // The Android SDK returned an error.  Use the j_ad_error object
+    // The Android SDK returned an error.  Use the native_ad_error object
     // to populate a AdResult with the error specifics.
     ad_result_internal.is_successful = false;
   } else if (ad_result_internal.code != kAdMobErrorNone) {
@@ -852,7 +853,7 @@ void JNI_notifyAdFailedToShowFullScreenContentEvent(JNIEnv* env, jclass clazz,
   AdResultInternal ad_result_internal;
   ad_result_internal.ad_result_type =
       AdResultInternal::kAdResultInternalFullScreenContentError;
-  ad_result_internal.j_ad_error = j_ad_error;
+  ad_result_internal.native_ad_error = j_ad_error;
 
   // Invoke AdMobInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.

--- a/admob/src/common/ad_result_internal.h
+++ b/admob/src/common/ad_result_internal.h
@@ -24,34 +24,61 @@
 
 namespace firebase {
 namespace admob {
-namespace internal {
 
-class AdResultInternal {
- public:
-  /// Returns true if the AdResult represents a successful result.
-  virtual bool is_successful() const = 0;
+#if FIREBASE_PLATFORM_ANDROID
+typedef jobject NativeSdkAdError;
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+typedef const NSError* NativeSdkAdError;
+#else
+typedef void* NativeSdkAdError;
+#endif
 
-  /// Retrieves an AdResult which represents the cause of this error.
-  ///
-  /// @return an AdResult which represents the cause of this AdResult.
-  /// If there was no cause then the methods of the result will return
-  /// defaults.
-  virtual AdResult GetCause() const = 0;
+struct AdResultInternal {
+  // The type of AdResult, based on the operation that was requested.
+  enum AdResultInternalType {
+    // Standard AdResult type for most Ad operations.
+    kAdResultInternalStandard = 0,
+    // AdResult represents an error the GMA SDK wrapper.
+    kAdResultInternalWrapperError,
+    // AdResult resulting from a LoadAd operation.
+    kAdResultInternalLoadAdError,
+    // ADResult resulting from an attempt to show a full screen ad.
+    kAdResultInternalFullScreenContentError,
+  };
 
-  /// Gets the error's code.
-  virtual int code() const = 0;
+  // Default constructor.
+  AdResultInternal() {
+    ad_result_type = kAdResultInternalStandard;
+    code = kAdMobErrorNone;
+    native_ad_error = nullptr;
+  }
 
-  /// Gets the domain of the error.
-  virtual const std::string& domain() const = 0;
+  // The type of AdResult, based on the operation that was requested.
+  AdResultInternalType ad_result_type;
 
-  /// Gets the message describing the error.
-  virtual const std::string& message() const = 0;
+  // True if this was a successful result.
+  bool is_successful;
 
-  /// Returns a log friendly string version of this object.
-  virtual const std::string& ToString() const = 0;
+  // An error code.
+  AdMobError code;
+
+  // A cached value of com.google.android.gms.ads.AdError.domain.
+  std::string domain;
+
+  // A cached value of com.google.android.gms.ads.AdError.message.
+  std::string message;
+
+  // A cached result from invoking com.google.android.gms.ads.AdError.ToString.
+  std::string to_string;
+
+  // If this is not a successful result, or if it's a wrapper error, then
+  // native_ad_error is a reference to a error object returned by the iOS or
+  // Android GMA SDK.
+  NativeSdkAdError native_ad_error;
+
+  Mutex mutex;
 };
 
-}  // namespace internal
 }  // namespace admob
 }  // namespace firebase
 

--- a/admob/src/common/ad_result_internal.h
+++ b/admob/src/common/ad_result_internal.h
@@ -37,7 +37,7 @@ struct AdResultInternal {
   // The type of AdResult, based on the operation that was requested.
   enum AdResultInternalType {
     // Standard AdResult type for most Ad operations.
-    kAdResultInternalStandard = 0,
+    kAdResultInternalAdError = 1,
     // AdResult represents an error the GMA SDK wrapper.
     kAdResultInternalWrapperError,
     // AdResult resulting from a LoadAd operation.
@@ -48,7 +48,7 @@ struct AdResultInternal {
 
   // Default constructor.
   AdResultInternal() {
-    ad_result_type = kAdResultInternalStandard;
+    ad_result_type = kAdResultInternalAdError;
     code = kAdMobErrorNone;
     native_ad_error = nullptr;
   }

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -128,6 +128,19 @@ enum AdMobError {
   kAdMobErrorApplicationIdentifierMissing,
   /// Android Ad String is invalid.
   kAdMobErrorInvalidAdString,
+  /// The ad has already been shown.
+  kAdMobErrorAdReused,
+  /// The ad can not be shown when app is not in the foreground.
+  kAdMobErrorAppNotInForeground,
+  /// A mediation adapter failed to show the ad.
+  kAdMobErrorMediationShowError,
+  /// The ad is not ready to be shown.
+  kAdMobErrorAdNotReady,
+  /// Ad is too large for the scene.
+  kAdMobErrorAdTooLarge,
+  /// Attempted to present ad from a non-main thread. This is an internal
+  /// error which should be reported to support if encountered.
+  kAdMobErrorNotMainThread,
   /// Fallback error for any unidentified cases.
   kAdMobErrorUnknown,
 };

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -128,8 +128,6 @@ enum AdMobError {
   kAdMobErrorApplicationIdentifierMissing,
   /// Android Ad String is invalid.
   kAdMobErrorInvalidAdString,
-  /// The ad has already been shown.
-  kAdMobErrorAdReused,
   /// The ad can not be shown when app is not in the foreground.
   kAdMobErrorAppNotInForeground,
   /// A mediation adapter failed to show the ad.

--- a/admob/src/ios/FADInterstitialDelegate.mm
+++ b/admob/src/ios/FADInterstitialDelegate.mm
@@ -54,9 +54,10 @@
 - (void)ad:(nonnull id<GADFullScreenPresentingAd>)ad
 didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
   firebase::admob::AdResultInternal ad_result_internal;
-  ad_result_internal.is_wrapper_error = false;
+  ad_result_internal.ad_result_type =
+    firebase::admob::AdResultInternal::kAdResultInternalFullScreenContentError;
   ad_result_internal.is_successful = false;
-  ad_result_internal.ios_error = error;
+  ad_result_internal.native_ad_error = error;
   // Invoke AdMobInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.
   const firebase::admob::AdResult& ad_result = firebase::admob::AdMobInternal::CreateAdResult(ad_result_internal);

--- a/admob/src/ios/FADRequest.h
+++ b/admob/src/ios/FADRequest.h
@@ -42,9 +42,13 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
                                        admob::AdMobError* error,
                                        std::string* error_message);
 
-// Converts the iOS error codes to the CPP platform independent error codes
-// defined in AdMobError.
-AdMobError MapADErrorCodeToCPPErrorCode(GADErrorCode error_code);
+// Converts the iOS error codes from an AdRequest to the CPP platform
+// independent error codes defined in AdMobError.
+AdMobError MapAdRequestErrorCodeToCPPErrorCode(GADErrorCode error_code);
+
+// Converts the iOS error codes from attempting to show a full screen
+// ad into the platform independent error codes defined in AdMobError.
+AdMobError MapFullScreenContentErrorCodeToCPPErrorCode(GADPresentationErrorCode error_code);
 
 }  // namespace admob
 }  // namespace firebase

--- a/admob/src/ios/FADRequest.mm
+++ b/admob/src/ios/FADRequest.mm
@@ -106,7 +106,7 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
   return gadRequest;
 }
 
-AdMobError MapADErrorCodeToCPPErrorCode(GADErrorCode error_code) {
+AdMobError MapAdRequestErrorCodeToCPPErrorCode(GADErrorCode error_code) {
   // iOS error code sourced from
   // https://developers.google.com/admob/ios/api/reference/Enums/GADErrorCode
   switch(error_code)
@@ -147,5 +147,27 @@ AdMobError MapADErrorCodeToCPPErrorCode(GADErrorCode error_code) {
   }
 }
 
+AdMobError MapFullScreenContentErrorCodeToCPPErrorCode(GADPresentationErrorCode error_code) {
+  // iOS error code sourced from
+  // https://developers.google.com/admob/ios/api/reference/Enums/GADPresentationErrorCode
+  switch(error_code)
+  {
+    case GADPresentationErrorCodeAdNotReady:     // 15
+      return kAdMobErrorAdNotReady;
+    case GADPresentationErrorCodeAdTooLarge:     // 16
+      return kAdMobErrorAdTooLarge;
+    case GADPresentationErrorCodeInternal:       // 17
+      return kAdMobErrorInternalError;
+    case GADPresentationErrorCodeAdAlreadyUsed:  // 18
+      return kAdMobErrorAdAlreadyUsed;
+    case GADPresentationErrorNotMainThread:      // 21
+      return kAdMobErrorNotMainThread;
+    case GADPresentationErrorMediation:          // 22
+      return kAdMobErrorMediationShowError;
+    default:
+      return kAdMobErrorUnknown;
+  }
 }
-}
+
+}  // namespace admob
+}  // namespace firebase

--- a/admob/src/ios/FADRewardedAdDelegate.mm
+++ b/admob/src/ios/FADRewardedAdDelegate.mm
@@ -54,9 +54,10 @@
 - (void)ad:(nonnull id<GADFullScreenPresentingAd>)ad
 didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
   firebase::admob::AdResultInternal ad_result_internal;
-  ad_result_internal.is_wrapper_error = false;
+  ad_result_internal.ad_result_type =
+    firebase::admob::AdResultInternal::kAdResultInternalFullScreenContentError;
   ad_result_internal.is_successful = false;
-  ad_result_internal.ios_error = error;
+  ad_result_internal.native_ad_error = error;
   // Invoke AdMobInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.
   const firebase::admob::AdResult& ad_result = firebase::admob::AdMobInternal::CreateAdResult(ad_result_internal);

--- a/admob/src/ios/ad_result_ios.h
+++ b/admob/src/ios/ad_result_ios.h
@@ -24,45 +24,6 @@ extern "C" {
 #import <Foundation/Foundation.h>
 #import <GoogleMobileAds/GoogleMobileAds.h>
 
-#include <string>
-
-#include "admob/src/include/firebase/admob/types.h"
-#include "app/src/mutex.h"
-
-namespace firebase {
-namespace admob {
-
-struct AdResultInternal {
-  // True if the result contains an error originating from C++/Java wrapper
-  // code. If false, then an Admob Android AdError has occurred.
-  bool is_wrapper_error;
-
-  // True if this was a successful result.
-  bool is_successful;
-
-  // True if this error data represents a result from a LoadAd request.
-  bool is_load_ad_error;
-
-  // An error code
-  AdMobError code;
-
-  // A cached value of com.google.android.gms.ads.AdError.domain
-  std::string domain;
-
-  // A cached value of com.google.android.gms.ads.AdError.message
-  std::string message;
-
-  // A cached result from invoking com.google.android.gms.ads.AdError.ToString.
-  std::string to_string;
-
-  // If this is not a successful result, or if it's a wrapper error, then
-  // ios_error is a pointer to an NSError produced by the Admob iOS SDK.
-  const NSError* ios_error;
-
-  Mutex mutex;
-};
-
-}  // namespace admob
-}  // namespace firebase
+#include "admob/src/common/ad_result_internal.h"
 
 #endif  // FIREBASE_ADMOB_SRC_IOS_AD_RESULT_IOS_H_

--- a/admob/src/ios/ad_result_ios.mm
+++ b/admob/src/ios/ad_result_ios.mm
@@ -22,6 +22,7 @@ extern "C" {
 
 #include <string>
 
+#include "admob/src/common/ad_result_internal.h"
 #include "admob/src/include/firebase/admob.h"
 #include "admob/src/ios/ad_result_ios.h"
 #include "admob/src/ios/response_info_ios.h"
@@ -39,13 +40,12 @@ AdResult::AdResult() {
   // an AdResult makes it to the application in this default state.
   internal_ = new AdResultInternal();
   internal_->is_successful = false;
-  internal_->is_wrapper_error = true;
-  internal_->is_load_ad_error = false;
+  internal_->ad_result_type = AdResultInternal::kAdResultInternalWrapperError;
   internal_->code = kAdMobErrorUninitialized;
   internal_->domain = "SDK";
   internal_->message = "This AdResult has not be initialized.";
   internal_->to_string = internal_->message;
-  internal_->ios_error = nullptr;
+  internal_->native_ad_error = nullptr;
 
   // While most data is passed into this object through the AdResultInternal
   // structure (above), the response_info_ is constructed when parsing
@@ -57,9 +57,8 @@ AdResult::AdResult(const AdResultInternal& ad_result_internal) {
   internal_ = new AdResultInternal();
 
   internal_->is_successful = ad_result_internal.is_successful;
-  internal_->is_wrapper_error = ad_result_internal.is_wrapper_error;
-  internal_->is_load_ad_error = ad_result_internal.is_load_ad_error;
-  internal_->ios_error = nullptr;
+  internal_->ad_result_type = ad_result_internal.ad_result_type;
+  internal_->native_ad_error = nullptr;
   response_info_ = new ResponseInfo();
 
   // AdResults can be returned on success, or for errors encountered in the C++
@@ -67,44 +66,53 @@ AdResult::AdResult(const AdResultInternal& ad_result_internal) {
   // differently across these three scenarios.
   if (internal_->is_successful) {
     internal_->code = kAdMobErrorNone;
-    internal_->is_wrapper_error = false;
     internal_->message = "";
     internal_->domain = "";
     internal_->to_string = "";
-  } else if (internal_->is_wrapper_error) {
+  } else if (internal_->ad_result_type ==
+             AdResultInternal::kAdResultInternalWrapperError) {
     // Wrapper errors come with prepopulated code, domain, etc, fields.
     internal_->code = ad_result_internal.code;
     internal_->domain = ad_result_internal.domain;
     internal_->message = ad_result_internal.message;
     internal_->to_string = ad_result_internal.to_string;
   } else {
-    FIREBASE_ASSERT(ad_result_internal.ios_error);
+    FIREBASE_ASSERT(ad_result_internal.native_ad_error);
 
     // AdResults based on Admob iOS SDK errors will fetch code, domain,
     // message, and to_string values from the ObjC object.
-    internal_->ios_error = ad_result_internal.ios_error;
+    internal_->native_ad_error = ad_result_internal.native_ad_error;
 
     // Error Code.  Map the iOS AdMob SDK error codes to our
     // platform-independent C++ SDK error codes.
-    internal_->code = MapADErrorCodeToCPPErrorCode((GADErrorCode)internal_->ios_error.code);
+    switch (internal_->ad_result_type) {
+      case AdResultInternal::kAdResultInternalFullScreenContentError:
+        // Full screen content errors have their own error codes.
+        internal_->code =
+            MapFullScreenContentErrorCodeToCPPErrorCode((GADPresentationErrorCode)internal_->native_ad_error.code);
+        break;
+      default:
+        internal_->code =
+            MapAdRequestErrorCodeToCPPErrorCode((GADErrorCode)internal_->native_ad_error.code);
+    }
 
-    internal_->domain = util::NSStringToString(internal_->ios_error.domain);
+    internal_->domain = util::NSStringToString(internal_->native_ad_error.domain);
     internal_->message =
-      util::NSStringToString(internal_->ios_error.localizedDescription);
+      util::NSStringToString(internal_->native_ad_error.localizedDescription);
 
     // Errors from LoadAd attempts have extra data pertaining to adapter
     // responses.
-    if (internal_->is_load_ad_error) {
+    if (internal_->ad_result_type == AdResultInternal::kAdResultInternalLoadAdError) {
       ResponseInfoInternal response_info_internal = ResponseInfoInternal( {
-        ad_result_internal.ios_error.userInfo[GADErrorUserInfoKeyResponseInfo]
+        ad_result_internal.native_ad_error.userInfo[GADErrorUserInfoKeyResponseInfo]
       });
       *response_info_ = ResponseInfo(response_info_internal);
     }
 
     NSString* ns_to_string = [[NSString alloc]initWithFormat:@"Received error with "
-        "domain: %@, code: %ld, message: %@", internal_->ios_error.domain,
-        (long)internal_->ios_error.code,
-        internal_->ios_error.localizedDescription];
+        "domain: %@, code: %ld, message: %@", internal_->native_ad_error.domain,
+        (long)internal_->native_ad_error.code,
+        internal_->native_ad_error.localizedDescription];
     internal_->to_string = util::NSStringToString(ns_to_string);
   }
 }
@@ -119,7 +127,7 @@ AdResult::~AdResult() {
   FIREBASE_ASSERT(internal_);
   FIREBASE_ASSERT(response_info_);
 
-  internal_->ios_error = nil;
+  internal_->native_ad_error = nil;
   delete internal_;
   internal_ = nullptr;
 
@@ -139,9 +147,10 @@ AdResult& AdResult::operator=(const AdResult& ad_result) {
     MutexLock(internal_->mutex);
     internal_ = new AdResultInternal();
 
-    internal_->ios_error = ad_result.internal_->ios_error;
+    internal_->native_ad_error = ad_result.internal_->native_ad_error;
 
     internal_->is_successful = ad_result.internal_->is_successful;
+    internal_->ad_result_type = ad_result.internal_->ad_result_type;
     internal_->code = ad_result.internal_->code;
     internal_->domain = ad_result.internal_->domain;
     internal_->message = ad_result.internal_->message;
@@ -152,7 +161,7 @@ AdResult& AdResult::operator=(const AdResult& ad_result) {
 
   // Deleting the internal deletes the mutex within it, so we have to delete
   // the internal after the mutex lock leaves scope.
-  preexisting_internal->ios_error = nullptr;
+  preexisting_internal->native_ad_error = nullptr;
   delete preexisting_internal;
 
   return *this;
@@ -166,12 +175,12 @@ bool AdResult::is_successful() const {
 std::unique_ptr<AdResult> AdResult::GetCause() const {
   FIREBASE_ASSERT(internal_);
 
-  NSError* cause = internal_->ios_error.userInfo[NSUnderlyingErrorKey];
+  NSError* cause = internal_->native_ad_error.userInfo[NSUnderlyingErrorKey];
   if (cause == nil) {
     return std::unique_ptr<AdResult>(nullptr);
   } else {
     AdResultInternal ad_result_internal;
-    ad_result_internal.ios_error = cause;
+    ad_result_internal.native_ad_error = cause;
     return std::unique_ptr<AdResult>(new AdResult(ad_result_internal));
   }
 }

--- a/admob/src/ios/adapter_response_info_ios.mm
+++ b/admob/src/ios/adapter_response_info_ios.mm
@@ -36,7 +36,7 @@ AdapterResponseInfo::AdapterResponseInfo(
   FIREBASE_ASSERT(internal.ad_network_response_info);
 
   AdResultInternal ad_result_internal;
-  ad_result_internal.ios_error = internal.ad_network_response_info.error;
+  ad_result_internal.native_ad_error = internal.ad_network_response_info.error;
   ad_result_ = AdResult(ad_result_internal);
   
   adapter_class_name_ = util::NSStringToString(

--- a/admob/src/ios/admob_ios.h
+++ b/admob/src/ios/admob_ios.h
@@ -38,8 +38,8 @@ void CompleteLoadAdInternalResult(
 
 // Parses information from the NSError to populate an AdResult
 // and completes the AdResult Future on iOS.
-void CompleteAdResultIOS(FutureCallbackData<AdResult>* callback_data,
-                         NSError *error);
+void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
+                         NSError *error, bool is_load_ad_error);
 
 
 // Converts the iOS Admob GADAdValue structure into a CPP

--- a/admob/src/ios/banner_view_internal_ios.mm
+++ b/admob/src/ios/banner_view_internal_ios.mm
@@ -231,7 +231,8 @@ void BannerViewInternalIOS::BannerViewDidFailToReceiveAdWithError(NSError *error
   firebase::MutexLock lock(mutex_);
   FIREBASE_ASSERT(error);
   if(ad_load_callback_data_ != nil) {
-    CompleteAdResultIOS(ad_load_callback_data_, error);
+    CompleteAdResultError(ad_load_callback_data_, error,
+                          /*is_load_ad_error=*/true);
     ad_load_callback_data_ = nil;
   }
 }

--- a/admob/src/ios/interstitial_ad_internal_ios.mm
+++ b/admob/src/ios/interstitial_ad_internal_ios.mm
@@ -154,7 +154,7 @@ void InterstitialAdInternalIOS::InterstitialDidFailToReceiveAdWithError(NSError 
   firebase::MutexLock lock(mutex_);
   FIREBASE_ASSERT(gad_error);
   if (ad_load_callback_data_ != nil) {
-    CompleteAdResultIOS(ad_load_callback_data_, gad_error);
+    CompleteAdResultError(ad_load_callback_data_, gad_error, /*is_load_ad_error=*/true);
     ad_load_callback_data_ = nil;
   }
 }

--- a/admob/src/ios/rewarded_ad_internal_ios.mm
+++ b/admob/src/ios/rewarded_ad_internal_ios.mm
@@ -160,7 +160,8 @@ void RewardedAdInternalIOS::RewardedAdDidFailToReceiveAdWithError(NSError *gad_e
   firebase::MutexLock lock(mutex_);
   FIREBASE_ASSERT(gad_error);
   if (ad_load_callback_data_ != nil) {
-    CompleteAdResultIOS(ad_load_callback_data_, gad_error);
+    CompleteAdResultError(ad_load_callback_data_, gad_error,
+                          /*is_load_ad_error=*/true);
     ad_load_callback_data_ = nil;
   }
 }

--- a/admob/src/stub/ad_result_stub.cc
+++ b/admob/src/stub/ad_result_stub.cc
@@ -16,15 +16,12 @@
 
 #include <string>
 
+#include "admob/src/common/ad_result_internal.h"
 #include "admob/src/include/firebase/admob.h"
 #include "admob/src/include/firebase/admob/types.h"
 
 namespace firebase {
 namespace admob {
-
-struct AdResultInternal {
-  char stub;
-};
 
 AdResult::AdResult() {}
 

--- a/app/src/util_android.h
+++ b/app/src/util_android.h
@@ -818,10 +818,10 @@ std::string JObjectClassName(JNIEnv* env, jobject obj);
 jobject StdVectorToJavaList(JNIEnv* env,
                             const std::vector<std::string>& string_vector);
 
-// Converts a `std::unordered_set<std::string>` to a `java.util.ArrayList<String>`
-// Returns a local ref to a List.
-jobject StdUnorderedSetToJavaList(JNIEnv* env,
-                            const std::unordered_set<std::string>& string_set);
+// Converts a `std::unordered_set<std::string>` to a
+// `java.util.ArrayList<String>` Returns a local ref to a List.
+jobject StdUnorderedSetToJavaList(
+    JNIEnv* env, const std::unordered_set<std::string>& string_set);
 
 // Converts an `std::map<const char*, const char*>` to a
 // `java.util.Map<String, String>`.

--- a/app/src/util_ios.h
+++ b/app/src/util_ios.h
@@ -200,8 +200,8 @@ NSMutableArray *StringUnorderedSetToNSMutableArray(
 
 // Convert a NSArray into a vector of strings.  Asserts if a non NSString
 // object is found in the array.
-void NSArrayOfNSStringToVectorOfString(
-  NSArray *array, std::vector<std::string> *string_vector);
+void NSArrayOfNSStringToVectorOfString(NSArray *array,
+                                       std::vector<std::string> *string_vector);
 
 // Convert a string map to NSDictionary.
 NSDictionary *StringMapToNSDictionary(

--- a/app/src/util_ios.h
+++ b/app/src/util_ios.h
@@ -17,15 +17,15 @@
 #ifndef FIREBASE_APP_SRC_UTIL_IOS_H_
 #define FIREBASE_APP_SRC_UTIL_IOS_H_
 
-#ifdef __OBJC__
-
-#import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
-
 #include <map>
 #include <string>
 #include <unordered_set>
 #include <vector>
+
+#ifdef __OBJC__
+
+#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 
 #include "app/src/include/firebase/variant.h"
 

--- a/app/src/util_ios.mm
+++ b/app/src/util_ios.mm
@@ -161,8 +161,7 @@ NSMutableArray *StringVectorToNSMutableArray(const std::vector<std::string> &vec
   return array;
 }
 
-NSMutableArray *StringUnorderedSetToNSMutableArray(
-    const std::unordered_set<std::string> &set) {
+NSMutableArray *StringUnorderedSetToNSMutableArray(const std::unordered_set<std::string> &set) {
   NSMutableArray<NSString *> *array = [[NSMutableArray alloc] initWithCapacity:set.size()];
   for (auto &element : set) {
     [array addObject:StringToNSString(element)];
@@ -170,7 +169,7 @@ NSMutableArray *StringUnorderedSetToNSMutableArray(
   return array;
 }
 
-void NSArrayOfNSStringToVectorOfString(NSArray* array, std::vector<std::string>* string_vector) {
+void NSArrayOfNSStringToVectorOfString(NSArray *array, std::vector<std::string> *string_vector) {
   string_vector->reserve(array.count);
   for (id object in array) {
     if (![object isKindOfClass:[NSString class]]) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Android and iOS GMA SDK implementations provide error codes which return only on FullScreen operation failures.  Android's code values overlap with those of the normal AdError space.

This change treats the FullScreenContent errors separately from AdResult operations, and maps them to the standard AdError enumerated codes.

Other notes:
  - Coalesced platform-specific AdResultInternal structure definitions into a common implementation.
  - Added enum to denote origin of AdResultInternal errors (AdErrors, LoadAds, SDK Wrapper & FullScreenContent errors). This replaced boolean flag identifiers.
  - Updated Intergration Test:
    - new tests for attempting to show an ad twice for Insterstitial and Rewarded ads.
    - added methods to access listener callback counters.
    - shortened some of the counter / callback names to increase readability.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

[Integration Tests CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1589089206)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***