### PR TITLE
Cancel unnecessary workflow run

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -112,7 +112,7 @@ jobs:
             else
               echo "::set-output name=requested_tests::expanded"
             fi
-          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged == true }} ]]; then
+          elif [[ "${{ github.event.action }}" == "closed" && ${{ github.event.pull_request.merged }} = true ]]; then
             echo "::set-output name=trigger::postsubmit_trigger"
             echo "::set-output name=pr_number::${{ github.event.pull_request.number }}"
             echo "::set-output name=requested_tests::auto"


### PR DESCRIPTION
Description
Close event trigger workflow incorrectly. PR is not merged, but the workflow didn't cancel itself as excepted.
https://github.com/firebase/firebase-unity-sdk/actions/runs/1861582366

Testing
Now workflow cancel itself correctly:
https://github.com/firebase/firebase-unity-sdk/runs/5241454052?check_suite_focus=true

Type of Change
Place an x the applicable box:

 Bug fix. Add the issue # below if applicable.
 New feature. A non-breaking change which adds functionality.
 Other, such as a build process or documentation change.