### PR TITLE
Test/gma ndk update

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -450,6 +450,8 @@ jobs:
             build_scripts/android/install_prereqs.sh
             pip install -r scripts/gha/requirements.txt
             python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
+            ls -l /tmp/android-ndk-r19
+            ls -l /tmp
       - name: Fetch prebuilt packaged SDK from previous run
         uses: dawidd6/action-download-artifact@v2
         if: ${{ github.event.inputs.test_packaged_sdk != '' }}

--- a/admob/admob_resources/AndroidManifest.xml
+++ b/admob/admob_resources/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.FirebaseCppSdkBuild">
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-sdk android:minSdkVersion="3"/>
+  <uses-sdk android:minSdkVersion="16"/>
 </manifest>

--- a/app/integration_test/LibraryManifest.xml
+++ b/app/integration_test/LibraryManifest.xml
@@ -18,6 +18,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.android.analytics.testapp.lib" >
 
-    <uses-sdk android:minSdkVersion='14'/>
+    <uses-sdk android:minSdkVersion='16'/>
     <application />
 </manifest>

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -102,3 +102,12 @@ set -e
 (cd /tmp && unzip -oq android-ndk-r19.zip && rm -f android-ndk-r19.zip)
 echo "NDK r19 has been downloaded into /tmp/android-ndk-r19"
 
+echo "Copying older NDK libs to new NDK download"
+echo "android 15"
+cp -r /tmp/android-ndk-r16b/platforms/android-15 /tmp/android-ndk-r19/platforms/android-15 
+ls -l /tmp/android-ndk-r19/platforms/android-15
+
+echo "android 14"
+cp -r /tmp/android-ndk-r16b/platforms/android-14 /tmp/android-ndk-r19/platforms/android-14 
+ls -l /tmp/android-ndk-r19/platforms/android-14
+echo "Done!"

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -89,15 +89,16 @@ fi
 
 # Retry up to 10 times because Curl has a tendency to timeout on
 # Github runners.
+echo "Download NDK r19"
 for retry in {1..10} error; do
     if [[ $retry == "error" ]]; then exit 5; fi
     curl --http1.1 -LSs \
     "https://dl.google.com/android/repository/android-ndk-r19-${platform}-x86_64.zip" \
-    --output /tmp/android-ndk-r22.zip && break
+    --output /tmp/android-ndk-r19.zip && break
     sleep 300
 done
 
 set -e
-(cd /tmp && unzip -oq android-ndk-r22.zip && rm -f android-ndk-r22.zip)
+(cd /tmp && unzip -oq android-ndk-r19.zip && rm -f android-ndk-r19.zip)
 echo "NDK r19 has been downloaded into /tmp/android-ndk-r19"
 

--- a/build_scripts/android/install_prereqs.sh
+++ b/build_scripts/android/install_prereqs.sh
@@ -86,3 +86,18 @@ if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 16\." "${NDK_ROOT}/source.p
 	    echo "NDK r16b has been downloaded into /tmp/android-ndk-r16b"
     fi
 fi
+
+# Retry up to 10 times because Curl has a tendency to timeout on
+# Github runners.
+for retry in {1..10} error; do
+    if [[ $retry == "error" ]]; then exit 5; fi
+    curl --http1.1 -LSs \
+    "https://dl.google.com/android/repository/android-ndk-r19-${platform}-x86_64.zip" \
+    --output /tmp/android-ndk-r22.zip && break
+    sleep 300
+done
+
+set -e
+(cd /tmp && unzip -oq android-ndk-r22.zip && rm -f android-ndk-r22.zip)
+echo "NDK r19 has been downloaded into /tmp/android-ndk-r19"
+

--- a/firestore/firestore_resources/AndroidManifest.xml
+++ b/firestore/firestore_resources/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.FirebaseCppSdkBuild">
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-sdk android:minSdkVersion="3"/>
+  <uses-sdk android:minSdkVersion="16"/>
 </manifest>

--- a/gma/gma_resources/AndroidManifest.xml
+++ b/gma/gma_resources/AndroidManifest.xml
@@ -2,5 +2,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
           package="com.google.FirebaseCppSdkBuild">
   <uses-permission android:name="android.permission.INTERNET"/>
-  <uses-sdk android:minSdkVersion="3"/>
+  <uses-sdk android:minSdkVersion="16"/>
 </manifest>

--- a/gma/integration_test/local.properties
+++ b/gma/integration_test/local.properties
@@ -1,0 +1,1 @@
+ndk.dir=/tmp/android-ndk-r19

--- a/messaging/AndroidManifest.xml
+++ b/messaging/AndroidManifest.xml
@@ -3,7 +3,7 @@
           package="${applicationId}"
           android:versionCode="1"
           android:versionName="1.0">
-  <uses-sdk android:minSdkVersion="10" />
+  <uses-sdk android:minSdkVersion="16" />
   <uses-permission android:name="android.permission.WAKE_LOCK" />
   <uses-permission android:name="com.google.android.c2dm.permission.RECEIVE" />
 

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -507,18 +507,18 @@ def _validate_android_environment_variables():
   # Different environments may have different NDK env vars specified. We look
   # for these, in this order, and set the others to the first found.
   # If none are set, we check the default location for the ndk.
-  ndk_path = None
+  ndk_path = "/tmp/android-ndk-r19"
   ndk_vars = [_NDK_ROOT, _ANDROID_NDK_HOME]
-  for env_var in ndk_vars:
-    val = os.environ.get(env_var)
-    if val:
-      ndk_path = val
-      break
-  if not ndk_path:
-    if android_home:
-      default_ndk_path = os.path.join(android_home, "ndk-bundle")
-      if os.path.isdir(default_ndk_path):
-        ndk_path = default_ndk_path
+  #for env_var in ndk_vars:
+  #  val = os.environ.get(env_var)
+  #  if val:
+  #    ndk_path = val
+  #    break
+  #if not ndk_path:
+  #  if android_home:
+  #    default_ndk_path = os.path.join(android_home, "ndk-bundle")
+  #    if os.path.isdir(default_ndk_path):
+  #      ndk_path = default_ndk_path
   if ndk_path:
     logging.info("Found ndk: %s", ndk_path)
     for env_var in ndk_vars:

--- a/testing/templates/ActivityManifest.xml.tmpl
+++ b/testing/templates/ActivityManifest.xml.tmpl
@@ -3,7 +3,7 @@
     package="com.google.firebase.test"
     android:versionCode="1"
     android:versionName="1.0.0">
-  <uses-sdk android:targetSdkVersion="25" android:minSdkVersion="14" />
+  <uses-sdk android:targetSdkVersion="25" android:minSdkVersion="16" />
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
   <application
       android:allowBackup="false"


### PR DESCRIPTION
Attempt to use a newer NDK.
For some reason gradle thinks that the NDK doesn't have a platforms directory, but running `ls` on the downloaded archive in `tmp` reveals that it does.

[Integration Test Run](https://github.com/firebase/firebase-cpp-sdk/runs/4928877576?check_suite_focus=true)