### PR TITLE
iOS: remove desktop sources that were mistakenly merged into app/CMakeLists.txt

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -158,8 +158,6 @@ set(app_android_SRCS
 set(app_ios_SRCS
     src/app_ios.mm
     src/util_ios.mm
-    src/heartbeat_date_storage_desktop.cc
-    src/heartbeat_info_desktop.cc
     src/invites/ios/invites_receiver_internal_ios.mm
     src/invites/ios/invites_ios_startup.mm
     src/uuid_ios_darwin.mm)


### PR DESCRIPTION
### Description
Since latest Xcode (13.3) and clang++ (apple 13.1.6) iOS apps can no longer compile as the linker complains about undefined symbols:
```
Undefined symbols for architecture arm64:
  "firebase::AppDataDir(char const*, bool, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >*)", referenced from:
      firebase::(anonymous namespace)::GetFilename(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char> >&) in firebase(heartbeat_date_storage_desktop.cc.o)

```
Taking a deeper look it seems like there is indeed an undefined symbol in firebase.xcframework:
```
         U __ZN8firebase10AppDataDirEPKcbPNSt3__112basic_stringIcNS2_11char_traitsIcEENS2_9allocatorIcEEEE
``` 
While searching for this symbol in the repo it seems to be defined in a file called app/src/filesystem_apple.mm and indeed it's not part of iOS source files in app/CMakeLists.txt.

It's not clear what has changed in Apple clang++ 13.1.6 compared to Apple clang++ 13.0.0 but somehow the former throws the aforementioned undefined symbol error.

There are 2 possible fixes, AFAIK:
1. add filesystem_apple.mm to iOS sources in the CMakeLists.txt file. 
2. remove heartbeat_date_storage_desktop.cc and heartbeat_info_desktop.cc as they're not needed by iOS build. 

I took the second approach as it seems to me this has been a mistake slipped in through the merge (which can as well be wrong).
***
### Testing
Built my app with the patched version on Xcode 13.3 and it managed to compile and work as expected.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
