### PR TITLE
Define flatbuffers schema for logged heartbeats

### DIFF
--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -65,7 +65,7 @@ set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS
 set(FLATC_ARGS "${FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS}")
 build_flatbuffers("${CMAKE_CURRENT_LIST_DIR}/google_services.fbs"
                   ""
-                  "app_generated_includes"
+                  "app_generated_google_services_includes"
                   "${FIREBASE_FLATBUFFERS_DEPENDENCIES}"
                   "${FIREBASE_GEN_FILE_DIR}/app"
                   ""
@@ -169,12 +169,36 @@ if (PLATFORM STREQUAL TVOS OR PLATFORM STREQUAL SIMULATOR_TVOS)
     src/invites/ios/invites_ios_startup.mm)
 endif()
 
+
+# Flatbuffer schemas used by the desktop implementation.
+set(desktop_flatbuffers_schema_dir
+    "${CMAKE_CURRENT_LIST_DIR}/src/heartbeat/schemas")
+set(desktop_flatbuffers_schemas
+    "${desktop_flatbuffers_schema_dir}/logged_heartbeats.fbs")
+set(FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS
+    "--no-union-value-namespacing"
+    "--gen-generated"
+    "--gen-object-api"
+    "--cpp-ptr-type" "flatbuffers::unique_ptr")
+# Because of a bug in the version of Flatbuffers we are pinned to,
+# additional flags need to be set.
+# also see if app_generated_includes will conflict
+set(FLATC_ARGS "${FLATBUFFERS_FLATC_SCHEMA_EXTRA_ARGS}")
+build_flatbuffers("${desktop_flatbuffers_schemas}"
+                  "${CMAKE_CURRENT_LIST_DIR}"
+                  "app_generated_includes"
+                  "${FIREBASE_FLATBUFFERS_DEPENDENCIES}"
+                  "${FIREBASE_GEN_FILE_DIR}/app"
+                  ""
+                  "")
+
 set(app_desktop_SRCS
     src/app_desktop.cc
     src/heartbeat_date_storage_desktop.cc
     src/heartbeat_info_desktop.cc
     src/invites/stub/invites_receiver_internal_stub.cc
-    src/variant_util.cc)
+    src/variant_util.cc
+    ${FIREBASE_GEN_FILE_DIR}/app/logged_heartbeats_generated.h)
 if(ANDROID)
   set(app_platform_SRCS
       "${app_android_SRCS}")

--- a/app/src/heartbeat/schemas/logged_heartbeats.fbs
+++ b/app/src/heartbeat/schemas/logged_heartbeats.fbs
@@ -1,0 +1,34 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace com.google.firebase.heartbeat.cpp; // TODO - pick namespace
+
+table LoggedHeartbeats {
+    // Last date for which a heartbeat was logged
+    // YYYY-MM-DD
+    last_logged_date:string;
+
+    user_agents:[UserAgentAndDates];
+}
+
+table UserAgentAndDates {
+    // User agent string
+    user_agent:string;
+
+    // List of dates for which a heartbeat was logged for this user agent
+    // YYYY-MM-DD
+    dates:[string];
+}
+
+root_type LoggedHeartbeats;

--- a/app/src/heartbeat/schemas/logged_heartbeats.fbs
+++ b/app/src/heartbeat/schemas/logged_heartbeats.fbs
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-namespace com.google.firebase.heartbeat.cpp; // TODO - pick namespace
+namespace com.google.firebase.cpp.heartbeat;
 
 table LoggedHeartbeats {
     // Last date for which a heartbeat was logged

--- a/app/src/heartbeat/schemas/logged_heartbeats.fbs
+++ b/app/src/heartbeat/schemas/logged_heartbeats.fbs
@@ -19,7 +19,7 @@ table LoggedHeartbeats {
     // YYYY-MM-DD
     last_logged_date:string;
 
-    user_agents:[UserAgentAndDates];
+    heartbeats:[UserAgentAndDates];
 }
 
 table UserAgentAndDates {


### PR DESCRIPTION
Defines a LoggedHeartbeats flatbuffer schema which contains a string representing the date that a heartbeat was last logged, and a list of entries where each entry contains a user agent string and a list of dates in which heartbeats were logged.