### PR TITLE
GMA  AdView::ad_size()

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -1003,27 +1003,27 @@ TEST_F(FirebaseGmaTest, TestAdViewAdSizeCompareOp) {
   EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
               AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
   EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
-              AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
+               AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
 
   EXPECT_TRUE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
   EXPECT_FALSE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) !=
+               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+
+  EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+  EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
 
   EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
-               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+               AdSize(100, 100));
   EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
-               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+              AdSize(100, 100));
 
-  EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
-               AdSize(100, 100));
-  EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
-               AdSize(100, 100));
-  
   EXPECT_FALSE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
                AdSize(100, 100));
   EXPECT_TRUE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) !=
-               AdSize(100, 100));
+              AdSize(100, 100));
 }
 
 TEST_F(FirebaseGmaTest, TestAdViewDestroyBeforeInitialization) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -987,6 +987,44 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdDestroyNotCalled) {
   WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
   delete ad_view;
 }
+
+TEST_F(FirebaseGmaTest, TestAdViewAdSizeCompareOp) {
+  using firebase::gma::AdSize;
+  EXPECT_TRUE(AdSize(50, 100) == AdSize(50, 100));
+  EXPECT_TRUE(AdSize(100, 50) == AdSize(100, 50));
+
+  EXPECT_FALSE(AdSize(10, 10) == AdSize(50, 50));
+
+  EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+              AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
+
+  EXPECT_TRUE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
+              AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+
+  EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+
+  EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize(100, 100));
+  EXPECT_FALSE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize(100, 100));
+}
+
+TEST_F(FirebaseGmaTest, TestAdViewDestroyBeforeInitialization) {
+  SKIP_TEST_ON_DESKTOP;
+  firebase::gma::AdView* ad_view = new firebase::gma::AdView();
+  WaitForCompletion(ad_view->Destroy(), "Destroy AdView");
+}
+
+TEST_F(FirebaseGmaTest, TestAdViewAdSizeBeforeInitialization) {
+  SKIP_TEST_ON_DESKTOP;
+  firebase::gma::AdView* ad_view = new firebase::gma::AdView();
+  const firebase::gma::AdSize& ad_size = firebase::gma::AdSize(0, 0);
+  EXPECT_TRUE(ad_view->ad_size() == ad_size);
+
+  WaitForCompletion(ad_view->Destroy(), "Destroy AdView");
+}
+
 TEST_F(FirebaseGmaTest, TestAdView) {
   TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
@@ -996,6 +1034,7 @@ TEST_F(FirebaseGmaTest, TestAdView) {
   WaitForCompletion(ad_view->Initialize(app_framework::GetWindowContext(),
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
+  EXPECT_TRUE(ad_view->ad_size() == banner_ad_size);
 
   // Set the listener.
   TestBoundingBoxListener bounding_box_listener;

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -992,21 +992,37 @@ TEST_F(FirebaseGmaTest, TestAdViewAdSizeCompareOp) {
   using firebase::gma::AdSize;
   EXPECT_TRUE(AdSize(50, 100) == AdSize(50, 100));
   EXPECT_TRUE(AdSize(100, 50) == AdSize(100, 50));
-
+  EXPECT_FALSE(AdSize(50, 100) == AdSize(100, 50));
   EXPECT_FALSE(AdSize(10, 10) == AdSize(50, 50));
 
+  EXPECT_FALSE(AdSize(50, 100) != AdSize(50, 100));
+  EXPECT_FALSE(AdSize(100, 50) != AdSize(100, 50));
+  EXPECT_TRUE(AdSize(50, 100) != AdSize(100, 50));
+  EXPECT_TRUE(AdSize(10, 10) != AdSize(50, 50));
+
   EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+              AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
+  EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
               AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100));
 
   EXPECT_TRUE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+  EXPECT_FALSE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) !=
+              AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
 
   EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
+  EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
                AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100));
 
   EXPECT_FALSE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) ==
                AdSize(100, 100));
+  EXPECT_TRUE(AdSize::GetLandscapeAnchoredAdaptiveBannerAdSize(100) !=
+               AdSize(100, 100));
+  
   EXPECT_FALSE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) ==
+               AdSize(100, 100));
+  EXPECT_TRUE(AdSize::GetPortraitAnchoredAdaptiveBannerAdSize(100) !=
                AdSize(100, 100));
 }
 

