### PR TITLE
Disable logging during AddCallback, which initializes too early.

### DIFF
--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -227,13 +227,7 @@ void AppCallback::AddCallback(AppCallback* callback) {
   }
   std::string name = callback->module_name();
   if (callbacks_->find(name) != callbacks_->end()) {
-    LogWarning(
-        "%s is already registered for callbacks on app initialization,  "
-        "ignoring.",
-        name.c_str());
   } else {
-    LogDebug("Registered app initializer %s (enabled: %d)", name.c_str(),
-             callback->enabled() ? 1 : 0);
     (*callbacks_)[name] = callback;
   }
 }


### PR DESCRIPTION
This causes logging to initialize when static constructors are running.
On Xcode 13, this causes a crash when Firebase App is initialized in
the wrong order.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
