### PR TITLE
When testing on the expanded matrix, run tests on M1 Mac (via custom runner) as well.

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -778,7 +778,7 @@ jobs:
     if: |
       ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, matrix.built_on) &&
+        contains(needs.check_and_prepare.outputs.matrix_os, strategy.matrix.built_on) &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -806,8 +806,7 @@ jobs:
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         contains(needs.check_and_prepare.outputs.matrix_arch_combined, 'arm64') &&
         needs.check_and_prepare.outputs.apis != '' &&
-        !cancelled() &&
-        !failure()
+        !cancelled()
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -221,7 +221,7 @@ jobs:
           --run_id ${{github.run_id}}
 
   build_desktop:
-    name: build-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}-${{ matrix.arch }}
+    name: build-desktop-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare]
     runs-on: ${{ matrix.os }}
     # Skip this if there is an empty matrix (which can happen if "auto" was set above).

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -408,7 +408,7 @@ jobs:
         run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
       - name: Install Cloud SDK
         if: ${{ !cancelled() }}
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
       - name: Upload Desktop Artifacts to GCS
         shell: bash
         if: ${{ !cancelled() }}
@@ -1082,7 +1082,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
       - name: Run Android integration tests on Real Device via FTL
         timeout-minutes: 60
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1184,7 +1184,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@master
+        uses: google-github-actions/setup-gcloud@main
       - name: Run iOS integration tests on Real Device via FTL
         # max 3 retry and 10m timeout for each testapp, plus other steps
         timeout-minutes: 60

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -807,7 +807,7 @@ jobs:
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         run: |
           echo "Cleaning up previous run"
