### PR TITLE
firestore_snappy.patch.txt: fix linux gcc inlining build error

### DIFF
--- a/cmake/external/firestore_snappy.patch.txt
+++ b/cmake/external/firestore_snappy.patch.txt
@@ -595,7 +595,6 @@ index 000000000..9f25c03d0
 +  BUILD_COMMAND     ""
 +  INSTALL_COMMAND   ""
 +  TEST_COMMAND      ""
-+  # Patch in the fix for linux gcc: https://github.com/google/snappy/pull/128
 +  PATCH_COMMAND     patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/snappy.patch
 +
 +  HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"

--- a/cmake/external/firestore_snappy.patch.txt
+++ b/cmake/external/firestore_snappy.patch.txt
@@ -558,7 +558,7 @@ new file mode 100644
 index 000000000..9f25c03d0
 --- /dev/null
 +++ b/cmake/external/snappy.cmake
-@@ -0,0 +1,39 @@
+@@ -0,0 +1,40 @@
 +# Copyright 2022 Google LLC
 +#
 +# Licensed under the Apache License, Version 2.0 (the "License");

--- a/cmake/external/firestore_snappy.patch.txt
+++ b/cmake/external/firestore_snappy.patch.txt
@@ -595,6 +595,26 @@ index 000000000..9f25c03d0
 +  BUILD_COMMAND     ""
 +  INSTALL_COMMAND   ""
 +  TEST_COMMAND      ""
++  # Patch in the fix for linux gcc: https://github.com/google/snappy/pull/128
++  PATCH_COMMAND     patch -Np1 -i ${CMAKE_CURRENT_LIST_DIR}/snappy.patch
 +
 +  HTTP_HEADER "${EXTERNAL_PROJECT_HTTP_HEADER}"
 +)
+diff --git a/cmake/external/snappy.patch b/cmake/external/snappy.patch
+new file mode 100644
+index 000000000..28bfb0837
+--- /dev/null
++++ b/cmake/external/snappy.patch
+@@ -0,0 +1,12 @@
++diff -Naur snappy/snappy.cc snappy_patched/snappy.cc
++--- snappy/snappy.cc	2022-04-12 20:44:55.000000000 -0400
+++++ snappy_patched/snappy.cc	2022-04-12 20:47:05.000000000 -0400
++@@ -1014,7 +1014,7 @@
++ }
++ 
++ SNAPPY_ATTRIBUTE_ALWAYS_INLINE
++-size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
+++inline size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
++   const uint8_t*& ip = *ip_p;
++   // This section is crucial for the throughput of the decompression loop.
++   // The latency of an iteration is fundamentally constrained by the


### PR DESCRIPTION
This is a follow-up to #885 and fixes the Snappy build on some older compilers (e.g. gcc-9.4.0 on linux).

This PR is based on this patch: https://github.com/google/snappy/pull/128

The build error looks like this:
```
snappy.cc:1017:8: warning: always_inline function might not be inlinable [-Wattributes]
 1017 | size_t AdvanceToNextTag(const uint8_t** ip_p, size_t* tag) {
      |        ^~~~~~~~~~~~~~~~
snappy.cc: In function ‘std::pair<const unsigned char*, long int> snappy::DecompressBranchless(const uint8_t*, const uint8_t*, ptrdiff_t, T, ptrdiff_t) [with T = char*]’:
snappy.cc:1017:8: error: inlining failed in call to always_inline ‘size_t snappy::AdvanceToNextTag(const uint8_t**, size_t*)’: function body can be overwritten at link time
snappy.cc:1097:43: note: called from here
 1097 |         size_t tag_type = AdvanceToNextTag(&ip, &tag);
      |                           ~~~~~~~~~~~~~~~~^~~~~~~~~~~
```

The fix is to explicitly mark `AdvanceToNextTag()` as `inline`.

e.g. https://github.com/firebase/firebase-unity-sdk/runs/5998971917