### PR TITLE
Add "reviewer roulette" workflow.

### DIFF
--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -33,7 +33,7 @@ jobs:
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
-            # Don't include this reviewer if they are already reviewing the PR.
+            # Don't include this reviewer if they are already reviewing the PR, or authored it.
             if [[ "${current_reviewers}" != *" $r "* && "$r" != "${author}" ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -5,13 +5,12 @@ on:
     types: [ labeled ]
 
 env:
-  triggerLabel: "reviewer-roulette"
   GITHUB_TOKEN: ${{ github.token }}
   reviewerList: "jonsimantov a-maurice DellaBitta cynthiajoan chkuang-g"
 
 jobs:
   assign_random_reviewer:
-    if: ${{ github.event.action == 'labeled' && github.event.label.name == env.triggerLabel }}
+    if: github.event.action == 'labeled' && github.event.label.name == 'reviewer-roulette'
     runs-on: ubuntu-latest
     steps:
       - name: Unset label

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -45,9 +45,9 @@ jobs:
           reviewer_list+=']'
           echo "Reviewer list: ${reviewer_list}"
           echo "::set-output name=reviewer_list::${reviewer_list}"
-          # If the list is empty, print an error. The following steps won't run.
+          # If the list is empty, print a warning. The following steps won't run.
           if [[ "${reviewer_list}" == "[]" ]]; then
-            echo "::error ::No reviewers available"
+            echo "::warning ::No reviewers available"
           fi
 
       - name: Choose random reviewer

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -1,0 +1,58 @@
+name: Reviewer Roulette
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+env:
+  triggerLabel: "reviewer-roulette"
+  GITHUB_TOKEN: ${{ github.token }}
+  reviewerList: "jonsimantov a-maurice DellaBitta cynthiajoan chkuang-g"
+
+jobs:
+  assign_random_reviewer:
+    if: github.event.action == "labeled" && github.event.label.name == env.triggerLabelPrefix
+    runs_on: ubuntu-latest
+    steps:
+      - name: Unset label
+        uses: buildsville/add-remove-label@v1
+        with:
+          token: ${{ github.token }}
+          label: "${{ github.event.label.name }}"
+          type: remove
+
+      - name: Create reviewer list
+        id: get-reviewers
+        run: |
+          current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, " ") }} '
+          echo "Current reviewers:${current_reviewers}"
+          reviewer_list='['
+          first=1
+          for r in ${{ env.reviewerList }}; do
+            # Don't include this reviewer if they are already reviewing the PR.
+            if [[ "${current_reviewers}" != *" $r "*]]; then
+              if [[ ${first} -eq 1 ]]; then
+                first=0
+              else
+                reviewer_list+=', '
+              fi
+              reviewer_list+="'$r'"
+            fi
+          done
+          reviewer_list+=']'
+          echo "Reviewer list: ${reviewer_list}"
+          echo "::set-output name=reviewer_list::${reviewer_list}"
+
+      - name: Choose random reviewer
+        id: choose-random
+        uses: KhannaAbhinav/random-selector-action@v1
+        data: ${{ steps.get-reviewers.outputs.reviewer_list }}
+
+      - name: Assign Reviewers to PR
+        uses: itsOliverBott/assign-pr-reviewers@release
+        with:
+          token: ${{ github.token }}
+          users: steps.choose-random.outputs.selectedValuesList[0]
+
+          
+

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   assign_random_reviewer:
-    if: github.event.action == 'labeled' && github.event.label.name == env.triggerLabel
+    if: ${{ github.event.action == 'labeled' && github.event.label.name == env.triggerLabel }}
     runs-on: ubuntu-latest
     steps:
       - name: Unset label

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -24,12 +24,14 @@ jobs:
         id: get-reviewers
         run: |
           current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
+          author='${{ github.event.pull_request.user.login }}'
           echo "Current reviewers:${current_reviewers}"
