### PR TITLE
Enable Firestore Emulator only when needed

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -891,8 +891,8 @@ jobs:
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-            npm install -g firebase-tools
-            firebase emulators:start --only firestore --project demo-example &
+          npm install -g firebase-tools
+          firebase emulators:start --only firestore --project demo-example &
       - name: Run Android integration tests on Emulator locally
         timeout-minutes: 90
         if: steps.get-device-type.outputs.device_type == 'virtual'
@@ -993,8 +993,8 @@ jobs:
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-            npm install -g firebase-tools
-            firebase emulators:start --only firestore --project demo-example &
+          npm install -g firebase-tools
+          firebase emulators:start --only firestore --project demo-example &
       - name: Run iOS integration tests on Simulator locally
         timeout-minutes: 90
         if: steps.get-device-type.outputs.device_type == 'virtual'
@@ -1086,11 +1086,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 3
           command: pip install -r scripts/gha/requirements.txt
-      - name: Setup Firebase Emulators
+      - name: Setup Firestore Emulator
         if: contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-            npm install -g firebase-tools
-            firebase emulators:start --only firestore --project demo-example &
+          npm install -g firebase-tools
+          firebase emulators:start --only firestore --project demo-example &
       - name: Run tvOS integration tests on Simulator locally
         timeout-minutes: 60
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -801,9 +801,14 @@ jobs:
             pip install -r scripts/gha/requirements.txt
             python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact testapps
       - name: Run Desktop integration tests
-        run: firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"'
         env:
           USE_FIRESTORE_EMULATOR: true
+        run: |
+          if [[ "${{ needs.check_and_prepare.outputs.apis }}" == *"firestore"* ]]; then
+            firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"'
+          else
+            python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"
+          fi
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash
@@ -883,10 +888,14 @@ jobs:
         with:
           node-version: 12.x
       - name: Setup Firestore Emulator
-        if: steps.get-device-type.outputs.device_type == 'virtual'
-        run: |
-          npm install -g firebase-tools
-          firebase emulators:start --only firestore --project demo-example &
+        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: |
+            npm install -g firebase-tools
+            firebase emulators:start --only firestore --project demo-example &
       - name: Run Android integration tests on Emulator locally
         timeout-minutes: 90
         if: steps.get-device-type.outputs.device_type == 'virtual'
@@ -985,12 +994,16 @@ jobs:
         with:
           node-version: 12.x
       - name: Setup Firestore Emulator
-        if: steps.get-device-type.outputs.device_type == 'virtual'
-        run: |
-          npm install -g firebase-tools
-          firebase emulators:start --only firestore --project demo-example &
+        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: |
+            npm install -g firebase-tools
+            firebase emulators:start --only firestore --project demo-example &
       - name: Run iOS integration tests on Simulator locally
-        timeout-minutes: 60
+        timeout-minutes: 90
         if: steps.get-device-type.outputs.device_type == 'virtual'
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
@@ -1081,9 +1094,14 @@ jobs:
           max_attempts: 3
           command: pip install -r scripts/gha/requirements.txt
       - name: Setup Firebase Emulators
-        run: |
-          npm install -g firebase-tools
-          firebase emulators:start --only firestore --project demo-example &
+        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          timeout_minutes: 3
+          max_attempts: 3
+          command: |
+            npm install -g firebase-tools
+            firebase emulators:start --only firestore --project demo-example &
       - name: Run tvOS integration tests on Simulator locally
         timeout-minutes: 60
         run: |

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -890,11 +890,7 @@ jobs:
           node-version: 12.x
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
+        run: |
             npm install -g firebase-tools
             firebase emulators:start --only firestore --project demo-example &
       - name: Run Android integration tests on Emulator locally
@@ -996,11 +992,7 @@ jobs:
           node-version: 12.x
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
+        run: |
             npm install -g firebase-tools
             firebase emulators:start --only firestore --project demo-example &
       - name: Run iOS integration tests on Simulator locally
@@ -1095,12 +1087,8 @@ jobs:
           max_attempts: 3
           command: pip install -r scripts/gha/requirements.txt
       - name: Setup Firebase Emulators
-        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-        uses: nick-invision/retry@v2
-        with:
-          timeout_minutes: 3
-          max_attempts: 3
-          command: |
+        if: contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        run: |
             npm install -g firebase-tools
             firebase emulators:start --only firestore --project demo-example &
       - name: Run tvOS integration tests on Simulator locally

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -803,6 +803,7 @@ jobs:
       - name: Run Desktop integration tests
         env:
           USE_FIRESTORE_EMULATOR: true
+        shell: bash
         run: |
           if [[ "${{ needs.check_and_prepare.outputs.apis }}" == *"firestore"* ]]; then
             firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps --logfile_name "desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}"'


### PR DESCRIPTION
### Description
1. Test timeout extend to 90 mins.
https://github.com/firebase/firebase-cpp-sdk/runs/5091186528?check_suite_focus=true
^ process timed out
2. Enable Firestore Emulator only when needed. 
https://github.com/firebase/firebase-cpp-sdk/runs/5092455184?check_suite_focus=true
^ SIGINT and seems like no tests ran

### Testing
See comments.

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
