### PR TITLE
Fix Linux x86 package installation on GH runners

### DIFF
--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -68,13 +68,13 @@ def install_x86_support_libraries(gha_build=False):
     packages = ['gcc-multilib', 'g++-multilib', 'libglib2.0-dev:i386',
                 'libsecret-1-dev:i386', 'libpthread-stubs0-dev:i386',
                 'libssl-dev:i386']
-    if gha_build:
-      # Workaround for GitHub runners, which have an incompatibility between the
-      # 64-bit and 32-bit versions of the Ubuntu package libpcre2-8-0. Downgrade
-      # the installed 64-bit version of the library to get around this issue.
-      # This will presumably be fixed in a future Ubuntu update. (If you remove
-      # it, remove the workaround further down this function as well.)
-      packages = ['--allow-downgrades'] + packages + ['libpcre2-8-0=10.34-7']
+    # if gha_build:
+    # Workaround for GitHub runners, which have an incompatibility between the
+    # 64-bit and 32-bit versions of the Ubuntu package libpcre2-8-0. Downgrade
+    # the installed 64-bit version of the library to get around this issue.
+    # This will presumably be fixed in a future Ubuntu update. (If you remove
+    # it, remove the workaround further down this function as well.)
+    # packages = ['--allow-downgrades'] + packages + ['libpcre2-8-0=10.34-7']
 
     # First check if these packages exist on the machine already
     devnull = open(os.devnull, "w")
@@ -87,15 +87,15 @@ def install_x86_support_libraries(gha_build=False):
       utils.run_command(['apt', 'update'], as_root=True, check=True)
       utils.run_command(['apt', 'install', '-V', '-y'] + packages, as_root=True, check=True)
 
-    if gha_build:
-      # One more workaround: downgrading libpcre2-8-0 above may have uninstalled
-      # libsecret, which is required for the Linux build. Force it to be
-      # reinstalled, but do it as a separate command to ensure that held
-      # packages aren't modified. (Once the workaround above is removed, this can
-      # be removed as well.)
-      # Note: "-f" = "fix" - let apt do what it needs to do to fix dependencies.
-      utils.run_command(['apt', 'install', '-f', '-V', '-y', 'libsecret-1-dev'],
-                        as_root=True, check=True, stdout=devnull, stderr=subprocess.STDOUT)
+    # if gha_build:
+    # One more workaround: downgrading libpcre2-8-0 above may have uninstalled
+    # libsecret, which is required for the Linux build. Force it to be
+    # reinstalled, but do it as a separate command to ensure that held
+    # packages aren't modified. (Once the workaround above is removed, this can
+    # be removed as well.)
+    # Note: "-f" = "fix" - let apt do what it needs to do to fix dependencies.
+    # utils.run_command(['apt', 'install', '-f', '-V', '-y', 'libsecret-1-dev'],
+    #                   as_root=True, check=True)
 
 
 def _install_cpp_dependencies_with_vcpkg(arch, msvc_runtime_library, use_openssl=False):

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -95,7 +95,7 @@ def install_x86_support_libraries(gha_build=False):
       # be removed as well.)
       # Note: "-f" = "fix" - let apt do what it needs to do to fix dependencies.
       utils.run_command(['apt', 'install', '-f', '-V', '-y', 'libsecret-1-dev'],
-                        as_root=True, check=True)
+                        as_root=True, check=True, stdout=devnull, stderr=subprocess.STDOUT)
 
 
 def _install_cpp_dependencies_with_vcpkg(arch, msvc_runtime_library, use_openssl=False):

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -68,13 +68,13 @@ def install_x86_support_libraries(gha_build=False):
     packages = ['gcc-multilib', 'g++-multilib', 'libglib2.0-dev:i386',
                 'libsecret-1-dev:i386', 'libpthread-stubs0-dev:i386',
                 'libssl-dev:i386']
-    # if gha_build:
-    # Workaround for GitHub runners, which have an incompatibility between the
-    # 64-bit and 32-bit versions of the Ubuntu package libpcre2-8-0. Downgrade
-    # the installed 64-bit version of the library to get around this issue.
-    # This will presumably be fixed in a future Ubuntu update. (If you remove
-    # it, remove the workaround further down this function as well.)
-    # packages = ['--allow-downgrades'] + packages + ['libpcre2-8-0=10.34-7']
+    if gha_build:
+      # Workaround for GitHub runners, which have an incompatibility between the
+      # 64-bit and 32-bit versions of the Ubuntu package libpcre2-8-0. Downgrade
+      # the installed 64-bit version of the library to get around this issue.
+      # This will presumably be fixed in a future Ubuntu update. (If you remove
+      # it, remove the workaround further down this function as well.)
+      packages = ['--allow-downgrades'] + packages + ['libpcre2-8-0=10.34-7']
 
     # First check if these packages exist on the machine already
     devnull = open(os.devnull, "w")
@@ -87,15 +87,15 @@ def install_x86_support_libraries(gha_build=False):
       utils.run_command(['apt', 'update'], as_root=True, check=True)
       utils.run_command(['apt', 'install', '-V', '-y'] + packages, as_root=True, check=True)
 
-    # if gha_build:
-    # One more workaround: downgrading libpcre2-8-0 above may have uninstalled
-    # libsecret, which is required for the Linux build. Force it to be
-    # reinstalled, but do it as a separate command to ensure that held
-    # packages aren't modified. (Once the workaround above is removed, this can
-    # be removed as well.)
-    # Note: "-f" = "fix" - let apt do what it needs to do to fix dependencies.
-    # utils.run_command(['apt', 'install', '-f', '-V', '-y', 'libsecret-1-dev'],
-    #                   as_root=True, check=True)
+    if gha_build:
+      # One more workaround: downgrading libpcre2-8-0 above may have uninstalled
+      # libsecret, which is required for the Linux build. Force it to be
+      # reinstalled, but do it as a separate command to ensure that held
+      # packages aren't modified. (Once the workaround above is removed, this can
+      # be removed as well.)
+      # Note: "-f" = "fix" - let apt do what it needs to do to fix dependencies.
+      utils.run_command(['apt', 'install', '-f', '-V', '-y', 'libsecret-1-dev:i386'],
+                        as_root=True, check=True)
 
 
 def _install_cpp_dependencies_with_vcpkg(arch, msvc_runtime_library, use_openssl=False):


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Installation of libsecret failed in https://github.com/firebase/firebase-cpp-sdk/runs/5473061295 due to GitHub runner environment change. The workaround now needs to manually specify i386 architecture when installing libsecret.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running Desktop PR checks should suffice.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
