### PR TITLE
Upgrade LevelDb dependency from a pinned commit to 1.23

### DIFF
--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -18,7 +18,7 @@ if(TARGET leveldb)
   return()
 endif()
 
-set(version e0d5f83a4f80060fe5b5d80025f0ad049bca430e)
+set(version 1.23)
 
 ExternalProject_Add(
   leveldb

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -567,6 +567,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    -   Firestore/Database (desktop): Upgrade LevelDb dependency to 1.23
+        ([#886](https://github.com/firebase/firebase-cpp-sdk/pull/886)).
+
 ### 8.10.0
 -   Changes
     -   General (iOS): Fixed additional issues on iOS 15 caused by early

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -569,7 +569,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
-    -   Firestore/Database (desktop): Upgrade LevelDb dependency to 1.23
+    -   Firestore/Database (Desktop): Upgrade LevelDb dependency to 1.23
         ([#886](https://github.com/firebase/firebase-cpp-sdk/pull/886)).
 
 ### 8.10.0


### PR DESCRIPTION
LevelDb version 1.23 is the first LevelDb release to include the pinned commit, https://github.com/google/leveldb/commit/e0d5f83a4f80060fe5b5d80025f0ad049bca430e.