### PR TITLE
[Experimental] Increase Android Emulator Test timeout from 10 mins to 20 mins

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -895,7 +895,7 @@ jobs:
           npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run Android integration tests on Emulator locally
-        timeout-minutes: 90
+        timeout-minutes: 120
         if: steps.get-device-type.outputs.device_type == 'virtual'
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -998,7 +998,7 @@ jobs:
           npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run iOS integration tests on Simulator locally
-        timeout-minutes: 90
+        timeout-minutes: 120
         if: steps.get-device-type.outputs.device_type == 'virtual'
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
@@ -1095,7 +1095,7 @@ jobs:
           npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run tvOS integration tests on Simulator locally
-        timeout-minutes: 60
+        timeout-minutes: 90
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --tvos_device "${{ matrix.tvos_device }}" \

--- a/scripts/gha/integration_testing/gameloop_android/app/src/androidTest/java/com/google/firebase/gameloop/GameLoopUITest.kt
+++ b/scripts/gha/integration_testing/gameloop_android/app/src/androidTest/java/com/google/firebase/gameloop/GameLoopUITest.kt
@@ -21,7 +21,7 @@ import org.junit.runner.RunWith
 class GameLoopUITest {
 
   companion object {
-    const val GAMELOOP_TIMEOUT = 10 * 60 * 1000L
+    const val GAMELOOP_TIMEOUT = 20 * 60 * 1000L
   }
 
   private lateinit var device: UiDevice

--- a/scripts/gha/integration_testing/gameloop_apple/gameloopUITests/gameloopUITests.swift
+++ b/scripts/gha/integration_testing/gameloop_apple/gameloopUITests/gameloopUITests.swift
@@ -101,8 +101,8 @@ class GameLoopLauncherUITests: XCTestCase {
     {
       return timeoutSecs
     } else {
-      // Default 8 minutes
-      return TimeInterval(8 * 60)
+      // Default 15 minutes
+      return TimeInterval(15 * 60)
     }
   }
 }


### PR DESCRIPTION
### Description
For firestore testapp, each individual test runs in less than 1 second locally.
However, in GHA, the run times of the individual tests and some are taking 5-10 seconds EACH.  This excessive runtime could easily add up to surpass the original 10 mins limit.
e.g. https://github.com/firebase/firebase-cpp-sdk/runs/5769606818?check_suite_focus=true

***
### Testing
See comment below
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
