### PR TITLE
firestore.cmake: go back to the old set(version X.Y.Z) syntax

### DIFF
--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -18,7 +18,11 @@ if(TARGET firestore)
   return()
 endif()
 
-function(GetReleasedDep version)
+# If the format of the line below changes, then be sure to update
+# https://github.com/firebase/firebase-cpp-sdk/blob/fd054fa016/.github/workflows/update-dependencies.yml#L81
+set(version CocoaPods-8.12.1)
+
+function(GetReleasedDep)
   message("Getting released firebase-ios-sdk @ ${version}")
   ExternalProject_Add(
     firestore
@@ -60,7 +64,7 @@ endfunction()
 
 if((NOT FIRESTORE_DEP_SOURCE) OR (FIRESTORE_DEP_SOURCE STREQUAL "RELEASED"))
   # Get from released dependency by default
-  GetReleasedDep("CocoaPods-8.12.1")
+  GetReleasedDep()
 else()
   if(FIRESTORE_DEP_SOURCE STREQUAL "TIP")
     GetTag("origin/master")


### PR DESCRIPTION
There were some major changes to `firestore.cmake` in #855, including replacing the line

```
set(version CocoaPods-8.12.1)
```

with

```
GetReleasedDep("CocoaPods-8.12.1")
```

However, the `update-dependencies.yml` workflow had the old syntax hardcoded: https://github.com/firebase/firebase-cpp-sdk/blob/fd054fa0163ab304f3f32e967112f62aa5fc3f54/.github/workflows/update-dependencies.yml#L81

This discrepancy caused the update of the Firestore SDK to be missed in #893.

This PR changes `firestore.cmake` back to the old syntax, and adds a comment so that this will be more difficult to mess up in the future.