### PR TITLE
firebase::gma::SetIsSameAppKeyEnabled

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -359,6 +359,13 @@ TEST_F(FirebaseGmaPreInitializationTests, TestDisableSDKCrashReporting) {
   firebase::gma::DisableSDKCrashReporting();
 }
 
+TEST_F(FirebaseGmaTest, TestSetAppKeyEnabled) {
+  // We can't test to see if this method successfully enables/disables
+  // the app key, but we're still calling it as a sanity check and to
+  // ensure the symbol exists in the library.
+  firebase::gma::SetIsSameAppKeyEnabled(true);
+}
+
 TEST_F(FirebaseGmaTest, TestGetAdRequest) { GetAdRequest(); }
 
 TEST_F(FirebaseGmaTest, TestGetAdRequestValues) {

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -656,6 +656,8 @@ void OpenAdInspector(AdParent parent, AdInspectorClosedListener* listener) {
   util::RunOnMainThread(env, g_activity, CallOpenAdInspector, call_data);
 }
 
+void SetIsSameAppKeyEnabled(bool is_enabled) {}
+
 // Release classes registered by this module.
 void ReleaseClasses(JNIEnv* env) {
   mobile_ads::ReleaseClass(env);

--- a/gma/src/include/firebase/gma.h
+++ b/gma/src/include/firebase/gma.h
@@ -162,6 +162,18 @@ RequestConfiguration GetRequestConfiguration();
 /// the ad inspector UI. Initialize must be called prior to this function.
 void OpenAdInspector(AdParent parent, AdInspectorClosedListener* listener);
 
+/// Controls whether the Google Mobile Ads SDK Same App Key is enabled.
+///
+/// This function must be invoked after GMA has been initialized. The value set
+/// persists across app sessions. The key is enabled by default.
+///
+/// This operation is supported on iOS only.  This is a no-op on Android
+/// systems.
+///
+/// @param[in] is_enabled whether the Google Mobile Ads SDK Same App Key is
+/// enabled.
+void SetIsSameAppKeyEnabled(bool is_enabled);
+
 /// @brief Terminate GMA.
 ///
 /// Frees resources associated with GMA that were allocated during

--- a/gma/src/ios/gma_ios.mm
+++ b/gma/src/ios/gma_ios.mm
@@ -249,6 +249,16 @@ void OpenAdInspector(AdParent ad_parent, AdInspectorClosedListener* listener) {
   });  
 }
 
+void SetIsSameAppKeyEnabled(bool is_enabled) {
+  dispatch_async(dispatch_get_main_queue(), ^{
+    if(is_enabled) {
+      [GADMobileAds.sharedInstance.requestConfiguration setSameAppKeyEnabled:YES];
+    } else {
+      [GADMobileAds.sharedInstance.requestConfiguration setSameAppKeyEnabled:NO];
+    }
+  });
+}
+
 Future<AdapterInitializationStatus> InitializeLastResult() {
   MutexLock lock(g_future_impl_mutex);
   return g_future_impl ? static_cast<const Future<AdapterInitializationStatus>&>(

--- a/gma/src/stub/gma_stub.cc
+++ b/gma/src/stub/gma_stub.cc
@@ -114,6 +114,7 @@ RequestConfiguration GetRequestConfiguration() {
 }
 
 void OpenAdInspector(AdParent parent, AdInspectorClosedListener* listener) {}
+void SetIsSameAppKeyEnabled(bool is_enabled) {}
 
 void Terminate() {
   FIREBASE_ASSERT(g_initialized);


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add a method for iOS Apps to toggle IsSameAppKeyEnabled.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1746988331)
[Packaging CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1746989289) -> [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1747429283)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***