-          rm -rf "${{ github.workspace }}"
+          rm -rf "${{ github.workspace }}"/*
       - uses: actions/checkout@v2
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         with:
@@ -818,39 +818,53 @@ jobs:
         with:
           path: testapps
           name: testapps-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
+      - name: Setup Firestore Emulator
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        run: |
+          npm install -g firebase-tools
+      - name: Create keychain (macOS)
+        if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        shell: bash
+        run: |
+          pwd
+          echo "Creating temporary keychain"
+          # Create a local keychain on Mac:
+          # Clean up previous temp keychain, if any.
+          security delete-keychain tmp-keychain || true
+          # Create temp keychain file.
+          security create-keychain -p '${{ secrets.TEST_SECRET }}' tmp-keychain
+          # Change the keychain list to the temp keychain.
+          security list-keychains -d user -s tmp-keychain
+          # Remove unlock timeout for temp keychain.
+          security set-keychain-settings tmp-keychain
+          # Unlock the keychain.
+          security unlock-keychain '${{ secrets.TEST_SECRET }}' tmp-keychain
+      - name: Restore google-services files
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        shell: bash
+        run: python scripts/gha/restore_secrets.py --passphrase '${{ secrets.TEST_SECRET }}' --artifact testapps
       - name: Run Desktop integration tests
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          if [[ '${{ runner.os }}' == "macOS" ]]; then
-            echo "Creating temporary keychain"
-            # Create a local keychain on Mac:
-            # Clean up previous temp keychain, if any.
-            security delete-keychain tmp-keychain || true
-            # Create temp keychain file.
-            security create-keychain -p "${{ secrets.TEST_SECRET }}" tmp-keychain
-            # Change the keychain list to the temp keychain.
-            security list-keychains -d user -s tmp-keychain
-            # Remove unlock timeout for temp keychain.
-            security set-keychain-settings tmp-keychain
-            # Unlock the keychain.
-            security unlock-keychain "${{ secrets.TEST_SECRET }}" tmp-keychain
-
-            # Use arch -arm64 prefix to ensure running on arm64.
-            cmd_prefix="arch -${{ matrix.arch }}"
-          fi
-          # Restore google-services files.
-          python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
-          set -x
-          ${cmd_prefix} python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}"
-          set +x
           if [[ '${{ runner.os }}' == 'macOS' ]]; then
-            # Remove the local keychain on Mac:
-            # Set back to the default login keychain.
-            security list-keychains -d user -s login.keychain
-            # Delete the keychain.
-            security delete-keychain tmp-keychain
+            # Use arch -arm64 prefix to ensure running on arm64.
+            cmd_prefix='arch -${{ matrix.arch }}'
           fi
+          set -x
+          ${cmd_prefix} firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}"'
+          set +x
+        env:
+          USE_FIRESTORE_EMULATOR: true
+      - name: Delete keychain (macOS)
+        if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        shell: bash
+        run: |
+          # Remove the local keychain on Mac:
+          # Set back to the default login keychain.
+          security list-keychains -d user -s login.keychain
+          # Delete the keychain, if it exists.
+          security delete-keychain tmp-keychain || true
       - name: Prepare results summary artifact
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
@@ -888,6 +902,12 @@ jobs:
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
+      - name: Clean up after this run
+        shell: bash
+        if: ${{ always() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        run: |
+          echo "Cleaning up after this run"
+          rm -rf "${{ github.workspace }}"/*
 
 
   test_desktop:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -847,7 +847,7 @@ jobs:
           echo "Creating temporary keychain"
           # Create a local keychain on Mac:
           # Clean up previous temp keychain, if any.
-          security delete-keychain tmp-keychain || true
+          security delete-keychain tmp-keychain 2> /dev/null || true
           # Create temp keychain file.
           security create-keychain -p '${{ secrets.TEST_SECRET }}' tmp-keychain
           # Change the keychain list to the temp keychain.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1308,7 +1308,7 @@ jobs:
 
   summarize_results:
     name: "summarize-results"
-    needs: [check_and_prepare, test_desktop, test_android, test_ios, test_tvos]
+    needs: [check_and_prepare, test_desktop, test_desktop_custom_runners, test_android, test_ios, test_tvos]
     runs-on: ubuntu-latest
     if: ${{ !cancelled() }}
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -848,14 +848,16 @@ jobs:
           # Create a local keychain on Mac:
           # Clean up previous temp keychain, if any.
           security delete-keychain tmp-keychain 2> /dev/null || true
-          # Create temp keychain file.
-          security create-keychain -p '${{ secrets.TEST_SECRET }}' tmp-keychain
+          # Create temp keychain file and unlock it.
+          # (Avoid passing in -p on command line by using interactive mode.)
+          # Also set it to default settings so there is no unlock timeout.
+          security -i <<EOF
+          create-keychain -p ${{ secrets.TEST_SECRET }} tmp-keychain
+          set-keychain-settings tmp-keychain
+          unlock-keychain -p ${{ secrets.TEST_SECRET }} tmp-keychain
+          EOF
           # Change the keychain list to the temp keychain.
           security list-keychains -d user -s tmp-keychain
-          # Remove unlock timeout for temp keychain.
-          security set-keychain-settings tmp-keychain
-          # Unlock the keychain.
-          security unlock-keychain -p '${{ secrets.TEST_SECRET }}' tmp-keychain
       - name: Restore google-services files
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
@@ -880,7 +882,7 @@ jobs:
           # Remove the local keychain on Mac:
           # Set back to the default login keychain.
           security list-keychains -d user -s login.keychain
-          # Delete the keychain, if it exists.
+          # Delete the temp keychain, if it exists.
           security delete-keychain tmp-keychain || true
       - name: Prepare results summary artifact
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -797,7 +797,7 @@ jobs:
   # Run tests that depend on custom (self-hosted) runners.
   # For now, this is only used for ARM Mac builds.
   test_desktop_custom_runners:
-    name: test-desktop-custom-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
+    name: test-desktop-selfhosted-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, firebase-cpp, '${{ matrix.runner_label }}' ]
     # Unfortunately, we can't use matrix.build_os in the contains() expressions

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -67,7 +67,6 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-      runner_tag_mac_arm: ${{ steps.matrix_config.outputs.runner_tag_mac_arm }}
   steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
@@ -343,7 +342,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm }}'
+            artifact_os='${{ env.runnerTagMacArm }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -797,7 +796,7 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm }}'
+        - runner_tag: macosarm-selfhosted
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -781,8 +781,8 @@ jobs:
     if: |
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
+        (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
         !cancelled() &&
         !failure()
     strategy:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -421,7 +421,6 @@ jobs:
         shell: bash
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         run: |
-          pushd ${{env.GCS_UPLOAD_DIR}}
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
             --issue_number ${{needs.check_and_prepare.outputs.pr_number}}\

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -408,7 +408,7 @@ jobs:
         run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
       - name: Install Cloud SDK
         if: ${{ !cancelled() }}
-        uses: google-github-actions/setup-gcloud@v0.3
+        uses: google-github-actions/setup-gcloud@v0
       - name: Upload Desktop Artifacts to GCS
         shell: bash
         if: ${{ !cancelled() }}
@@ -1082,7 +1082,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@v0.3
+        uses: google-github-actions/setup-gcloud@v0
       - name: Run Android integration tests on Real Device via FTL
         timeout-minutes: 60
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1184,7 +1184,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@v0.3
+        uses: google-github-actions/setup-gcloud@v0
       - name: Run iOS integration tests on Real Device via FTL
         # max 3 retry and 10m timeout for each testapp, plus other steps
         timeout-minutes: 60

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,6 +48,10 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
+  # All self-hosted ARM Mac runners should have this label. Due to how
+  # our custom reporting works, it must be exactly two words separated
+  # by a hyphen, and the second word will be omitted from the summary
+  # log.
   runnerLabelMacArm64: 'macosarm-custom'
 
 jobs:
@@ -67,6 +71,7 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
+      # Copy the runner label here because matrix specifiers cannot see env.
       runner_label_mac_arm64: ${{ env.runnerLabelMacArm64 }}
     steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
@@ -795,12 +800,11 @@ jobs:
         include:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the label for the self-hosted runner. This should be the
-        # same as the label used in the artifact name. Also specify the OS that
-        # the testapps were built on originally, and the architecture to run on.
+        # same as the label used in the artifact name in build_desktop above.
         - runner_label: '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}'
-          # Only run the steps if build_os was included in the list of target OSes.
+          # Also specify the OS that the testapps were built on originally.
+          # (We won't run any tests unless that OS was included in the build matrix.)
           build_os: macos-latest
-          arch: arm64
     steps:
       - name: Clean up previous run
         shell: bash
@@ -818,6 +822,8 @@ jobs:
         with:
           path: testapps
           name: testapps-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
+      # Omit all of the prerequisites steps; we ensure that our self-hosted runners
+      # are configured with all prereqs already installed.
       - name: Create keychain (macOS)
         if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
@@ -843,9 +849,9 @@ jobs:
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          if [[ '${{ runner.os }}' == 'macOS' ]]; then
-            # Use arch -arm64 prefix to ensure running on arm64.
-            cmd_prefix='arch -${{ matrix.arch }}'
+          if [[ '${{ matrix.runner_label }}' == '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}' ]]; then
+            # Mac ARM64 only: Use arch -arm64 prefix to ensure that the app is running on arm64.
+            cmd_prefix='arch -arm64'
           fi
           set -x
           ${cmd_prefix} firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}"'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -217,12 +217,12 @@ jobs:
         os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
         arch: ${{ fromJson(needs.check_and_prepare.outputs.matrix_arch_mac) }}
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
+        # Only build for arm64 on Mac.
         exclude:
-      # Only build for arm64 on Mac.
         - os: ubuntu-latest
           arch: arm64
         - os: windows-latest
-         arch: arm64
+          arch: arm64
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -855,7 +855,7 @@ jobs:
           # Remove unlock timeout for temp keychain.
           security set-keychain-settings tmp-keychain
           # Unlock the keychain.
-          security unlock-keychain '${{ secrets.TEST_SECRET }}' tmp-keychain
+          security unlock-keychain -p '${{ secrets.TEST_SECRET }}' tmp-keychain
       - name: Restore google-services files
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -855,8 +855,9 @@ jobs:
           set-keychain-settings tmp-keychain
           unlock-keychain -p ${{ secrets.TEST_SECRET }} tmp-keychain
           EOF
-          # Change the keychain list to the temp keychain.
+          # Change the keychain list and default keychain to the temp keychain.
           security list-keychains -d user -s tmp-keychain
+          security default-keychain -s tmp-keychain
       - name: Restore google-services files
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -774,11 +774,11 @@ jobs:
   test_desktop_macos_arm:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, macOS, '${{ matrix.os }}' ]
+    runs-on: [self-hosted, '${{ matrix.os }}' ]
     if: |
       ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
+        contains(needs.check_and_prepare.outputs.matrix_os, matrix.built_on) &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&
@@ -787,8 +787,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ macosarm-selfhosted ]
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
+        include:
+        - os: macosarm-selfhosted
+          built_on: macos-latest
     steps:
       - name: Clear directory
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -51,7 +51,7 @@ env:
   # This must consist of two words separated by a hyphen.
   # The first word will be used in reports, the second
   # will be removed.
-  armMacRunerTag: 'macosarm-internal'
+  runnerTagMacArm64: 'macosarm-custom'
 
 jobs:
   check_and_prepare:
@@ -70,7 +70,8 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-    steps:
+      runner_tag_mac_arm64: ${{ env.runnerTagMacArm64 }}
+  steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
       uses: lannonbr/repo-permission-check-action@2.0.0
@@ -344,7 +345,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os='${{ env.armMacRunerTag }}'
+            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -798,7 +799,7 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: ${{ env.armMacRunerTag }}
+        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,10 +48,6 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
-  # This must consist of two words separated by a hyphen.
-  # The first word will be used in reports, the second
-  # will be removed.
-  runnerTagMacArm64: 'macosarm-custom'
 
 jobs:
   check_and_prepare:
@@ -70,7 +66,10 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-      runner_tag_mac_arm64: '${{ env.runnerTagMacArm64 }}'
+      # This must consist of two words separated by a hyphen.
+      # The first word will be used in reports, the second
+      # will be removed.
+      runner_tag_mac_arm64: 'macosarm-custom'
   steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,6 +48,7 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
+  runnerTagMacArm: 'macosarm-selfhosted'
 
 jobs:
   check_and_prepare:
@@ -66,10 +67,7 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-      # This must consist of two words separated by a hyphen.
-      # The first word will be used in reports, the second
-      # will be removed.
-      runner_tag_mac_arm: 'macosarm-custom'
+      runner_tag_mac_arm: ${{ steps.matrix_config.outputs.runner_tag_mac_arm }}
   steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
@@ -80,6 +78,7 @@ jobs:
     ### trigger value: manual_trigger, scheduled_trigger, label_trigger, postsubmit_trigger
     - id: set_outputs
       run: |
+        echo "::set-output name=runner_tag_mac_arm::${{env.runnerTagMacArm}}"
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           if [[ "${{ github.event.inputs.test_pull_request }}" != "nightly-packaging" ]]; then
             # Triggered manually

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -358,7 +358,7 @@ jobs:
         run: |
           if [ ! -f build-results-${{ steps.build_tests.outputs.artifact_name }}.log.json ]; then
             # No summary was created, make a placeholder one.
-            echo "__SUMMARY_MISSING__" > ${{ steps.build_tests.outputs.artifact_name }}.log.json
+            echo "__SUMMARY_MISSING__" > build-results-${{ steps.build_tests.outputs.artifact_name }}.log.json
           fi
       - name: Upload Desktop integration tests artifact
         uses: actions/upload-artifact@v2.2.2
@@ -411,7 +411,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-${{ steps.build_tests.outputs.artifact_name }}
+          cat build-results-${{ steps.build_tests.outputs.artifact_name }}.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -217,12 +217,12 @@ jobs:
         os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
         arch: ${{ fromJson(needs.check_and_prepare.outputs.matrix_arch_mac) }}
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
-      exclude:
+        exclude:
       # Only build for arm64 on Mac.
-      - os: ubuntu-latest
-        arch: arm64
-      - os: windows-latest
-        arch: arm64
+        - os: ubuntu-latest
+          arch: arm64
+        - os: windows-latest
+         arch: arm64
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -781,7 +781,8 @@ jobs:
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
-        !cancelled()
+        !cancelled() &&
+        !failure()
       }}
     strategy:
       fail-fast: false
@@ -800,6 +801,13 @@ jobs:
         with:
           path: testapps
           name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+      - name: Restore google-services files
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 2
+          max_attempts: 3
+          shell: bash
+          command: python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
       - name: Run Desktop integration tests
         run: arch -arm64 python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"
       - name: Prepare results summary artifact

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -372,7 +372,7 @@ jobs:
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-${{ steps.build_tests.outputs.artifact_name }}
+          path: build-results-${{ steps.build_tests.outputs.artifact_name }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Cleanup Local Copies of Uploaded Artifacts
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -408,7 +408,7 @@ jobs:
         run: echo "CLOUDSDK_PYTHON=${{env.pythonLocation}}\python.exe" >> $GITHUB_ENV
       - name: Install Cloud SDK
         if: ${{ !cancelled() }}
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v0.3
       - name: Upload Desktop Artifacts to GCS
         shell: bash
         if: ${{ !cancelled() }}
@@ -1082,7 +1082,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v0.3
       - name: Run Android integration tests on Real Device via FTL
         timeout-minutes: 60
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1184,7 +1184,7 @@ jobs:
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
-        uses: google-github-actions/setup-gcloud@main
+        uses: google-github-actions/setup-gcloud@v0.3
       - name: Run iOS integration tests on Real Device via FTL
         # max 3 retry and 10m timeout for each testapp, plus other steps
         timeout-minutes: 60

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -818,7 +818,6 @@ jobs:
         with:
           path: testapps
           name: testapps-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
-      - name: Setup Firestore Emulator
       - name: Create keychain (macOS)
         if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -69,7 +69,7 @@ jobs:
       # This must consist of two words separated by a hyphen.
       # The first word will be used in reports, the second
       # will be removed.
-      runner_tag_mac_arm64: 'macosarm-custom'
+      runner_tag_mac_arm: 'macosarm-custom'
   steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
@@ -344,7 +344,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
+            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -798,7 +798,7 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
+        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm }}'
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -821,6 +821,11 @@ jobs:
           # Also specify the OS that the testapps were built on originally.
           # (We won't run any tests unless that OS was included in the build matrix.)
           build_os: macos-latest
+        exclude:
+        # Until we support building openssl from source, we can't link to system
+        # openssl when cross-compiling, so exclude openssl from mac arm64 testing.
+        - build_os: macos-latest
+          ssl_variant: openssl
     steps:
       - name: Clean up previous run
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -890,7 +890,7 @@ jobs:
         env:
           USE_FIRESTORE_EMULATOR: true
       - name: Delete keychain (macOS)
-        if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        if: ${{ always() && runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
           # Remove the local keychain on Mac:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -819,9 +819,6 @@ jobs:
           path: testapps
           name: testapps-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
       - name: Setup Firestore Emulator
-        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
-        run: |
-          npm install -g firebase-tools
       - name: Create keychain (macOS)
         if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -843,7 +843,6 @@ jobs:
         if: ${{ runner.os == 'macOS' && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          pwd
           echo "Creating temporary keychain"
           # Create a local keychain on Mac:
           # Clean up previous temp keychain, if any.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -775,12 +775,12 @@ jobs:
     name: test-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, '${{ matrix.runner_tag }}' ]
+    # Unfortunately, we can't use matrix.build_os on the first contains() below.
+    # If we ever have other self-hosted runner OSes, we'll need to expand it
+    # to include other platforms.
     if: |
-        contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        # Unfortunately, we can't use matrix.build_os on the following contains().
-        # If we ever have other self-hosted runner OSes, we'll need to expand it
-        # to include other platforms.
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
+        contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,6 +48,10 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
+  # This must consist of two words separated by a hyphen.
+  # The first word will be used in reports, the second
+  # will be removed.
+  armMacRunerTag: 'macosarm-internal'
 
 jobs:
   check_and_prepare:
@@ -340,7 +344,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os=macosarm-selfhosted
+            artifact_os='${{ env.armMacRunerTag }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -771,8 +775,10 @@ jobs:
             exit 1
           fi
 
-  test_desktop_macos_arm:
-    name: test-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
+  # Run tests that depend on special self-hosted runners.
+  # For now, this is only ARM Mac builds.
+  test_desktop_special_runners:
+    name: test-desktop-self-hosted-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, '${{ matrix.runner_tag }}' ]
     # Unfortunately, we can't use matrix.build_os on the first contains() below.
@@ -792,7 +798,7 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: macosarm-selfhosted
+        - runner_tag: ${{ env.armMacRunerTag }}
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -63,7 +63,9 @@ jobs:
       pr_number: ${{ steps.set_outputs.outputs.pr_number }}
       matrix_platform: ${{ steps.matrix_config.outputs.matrix_platform }}
       matrix_os: ${{ steps.matrix_config.outputs.matrix_os }}
-      matrix_arch_mac: ${{ steps.matrix_config.outputs.matrix_arch_mac }}
+      matrix_arch_macos: ${{ steps.matrix_config.outputs.matrix_arch_macos }}
+      matrix_arch_windows_linux: ${{ steps.matrix_config.outputs.matrix_arch_windows_linux }}
+      matrix_arch_combined: ${{ steps.matrix_config.outputs.matrix_arch_combined }}
       matrix_ssl: ${{ steps.matrix_config.outputs.matrix_ssl }}
       apis: ${{ steps.matrix_config.outputs.apis }}
       mobile_test_on: ${{ steps.matrix_config.outputs.mobile_test_on }}
@@ -185,7 +187,14 @@ jobs:
         echo "::set-output name=apis::${apis}"
         echo "::set-output name=matrix_platform::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k platform -o "${{github.event.inputs.platforms}}" --apis ${apis} )"
         echo "::set-output name=matrix_os::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k os -o "${{github.event.inputs.operating_systems}}")"
-        echo "::set-output name=matrix_arch_mac::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k architecture_macos)"
+        echo "::set-output name=matrix_arch_macos::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k architecture_macos)"
+        echo "::set-output name=matrix_arch_windows_linux::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k architecture_windows_linux)"
+        # Combine architecture_macos and architecture_windows_linux to get a list of all architectures for the build matrix.
+        matrix_arch_combined=`echo $( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k architecture_macos | sed 's/[]\[,]//g') \
+                                   $( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k architecture_windows_linux | sed 's/[]\[,]//g' ) \
+                                   | sed 's/ /\n/g' | sort | uniq`
+        matrix_arch_combined_json=["$(echo ${matrix_arch_combined} | sed 's/ /,/g')"]
+        echo "::set-output name=matrix_arch_combined::${matrix_arch_combined_json}"
         # If building against a packaged SDK, only use boringssl.
         if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
           echo "::warning ::Downloading SDK package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
@@ -222,14 +231,19 @@ jobs:
       fail-fast: false
       matrix:
         os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
-        arch: ${{ fromJson(needs.check_and_prepare.outputs.matrix_arch_mac) }}
+        arch: ${{ fromJson(needs.check_and_prepare.outputs.matrix_arch_combined) }}
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
-        # Only build for arm64 on Mac.
+        # Because matrix_arch_combined combines mac, linux, and windows, we need a few exclusions.
         exclude:
+          # Only allow building for arm64 on Mac.
         - os: ubuntu-latest
           arch: arm64
         - os: windows-latest
           arch: arm64
+          # Only allow building for x86 on Windows and Linux.
+          # (Not currently used, but it could be in the future.)
+        - os: macos-latest
+          arch: x86
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -784,12 +798,13 @@ jobs:
     name: test-desktop-custom-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, '${{ matrix.runner_label }}' ]
-    # Unfortunately, we can't use matrix.build_os on the first contains() below.
-    # If we ever have other self-hosted runner OSes, we'll need to expand it
-    # to include other platforms.
+    # Unfortunately, we can't use matrix.build_os in the contains() expressions
+    # below. If we ever have other self-hosted runner OSes, we'll need to modify
+    # the 'if' here to include other platforms.
     if: |
-        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
+        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
+        contains(needs.check_and_prepare.outputs.matrix_arch_combined, 'arm64') &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&
         !failure()

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -775,10 +775,13 @@ jobs:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, '${{ matrix.os }}' ]
+    env:
+      # OS that this testapp was built on.
+      build_os: ${{ matrix.build_os }}
     if: |
       ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, strategy.matrix.built_on) &&
+        contains(needs.check_and_prepare.outputs.matrix_os, env.build_os) &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&
@@ -790,7 +793,7 @@ jobs:
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
         include:
         - os: macosarm-selfhosted
-          built_on: macos-latest
+          build_os: macos-latest
     steps:
       - name: Clear directory
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -70,7 +70,7 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-      runner_tag_mac_arm64: ${{ env.runnerTagMacArm64 }}
+      runner_tag_mac_arm64: '${{ env.runnerTagMacArm64 }}'
   steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -774,7 +774,7 @@ jobs:
   test_desktop_macos_arm:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, macOS, macosarm-selfhosted]
+    runs-on: [self-hosted, macOS, '${{ matrix.os }}' ]
     if: |
       ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,7 +48,7 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
-  runnerTagMacArm64: 'macosarm-selfhosted'
+  runnerLabelMacArm64: 'macosarm-custom'
 
 jobs:
   check_and_prepare:
@@ -67,7 +67,7 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-      runner_tag_mac_arm64: ${{ env.runnerTagMacArm64 }}
+      runner_label_mac_arm64: ${{ env.runnerLabelMacArm64 }}
     steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
@@ -342,7 +342,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
+            artifact_os='${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -773,12 +773,12 @@ jobs:
             exit 1
           fi
 
-  # Run tests that depend on special self-hosted runners.
-  # For now, this is only ARM Mac builds.
-  test_desktop_special_runners:
-    name: test-desktop-self-hosted-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
+  # Run tests that depend on custom (self-hosted) runners.
+  # For now, this is only used for ARM Mac builds.
+  test_desktop_custom_runners:
+    name: test-desktop-custom-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, '${{ matrix.runner_tag }}' ]
+    runs-on: [self-hosted, '${{ matrix.runner_label }}' ]
     # Unfortunately, we can't use matrix.build_os on the first contains() below.
     # If we ever have other self-hosted runner OSes, we'll need to expand it
     # to include other platforms.
@@ -794,9 +794,10 @@ jobs:
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
         include:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
-        # specify the tag of the self-hosted runner (and of the testapps to run),
-        # and the OS that the testapps were built on originally.
-        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
+        # specify the label for the self-hosted runner. This should be the
+        # same as the label used in the artifact name. Also specify the OS that
+        # the testapps were built on originally, and the architecture to run on.
+        - runner_label: '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}'
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
           arch: arm64
@@ -816,7 +817,7 @@ jobs:
         uses: actions/download-artifact@v2.0.8
         with:
           path: testapps
-          name: testapps-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
+          name: testapps-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
       - name: Run Desktop integration tests
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
@@ -841,7 +842,7 @@ jobs:
           # Restore google-services files.
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
           set -x
-          ${cmd_prefix} python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}"
+          ${cmd_prefix} python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}"
           set +x
           if [[ '${{ runner.os }}' == 'macOS' ]]; then
             # Remove the local keychain on Mac:
@@ -854,15 +855,15 @@ jobs:
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          if [ ! -f testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log.json ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log.json
+          if [ ! -f testapps/test-results-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}.log.json ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}.log.json
           fi
       - name: Upload Desktop test results artifact
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         uses: actions/upload-artifact@v2.2.2
         with:
           name: log-artifact
-          path: testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}*
+          path: testapps/test-results-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
@@ -883,7 +884,7 @@ jobs:
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          cat testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log
+          cat testapps/test-results-desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -772,12 +772,15 @@ jobs:
           fi
 
   test_desktop_macos_arm:
-    name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+    name: test-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, '${{ matrix.os }}' ]
+    runs-on: [self-hosted, '${{ matrix.runner_tag }}' ]
     if: |
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, job.strategy.matrix.build_os) &&
+        # Unfortunately, we can't use matrix.build_os on the following contains().
+        # If we ever have other self-hosted runner OSes, we'll need to expand it
+        # to include other platforms.
+        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&
@@ -787,51 +790,56 @@ jobs:
       matrix:
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
         include:
-        - os: macosarm-selfhosted
+        # Unlike the other matrices, we don't set a matrix.os here. Instead,
+        # specify the tag of the self-hosted runner (and of the testapps to run),
+        # and the OS that the testapps were built on originally.
+        - runner_tag: macosarm-selfhosted
+          # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:
-      - name: Clear directory
+      - name: Clean up previous run
         shell: bash
-        run: rm -rf firebase-cpp-sdk testapps
+        run: |
+          echo "Cleaning up previous run"
+          rm -rf "${{ github.workspace }}"
       - uses: actions/checkout@v2
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Desktop integration tests artifact
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: testapps
-          name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-      - name: Restore google-services files
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 2
-          max_attempts: 3
-          shell: bash
-          command: python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
+          name: testapps-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}
       - name: Run Desktop integration tests
-        run: arch -arm64 python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"
-      - name: Prepare results summary artifact
-        if: ${{ !cancelled() }}
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          if [ ! -f testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
+          python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
+          arch -arm64 python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}"
+      - name: Prepare results summary artifact
+        if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
+        shell: bash
+        run: |
+          if [ ! -f testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log.json ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log.json
           fi
       - name: Upload Desktop test results artifact
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         uses: actions/upload-artifact@v2.2.2
         with:
           name: log-artifact
-          path: testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}*
+          path: testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
-        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         uses: actions/download-artifact@v2.0.8
         with:
           path: test_results
           name: log-artifact
       - name: Update PR label and comment
-        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
+        if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         run: |
           python scripts/gha/it_workflow.py --stage progress \
             --token ${{github.token}} \
@@ -840,10 +848,10 @@ jobs:
             --commit ${{needs.check_and_prepare.outputs.github_ref}} \
             --run_id ${{github.run_id}}
       - name: Summarize test results
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
-          cat testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log
+          cat testapps/test-results-desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -340,7 +340,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os=macosarm-latest
+            artifact_os=macosarm-selfhosted
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -774,13 +774,15 @@ jobs:
   test_desktop_macos_arm:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, macOS, ${{ matrix.os }}]
+    runs-on: [self-hosted, macOS, macosarm-selfhosted]
     if: |
+      ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled()
+      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -779,14 +779,12 @@ jobs:
       # OS that this testapp was built on.
       build_os: ${{ matrix.build_os }}
     if: |
-      ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, env.build_os) &&
+        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&
         !failure()
-      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -316,7 +316,7 @@ jobs:
           workflow: 'cpp-packaging.yml'
           run_id: ${{ github.event.inputs.test_packaged_sdk }}
       - name: Build integration tests
-        id: build-tests
+        id: build_tests
         shell: bash
         env:
           CCACHE_DIR: ${{ github.workspace }}/ccache_dir
@@ -356,28 +356,28 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-${{ steps.build-tests.artifact_name }}.log.json ]; then
+          if [ ! -f build-results-${{ steps.build_tests.outputs.artifact_name }}.log.json ]; then
             # No summary was created, make a placeholder one.
-            echo "__SUMMARY_MISSING__" > ${{ steps.build-tests.artifact_name }}.log.json
+            echo "__SUMMARY_MISSING__" > ${{ steps.build_tests.outputs.artifact_name }}.log.json
           fi
       - name: Upload Desktop integration tests artifact
         uses: actions/upload-artifact@v2.2.2
         if: ${{ !cancelled() }}
         with:
-          name: testapps-${{ steps.build-tests.artifact_name }}
-          path: testapps-${{ steps.build-tests.artifact_name }}
+          name: testapps-${{ steps.build_tests.outputs.artifact_name }}
+          path: testapps-${{ steps.build_tests.outputs.artifact_name }}
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Desktop build results artifact
         uses: actions/upload-artifact@v2.2.2
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-${{ steps.build-tests.artifact_name }}
+          path: build-results-${{ steps.build_tests.outputs.artifact_name }}
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Cleanup Local Copies of Uploaded Artifacts
         shell: bash
         run: |
-          rm -rf testapps-${{ steps.build-tests.artifact_name }}
+          rm -rf testapps-${{ steps.build_tests.outputs.artifact_name }}
       - name: Set CLOUDSDK_PYTHON (Windows)
         shell: bash
         if: startsWith(matrix.os, 'windows') && !cancelled()
@@ -411,7 +411,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-${{ steps.build-tests.artifact_name }}
+          cat build-results-${{ steps.build_tests.outputs.artifact_name }}
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -775,12 +775,10 @@ jobs:
     name: test-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, '${{ matrix.os }}' ]
-    env:
-      # OS that this testapp was built on.
-      build_os: ${{ matrix.build_os }}
     if: |
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, '${{ env.build_os }}') &&
+        contains(needs.check_and_prepare.outputs.matrix_os,
+                 jobs.test_desktop_macos_arm.strategy.matrix.build_os) &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -799,6 +799,7 @@ jobs:
     steps:
       - name: Clean up previous run
         shell: bash
+        if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         run: |
           echo "Cleaning up previous run"
           rm -rf "${{ github.workspace }}"

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,7 +48,7 @@ env:
   pythonVersion: '3.7'
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
-  runnerTagMacArm: 'macosarm-selfhosted'
+  runnerTagMacArm64: 'macosarm-selfhosted'
 
 jobs:
   check_and_prepare:
@@ -67,7 +67,8 @@ jobs:
       xcode_version: ${{ steps.matrix_config.outputs.xcode_version }}
       ios_device: ${{ steps.matrix_config.outputs.ios_device }}
       tvos_device: ${{ steps.matrix_config.outputs.tvos_device }}
-  steps:
+      runner_tag_mac_arm64: ${{ env.runnerTagMacArm64 }}
+    steps:
     ### Fail the workflow if the user does not have admin access to run the tests.
     - name: Check if user has permission to trigger tests
       uses: lannonbr/repo-permission-check-action@2.0.0
@@ -77,7 +78,6 @@ jobs:
     ### trigger value: manual_trigger, scheduled_trigger, label_trigger, postsubmit_trigger
     - id: set_outputs
       run: |
-        echo "::set-output name=runner_tag_mac_arm::${{env.runnerTagMacArm}}"
         if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
           if [[ "${{ github.event.inputs.test_pull_request }}" != "nightly-packaging" ]]; then
             # Triggered manually
@@ -342,7 +342,7 @@ jobs:
           # Special handling for MacOS ARM build.
           artifact_os=${{ matrix.os }}
           if [[ "${{ matrix.os }}" == "macos-latest" && "${{ matrix.arch }}" == "arm64" ]]; then
-            artifact_os='${{ env.runnerTagMacArm }}'
+            artifact_os='${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
             additional_flags+=(--arch arm64)
           fi
           echo "::set-output name=artifact_name::desktop-${artifact_os}-${{ matrix.ssl_variant }}"
@@ -796,7 +796,7 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: macosarm-selfhosted
+        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64}}'
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
     steps:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -195,11 +195,11 @@ jobs:
                                    | sed 's/ /\n/g' | sort | uniq`
         matrix_arch_combined_json=["$(echo ${matrix_arch_combined} | sed 's/ /,/g')"]
         echo "::set-output name=matrix_arch_combined::${matrix_arch_combined_json}"
-        # If building against a packaged SDK, only use boringssl.
+        # If building against a packaged SDK, consider it as using boringssl, as the packaged SDK uses boringssl under the hood.
+        # This avoids trying to install openssl on the system when compiling against the packaged SDK.
         if [[ -n "${{ github.event.inputs.test_packaged_sdk }}" ]]; then
           echo "::warning ::Downloading SDK package from previous run: https://github.com/${{github.repository}}/actions/runs/${{ github.event.inputs.test_packaged_sdk }}"
-          # Because the mobile tests require this value to be set to 'openssl', set it to 'openssl' here. It won't actually matter later.
-          echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ssl_lib -o openssl )"
+          echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ssl_lib -o boringssl )"
         else
           echo "::set-output name=matrix_ssl::$( python scripts/gha/print_matrix_configuration.py -w integration_tests ${TEST_MATRIX_PARAM} -k ssl_lib -o "${{github.event.inputs.desktop_ssl_variants}}" )"
         fi
@@ -244,6 +244,9 @@ jobs:
           # (Not currently used, but it could be in the future.)
         - os: macos-latest
           arch: x86
+          # Until we support building openssl from source, we can't link to system openssl when cross-compiling.
+        - ssl_variant: openssl
+          arch: arm64
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -796,9 +796,10 @@ jobs:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the tag of the self-hosted runner (and of the testapps to run),
         # and the OS that the testapps were built on originally.
-        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64}}'
+        - runner_tag: '${{ needs.check_and_prepare.outputs.runner_tag_mac_arm64 }}'
           # Only run the steps if build_os was included in the list of target OSes.
           build_os: macos-latest
+          arch: arm64
     steps:
       - name: Clean up previous run
         shell: bash
@@ -820,8 +821,35 @@ jobs:
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
         run: |
+          if [[ '${{ runner.os }}' == "macOS" ]]; then
+            echo "Creating temporary keychain"
+            # Create a local keychain on Mac:
+            # Clean up previous temp keychain, if any.
+            security delete-keychain tmp-keychain || true
+            # Create temp keychain file.
+            security create-keychain -p "${{ secrets.TEST_SECRET }}" tmp-keychain
+            # Change the keychain list to the temp keychain.
+            security list-keychains -d user -s tmp-keychain
+            # Remove unlock timeout for temp keychain.
+            security set-keychain-settings tmp-keychain
+            # Unlock the keychain.
+            security unlock-keychain "${{ secrets.TEST_SECRET }}" tmp-keychain
+
+            # Use arch -arm64 prefix to ensure running on arm64.
+            cmd_prefix="arch -${{ matrix.arch }}"
+          fi
+          # Restore google-services files.
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
-          arch -arm64 python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}"
+          set -x
+          ${cmd_prefix} python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_tag }}-${{ matrix.ssl_variant }}"
+          set +x
+          if [[ '${{ runner.os }}' == 'macOS' ]]; then
+            # Remove the local keychain on Mac:
+            # Set back to the default login keychain.
+            security list-keychains -d user -s login.keychain
+            # Delete the keychain.
+            security delete-keychain tmp-keychain
+          fi
       - name: Prepare results summary artifact
         if: ${{ !cancelled() && contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -782,7 +782,6 @@ jobs:
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
         needs.check_and_prepare.outputs.apis != '' &&
-        (github.event_name == 'workflow_dispatch' || github.event_name == 'schedule') &&
         !cancelled() &&
         !failure()
     strategy:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -871,6 +871,9 @@ jobs:
           if [[ '${{ matrix.runner_label }}' == '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}' ]]; then
             # Mac ARM64 only: Use arch -arm64 prefix to ensure that the app is running on arm64.
             cmd_prefix='arch -arm64'
+            # ARM Mac requires a firestore.json to specify the host as 127.0.0.1 rather than localhost.
+            # Otherwise the Firestore emulator cannot connect, probably because localhost is ipv6.
+            echo '{"emulators":{"firestore":{"port":"8080","host":"127.0.0.1"}}}' > firebase.json
           fi
           set -x
           ${cmd_prefix} firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}"'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -780,7 +780,7 @@ jobs:
       build_os: ${{ matrix.build_os }}
     if: |
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
+        contains(needs.check_and_prepare.outputs.matrix_os, '${{ env.build_os }}') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -799,7 +799,7 @@ jobs:
   test_desktop_custom_runners:
     name: test-desktop-custom-${{ matrix.runner_label }}-${{ matrix.ssl_variant }}
     needs: [check_and_prepare, build_desktop]
-    runs-on: [self-hosted, '${{ matrix.runner_label }}' ]
+    runs-on: [self-hosted, firebase-cpp, '${{ matrix.runner_label }}' ]
     # Unfortunately, we can't use matrix.build_os in the contains() expressions
     # below. If we ever have other self-hosted runner OSes, we'll need to modify
     # the 'if' here to include other platforms.
@@ -813,15 +813,17 @@ jobs:
       fail-fast: false
       matrix:
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
+        build_os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
         include:
         # Unlike the other matrices, we don't set a matrix.os here. Instead,
         # specify the label for the self-hosted runner. This should be the
         # same as the label used in the artifact name in build_desktop above.
-        - runner_label: '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}'
-          # Also specify the OS that the testapps were built on originally.
-          # (We won't run any tests unless that OS was included in the build matrix.)
-          build_os: macos-latest
+        - build_os: macos-latest
+          runner_label: '${{ needs.check_and_prepare.outputs.runner_label_mac_arm64 }}'
         exclude:
+        # No custom tests for Linux or Windows ... for now.
+        - build_os: ubuntu-latest
+        - build_os: windows-latest
         # Until we support building openssl from source, we can't link to system
         # openssl when cross-compiling, so exclude openssl from mac arm64 testing.
         - build_os: macos-latest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -776,13 +776,11 @@ jobs:
     needs: [check_and_prepare, build_desktop]
     runs-on: [self-hosted, macOS, ${{ matrix.os }}]
     if: |
-      ${{
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
         contains(needs.check_and_prepare.outputs.matrix_os, 'macos-latest') &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled()
-      }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -861,7 +861,10 @@ jobs:
       - name: Restore google-services files
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash
-        run: python scripts/gha/restore_secrets.py --passphrase '${{ secrets.TEST_SECRET }}' --artifact testapps
+        run: |
+          python scripts/gha/restore_secrets.py --passphrase_file=- --artifact testapps <<EOF
+          ${{ secrets.TEST_SECRET }}
+          EOF
       - name: Run Desktop integration tests
         if: ${{ contains(needs.check_and_prepare.outputs.matrix_os, matrix.build_os) }}
         shell: bash

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -789,6 +789,9 @@ jobs:
         os: [ macosarm-selfhosted ]
         ssl_variant: ${{ fromJson(needs.check_and_prepare.outputs.matrix_ssl) }}
     steps:
+      - name: Clear directory
+        shell: bash
+        run: rm -rf firebase-cpp-sdk testapps
       - uses: actions/checkout@v2
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -777,8 +777,7 @@ jobs:
     runs-on: [self-hosted, '${{ matrix.os }}' ]
     if: |
         contains(needs.check_and_prepare.outputs.matrix_platform, 'Desktop') &&
-        contains(needs.check_and_prepare.outputs.matrix_os,
-                 jobs.test_desktop_macos_arm.strategy.matrix.build_os) &&
+        contains(needs.check_and_prepare.outputs.matrix_os, job.strategy.matrix.build_os) &&
         github.event_name == 'workflow_dispatch' &&
         needs.check_and_prepare.outputs.apis != '' &&
         !cancelled() &&

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -120,7 +120,8 @@ PARAMETERS = {
       MINIMAL_KEY: {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
-        "apis": "firestore"
+        "apis": "firestore",
+        "architecture_macos": ["x64"],
       },
 
       EXPANDED_KEY: {
@@ -128,6 +129,7 @@ PARAMETERS = {
         "android_device": ["android_target", "android_latest", "emulator_target", "emulator_latest", "emulator_32bit"],
         "ios_device": ["ios_min", "ios_target", "ios_latest", "simulator_min", "simulator_target", "simulator_latest"],
         "tvos_device": ["tvos_simulator"],
+        "architecture_macos": ["x64", "arm64"]
       }
     },
     "config": {

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -132,7 +132,7 @@ PARAMETERS = {
       }
     },
     "config": {
-      "apis": "admob,analytics,auth,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
+      "apis": "auth", #admob,analytics,auth,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
       "mobile_test_on": "real,virtual"
     }
   },

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -121,7 +121,6 @@ PARAMETERS = {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
         "apis": "firestore",
-        "architecture_macos": ["x64"],
       },
 
       EXPANDED_KEY: {

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -108,7 +108,7 @@ PARAMETERS = {
       "tvos_device": ["tvos_simulator"],
       "build_type": ["Debug"],
       "architecture_windows_linux": ["x64"],
-      "architecture_macos": ["x64", "arm64"],
+      "architecture_macos": ["x64"],
       "msvc_runtime": ["dynamic"],
       "cpp_compiler_windows": ["VisualStudio2019"],
       "cpp_compiler_linux": ["clang-11.0"],

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -120,7 +120,7 @@ PARAMETERS = {
       MINIMAL_KEY: {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
-        "apis": "firestore",
+        "apis": "firestore"
       },
 
       EXPANDED_KEY: {
@@ -128,7 +128,7 @@ PARAMETERS = {
         "android_device": ["android_target", "android_latest", "emulator_target", "emulator_latest", "emulator_32bit"],
         "ios_device": ["ios_min", "ios_target", "ios_latest", "simulator_min", "simulator_target", "simulator_latest"],
         "tvos_device": ["tvos_simulator"],
-        "architecture_macos": ["x64", "arm64"],
+        "architecture_macos": ["x64", "arm64"]
       }
     },
     "config": {

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -108,7 +108,7 @@ PARAMETERS = {
       "tvos_device": ["tvos_simulator"],
       "build_type": ["Debug"],
       "architecture_windows_linux": ["x64"],
-      "architecture_macos": ["x64"],
+      "architecture_macos": ["x64", "arm64"],
       "msvc_runtime": ["dynamic"],
       "cpp_compiler_windows": ["VisualStudio2019"],
       "cpp_compiler_linux": ["clang-11.0"],
@@ -121,6 +121,9 @@ PARAMETERS = {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
         "apis": "firestore",
+        # Ensure only one architecture is built.
+        "architecture_windows_linux": ["x64"],
+        "architecture_macos": ["x64"],
       },
 
       EXPANDED_KEY: {
@@ -128,7 +131,6 @@ PARAMETERS = {
         "android_device": ["android_target", "android_latest", "emulator_target", "emulator_latest", "emulator_32bit"],
         "ios_device": ["ios_min", "ios_target", "ios_latest", "simulator_min", "simulator_target", "simulator_latest"],
         "tvos_device": ["tvos_simulator"],
-        "architecture_macos": ["x64", "arm64"]
       }
     },
     "config": {

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -132,7 +132,7 @@ PARAMETERS = {
       }
     },
     "config": {
-      "apis": "auth", #admob,analytics,auth,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
+      "apis": "admob,analytics,auth,database,dynamic_links,firestore,functions,installations,messaging,remote_config,storage",
       "mobile_test_on": "real,virtual"
     }
   },
@@ -155,6 +155,7 @@ BUILD_CONFIGS = {
   "windows": ["ssl_lib", "build_type", "architecture_windows_linux", "msvc_runtime", "cpp_compiler_windows"],
   "ubuntu": ["ssl_lib", "build_type", "architecture_windows_linux", "cpp_compiler_linux"],
   "macos": ["ssl_lib", "architecture_macos", "xcode_version"],
+  "macosarm": ["ssl_lib", "architecture_macos", "xcode_version"],
   "android": ["os", "ndk_version", "build_tools", "platform_version", "android_device"],
   "ios": ["os", "xcode_version", "ios_device"],
   "tvos": ["os", "xcode_version", "tvos_device"]

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -108,7 +108,7 @@ PARAMETERS = {
       "tvos_device": ["tvos_simulator"],
       "build_type": ["Debug"],
       "architecture_windows_linux": ["x64"],
-      "architecture_macos": ["x64", "arm64"],
+      "architecture_macos": ["x64"],
       "msvc_runtime": ["dynamic"],
       "cpp_compiler_windows": ["VisualStudio2019"],
       "cpp_compiler_linux": ["clang-11.0"],
@@ -121,9 +121,6 @@ PARAMETERS = {
         "os": ["ubuntu-latest"],
         "platform": ["Desktop"],
         "apis": "firestore",
-        # Ensure only one architecture is built.
-        "architecture_windows_linux": ["x64"],
-        "architecture_macos": ["x64"],
       },
 
       EXPANDED_KEY: {
@@ -131,6 +128,7 @@ PARAMETERS = {
         "android_device": ["android_target", "android_latest", "emulator_target", "emulator_latest", "emulator_32bit"],
         "ios_device": ["ios_min", "ios_target", "ios_latest", "simulator_min", "simulator_target", "simulator_latest"],
         "tvos_device": ["tvos_simulator"],
+        "architecture_macos": ["x64", "arm64"],
       }
     },
     "config": {

--- a/scripts/gha/restore_secrets.py
+++ b/scripts/gha/restore_secrets.py
@@ -22,7 +22,7 @@ python restore_secrets.py --passphrase_file [--repo_dir <path_to_repo>]
 --passphrase: Passphrase to decrypt the files. This option is insecure on a
     multi-user machine; use the --passphrase_file option instead.
 --passphrase_file: Specify a file to read the passphrase from (only reads the
-    first line).
+    first line). Use "-" (without quotes) for stdin.
 --repo_dir: Path to C++ SDK Github repository. Defaults to current directory.
 
 This script will perform the following:
@@ -48,7 +48,8 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string("repo_dir", os.getcwd(), "Path to C++ SDK Github repo.")
 flags.DEFINE_string("passphrase", None, "The passphrase itself.")
-flags.DEFINE_string("passphrase_file", None, "Path to file with passphrase.")
+flags.DEFINE_string("passphrase_file", None,
+                    "Path to file with passphrase. Use \"-\" (without quotes) for stdin.")
 flags.DEFINE_string("artifact", None, "Artifact Path, google-services.json will be placed here.")
 
 
@@ -60,6 +61,8 @@ def main(argv):
   # The passphrase is sensitive, do not log.
   if FLAGS.passphrase:
     passphrase = FLAGS.passphrase
+  elif FLAGS.passphrase_file == "-":
+    passphrase = input()
   elif FLAGS.passphrase_file:
     with open(FLAGS.passphrase_file, "r") as f:
       passphrase = f.readline().strip()


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

If running tests against the expanded matrix, it will build an ARM64 version of the integration tests, and run it on an M1 Mac GitHub runner that we host ourselves.

For security purposes, this job does not use any third-party marketplace actions, nor does it pass in secrets on the command line.

The test_desktop_custom_runner step is written as generically as possible to support other custom runners we may add in the future.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Run integration-tests workflow on the expanded matrix. This works both on prebuilt SDK and from source.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
