### PR TITLE
Update FTL iOS test command

### DIFF
--- a/scripts/gha/test_lab.py
+++ b/scripts/gha/test_lab.py
@@ -173,9 +173,6 @@ def main(argv):
   gcs_base_dir = gcs.get_unique_gcs_id()
   logging.info("Store results in %s", gcs.relative_path_to_gs_uri(gcs_base_dir))
 
-  if has_ios:
-    _install_gcloud_beta()
-
   tests = []
   for device, platform, path in testapps:
     # e.g. /testapps/unity/firebase_auth/app.apk -> unity_firebase_auth_app_apk
@@ -311,7 +308,7 @@ class Test(object):
     if self.platform == _ANDROID:
       cmd = [gcs.GCLOUD, "firebase", "test", "android", "run"]
     elif self.platform == _IOS:
-      cmd = [gcs.GCLOUD, "beta", "firebase", "test", "ios", "run"]
+      cmd = [gcs.GCLOUD, "firebase", "test", "ios", "run"]
     else:
       raise ValueError("Invalid platform, must be 'Android' or 'iOS'")
     return cmd + self.device.get_gcloud_flags() + [


### PR DESCRIPTION
### Description
FTL iOS test command is flaky: https://github.com/firebase/firebase-cpp-sdk/runs/5331886963?check_suite_focus=true#step:12:247

It seems FTL deprecated the beta version CMD, and replaced with the new one: https://cloud.google.com/sdk/gcloud/reference/firebase/test/ios/run
***
### Testing
See the comment
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
