### PR TITLE
Heartbeat logging passthrough for FIS for mobile platforms.

### DIFF
--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -197,7 +197,6 @@ void InstallationsInternal::LogHeartbeat(const firebase::App& app) {
   FIREBASE_ASSERT(installations_instance_local);
   env->DeleteLocalRef(installations_instance_local);
   env->DeleteLocalRef(platform_app);
-  LogDebug("%s API Initialized", kApiIdentifier);
 }
 
 Future<std::string> InstallationsInternal::GetId() {

--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -186,6 +186,20 @@ void InstallationsInternal::Cleanup() {
   }
 }
 
+void InstallationsInternal::LogHeartbeat(const firebase::App& app) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  JNIEnv* env = app.GetJNIEnv();
+  jobject platform_app = app.GetPlatformApp();
+  jclass installations_class = installations::GetClass();
+  jobject installations_instance_local = env->CallStaticObjectMethod(
+      installations_class,
+      installations::GetMethodId(installations::kGetInstance), platform_app);
+  FIREBASE_ASSERT(installations_instance_local);
+  env->DeleteLocalRef(installations_instance_local);
+  env->DeleteLocalRef(platform_app);
+  LogDebug("%s API Initialized", kApiIdentifier);
+}
+
 Future<std::string> InstallationsInternal::GetId() {
   const auto handle =
       future_impl_.SafeAlloc<std::string>(kInstallationsFnGetId);

--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -15,6 +15,7 @@
 #include "installations/src/android/installations_android.h"
 
 #include "app/src/util.h"
+#include "app/src/util_android.h"
 #include "installations/src/common.h"
 
 namespace firebase {
@@ -194,7 +195,7 @@ void InstallationsInternal::LogHeartbeat(const firebase::App& app) {
   jobject installations_instance_local = env->CallStaticObjectMethod(
       installations_class,
       installations::GetMethodId(installations::kGetInstance), platform_app);
-  FIREBASE_ASSERT(installations_instance_local);
+  firebase::util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(installations_instance_local);
   env->DeleteLocalRef(platform_app);
 }

--- a/installations/src/android/installations_android.h
+++ b/installations/src/android/installations_android.h
@@ -34,6 +34,10 @@ class InstallationsInternal {
   explicit InstallationsInternal(const firebase::App& app);
   ~InstallationsInternal();
 
+  // Platform-specific method that causes a heartbeat to be logged.
+  // See go/firebase-platform-logging-design for more information.
+  static void LogHeartbeat(const firebase::App& app);
+
   Future<std::string> GetId();
   Future<std::string> GetIdLastResult();
 

--- a/installations/src/include/firebase/installations.h
+++ b/installations/src/include/firebase/installations.h
@@ -105,7 +105,6 @@ class Installations {
 
  private:
   explicit Installations(App* app);
-
   static Installations* FindInstallations(App* app);
   // Installations internal initialize.
   bool InitInternal();

--- a/installations/src/include/firebase/installations.h
+++ b/installations/src/include/firebase/installations.h
@@ -105,6 +105,7 @@ class Installations {
 
  private:
   explicit Installations(App* app);
+
   static Installations* FindInstallations(App* app);
   // Installations internal initialize.
   bool InitInternal();

--- a/installations/src/installations.cc
+++ b/installations/src/installations.cc
@@ -32,6 +32,9 @@ Installations* Installations::GetInstance(App* app) {
   // Return the Installations if it already exists.
   Installations* existing_installations = FindInstallations(app);
   if (existing_installations) {
+    // Log heartbeat data when instance getters are called.
+    // See go/firebase-platform-logging-design for more information.
+    InstallationsInternal::LogHeartbeat(*app);
     return existing_installations;
   }
 

--- a/installations/src/ios/installations_ios.h
+++ b/installations/src/ios/installations_ios.h
@@ -42,6 +42,10 @@ class InstallationsInternal {
   explicit InstallationsInternal(const firebase::App& app);
   ~InstallationsInternal();
 
+  // Platform-specific method that causes a heartbeat to be logged.
+  // See go/firebase-platform-logging-design for more information.
+  static void LogHeartbeat(const firebase::App& app);
+
   Future<std::string> GetId();
   Future<std::string> GetIdLastResult();
 

--- a/installations/src/ios/installations_ios.mm
+++ b/installations/src/ios/installations_ios.mm
@@ -43,7 +43,7 @@ InstallationsInternal::~InstallationsInternal() {
 void InstallationsInternal::LogHeartbeat(const firebase::App& app) {
   // Calling the native getter is sufficient to cause a Heartbeat to be logged.
   FIRApp *platform_app = app.GetPlatformApp();
-  [FIRInstallations installationsWithApp:platform_app]
+  [FIRInstallations installationsWithApp:platform_app];
 }
 
 bool InstallationsInternal::Initialized() const{

--- a/installations/src/ios/installations_ios.mm
+++ b/installations/src/ios/installations_ios.mm
@@ -40,6 +40,12 @@ InstallationsInternal::~InstallationsInternal() {
   // Destructor is necessary for ARC garbage collection.
 }
 
+void InstallationsInternal::LogHeartbeat(const firebase::App& app) {
+  // Calling the native getter is sufficient to cause a Heartbeat to be logged.
+  FIRApp *platform_app = app.GetPlatformApp();
+  [FIRInstallations installationsWithApp:platform_app]
+}
+
 bool InstallationsInternal::Initialized() const{
   return true;
 }

--- a/installations/src/stub/installations_stub.cc
+++ b/installations/src/stub/installations_stub.cc
@@ -26,6 +26,8 @@ InstallationsInternal::InstallationsInternal(const firebase::App& app)
 
 InstallationsInternal::~InstallationsInternal() {}
 
+void InstallationsInternal::LogHeartbeat(const firebase::App& app) {}
+
 bool InstallationsInternal::Initialized() const { return true; }
 
 void InstallationsInternal::Cleanup() {}

--- a/installations/src/stub/installations_stub.h
+++ b/installations/src/stub/installations_stub.h
@@ -31,6 +31,10 @@ class InstallationsInternal {
   explicit InstallationsInternal(const firebase::App& app);
   ~InstallationsInternal();
 
+  // Platform-specific method that causes a heartbeat to be logged.
+  // See go/firebase-platform-logging-design for more information.
+  static void LogHeartbeat(const firebase::App& app);
+
   Future<std::string> GetId();
   Future<std::string> GetIdLastResult();
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update c++ FIS GetInstance to always call native FIS getters so that any logging internal to the native implementations will be triggered.
This is as described in the "How data is collected" section of
https://docs.google.com/document/d/1eVlEmjdxSsXsvnzGiRYYfb0RtfWRLi3yo9vHj0NhqE4/edit#heading=h.ohspo4gdlkj0 

This is effectively the same as https://github.com/firebase/firebase-cpp-sdk/pull/846, but for FIS
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

This is effectively no-op for now, since native SDKs do not yet log heartbeats.
Once heartbeat logging from getters is supported, manual testing will verify the process end to end.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.

This is a minor change in order to enable a new feature in the future.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