+          echo Author:${author}"
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR.
-            if [[ "${current_reviewers}" != *" $r "* ]]; then
+            if [[ "${current_reviewers}" != *" $r "* && "$r" != "${author}" ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else
@@ -43,12 +45,14 @@ jobs:
           echo "::set-output name=reviewer_list::${reviewer_list}"
 
       - name: Choose random reviewer
+        if: ${{ steps.get-reviewers.outputs.reviewer_list != '[]' }}
         id: choose-random
         uses: KhannaAbhinav/random-selector-action@v1
         with:
           data: ${{ steps.get-reviewers.outputs.reviewer_list }}
 
       - name: Assign Reviewers to PR
+        if: ${{ steps.get-reviewers.outputs.reviewer_list != '[]' }}
         uses: itsOliverBott/assign-pr-reviewers@release
         with:
           token: ${{ github.token }}

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Create reviewer list
         id: get-reviewers
         run: |
-          current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, " ") }} '
+          current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           echo "Current reviewers:${current_reviewers}"
           reviewer_list='['
           first=1

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -25,6 +25,7 @@ jobs:
           # Get the current reviewers and the author of the PR, to exclude them from the list.
           # Duplicates don't matter, so get the list of requested reviewers *and* the list of
           # completed reviews.
+          print '${{ toJSON(github.event.pull_request.reviews) }}'
           current_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           current_reviewers+='${{ join(github.event.pull_request.reviews.*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -23,9 +23,12 @@ jobs:
         id: get-reviewers
         run: |
           # Get the current reviewers and the author of the PR, to exclude them from the list.
-          current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
+          # Duplicates don't matter, so get the list of requested reviewers *and* the list of
+          # completed reviews.
+          current_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
+          current_reviewers+='${{ join(github.event.pull_request.reviews.*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
-          echo "Current reviewers:${current_reviewers}"
+          echo "Current reviewers: ${current_reviewers}"
           echo "Author: ${author}"
 
           # Build a JSON list of reviewers to choose from.
