### PR TITLE
Don't report test error if it's indeed build errors

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -755,7 +755,7 @@ jobs:
   trigger_integration_tests:
     # Trigger the integration_tests workflow.
     needs: [merge_packages, download_sdk_package, cleanup_packaging_artifacts]
-    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled()
+    if: (github.event.inputs.skipIntegrationTests == 0 || github.event.inputs.skipIntegrationTests == '') && !cancelled() && !failure()
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repo

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -347,13 +347,13 @@ jobs:
             # No summary was created, make a placeholder one.
             echo "__SUMMARY_MISSING__" > build-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
           fi
-      # - name: Upload Desktop integration tests artifact
-      #   uses: actions/upload-artifact@v3
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-      #     path: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-      #     retention-days: ${{ env.artifactRetentionDays }}
+      - name: Upload Desktop integration tests artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+          path: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+          retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Desktop build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
@@ -493,13 +493,13 @@ jobs:
           if [ ! -f build-results-android-${{ matrix.os }}.log.json ]; then
             echo "__SUMMARY_MISSING__" > build-results-android-${{ matrix.os }}.log.json
           fi
-      # - name: Upload Android integration tests artifact
-      #   uses: actions/upload-artifact@v3
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     name: testapps-android-${{ matrix.os }}
-      #     path: testapps-android-${{ matrix.os }}
-      #     retention-days: ${{ env.artifactRetentionDays }}
+      - name: Upload Android integration tests artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: testapps-android-${{ matrix.os }}
+          path: testapps-android-${{ matrix.os }}
+          retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
@@ -610,13 +610,13 @@ jobs:
           if [ ! -f build-results-ios-macos-latest.log.json ]; then
             echo "__SUMMARY_MISSING__" > build-results-ios-macos-latest.log.json
           fi
-      # - name: Upload iOS integration tests artifact
-      #   uses: actions/upload-artifact@v3
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     name: testapps-ios-macos-latest
-      #     path: testapps-ios-macos-latest
-      #     retention-days: ${{ env.artifactRetentionDays }}
+      - name: Upload iOS integration tests artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: testapps-ios-macos-latest
+          path: testapps-ios-macos-latest
+          retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
@@ -727,13 +727,13 @@ jobs:
           name: testapps-tvos-macos-latest
           path: testapps-tvos-macos-latest
           retention-days: ${{ env.artifactRetentionDays }}
-      # - name: Upload tvOS build results artifact
-      #   uses: actions/upload-artifact@v3
-      #   if: ${{ !cancelled() }}
-      #   with:
-      #     name: log-artifact
-      #     path: build-results-tvos-macos-latest*
-      #     retention-days: ${{ env.artifactRetentionDays }}
+      - name: Upload tvOS build results artifact
+        uses: actions/upload-artifact@v3
+        if: ${{ !cancelled() }}
+        with:
+          name: log-artifact
+          path: build-results-tvos-macos-latest*
+          retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
         uses: actions/download-artifact@v3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -347,15 +347,15 @@ jobs:
             # No summary was created, make a placeholder one.
             echo "__SUMMARY_MISSING__" > build-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
           fi
-      - name: Upload Desktop integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
-        if: ${{ !cancelled() }}
-        with:
-          name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-          path: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
-          retention-days: ${{ env.artifactRetentionDays }}
+      # - name: Upload Desktop integration tests artifact
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ !cancelled() }}
+      #   with:
+      #     name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+      #     path: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
+      #     retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Desktop build results artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
@@ -379,7 +379,7 @@ jobs:
           python scripts/gha/gcs_uploader.py --testapp_dir ta --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -493,15 +493,15 @@ jobs:
           if [ ! -f build-results-android-${{ matrix.os }}.log.json ]; then
             echo "__SUMMARY_MISSING__" > build-results-android-${{ matrix.os }}.log.json
           fi
