### PR TITLE
Increase Maven Connection Stability in GHA Android Builds

### DIFF
--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -57,9 +57,11 @@ set +e
 # Retry the build up to 10 times, because the build fetches files from
 # maven and elsewhere, and occasionally the GitHub runners have
 # network connectivity issues that cause the download to fail.
+gradleparams="-Dhttp.keepAlive=false -Dmaven.wagon.http.pool=false\
+ -Dmaven.wagon.httpconnectionManager.ttlSeconds=120"
 for retry in {1..10} error; do
     if [[ $retry == "error" ]]; then exit 5; fi
-    ./gradlew assembleRelease && break
+    ./gradlew assembleRelease "${gradleparams}" && break
     sleep 300
 done
 set -e

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -483,6 +483,9 @@ def _build_android(project_dir, sdk_dir):
   gradle_properties = os.path.join(project_dir, "gradle.properties")
   with open(gradle_properties, "a+") as f:
     f.write("systemProp.firebase_cpp_sdk.dir=" + sdk_dir + "\n")
+    f.write("http.keepAlive=false\n")
+    f.write("maven.wagon.http.pool=false\n")
+    f.write("maven.wagon.httpconnectionManager.ttlSeconds=120")
   # This will log the versions of dependencies for debugging purposes.
   _run([gradlew, "dependencies", "--configuration", "debugCompileClasspath"])
   _run([gradlew, "assembleDebug", "--stacktrace"])


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Attempt to reduce Android CI build flake caused by network connection timeouts to the Maven repo.

Following instructions from the [GHA Github Repo Issues forum](https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080). The fix seems to be very popular with 34 other closed issues referencing it.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1725527077)
[Packaging CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1725702547) -> [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1726082882)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