@@ -33,7 +36,7 @@ jobs:
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR, or authored it.
-            if [[ "${current_reviewers}" != *" $r "* && "$r" != "${author}" ]]; then
+            if [[ " ${current_reviewers} " != *" $r "* && "$r" != "${author}" ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -20,9 +20,9 @@ jobs:
           type: remove
 
       - name: Get PR reviews
-        id: get-reviews
+        id: get-completed-reviews
         run: |
-          url="https://api.github.com/repos/${{ github.event.pull_request.repository.owner.login }}/${{ github.event.pull_request.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews"
+          url="${{ github.event.pull_request.url }}/reviews"
           echo "${url}"
           response=$(curl -s -X GET \
             -H 'Accept: application/vnd.github.v3+json' \
@@ -39,9 +39,10 @@ jobs:
           # completed reviews.
           echo '${{ toJSON(github.event) }}'
           requested_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
+          completed_reviewers='${{ join(fromJSON(steps.get-completed-reviews.outputs.reviews).*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
-          echo "Requested reviews: ${requested_reviewers}"
-          echo Completed reviews: ${requested_reviewers}"
+          echo "Requested reviewers: ${requested_reviewers}"
+          echo Completed reviewers: ${completed_reviewers}"
           echo "Author: ${author}"
           all_reviewers="${requested_reviews} ${completed_reviews}"
 

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -12,7 +12,7 @@ env:
 jobs:
   assign_random_reviewer:
     if: github.event.action == "labeled" && github.event.label.name == env.triggerLabelPrefix
-    runs_on: ubuntu-latest
+    runs-on: ubuntu-latest
     steps:
       - name: Unset label
         uses: buildsville/add-remove-label@v1

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -19,8 +19,8 @@ jobs:
           label: "${{ github.event.label.name }}"
           type: remove
 
-      - name: Get completed reviews
-        id: get-reviewers
+      - name: Get PR reviews
+        id: get-reviews
         run: |
           url="https://api.github.com/repos/${{ github.event.pull_request.repository.owner.login }}/${{ github.event.pull_request.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews"
           echo "${url}"
@@ -29,6 +29,7 @@ jobs:
             -H 'Authorization: token ${{ github.token }}' \
             "${url}")
           echo "${response}"
+          echo "::set-output name=reviews::${response}"
 
       - name: Create reviewer list
         id: get-reviewers

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -52,7 +52,7 @@ jobs:
         uses: itsOliverBott/assign-pr-reviewers@release
         with:
           token: ${{ github.token }}
-          users: steps.choose-random.outputs.selectedValuesList[0]
+          users: ${{ steps.choose-random.outputs.selectedValuesList[0] }}
 
           
 

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -29,7 +29,7 @@ jobs:
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR.
-            if [[ "${current_reviewers}" != *" $r "*]]; then
+            if [[ "${current_reviewers}" != *" $r "* ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -29,7 +29,9 @@ jobs:
             -H 'Authorization: token ${{ github.token }}' \
             "${url}")
           echo "${response}"
-          echo "::set-output name=reviews::${response}"
+          echo "PR_REVIEWS<<EOF" >> $GITHUB_ENV
+          echo "${response}" >> $GITHUB_ENV
+          echo "EOF" >> $GITHUB_ENV
 
       - name: Create reviewer list
         id: get-reviewers
@@ -39,7 +41,7 @@ jobs:
           # completed reviews.
           echo '${{ toJSON(github.event) }}'
           requested_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
-          completed_reviewers='${{ join(fromJSON(steps.get-completed-reviews.outputs.reviews).*.user.login, ' ') }} '
+          completed_reviewers='${{ join(fromJSON(env.PR_REVIEWS).*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
           echo "Requested reviewers: ${requested_reviewers}"
           echo Completed reviewers: ${completed_reviewers}"

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -46,7 +46,8 @@ jobs:
       - name: Choose random reviewer
         id: choose-random
         uses: KhannaAbhinav/random-selector-action@v1
-        data: ${{ steps.get-reviewers.outputs.reviewer_list }}
+        with:
+          data: ${{ steps.get-reviewers.outputs.reviewer_list }}
 
       - name: Assign Reviewers to PR
         uses: itsOliverBott/assign-pr-reviewers@release

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -45,14 +45,14 @@ jobs:
           echo "Requested reviewers: ${requested_reviewers}"
           echo "Completed reviewers: ${completed_reviewers}"
           echo "Author: ${author}"
-          skip_users="${author} ${requested_reviewers} ${completed_reviewers}"
+          exclude_list="${author} ${requested_reviewers} ${completed_reviewers}"
 
           # Build a JSON list of reviewers to choose from.
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR, or authored it.
-            if [[ " ${skip_users} " != *" $r "* ]]; then
+            if [[ " ${exclude_list} " != *" $r "* ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   assign_random_reviewer:
-    if: github.event.action == "labeled" && github.event.label.name == env.triggerLabelPrefix
+    if: github.event.action == 'labeled' && github.event.label.name == env.triggerLabel
     runs-on: ubuntu-latest
     steps:
       - name: Unset label

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -19,6 +19,16 @@ jobs:
           label: "${{ github.event.label.name }}"
           type: remove
 
+      - name: Get completed reviews
+        id: get-reviewers
+        run: |
+          url="https://api.github.com/repos/${{ github.event.pull_request.repository.owner.login }}/${{ github.event.pull_request.repository.name }}/pull_request/${{ github.event.pull_request.number }}/reviews"
+          response=$(curl -s -X GET \
+            '-H', 'Accept: application/vnd.github.v3+json', \
+            '-H', 'Authorization: token ${{ github.token }},' \
+            "${url}")
+          echo "${response}"
+
       - name: Create reviewer list
         id: get-reviewers
         run: |
@@ -26,18 +36,19 @@ jobs:
           # Duplicates don't matter, so get the list of requested reviewers *and* the list of
           # completed reviews.
           echo '${{ toJSON(github.event) }}'
-          current_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
-          current_reviewers+='${{ join(github.event.pull_request.reviews.*.user.login, ' ') }} '
+          requested_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
-          echo "Current reviewers: ${current_reviewers}"
+          echo "Requested reviews: ${requested_reviewers}"
+          echo Completed reviews: ${requested_reviewers}"
           echo "Author: ${author}"
+          all_reviewers="${requested_reviews} ${completed_reviews}"
 
           # Build a JSON list of reviewers to choose from.
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR, or authored it.
-            if [[ " ${current_reviewers} " != *" $r "* && "$r" != "${author}" ]]; then
+            if [[ " ${all_reviewers} " != *" $r "* && "$r" != "${author}" ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -23,10 +23,13 @@ jobs:
       - name: Create reviewer list
         id: get-reviewers
         run: |
+          # Get the current reviewers and the author of the PR, to exclude them from the list.
           current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
           echo "Current reviewers:${current_reviewers}"
           echo "Author: ${author}"
+
+          # Build a JSON list of reviewers to choose from.
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
@@ -56,4 +59,4 @@ jobs:
         uses: itsOliverBott/assign-pr-reviewers@release
         with:
           token: ${{ github.token }}
-          users: ${{ steps.choose-random.outputs.selectedValuesList }}
+          users: ${{ toJSON(steps.choose-random.outputs.selectedValuesList)[0] }}

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -20,14 +20,14 @@ jobs:
           type: remove
 
       - name: Get PR reviews
-        id: get-completed-reviews
+        # Put the JSON string for all the PR's completed reviews into env.PR_REVIEWS
         run: |
           url="${{ github.event.pull_request.url }}/reviews"
           echo "${url}"
           response=$(curl -s -X GET \
             -H 'Accept: application/vnd.github.v3+json' \
             -H 'Authorization: token ${{ github.token }}' \
-            "${url}")
+            "${url}?per_page=100")
           echo "${response}"
           echo "PR_REVIEWS<<EOF" >> $GITHUB_ENV
           echo "${response}" >> $GITHUB_ENV

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -22,10 +22,11 @@ jobs:
       - name: Get completed reviews
         id: get-reviewers
         run: |
-          url="https://api.github.com/repos/${{ github.event.pull_request.repository.owner.login }}/${{ github.event.pull_request.repository.name }}/pull_request/${{ github.event.pull_request.number }}/reviews"
+          url="https://api.github.com/repos/${{ github.event.pull_request.repository.owner.login }}/${{ github.event.pull_request.repository.name }}/pulls/${{ github.event.pull_request.number }}/reviews"
+          echo "${url}"
           response=$(curl -s -X GET \
-            '-H', 'Accept: application/vnd.github.v3+json', \
-            '-H', 'Authorization: token ${{ github.token }},' \
+            -H 'Accept: application/vnd.github.v3+json' \
+            -H 'Authorization: token ${{ github.token }}' \
             "${url}")
           echo "${response}"
 

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -56,7 +56,4 @@ jobs:
         uses: itsOliverBott/assign-pr-reviewers@release
         with:
           token: ${{ github.token }}
-          users: ${{ steps.choose-random.outputs.selectedValuesList[0] }}
-
-          
-
+          users: ${{ steps.choose-random.outputs.selectedValuesList }}

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -5,7 +5,7 @@ on:
     types: [ labeled ]
 
 env:
-  reviewerList: "jonsimantov a-maurice DellaBitta cynthiajoan chkuang-g"
+  reviewerList: "jonsimantov a-maurice DellaBitta cynthiajoan chkuang-g AlmostMatt"
 
 jobs:
   assign_random_reviewer:

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -5,7 +5,6 @@ on:
     types: [ labeled ]
 
 env:
-  GITHUB_TOKEN: ${{ github.token }}
   reviewerList: "jonsimantov a-maurice DellaBitta cynthiajoan chkuang-g"
 
 jobs:

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -25,7 +25,7 @@ jobs:
           # Get the current reviewers and the author of the PR, to exclude them from the list.
           # Duplicates don't matter, so get the list of requested reviewers *and* the list of
           # completed reviews.
-          print '${{ toJSON(github.event.pull_request.reviews) }}'
+          echo '${{ toJSON(github.event) }}'
           current_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           current_reviewers+='${{ join(github.event.pull_request.reviews.*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -39,12 +39,11 @@ jobs:
           # Get the current reviewers and the author of the PR, to exclude them from the list.
           # Duplicates don't matter, so get the list of requested reviewers *and* the list of
           # completed reviews.
-          echo '${{ toJSON(github.event) }}'
           requested_reviewers='${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           completed_reviewers='${{ join(fromJSON(env.PR_REVIEWS).*.user.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
           echo "Requested reviewers: ${requested_reviewers}"
-          echo Completed reviewers: ${completed_reviewers}"
+          echo "Completed reviewers: ${completed_reviewers}"
           echo "Author: ${author}"
           all_reviewers="${requested_reviews} ${completed_reviews}"
 

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -45,14 +45,14 @@ jobs:
           echo "Requested reviewers: ${requested_reviewers}"
           echo "Completed reviewers: ${completed_reviewers}"
           echo "Author: ${author}"
-          all_reviewers="${requested_reviewers} ${completed_reviewers}"
+          skip_users="${author} ${requested_reviewers} ${completed_reviewers}"
 
           # Build a JSON list of reviewers to choose from.
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do
             # Don't include this reviewer if they are already reviewing the PR, or authored it.
-            if [[ " ${all_reviewers} " != *" $r "* && "$r" != "${author}" ]]; then
+            if [[ " ${skip_users} " != *" $r "* ]]; then
               if [[ ${first} -eq 1 ]]; then
                 first=0
               else

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -59,4 +59,4 @@ jobs:
         uses: itsOliverBott/assign-pr-reviewers@release
         with:
           token: ${{ github.token }}
-          users: ${{ toJSON(steps.choose-random.outputs.selectedValuesList)[0] }}
+          users: ${{ fromJSON(steps.choose-random.outputs.selectedValuesList)[0] }}

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -46,6 +46,10 @@ jobs:
           reviewer_list+=']'
           echo "Reviewer list: ${reviewer_list}"
           echo "::set-output name=reviewer_list::${reviewer_list}"
+          # If the list is empty, print an error. The following steps won't run.
+          if [[ "${reviewer_list}" == "[]" ]]; then
+            echo "::error ::No reviewers available"
+          fi
 
       - name: Choose random reviewer
         if: ${{ steps.get-reviewers.outputs.reviewer_list != '[]' }}

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -35,7 +35,7 @@ jobs:
               else
                 reviewer_list+=', '
               fi
-              reviewer_list+="'$r'"
+              reviewer_list+="\"$r\""
             fi
           done
           reviewer_list+=']'

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -45,7 +45,7 @@ jobs:
           echo "Requested reviewers: ${requested_reviewers}"
           echo "Completed reviewers: ${completed_reviewers}"
           echo "Author: ${author}"
-          all_reviewers="${requested_reviews} ${completed_reviews}"
+          all_reviewers="${requested_reviewers} ${completed_reviewers}"
 
           # Build a JSON list of reviewers to choose from.
           reviewer_list='['

--- a/.github/workflows/reviewer-roulette.yml
+++ b/.github/workflows/reviewer-roulette.yml
@@ -26,7 +26,7 @@ jobs:
           current_reviewers=' ${{ join(github.event.pull_request.requested_reviewers.*.login, ' ') }} '
           author='${{ github.event.pull_request.user.login }}'
           echo "Current reviewers:${current_reviewers}"
-          echo Author:${author}"
+          echo "Author: ${author}"
           reviewer_list='['
           first=1
           for r in ${{ env.reviewerList }}; do


### PR DESCRIPTION
Add a label '**reviewer-roulette**', which randomly assigns a new Firebase C++ SDK code reviewer.

It won't assign the author of the PR as a reviewer, nor anyone already set as a reviewer, nor anyone who has previously reviewed the PR.
