### PR TITLE
Remove the "unapproved C++ header" lint warning.

### DIFF
--- a/scripts/gha/lint_commenter.py
+++ b/scripts/gha/lint_commenter.py
@@ -47,7 +47,7 @@ IGNORE_LINT_WARNINGS = [
 ]
 # Exclude files within the following paths (specified as regexes).
 EXCLUDE_PATH_REGEX = [
-  # These files are copied from an external repo and our outside our control.
+  # These files are copied from an external repo and are outside our control.
   r'^analytics/ios_headers/'
 ]
 # The linter gives every error a confidence score.

--- a/scripts/gha/lint_commenter.py
+++ b/scripts/gha/lint_commenter.py
@@ -37,15 +37,18 @@ from unidiff import PatchSet
 import urllib.parse
 
 # Put any lint warnings you want to fully ignore into this list.
+# (Include a short explanation of why.)
 IGNORE_LINT_WARNINGS = [
-  'build/include_subdir',
-  'readability/casting',
-  'whitespace/indent',
-  'whitespace/line_length'
+  'build/include_subdir',   # doesn't know about our include paths
+  'build/c++11',            # ignore "unapproved c++11 header" warning
+  'readability/casting',    # allow non-C++ casts in rare occasions
+  'whitespace/indent',      # we rely on our code formatter for this...
+  'whitespace/line_length'  # ...and for this
 ]
-# Exclude files within the following paths (specified as regexes)
+# Exclude files within the following paths (specified as regexes).
 EXCLUDE_PATH_REGEX = [
-    r'^analytics/ios_headers/'
+  # These files are copied from an external repo and our outside our control.
+  r'^analytics/ios_headers/'
 ]
 # The linter gives every error a confidence score.
 # 1 = It's most likely not really an issue.


### PR DESCRIPTION
### Description
Remove the "unapproved C++ header" lint warning.

(Also add a note explaining each lint warning we ignore.)
***
### Testing
Ran lint_commenter.py script to ensure it doesn't fail.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
