### PR TITLE
Set the FIRESTORE_INCLUDE_OBJC cmake cache var to NO

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,10 @@ if(FIREBASE_INCLUDE_FIRESTORE AND DESKTOP)
   set(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD ON)
 endif()
 
+# Disable compiling the Objective-C (and Swift) stuff from the
+# firebase-ios-sdk since it's not needed and can sometimes fail to build.
+set(FIRESTORE_INCLUDE_OBJC NO)
+
 if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
   # Quote meta characters in ${CMAKE_CURRENT_LIST_DIR} so we can
   # match it in a regex.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 
 # Disable compiling the Objective-C (and Swift) stuff from the
 # firebase-ios-sdk since it's not needed and can sometimes fail to build.
-set(FIRESTORE_INCLUDE_OBJC NO)
+set(FIRESTORE_INCLUDE_OBJC OFF CACHE BOOL "Disabled for the CPP SDK")
 
 if(FIREBASE_CPP_USE_PRIOR_GRADLE_BUILD)
   # Quote meta characters in ${CMAKE_CURRENT_LIST_DIR} so we can


### PR DESCRIPTION
This won't have any effects until the iOS dependencies are updated to a version that includes https://github.com/firebase/firebase-ios-sdk/pull/9658.

Setting the cmake cache variable `FIRESTORE_INCLUDE_OBJC` to `NO` will work around the `unknown attribute 'swift_async'` build error introduced by https://github.com/firebase/firebase-ios-sdk/pull/9502, and that will be picked up the next time that the iOS dependencies in this repository are upgraded. This fixes the build error because the file with the problematic code is no longer included in the build.

See https://github.com/firebase/firebase-ios-sdk/pull/9658 for more details.