### PR TITLE
Heartbeat logging passthrough for Auth on Mobile Platforms

### DIFF
--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -193,14 +193,6 @@ static void ReleaseClasses(JNIEnv* env) {
   ReleaseCommonClasses(env);
 }
 
-void LogHeartbeat(Auth* auth) {
-  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
-  JNIEnv* env = Env(auth->auth_data);
-  jobject platform_app = auth->app()->GetPlatformApp();
-  env->CallStaticObjectMethod(
-      auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
-}
-
 void* CreatePlatformAuth(App* app) {
   // Grab varous java objects from the app.
   JNIEnv* env = app->GetJNIEnv();
@@ -315,6 +307,14 @@ void Auth::DestroyPlatformAuth(AuthData* auth_data) {
     ReleaseClasses(env);
     util::Terminate(env);
   }
+}
+
+void LogHeartbeat(Auth* auth) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  JNIEnv* env = Env(auth->auth_data);
+  jobject platform_app = auth->app()->GetPlatformApp();
+  env->CallStaticObjectMethod(
+      auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
 }
 
 JNIEXPORT void JNICALL JniAuthStateListener_nativeOnAuthStateChanged(

--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -316,8 +316,8 @@ void LogHeartbeat(Auth* auth) {
   jobject j_auth_impl = env->CallStaticObjectMethod(
       auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
   util::CheckAndClearJniExceptions(env);
-  env->DeleteLocalRef(platform_app);
   env->DeleteLocalRef(j_auth_impl);
+  env->DeleteLocalRef(platform_app);
 }
 
 JNIEXPORT void JNICALL JniAuthStateListener_nativeOnAuthStateChanged(

--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -311,8 +311,8 @@ void Auth::DestroyPlatformAuth(AuthData* auth_data) {
 
 void LogHeartbeat(Auth* auth) {
   // Calling the native getter is sufficient to cause a Heartbeat to be logged.
-  JNIEnv* env = Env(auth->auth_data);
-  jobject platform_app = auth->app()->GetPlatformApp();
+  JNIEnv* env = Env(auth->auth_data_);
+  jobject platform_app = auth->app().GetPlatformApp();
   jobject j_auth_impl = env->CallStaticObjectMethod(
       auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
   util::CheckAndClearJniExceptions(env);

--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -313,8 +313,11 @@ void LogHeartbeat(Auth* auth) {
   // Calling the native getter is sufficient to cause a Heartbeat to be logged.
   JNIEnv* env = Env(auth->auth_data);
   jobject platform_app = auth->app()->GetPlatformApp();
-  env->CallStaticObjectMethod(
+  jobject j_auth_impl = env->CallStaticObjectMethod(
       auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
+  util::CheckAndClearJniExceptions(env);
+  env->DeleteLocalRef(platform_app);
+  env->DeleteLocalRef(j_auth_impl);
 }
 
 JNIEXPORT void JNICALL JniAuthStateListener_nativeOnAuthStateChanged(

--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -193,6 +193,14 @@ static void ReleaseClasses(JNIEnv* env) {
   ReleaseCommonClasses(env);
 }
 
+void LogHeartbeat(Auth* auth) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  JNIEnv* env = Env(auth->auth_data);
+  jobject platform_app = auth->app()->GetPlatformApp();
+  env->CallStaticObjectMethod(
+      auth::GetClass(), auth::GetMethodId(auth::kGetInstance), platform_app);
+}
+
 void* CreatePlatformAuth(App* app) {
   // Grab varous java objects from the app.
   JNIEnv* env = app->GetJNIEnv();

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -68,6 +68,7 @@ Auth* Auth::GetAuth(App* app, InitResult* init_result_out) {
   Auth* existing_auth = FindAuth(app);
   if (existing_auth) {
     if (init_result_out != nullptr) *init_result_out = kInitResultSuccess;
+    LogHeartbeat(existing_auth);
     return existing_auth;
   }
 

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -68,6 +68,8 @@ Auth* Auth::GetAuth(App* app, InitResult* init_result_out) {
   Auth* existing_auth = FindAuth(app);
   if (existing_auth) {
     if (init_result_out != nullptr) *init_result_out = kInitResultSuccess;
+    // Log heartbeat data when instance getters are called.
+    // See go/firebase-platform-logging-design for more information.
     LogHeartbeat(existing_auth);
     return existing_auth;
   }

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -33,6 +33,9 @@ enum CredentialApiFunction {
 // Platform-specific method to create the wrapped Auth class.
 void* CreatePlatformAuth(App* app);
 
+// Platform-specific method that causes a heartbeat to be logged.
+void LogHeartbeat(Auth* auth);
+
 // Platform-specific method to initialize AuthData.
 void InitPlatformAuth(AuthData* auth_data);
 

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -33,14 +33,14 @@ enum CredentialApiFunction {
 // Platform-specific method to create the wrapped Auth class.
 void* CreatePlatformAuth(App* app);
 
-// Platform-specific method that causes a heartbeat to be logged.
-void LogHeartbeat(Auth* auth);
-
 // Platform-specific method to initialize AuthData.
 void InitPlatformAuth(AuthData* auth_data);
 
 // Platform-specific method to destroy the wrapped Auth class.
 void DestroyPlatformAuth(AuthData* auth_data);
+
+// Platform-specific method that causes a heartbeat to be logged.
+void LogHeartbeat(Auth* auth);
 
 // All the result functions are similar.
 // Just return the local Future, cast to the proper result type.

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -40,6 +40,7 @@ void InitPlatformAuth(AuthData* auth_data);
 void DestroyPlatformAuth(AuthData* auth_data);
 
 // Platform-specific method that causes a heartbeat to be logged.
+// See go/firebase-platform-logging-design for more information.
 void LogHeartbeat(Auth* auth);
 
 // All the result functions are similar.

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -82,10 +82,6 @@ Future<ResultT> DoSignInWithCredential(Promise<ResultT> promise,
 
 }  // namespace
 
-void LogHeartbeat(Auth* const auth) {
-  // This is a stub until desktop implementation supports heartbeat logging.
-}
-
 void* CreatePlatformAuth(App* const app) {
   FIREBASE_ASSERT_RETURN(nullptr, app);
 
@@ -97,6 +93,9 @@ void* CreatePlatformAuth(App* const app) {
 
 void InitializeFunctionRegistryListener(AuthData* auth_data);
 void DestroyFunctionRegistryListener(AuthData* auth_data);
+
+// This is a stub until desktop implementation supports heartbeat logging.
+void LogHeartbeat(Auth* const auth) {}
 
 IdTokenRefreshListener::IdTokenRefreshListener() : token_timestamp_(0) {}
 

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -94,7 +94,8 @@ void* CreatePlatformAuth(App* const app) {
 void InitializeFunctionRegistryListener(AuthData* auth_data);
 void DestroyFunctionRegistryListener(AuthData* auth_data);
 
-// This is a stub until desktop implementation supports heartbeat logging.
+// TODO(b/211006737): This is a stub until desktop implementation supports
+// heartbeat logging.
 void LogHeartbeat(Auth* const auth) {}
 
 IdTokenRefreshListener::IdTokenRefreshListener() : token_timestamp_(0) {}

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -82,6 +82,10 @@ Future<ResultT> DoSignInWithCredential(Promise<ResultT> promise,
 
 }  // namespace
 
+void LogHeartbeat(Auth* const auth) {
+  // This is a stub until desktop implementation supports heartbeat logging.
+}
+
 void* CreatePlatformAuth(App* const app) {
   FIREBASE_ASSERT_RETURN(nullptr, app);
 

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -532,6 +532,7 @@ class Auth {
   friend void EnableTokenAutoRefresh(AuthData* authData);
   friend void DisableTokenAutoRefresh(AuthData* authData);
   friend void ResetTokenRefreshCounter(AuthData* authData);
+  friend void LogHeartbeat(Auth* auth);
   /// @endcond
 
   // Find Auth instance using App.  Return null if the instance does not exist.

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -225,7 +225,7 @@ void Auth::DestroyPlatformAuth(AuthData *auth_data) {
 
 void LogHeartbeat(Auth *auth) {
   // Calling the native getter is sufficient to cause a Heartbeat to be logged.
-  [FIRAuth authWithApp:auth->app()->GetPlatformApp()];
+  [FIRAuth authWithApp:auth->app().GetPlatformApp()];
 }
 
 Future<Auth::FetchProvidersResult> Auth::FetchProvidersForEmail(const char *email) {

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -135,6 +135,11 @@ struct ListenerHandleHolder {
   T handle;
 };
 
+void LogHeartbeat(Auth* auth) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  [FIRAuth authWithApp:auth->app()->GetPlatformApp()];
+}
+
 // Platform-specific method to create the wrapped Auth class.
 void *CreatePlatformAuth(App *app) {
   // Grab the auth for our app.

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -135,11 +135,6 @@ struct ListenerHandleHolder {
   T handle;
 };
 
-void LogHeartbeat(Auth* auth) {
-  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
-  [FIRAuth authWithApp:auth->app()->GetPlatformApp()];
-}
-
 // Platform-specific method to create the wrapped Auth class.
 void *CreatePlatformAuth(App *app) {
   // Grab the auth for our app.
@@ -226,6 +221,11 @@ void Auth::DestroyPlatformAuth(AuthData *auth_data) {
   // Release the FIRAuth* that we allocated in CreatePlatformAuth().
   delete auth_data_ios;
   auth_data->auth_impl = nullptr;
+}
+
+void LogHeartbeat(Auth* auth) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  [FIRAuth authWithApp:auth->app()->GetPlatformApp()];
 }
 
 Future<Auth::FetchProvidersResult> Auth::FetchProvidersForEmail(const char *email) {

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -223,7 +223,7 @@ void Auth::DestroyPlatformAuth(AuthData *auth_data) {
   auth_data->auth_impl = nullptr;
 }
 
-void LogHeartbeat(Auth* auth) {
+void LogHeartbeat(Auth *auth) {
   // Calling the native getter is sufficient to cause a Heartbeat to be logged.
   [FIRAuth authWithApp:auth->app()->GetPlatformApp()];
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update c++ GetAuth to always call native auth getters so that any logging internal to the native auth implementations will be triggered.
This is as described in the "How data is collected" section of
https://docs.google.com/document/d/1eVlEmjdxSsXsvnzGiRYYfb0RtfWRLi3yo9vHj0NhqE4/edit#heading=h.ohspo4gdlkj0 

This change is currently only for Auth, but similar changes will be done separately for Database, Firestore, Functions, Installation and Remote Config.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

This is effectively no-op for now, since native SDKs do not yet log heartbeats.
Once heartbeat logging from getters is supported, manual testing will verify the process end to end.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.

This is a minor change in order to enable a new feature in the future.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
