### PR TITLE
Cancel workflows for previous commits in a PR when new commits are pushed

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -15,6 +15,10 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
   xcodeVersion: "12.4"  # Only affects Mac runners, and only for prerequisites.
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -16,7 +16,7 @@ env:
   xcodeVersion: "12.4"  # Only affects Mac runners, and only for prerequisites.
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -11,6 +11,10 @@ env:
   statusLabelFailed: "tests: failed"
   skipReleaseNotesLabel: "skip-release-notes"
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   file_format_check:
     runs-on: ubuntu-latest

--- a/.github/workflows/checks_secure.yml
+++ b/.github/workflows/checks_secure.yml
@@ -5,6 +5,10 @@ on:
   pull_request_target:
     types: [synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   dismiss_stale_approvals:
     # Dismiss stale approvals for non-admins or if this PR comes from a fork.

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -14,6 +14,10 @@ env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir
   GITHUB_TOKEN: ${{ github.token }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -15,7 +15,7 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -132,11 +132,6 @@ jobs:
       run: |
         sleep 300
         exit 1  # fail out if the cancellation above somehow failed.
-    - name: Cancel previous runs on the same PR
-      if: steps.set_outputs.outputs.trigger == 'label_trigger' 
-      uses: styfle/cancel-workflow-action@0.8.0
-      with:
-        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
       with:
         ref: ${{steps.set_outputs.outputs.github_ref}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,6 +47,10 @@ env:
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check_and_prepare:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -47,10 +47,6 @@ env:
   artifactRetentionDays: 2
   GITHUB_TOKEN: ${{ github.token }}
 
-concurrency:
-  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
-  cancel-in-progress: true
-
 jobs:
   check_and_prepare:
     runs-on: ubuntu-latest
@@ -132,6 +128,11 @@ jobs:
       run: |
         sleep 300
         exit 1  # fail out if the cancellation above somehow failed.
+    - name: Cancel previous runs on the same PR
+      if: steps.set_outputs.outputs.trigger == 'label_trigger' 
+      uses: styfle/cancel-workflow-action@0.8.0
+      with:
+        access_token: ${{ github.token }}
     - uses: actions/checkout@v2
       with:
         ref: ${{steps.set_outputs.outputs.github_ref}}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -13,6 +13,10 @@ on:
 env:
   GITHUB_TOKEN: ${{ github.token }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   prepare_matrix:
     runs-on: ubuntu-latest

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -14,7 +14,7 @@ env:
   GITHUB_TOKEN: ${{ github.token }}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened,synchronize]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint_warnings_check_and_comment:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Description

To save the runner resource, use [concurrency](https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#concurrency) to prevent previous workflows from running. This can occur in PRs where the author raises multiple commits in quick succession.

***
### Testing
Previous commits cancelled:
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1994908024
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1994908021
https://github.com/firebase/firebase-cpp-sdk/actions/runs/1994908019
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