--- a/gma/src/android/ad_view_internal_android.cc
+++ b/gma/src/android/ad_view_internal_android.cc
@@ -108,6 +108,7 @@ struct NulleryInvocationOnMainThreadData {
 
 AdViewInternalAndroid::AdViewInternalAndroid(AdView* base)
     : AdViewInternal(base),
+      ad_size_(0, 0),
       helper_(nullptr),
       initialized_(false),
       destroyed_(false) {
@@ -265,6 +266,7 @@ Future<void> AdViewInternalAndroid::Initialize(AdParent parent,
   }
 
   initialized_ = true;
+  ad_size_ = size;
 
   FutureCallbackData<void>* callback_data =
       CreateVoidFutureCallbackData(kAdViewFnSetPosition, &future_data_);

--- a/gma/src/android/ad_view_internal_android.h
+++ b/gma/src/android/ad_view_internal_android.h
@@ -84,27 +84,31 @@ class AdViewInternalAndroid : public AdViewInternal {
   Future<void> Resume() override;
   Future<void> Destroy() override;
   bool is_initialized() const override { return initialized_; }
+  const AdSize& ad_size() const override { return ad_size_; }
 
  private:
-  // Reference to the Java helper object used to interact with the Mobile Ads
-  // SDK.
-  jobject helper_;
+  // Convenience method to "dry" the JNI calls that don't take parameters beyond
+  // the future callback pointer.
+  Future<void> InvokeNullary(AdViewFn fn, ad_view_helper::Method method);
 
   // Reference to the Android AdView object used to display AdView ads.
   jobject ad_view_;
+
+  // The AdSize that was used to initialize the ad.
+  AdSize ad_size_;
+
+  // Marks if Destroy() was called on the object.
+  bool destroyed_;
+
+  // Reference to the Java helper object used to interact with the Mobile Ads
+  // SDK.
+  jobject helper_;
 
   // Tracks if this AdView has been initialized.
   bool initialized_;
 
   // Mutex to guard against concurrent operations;
   Mutex mutex_;
-
-  // Marks if Destroy() was called on the object.
-  bool destroyed_;
-
-  // Convenience method to "dry" the JNI calls that don't take parameters beyond
-  // the future callback pointer.
-  Future<void> InvokeNullary(AdViewFn fn, ad_view_helper::Method method);
 };
 
 }  // namespace internal

--- a/gma/src/android/ad_view_internal_android.h
+++ b/gma/src/android/ad_view_internal_android.h
@@ -84,7 +84,7 @@ class AdViewInternalAndroid : public AdViewInternal {
   Future<void> Resume() override;
   Future<void> Destroy() override;
   bool is_initialized() const override { return initialized_; }
-  const AdSize& ad_size() const override { return ad_size_; }
+  AdSize ad_size() const override { return ad_size_; }
 
  private:
   // Convenience method to "dry" the JNI calls that don't take parameters beyond

--- a/gma/src/common/ad_view.cc
+++ b/gma/src/common/ad_view.cc
@@ -202,5 +202,7 @@ BoundingBox AdView::bounding_box() const {
   return internal_->bounding_box();
 }
 
+const AdSize& AdView::ad_size() const { return internal_->ad_size(); }
+
 }  // namespace gma
 }  // namespace firebase

--- a/gma/src/common/ad_view.cc
+++ b/gma/src/common/ad_view.cc
@@ -202,7 +202,7 @@ BoundingBox AdView::bounding_box() const {
   return internal_->bounding_box();
 }
 
-const AdSize& AdView::ad_size() const { return internal_->ad_size(); }
+AdSize AdView::ad_size() const { return internal_->ad_size(); }
 
 }  // namespace gma
 }  // namespace firebase

