### PR TITLE
GMA - Fix Error in JNI method invocation on BannerView destruction

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -677,6 +677,7 @@ TEST_F(FirebaseGmaTest, TestBannerViewLoadAd) {
                                        kBannerAdUnit, banner_ad_size),
                     "Initialize");
   WaitForCompletion(banner->LoadAd(GetAdRequest()), "LoadAd");
+  WaitForCompletion(banner->Destroy(), "Destroy");
   delete banner;
 }
 
@@ -904,7 +905,18 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadAndShow) {
   delete rewarded;
 }
 
-// Other Banner View Tests
+// Other Banner View Tests.
+TEST_F(FirebaseGmaTest, TestBannerViewLoadAdDestroyNotCalled) {
+  SKIP_TEST_ON_DESKTOP;
+
+  const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+  firebase::gma::BannerView* banner = new firebase::gma::BannerView();
+  WaitForCompletion(banner->Initialize(app_framework::GetWindowContext(),
+                                       kBannerAdUnit, banner_ad_size),
+                    "Initialize");
+  WaitForCompletion(banner->LoadAd(GetAdRequest()), "LoadAd");
+  delete banner;
+}
 
 TEST_F(FirebaseGmaTest, TestBannerView) {
   TEST_REQUIRES_USER_INTERACTION;

--- a/gma/src/android/banner_view_internal_android.cc
+++ b/gma/src/android/banner_view_internal_android.cc
@@ -145,8 +145,13 @@ BannerViewInternalAndroid::BannerViewInternalAndroid(BannerView* base)
 
 BannerViewInternalAndroid::~BannerViewInternalAndroid() {
   firebase::MutexLock lock(mutex_);
-  JNIEnv* env = ::firebase::gma::GetJNI();
+  if (!destroyed_) {
+    LogWarning(
+        "Warning: AdView destructor invoked before the application "
+        " called Destroy() on the object. A Memory Leak may occur.");
+  }
 
+  JNIEnv* env = ::firebase::gma::GetJNI();
   env->DeleteGlobalRef(ad_view_);
   ad_view_ = nullptr;
 

--- a/gma/src/android/banner_view_internal_android.cc
+++ b/gma/src/android/banner_view_internal_android.cc
@@ -144,13 +144,6 @@ BannerViewInternalAndroid::~BannerViewInternalAndroid() {
   firebase::MutexLock lock(mutex_);
   JNIEnv* env = ::firebase::gma::GetJNI();
 
-  // The application should have invoked Destroy already, but
-  // invoke it now just in case they haven't in the hope that
-  // we can prevent leaking memory.
-  env->CallVoidMethod(
-      helper_, banner_view_helper::GetMethodId(banner_view_helper::kDestroy),
-      /*callbackDataPtr=*/nullptr, /*destructor_invocation=*/true);
-
   env->DeleteGlobalRef(ad_view_);
   ad_view_ = nullptr;
 

--- a/gma/src/android/banner_view_internal_android.cc
+++ b/gma/src/android/banner_view_internal_android.cc
@@ -107,7 +107,10 @@ struct NulleryInvocationOnMainThreadData {
 };
 
 BannerViewInternalAndroid::BannerViewInternalAndroid(BannerView* base)
-    : BannerViewInternal(base), helper_(nullptr), initialized_(false) {
+    : BannerViewInternal(base),
+      helper_(nullptr),
+      initialized_(false),
+      destroyed_(false) {
   firebase::MutexLock lock(mutex_);
 
   JNIEnv* env = ::firebase::gma::GetJNI();
@@ -378,6 +381,7 @@ Future<void> BannerViewInternalAndroid::Resume() {
 
 Future<void> BannerViewInternalAndroid::Destroy() {
   firebase::MutexLock lock(mutex_);
+  destroyed_ = true;
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kBannerViewFnDestroy, &future_data_);
   Future<void> future =

--- a/gma/src/android/banner_view_internal_android.h
+++ b/gma/src/android/banner_view_internal_android.h
@@ -99,6 +99,9 @@ class BannerViewInternalAndroid : public BannerViewInternal {
   // Mutex to guard against concurrent operations;
   Mutex mutex_;
 
+  // Marks if Destroy() was called on the object.
+  bool destroyed_;
+
   // Convenience method to "dry" the JNI calls that don't take parameters beyond
   // the future callback pointer.
   Future<void> InvokeNullary(BannerViewFn fn,

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -945,6 +945,13 @@ void JNI_BannerViewHelper_notifyAdPaidEvent(JNIEnv* env, jclass clazz,
   internal->NotifyListenerOfPaidEvent(ad_value);
 }
 
+void JNI_BannerViewHelper_releaseGlobalReference(JNIEnv* env, jclass clazz,
+                                                 jlong data_ptr) {
+  FIREBASE_ASSERT(data_ptr);
+  jobject ad_view = reinterpret_cast<jobject>(data_ptr);
+  env->DeleteGlobalRef(ad_view);
+}
+
 // JNI functions specific to RewardedAds
 //
 void JNI_RewardedAd_UserEarnedReward(JNIEnv* env, jclass clazz, jlong data_ptr,
@@ -982,7 +989,8 @@ bool RegisterNatives() {
        reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdOpened)},
       {"notifyPaidEvent", "(JLjava/lang/String;IJ)V",
        reinterpret_cast<void*>(&JNI_BannerViewHelper_notifyAdPaidEvent)},
-  };
+      {"releaseBannerViewGlobalReferenceCallback", "(J)V",
+       reinterpret_cast<void*>(&JNI_BannerViewHelper_releaseGlobalReference)}};
   static const JNINativeMethod kInterstitialMethods[] = {
       {"completeInterstitialAdFutureCallback", "(JILjava/lang/String;)V",
        reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},

--- a/gma/src/include/firebase/gma/banner_view.h
+++ b/gma/src/include/firebase/gma/banner_view.h
@@ -173,6 +173,8 @@ class BannerView : public AdView {
   Future<void> ResumeLastResult() const override;
 
   /// Cleans up and deallocates any resources used by the @ref BannerView.
+  /// You must call this asynchronous operation before this object's destructor
+  /// is invoked or risk leaking device resources.
   Future<void> Destroy() override;
 
   /// Returns a @ref Future containing the status of the last call to

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/BannerViewHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/BannerViewHelper.java
@@ -170,11 +170,12 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
             mBannerViewInternalPtr = CPP_NULLPTR;
           }
           mActivity = null;
-
-          // BannerView's C++ destructor does not pass a future
-          // to callback and complete, since that would cause the destructor
-          // to block.
-          if (callbackDataPtr != CPP_NULLPTR) {
+          if (destructor_invocation) {
+            // BannerView's C++ destructor does not pass a future
+            // to callback and complete, but the reference to this object
+            // which should be released.
+            releaseBannerViewGlobalReferenceCallback(callbackDataPtr);
+          } else {
             completeBannerViewFutureCallback(callbackDataPtr, ConstantsHelper.CALLBACK_ERROR_NONE,
                 ConstantsHelper.CALLBACK_ERROR_MESSAGE_NONE);
           }
@@ -592,6 +593,12 @@ public class BannerViewHelper implements ViewTreeObserver.OnPreDrawListener {
    */
   public static native void completeBannerViewFutureCallback(
       long nativeInternalPtr, int errorCode, String errorMessage);
+
+  /**
+   * Native callback to instruct the C++ wrapper to release its global reference on this
+   * object.
+   */
+  public static native void releaseBannerViewGlobalReferenceCallback(long nativeInternalPtr);
 
   /**
    * Native callback invoked upon successfully loading an ad.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

There were stability issues when calling a JNI method and then immediately removing the global reference.  This manifested in JNI corruption errors on simulators.  

The previous BannerView destructor attempted to protect developers from accidentally leaking resources if the BannerView's destructor was called before the Destroy() method was invoked.  Our protected caused JNI assertions in simulators where the JNI parameters were corrupted.  I assume this was due to the  JNI object reference being deleted admist an asynchronous operation.

Therefore this change removes the attempt o invoke the JNI Destroy() method in the destructor on Android.  BannerView's header comments are updated to explicitly state that Destroy should be invoked before the C++ object's destructor is called.  Additionally log a warning if this scenario occurs.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


* Local Simulator Testing
* [Integration CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1680038278)
* [Packaging CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1680041167) and its [Integration Tests](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1680392713)

***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