-      - name: Upload Android integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
-        if: ${{ !cancelled() }}
-        with:
-          name: testapps-android-${{ matrix.os }}
-          path: testapps-android-${{ matrix.os }}
-          retention-days: ${{ env.artifactRetentionDays }}
+      # - name: Upload Android integration tests artifact
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ !cancelled() }}
+      #   with:
+      #     name: testapps-android-${{ matrix.os }}
+      #     path: testapps-android-${{ matrix.os }}
+      #     retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload Android build results artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
@@ -509,7 +509,7 @@ jobs:
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -610,15 +610,15 @@ jobs:
           if [ ! -f build-results-ios-macos-latest.log.json ]; then
             echo "__SUMMARY_MISSING__" > build-results-ios-macos-latest.log.json
           fi
-      - name: Upload iOS integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
-        if: ${{ !cancelled() }}
-        with:
-          name: testapps-ios-macos-latest
-          path: testapps-ios-macos-latest
-          retention-days: ${{ env.artifactRetentionDays }}
+      # - name: Upload iOS integration tests artifact
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ !cancelled() }}
+      #   with:
+      #     name: testapps-ios-macos-latest
+      #     path: testapps-ios-macos-latest
+      #     retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS build results artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
@@ -626,7 +626,7 @@ jobs:
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -721,22 +721,22 @@ jobs:
             echo "__SUMMARY_MISSING__" > build-results-tvos-macos-latest.log.json
           fi
       - name: Upload tvOS integration tests artifact
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: testapps-tvos-macos-latest
           path: testapps-tvos-macos-latest
           retention-days: ${{ env.artifactRetentionDays }}
-      - name: Upload tvOS build results artifact
-        uses: actions/upload-artifact@v2.2.2
-        if: ${{ !cancelled() }}
-        with:
-          name: log-artifact
-          path: build-results-tvos-macos-latest*
-          retention-days: ${{ env.artifactRetentionDays }}
+      # - name: Upload tvOS build results artifact
+      #   uses: actions/upload-artifact@v3
+      #   if: ${{ !cancelled() }}
+      #   with:
+      #     name: log-artifact
+      #     path: build-results-tvos-macos-latest*
+      #     retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -776,7 +776,7 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Desktop integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}
@@ -814,19 +814,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}" && ! -f testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}.log.json
           fi
       - name: Upload Desktop test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-desktop-${{ matrix.os }}-${{ matrix.ssl_variant }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -866,7 +867,7 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download Android integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-android-${{ matrix.build_os }}
@@ -918,19 +919,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json" ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-android-${{ matrix.build_os }}" && ! -f "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json" ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}.log.json"
           fi
       - name: Upload Android test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-android-${{ matrix.build_os }}-${{ matrix.android_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -969,7 +971,7 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download iOS integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-ios-macos-latest
@@ -1021,19 +1023,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json" ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-ios-macos-latest" && ! -f "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json" ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json"
           fi
       - name: Upload iOS test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -1072,7 +1075,7 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
       - name: Download tvOS integration tests artifact
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: testapps
           name: testapps-tvos-macos-latest
@@ -1102,19 +1105,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json" ]; then
+          # If testapps do not exist, then it's a build error not test error. 
+          if [ -d "testapps/testapps-tvos-macos-latest" && ! -f "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json" ]; then
             mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json"
           fi
       - name: Upload tvOS test results artifact
         if: ${{ !cancelled() }}
-        uses: actions/upload-artifact@v2.2.2
+        uses: actions/upload-artifact@v3
         with:
           name: log-artifact
           path: testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact
@@ -1152,7 +1156,7 @@ jobs:
       - name: Install python deps
         run: pip install -r scripts/gha/requirements.txt
       - name: Download log artifacts
-        uses: actions/download-artifact@v2.0.8
+        uses: actions/download-artifact@v3
         with:
           path: test_results
           name: log-artifact


### PR DESCRIPTION
### Description
0. updated artifact related action version
1. If packaging workflow failed, don't run integeration test workflow. [e.g.](https://github.com/firebase/firebase-cpp-sdk/runs/5446230846?check_suite_focus=true)
2. If build testapps job failed (no testapp artifacts), don't report "missing log" test error. [e.g.](https://github.com/firebase/firebase-cpp-sdk/runs/5420852601?check_suite_focus=true#step:4:13)

Will have followup design about passing failure jobs info to next jobs.
***
### Testing
See the comment below
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
