### PR TITLE
future.h: replace std::mutex with firebase::Mutex

### DIFF
--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -20,10 +20,10 @@
 #include <stddef.h>
 #include <stdint.h>
 
-#include <mutex>
 #include <utility>
 
 #include "firebase/internal/common.h"
+#include "firebase/internal/mutex.h"
 
 #ifdef FIREBASE_USE_STD_FUNCTION
 #include <functional>
@@ -310,7 +310,7 @@ class FutureBase {
 
   /// Returns true if the two Futures reference the same result.
   bool operator==(const FutureBase& rhs) const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    MutexLock lock(mutex_);
     return api_ == rhs.api_ && handle_ == rhs.handle_;
   }
 
@@ -320,7 +320,7 @@ class FutureBase {
 #if defined(INTERNAL_EXPERIMENTAL)
   /// Returns the API-specific handle. Should only be called by the API.
   FutureHandle GetHandle() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    MutexLock lock(mutex_);
     return handle_;
   }
 #endif  // defined(INTERNAL_EXPERIMENTAL)
@@ -328,7 +328,7 @@ class FutureBase {
  protected:
   /// @cond FIREBASE_APP_INTERNAL
 
-  mutable std::mutex mutex_;
+  mutable Mutex mutex_;
 
   /// Backpointer to the issuing API class.
   /// Set to nullptr when Future is invalidated.


### PR DESCRIPTION
Replace `std::mutex` with `firebase::Mutex` in `future.h`.

This is the fourth, and last, PR (the previous ones being #751, #792, and #795) towards moving `firebase::Mutex` into the public-internal includes directory, so that it can be used by `future.h`. See #747 for the rationale.

Googlers can see b/206520921 for more details.