### PR TITLE
Don't call FIRConfiguration setLoggerLevel: before FIRApp exists.

### DIFF
--- a/app/src/app_ios.h
+++ b/app/src/app_ios.h
@@ -17,12 +17,16 @@
 #ifndef FIREBASE_APP_SRC_APP_IOS_H_
 #define FIREBASE_APP_SRC_APP_IOS_H_
 #include "FIRApp.h"
+#include "FIRConfiguration.h"
 #include "app/src/util_ios.h"
 
 namespace firebase {
 
 namespace internal {
 OBJ_C_PTR_WRAPPER_NAMED(AppInternal, FIRApp);
+
+void SetFirConfigurationLoggerLevel(FIRLoggerLevel level);
+
 }  // namespace internal
 
 }  // namespace firebase

--- a/app/src/app_ios.mm
+++ b/app/src/app_ios.mm
@@ -288,6 +288,8 @@ bool App::IsDataCollectionDefaultEnabled() const {
 
 FIRApp* App::GetPlatformApp() const { return internal_->get(); }
 
+namespace internal {
+
 void SetFirConfigurationLoggerLevel(FIRLoggerLevel level) {
   // Check if a FIRApp has been created. FIRApp.allApps will return a
   // list of all FIRApps, or nil if no FIRApp has been created yet.
@@ -302,5 +304,6 @@ void SetFirConfigurationLoggerLevel(FIRLoggerLevel level) {
     g_delayed_fir_configuration_logger_level_set = true;
   }
 }
+}  // namespace internal
 
 }  // namespace firebase

--- a/app/src/app_ios.mm
+++ b/app/src/app_ios.mm
@@ -159,14 +159,14 @@ static FIRApp* CreatePlatformApp(const AppOptions& options, const char* name) {
             [FIRApp configureWithName:@(name) options:platform_options];
           }
           platform_app = GetPlatformAppByName(name);
-	  // If the logger level was cached due to logging happening prior to
-	  // App's initialization, apply the delayed setting now, when FIRApp
-	  // is guaranteed to exist and we are in the main thread.
-	  if (g_delayed_fir_configuration_logger_level_set) {
-	    g_delayed_fir_configuration_logger_level_set = false;
-	    [[FIRConfiguration sharedInstance]
-	      setLoggerLevel:g_delayed_fir_configuration_logger_level];
-	  }
+          // If the logger level was cached due to logging happening prior to
+          // App's initialization, apply the delayed setting now, when FIRApp
+          // is guaranteed to exist and we are in the main thread.
+          if (g_delayed_fir_configuration_logger_level_set) {
+            g_delayed_fir_configuration_logger_level_set = false;
+            [[FIRConfiguration sharedInstance]
+                setLoggerLevel:g_delayed_fir_configuration_logger_level];
+          }
         } @catch (NSException* e) {
           LogError("Unable to configure Firebase app (%s)",
                    util::NSStringToString(e.reason).c_str());

--- a/app/src/app_ios.mm
+++ b/app/src/app_ios.mm
@@ -133,6 +133,10 @@ static FIRApp* GetPlatformAppByName(const char* name) {
   return platform_app;
 }
 
+// Settings cached by SetFirConfigurationLoggerLevel if App wasn't already initialized.
+static bool g_delayed_fir_configuration_logger_level_set = false;
+static FIRLoggerLevel g_delayed_fir_configuration_logger_level = FIRLoggerLevelWarning;
+
 // Create an iOS FIRApp instance.
 static FIRApp* CreatePlatformApp(const AppOptions& options, const char* name) {
   __block FIRApp* platform_app = nil;
@@ -155,6 +159,14 @@ static FIRApp* CreatePlatformApp(const AppOptions& options, const char* name) {
             [FIRApp configureWithName:@(name) options:platform_options];
           }
           platform_app = GetPlatformAppByName(name);
+	  // If the logger level was cached due to logging happening prior to
+	  // App's initialization, apply the delayed setting now, when FIRApp
+	  // is guaranteed to exist and we are in the main thread.
+	  if (g_delayed_fir_configuration_logger_level_set) {
+	    g_delayed_fir_configuration_logger_level_set = false;
+	    [[FIRConfiguration sharedInstance]
+	      setLoggerLevel:g_delayed_fir_configuration_logger_level];
+	  }
         } @catch (NSException* e) {
           LogError("Unable to configure Firebase app (%s)",
                    util::NSStringToString(e.reason).c_str());
@@ -275,5 +287,20 @@ bool App::IsDataCollectionDefaultEnabled() const {
 }
 
 FIRApp* App::GetPlatformApp() const { return internal_->get(); }
+
+void SetFirConfigurationLoggerLevel(FIRLoggerLevel level) {
+  // Check if a FIRApp has been created. FIRApp.allApps will return a
+  // list of all FIRApps, or nil if no FIRApp has been created yet.
+  if (FIRApp.allApps != nil) {
+    // FIRApp has already been initialized, it's safe to set this
+    // value now.
+    [[FIRConfiguration sharedInstance] setLoggerLevel:level];
+  } else {
+    // FIRApp has not yet been initialized. Cache this value to set
+    // later, in CreatePlatformApp().
+    g_delayed_fir_configuration_logger_level = level;
+    g_delayed_fir_configuration_logger_level_set = true;
+  }
+}
 
 }  // namespace firebase

--- a/app/src/log_ios.mm
+++ b/app/src/log_ios.mm
@@ -20,6 +20,7 @@
 
 #import "FIRConfiguration.h"
 
+#include "app/src/app_ios.h"
 #include "app/src/include/firebase/internal/common.h"
 
 #include <stdarg.h>
@@ -61,7 +62,7 @@ void LogInitialize() {
 // Set the platform specific SDK log level.
 void LogSetPlatformLevel(LogLevel level) {
   assert(level < FIREBASE_ARRAYSIZE(kCppToIOSLogLevel));
-  [[FIRConfiguration sharedInstance] setLoggerLevel:kCppToIOSLogLevel[level]];
+  firebase::internal::SetFirConfigurationLoggerLevel(kCppToIOSLogLevel[level]);
 }
 
 // Log a firebase message.

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -227,7 +227,13 @@ void AppCallback::AddCallback(AppCallback* callback) {
   }
   std::string name = callback->module_name();
   if (callbacks_->find(name) != callbacks_->end()) {
+    LogWarning(
+        "%s is already registered for callbacks on app initialization,  "
+        "ignoring.",
+        name.c_str());
   } else {
+    LogDebug("Registered app initializer %s (enabled: %d)", name.c_str(),
+             callback->enabled() ? 1 : 0);
     (*callbacks_)[name] = callback;
   }
 }

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -567,6 +567,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    -   General (iOS): Fixed additional issues on iOS 15 caused by early
+        initialization of Firebase iOS SDK.
+
 ### 8.9.0
 -   Changes
     -   General (iOS): Fixed an intermittent crash on iOS 15 caused by


### PR DESCRIPTION
### Description
Don't call FIRConfiguration setLoggerLevel: before FIRApp exists. 

Instead, cache the value, and call setLoggerLevel later, after the iOS FIRApp instance is created.

This should be a safer fix to prevent FIRApp from being automatically initialized when logging occurs too early in the Unity SDK, which is causing a crash on iOS 15 devices in certain cases (in particular in the Firebase Unity SDK).

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

@a-maurice to manually test in Firebase Unity SDK.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
