### PR TITLE
Add missing :gma:gma_resources to firebaseResourceDependenciesMap

### DIFF
--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -55,6 +55,7 @@ def firebaseResourceDependenciesMap = [
   'auth' : [':auth:auth_resources'],
   'database' : [':database:database_resources'],
   'firestore' : [':firestore:firestore_resources'],
+  'gma' : [':gma:gma_resources'],
   'storage' : [':storage:storage_resources']
 ]
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

For some reason, having :gma:gma_resources missing from firebaseResourceDependenciesMap causes the Android build to hang on Windows, on the final linker step. Most likely, the error that this missing dependency causes is being lost due to a race condition, resulting in Gradle hanging. This step happens right before proguarding, so it's also possible that this race condition is causing Windows to wait indefinitely before starting proguarding.

Whatever the causes, fixing this issue fixes the Android build hang on Windows.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Ran Android integration test on Windows.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