--- a/gma/src/common/ad_view_internal.h
+++ b/gma/src/common/ad_view_internal.h
@@ -118,7 +118,7 @@ class AdViewInternal {
   virtual bool is_initialized() const = 0;
 
   // Returns the size of the loaded ad.
-  virtual const AdSize& ad_size() const = 0;
+  virtual AdSize ad_size() const = 0;
 
  protected:
   friend class firebase::gma::AdView;

--- a/gma/src/common/ad_view_internal.h
+++ b/gma/src/common/ad_view_internal.h
@@ -117,6 +117,9 @@ class AdViewInternal {
   // Returns if the AdView has been initialized.
   virtual bool is_initialized() const = 0;
 
+  // Returns the size of the loaded ad.
+  virtual const AdSize& ad_size() const = 0;
+
  protected:
   friend class firebase::gma::AdView;
 

--- a/gma/src/include/firebase/gma/ad_view.h
+++ b/gma/src/include/firebase/gma/ad_view.h
@@ -203,6 +203,12 @@ class AdView {
   /// @ref Destroy.
   Future<void> DestroyLastResult() const;
 
+  /// Returns the AdSize of the AdView.
+  ///
+  /// @return An @ref AdSize object representing the size of the ad.  If this
+  /// view has not been initialized then the AdSize will be 0,0.
+  const AdSize& ad_size() const;
+
  protected:
   /// Pointer to a listener for AdListener events.
   AdListener* ad_listener_;

--- a/gma/src/include/firebase/gma/ad_view.h
+++ b/gma/src/include/firebase/gma/ad_view.h
@@ -207,7 +207,7 @@ class AdView {
   ///
   /// @return An @ref AdSize object representing the size of the ad.  If this
   /// view has not been initialized then the AdSize will be 0,0.
-  const AdSize& ad_size() const;
+  AdSize ad_size() const;
 
  protected:
   /// Pointer to a listener for AdListener events.

--- a/gma/src/ios/ad_view_internal_ios.h
+++ b/gma/src/ios/ad_view_internal_ios.h
@@ -52,6 +52,7 @@ class AdViewInternalIOS : public AdViewInternal {
   void set_bounding_box(const BoundingBox& bounding_box) {
     bounding_box_ = bounding_box;
   }
+  const AdSize& ad_size() const override { return ad_size_; }
 
 #ifdef __OBJC__
   void AdViewDidReceiveAd();
@@ -62,23 +63,26 @@ class AdViewInternalIOS : public AdViewInternal {
   /// Contains information to asynchronously complete the LoadAd Future.
   FutureCallbackData<AdResult>* ad_load_callback_data_;
 
-  /// Prevents duplicate invocations of initailize on the AdView.
-  bool initialized_;
+  // The AdSize that was used to initialize the ad.
+  AdSize ad_size_;
 
   /// The FADAdView object. Declared as an "id" type to avoid referencing an
   /// Objective-C++ class in this header.
   id ad_view_;
 
-  // Mutex to guard against concurrent operations;
-  Mutex mutex_;
+  /// A cached bounding box from the last update, accessible for processes
+  /// running on non-UI threads.
+  BoundingBox bounding_box_;
 
   /// A mutex used to handle the destroy behavior, as it is asynchronous,
   /// and needs to be waited on in the destructor.
   Mutex destroy_mutex_;
 
-  /// A cached bounding box from the last update, accessible for processes
-  /// running on non-UI threads.
-  BoundingBox bounding_box_;
+  /// Prevents duplicate invocations of initailize on the AdView.
+  bool initialized_;
+
+  // Mutex to guard against concurrent operations;
+  Mutex mutex_;
 };
 
 }  // namespace internal

--- a/gma/src/ios/ad_view_internal_ios.h
+++ b/gma/src/ios/ad_view_internal_ios.h
@@ -52,7 +52,7 @@ class AdViewInternalIOS : public AdViewInternal {
   void set_bounding_box(const BoundingBox& bounding_box) {
     bounding_box_ = bounding_box;
   }
-  const AdSize& ad_size() const override { return ad_size_; }
+  AdSize ad_size() const override { return ad_size_; }
 
 #ifdef __OBJC__
   void AdViewDidReceiveAd();

--- a/gma/src/ios/ad_view_internal_ios.mm
+++ b/gma/src/ios/ad_view_internal_ios.mm
@@ -29,9 +29,10 @@ namespace internal {
 AdViewInternalIOS::AdViewInternalIOS(AdView* base)
     : AdViewInternal(base),
       ad_load_callback_data_(nil),
-      initialized_(false),
+      ad_size_(0,0),
       ad_view_(nil),
-      destroy_mutex_(Mutex::kModeNonRecursive) {}
+      destroy_mutex_(Mutex::kModeNonRecursive),
+      initialized_(false) {}
 
 AdViewInternalIOS::~AdViewInternalIOS() {
   Destroy();
@@ -51,6 +52,7 @@ Future<void> AdViewInternalIOS::Initialize(AdParent parent,
       kAdAlreadyInitializedErrorMessage, future_handle, &future_data_);
   } else {
     initialized_ = true;
+    ad_size_ = size;
     dispatch_async(dispatch_get_main_queue(), ^{
       ad_view_ = [[FADAdView alloc] initWithView:parent
                                               adUnitID:@(ad_unit_id)

--- a/gma/src/stub/ad_view_internal_stub.h
+++ b/gma/src/stub/ad_view_internal_stub.h
@@ -73,7 +73,7 @@ class AdViewInternalStub : public AdViewInternal {
 
   bool is_initialized() const override { return true; }
 
-  const AdSize& ad_size() const override { return AdSize(0, 0); }
+  AdSize ad_size() const override { return AdSize(0, 0); }
 
  private:
   Future<void> CreateAndCompleteFutureStub(AdViewFn fn) {

--- a/gma/src/stub/ad_view_internal_stub.h
+++ b/gma/src/stub/ad_view_internal_stub.h
@@ -73,6 +73,8 @@ class AdViewInternalStub : public AdViewInternal {
 
   bool is_initialized() const override { return true; }
 
+  const AdSize& ad_size() const override { return AdSize(0, 0); }
+
  private:
   Future<void> CreateAndCompleteFutureStub(AdViewFn fn) {
     return CreateAndCompleteFuture(fn, kAdErrorCodeNone, nullptr,


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add a method to retrieve the AdSize that was used to initialize the AdView.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1786111124)
[Packaging CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1786111919) -> [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/1786633499)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
