### PR TITLE
Modify Test Framework to make it able to trigger only UI tests in testapps (skip non UI tests)

### DIFF
--- a/gma/integration_test/AndroidManifest.xml
+++ b/gma/integration_test/AndroidManifest.xml
@@ -42,6 +42,11 @@
         <category android:name="android.intent.category.DEFAULT"/>
         <data android:mimeType="application/javascript"/>
       </intent-filter>
+      <intent-filter>
+        <action android:name="com.google.intent.action.UI_TEST"/>
+        <category android:name="android.intent.category.DEFAULT"/>
+        <data android:mimeType="application/javascript"/>
+      </intent-filter>
     </activity>
     <meta-data android:name="com.google.test.loops" android:value="1" />
   </application>

--- a/gma/integration_test/Info.plist
+++ b/gma/integration_test/Info.plist
@@ -31,6 +31,7 @@
 			<array>
 				<string>REPLACE_WITH_REVERSED_CLIENT_ID</string>
 				<string>firebase-game-loop</string>
+				<string>firebase-ui-test</string>
 			</array>
 		</dict>
 	</array>

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -161,6 +161,14 @@ class FirebaseGmaTest : public FirebaseTest {
   static firebase::App* shared_app_;
 };
 
+class FirebaseGmaUITest : public FirebaseGmaTest {
+ public:
+  FirebaseGmaUITest();
+  ~FirebaseGmaUITest() override;
+
+  void SetUp() override;
+};
+
 // Runs GMA Tests on methods and functions that should be run
 // before GMA initializes.
 class FirebaseGmaPreInitializationTests : public FirebaseGmaTest {
@@ -233,6 +241,7 @@ FirebaseGmaTest::FirebaseGmaTest() {}
 FirebaseGmaTest::~FirebaseGmaTest() {}
 
 void FirebaseGmaTest::SetUp() {
+  TEST_DOES_NOT_REQUIRE_USER_INTERACTION;
   FirebaseTest::SetUp();
 
   // This example uses ad units that are specially configured to return test ads
@@ -272,6 +281,26 @@ firebase::gma::AdRequest FirebaseGmaTest::GetAdRequest() {
   request.add_neighboring_content_urls(kNeighboringContentURLs);
 
   return request;
+}
+
+FirebaseGmaUITest::FirebaseGmaUITest() {}
+
+FirebaseGmaUITest::~FirebaseGmaUITest() {}
+
+void FirebaseGmaUITest::SetUp() {
+  TEST_REQUIRES_USER_INTERACTION;
+  FirebaseTest::SetUp();
+  // This example uses ad units that are specially configured to return test ads
+  // for every request. When using your own ad unit IDs, however, it's important
+  // to register the device IDs associated with any devices that will be used to
+  // test the app. This ensures that regardless of the ad unit ID, those
+  // devices will always receive test ads in compliance with GMA policy.
+  //
+  // Device IDs can be obtained by checking the logcat or the Xcode log while
+  // debugging. They appear as a long string of hex characters.
+  firebase::gma::RequestConfiguration request_configuration;
+  request_configuration.test_device_ids = kTestDeviceIDs;
+  firebase::gma::SetRequestConfiguration(request_configuration);
 }
 
 FirebaseGmaPreInitializationTests::FirebaseGmaPreInitializationTests() {}
@@ -460,8 +489,8 @@ class TestAdInspectorClosedListener
 };
 
 // Ensure we can open the AdInspector and listen to its events.
-TEST_F(FirebaseGmaTest, TestAdInspector) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestAdInspector) {
+  // TEST_REQUIRES_USER_INTERACTION;
   TestAdInspectorClosedListener listener;
 
   firebase::gma::OpenAdInspector(app_framework::GetWindowController(),
@@ -790,8 +819,8 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
 
 // Interactive test section.  These have been placed up front so that the
 // tester doesn't get bored waiting for them.
-TEST_F(FirebaseGmaTest, TestAdViewAdOpenedAdClosed) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestAdViewAdOpenedAdClosed) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -859,8 +888,8 @@ TEST_F(FirebaseGmaTest, TestAdViewAdOpenedAdClosed) {
   delete ad_view;
 }
 
-TEST_F(FirebaseGmaTest, TestInterstitialAdLoadAndShow) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestInterstitialAdLoadAndShow) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   firebase::gma::InterstitialAd* interstitial =
@@ -914,8 +943,8 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadAndShow) {
   delete interstitial;
 }
 
-TEST_F(FirebaseGmaTest, TestRewardedAdLoadAndShow) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestRewardedAdLoadAndShow) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
@@ -1120,8 +1149,8 @@ TEST_F(FirebaseGmaTest, TestAdViewAdSizeBeforeInitialization) {
   WaitForCompletion(ad_view->Destroy(), "Destroy AdView");
 }
 
-TEST_F(FirebaseGmaTest, TestAdView) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestAdView) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -1742,8 +1771,8 @@ TEST_F(FirebaseGmaTest, TestRewardedAdErrorBadExtrasClassName) {
 }
 
 // Stress tests.  These take a while so run them near the end.
-TEST_F(FirebaseGmaTest, TestAdViewStress) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestAdViewStress) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1764,8 +1793,8 @@ TEST_F(FirebaseGmaTest, TestAdViewStress) {
   }
 }
 
-TEST_F(FirebaseGmaTest, TestInterstitialAdStress) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestInterstitialAdStress) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1784,8 +1813,8 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdStress) {
   }
 }
 
-TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
-  TEST_REQUIRES_USER_INTERACTION;
+TEST_F(FirebaseGmaUITest, TestRewardedAdStress) {
+  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -490,7 +490,6 @@ class TestAdInspectorClosedListener
 
 // Ensure we can open the AdInspector and listen to its events.
 TEST_F(FirebaseGmaUITest, TestAdInspector) {
-  // TEST_REQUIRES_USER_INTERACTION;
   TestAdInspectorClosedListener listener;
 
   firebase::gma::OpenAdInspector(app_framework::GetWindowController(),
@@ -820,7 +819,6 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
 // Interactive test section.  These have been placed up front so that the
 // tester doesn't get bored waiting for them.
 TEST_F(FirebaseGmaUITest, TestAdViewAdOpenedAdClosed) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -889,7 +887,6 @@ TEST_F(FirebaseGmaUITest, TestAdViewAdOpenedAdClosed) {
 }
 
 TEST_F(FirebaseGmaUITest, TestInterstitialAdLoadAndShow) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   firebase::gma::InterstitialAd* interstitial =
@@ -944,7 +941,6 @@ TEST_F(FirebaseGmaUITest, TestInterstitialAdLoadAndShow) {
 }
 
 TEST_F(FirebaseGmaUITest, TestRewardedAdLoadAndShow) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
@@ -1150,7 +1146,6 @@ TEST_F(FirebaseGmaTest, TestAdViewAdSizeBeforeInitialization) {
 }
 
 TEST_F(FirebaseGmaUITest, TestAdView) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
@@ -1772,7 +1767,6 @@ TEST_F(FirebaseGmaTest, TestRewardedAdErrorBadExtrasClassName) {
 
 // Stress tests.  These take a while so run them near the end.
 TEST_F(FirebaseGmaUITest, TestAdViewStress) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1794,7 +1788,6 @@ TEST_F(FirebaseGmaUITest, TestAdViewStress) {
 }
 
 TEST_F(FirebaseGmaUITest, TestInterstitialAdStress) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {
@@ -1814,7 +1807,6 @@ TEST_F(FirebaseGmaUITest, TestInterstitialAdStress) {
 }
 
 TEST_F(FirebaseGmaUITest, TestRewardedAdStress) {
-  // TEST_REQUIRES_USER_INTERACTION;
   SKIP_TEST_ON_DESKTOP;
 
   for (int i = 0; i < 10; ++i) {

--- a/scripts/gha/ui_testing/uitest_android/app/src/androidTest/java/com/google/firebase/uitest/UITest.java
+++ b/scripts/gha/ui_testing/uitest_android/app/src/androidTest/java/com/google/firebase/uitest/UITest.java
@@ -139,7 +139,8 @@ public class UITest {
 
     String gamePackageName = "com.google.android.admob.testapp";
     File dir = new File(context.getFilesDir(), gamePackageName);
-    if (!dir.exists()) dir.mkdirs();
+    if (!dir.exists())
+      dir.mkdirs();
     String filename = "Results1.json";
     File file = new File(dir, filename);
     try {
@@ -148,8 +149,11 @@ public class UITest {
       e.printStackTrace();
     }
     Log.d("TAG", "Test Result Path :" + file);
-    Uri fileUri = FileProvider.getUriForFile(context, "com.google.firebase.uitest.fileprovider", file);
-    intent.setPackage(gamePackageName).setDataAndType(fileUri, "application/javascript").addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
+    Uri fileUri =
+        FileProvider.getUriForFile(context, "com.google.firebase.uitest.fileprovider", file);
+    intent.setPackage(gamePackageName)
+        .setDataAndType(fileUri, "application/javascript")
+        .addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
     context.startActivity(intent);
   }
 

--- a/scripts/gha/ui_testing/uitest_android/app/src/androidTest/java/com/google/firebase/uitest/UITest.java
+++ b/scripts/gha/ui_testing/uitest_android/app/src/androidTest/java/com/google/firebase/uitest/UITest.java
@@ -19,7 +19,10 @@ import static androidx.test.platform.app.InstrumentationRegistry.getInstrumentat
 
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.util.Log;
+import androidx.core.content.FileProvider;
 import androidx.test.ext.junit.runners.AndroidJUnit4;
 import androidx.test.uiautomator.By;
 import androidx.test.uiautomator.UiDevice;
@@ -28,6 +31,8 @@ import androidx.test.uiautomator.UiObject2;
 import androidx.test.uiautomator.UiObjectNotFoundException;
 import androidx.test.uiautomator.UiSelector;
 import androidx.test.uiautomator.Until;
+import java.io.File;
+import java.io.IOException;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -127,7 +132,24 @@ public class UITest {
   private void launchApp(String packageName) {
     Context context = getApplicationContext();
     Intent intent = context.getPackageManager().getLaunchIntentForPackage(packageName);
+    intent.setAction("com.google.intent.action.UI_TEST");
+    intent.addCategory(Intent.CATEGORY_DEFAULT);
+    intent.setType("application/javascript");
     intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TASK); // Clear out any previous instances
+
+    String gamePackageName = "com.google.android.admob.testapp";
+    File dir = new File(context.getFilesDir(), gamePackageName);
+    if (!dir.exists()) dir.mkdirs();
+    String filename = "Results1.json";
+    File file = new File(dir, filename);
+    try {
+      file.createNewFile();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+    Log.d("TAG", "Test Result Path :" + file);
+    Uri fileUri = FileProvider.getUriForFile(context, "com.google.firebase.uitest.fileprovider", file);
+    intent.setPackage(gamePackageName).setDataAndType(fileUri, "application/javascript").addFlags(Intent.FLAG_GRANT_WRITE_URI_PERMISSION);
     context.startActivity(intent);
   }
 

--- a/scripts/gha/ui_testing/uitest_android/app/src/main/AndroidManifest.xml
+++ b/scripts/gha/ui_testing/uitest_android/app/src/main/AndroidManifest.xml
@@ -1,11 +1,23 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.google.firebase.uitest">
 
+  <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+
   <application
       android:allowBackup="true"
       android:label="@string/app_name"
       android:supportsRtl="true"
       android:theme="@style/AppTheme" >
+
+    <provider
+        android:authorities="com.google.firebase.uitest.fileprovider"
+        android:name="androidx.core.content.FileProvider"
+        android:exported="false"
+        android:grantUriPermissions="true">
+      <meta-data
+          android:name="android.support.FILE_PROVIDER_PATHS"
+          android:resource="@xml/file_paths"/>
+    </provider>
   </application>
 
 </manifest>

--- a/scripts/gha/ui_testing/uitest_android/app/src/main/res/xml/file_paths.xml
+++ b/scripts/gha/ui_testing/uitest_android/app/src/main/res/xml/file_paths.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<paths>
+  <files-path
+      name="files"
+      path="/"/>
+</paths>

--- a/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestApp/ViewController.swift
+++ b/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestApp/ViewController.swift
@@ -19,11 +19,19 @@
 
 import UIKit
 
+/// Minimal view controller to launch the game loop.
 class ViewController: UIViewController {
 
+  /// Run the game loop as soon as we load.
   override func viewDidLoad() {
     super.viewDidLoad()
-    // Do any additional setup after loading the view.
+    NSLog("Starting UI Test")
+    launchGame()
   }
 
+  /// Launch the app under test by calling our custom URL scheme.
+  func launchGame() {
+    let url = URL(string: "firebase-ui-test://")!
+    UIApplication.shared.open(url)
+  }
 }

--- a/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestApp/ViewController.swift
+++ b/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestApp/ViewController.swift
@@ -19,10 +19,10 @@
 
 import UIKit
 
-/// Minimal view controller to launch the game loop.
+/// Minimal view controller to launch the UI tests.
 class ViewController: UIViewController {
 
-  /// Run the game loop as soon as we load.
+  /// Run the UI Test as soon as we load.
   override func viewDidLoad() {
     super.viewDidLoad()
     NSLog("Starting UI Test")

--- a/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestAppUITests/FirebaseCppUITestAppUITests.swift
+++ b/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestAppUITests/FirebaseCppUITestAppUITests.swift
@@ -28,6 +28,7 @@ class FirebaseCppUITestAppUITests: XCTestCase {
     // Periodically check and dismiss dialogs with "Allow" or "OK"
     Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { (_) in
 #if os(iOS)
+      NSLog("finding springboard ...")
       let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
       for button in [springboard.buttons["Open"], springboard.buttons["Allow"], springboard.buttons["OK"]] {
         if button.exists {

--- a/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestAppUITests/FirebaseCppUITestAppUITests.swift
+++ b/scripts/gha/ui_testing/uitest_apple/FirebaseCppUITestAppUITests/FirebaseCppUITestAppUITests.swift
@@ -21,34 +21,60 @@ import XCTest
 
 class FirebaseCppUITestAppUITests: XCTestCase {
 
-  override func setUp() {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-
-    // In UI tests it is usually best to stop immediately when a failure occurs.
-    continueAfterFailure = false
-
-    // UI tests must launch the application that they test. Doing this in setup will make sure it happens for each test method.
-    XCUIApplication().launch()
-
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-  }
-
-  override func tearDown() {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
-
   func testGMA() {
+    // Launch this Helper App
+    let helperApp = XCUIApplication()
+
+    // Periodically check and dismiss dialogs with "Allow" or "OK"
+    Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { (_) in
+#if os(iOS)
+      let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+      for button in [springboard.buttons["Open"], springboard.buttons["Allow"], springboard.buttons["OK"]] {
+        if button.exists {
+          NSLog("Dismissing system dialog")
+          button.tap()
+        }
+      }
+#elseif os(tvOS)
+      NSLog("finding pineboard ...")
+      let pineboard = XCUIApplication(bundleIdentifier: "com.apple.PineBoard")
+      for button in [pineboard.buttons["Open"], pineboard.buttons["Allow"], pineboard.buttons["OK"]] {
+        if button.exists {
+          NSLog("Dismissing system dialog")
+          let remote: XCUIRemote = XCUIRemote.shared
+          remote.press(.select)
+        }
+      }
+#endif
+    }
+
+    // Launch UI Test App
+    helperApp.launch()
+    // Wait until UI Test App open Integration Test App
+    helperApp.wait(for: .runningBackground, timeout: 20)
+
+    // Wait until Integration Test App closed (testing finished)
+    let expectation = XCTestExpectation(description: "Integration Test App closed")
+    Timer.scheduledTimer(withTimeInterval: 5, repeats: true) { (_) in
+      if helperApp.state == .runningForeground {
+        NSLog("Integration Test App closed... UI Test App back to foreground...")
+        expectation.fulfill()
+      } else {
+        NSLog("Testing... UI Test App in background...")
+      }
+    }
+
+
+    // Start Automated UI Test
     let app = XCUIApplication(bundleIdentifier: "com.google.ios.admob.testapp")
-    app.launch()
 
     // TestAdViewAdClick
     var reference = app.staticTexts["Test mode"]
     XCTAssertTrue(reference.waitForExistence(timeout: 60))
-    // click on the center point of the "Test Ad" TextView, where the Ad present
+    // Click on the center point of the "Test Ad" TextView, where the Ad present
     var x = (reference.frame.origin.x + reference.frame.width)/2
     var y = (reference.frame.origin.y + reference.frame.height)/2
-    sleep(5)  // wait until button hittable
+    sleep(5)  // Wait until button hittable
     let ad_view = app.findElement(at: CGPoint(x: x, y: y))
     ad_view.tap()
     sleep(5)
@@ -59,11 +85,11 @@ class FirebaseCppUITestAppUITests: XCTestCase {
     // TestInterstitialAdClose
     reference = app.staticTexts["Test mode"]
     XCTAssertTrue(reference.waitForExistence(timeout: 60))
-    // click the top left corner close bottom.
+    // Click the top left corner close bottom.
     // Use "Test Ad" TextView bottom position as the reference
     x = (reference.frame.origin.y + reference.frame.height)/2
     y = (reference.frame.origin.y + reference.frame.height)/2
-    sleep(5)  // wait until button hittable
+    sleep(5)  // Wait until button hittable
     let interstitial_ad_close_button = app.findElement(at: CGPoint(x: x, y: y))
     interstitial_ad_close_button.tap()
 
@@ -72,10 +98,10 @@ class FirebaseCppUITestAppUITests: XCTestCase {
     // TestInterstitialAdClickAndClose
     reference = app.staticTexts["Test mode"]
     XCTAssertTrue(reference.waitForExistence(timeout: 60))
-    // click the center point of the device, where the Ad present
+    // Click the center point of the device, where the Ad present
     x = app.frame.width/2
     y = app.frame.height/2
-    sleep(5)  // wait until button hittable
+    sleep(5)  // Wait until button hittable
     let interstitial_ad = app.findElement(at: CGPoint(x: x, y: y))
     interstitial_ad.tap()
     sleep(5)
@@ -88,11 +114,11 @@ class FirebaseCppUITestAppUITests: XCTestCase {
     // TestRewardedAdClose
     reference = app.webViews.staticTexts.containing(NSPredicate(format: "label CONTAINS 'seconds'")).element
     XCTAssertTrue(reference.waitForExistence(timeout: 60))
-    // click the top right corner close bottom.
+    // Click the top right corner close bottom.
     // Use "* seconds" TextView right position as the reference
     x = (reference.frame.origin.x + reference.frame.width + app.frame.width)/2
     y = (reference.frame.origin.y + reference.frame.height)/2
-    sleep(5)  // wait until button hittable
+    sleep(5)  // Wait until button hittable
     let rewarded_ad_close_button = app.findElement(at: CGPoint(x: x, y: y))
     rewarded_ad_close_button.tap()
 

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -333,10 +333,6 @@ JNIEnv* GetJniEnv() {
   return result == JNI_OK ? env : nullptr;
 }
 
-bool IsUserInteractionAllowed() {
-  return app_framework::g_logging_utils_data->IsUserInteractionAllowed();
-}
-
 bool IsLoggingToFile() {
   return app_framework::g_logging_utils_data->IsLoggingToFile();
 }

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -314,6 +314,10 @@ JNIEnv* GetJniEnv() {
   return result == JNI_OK ? env : nullptr;
 }
 
+bool IsUserInteractionAllowed() {
+  return app_framework::g_logging_utils_data->IsUserInteractionAllowed();
+}
+
 bool IsLoggingToFile() {
   return app_framework::g_logging_utils_data->IsLoggingToFile();
 }

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -169,7 +169,7 @@ class LoggingUtilsData {
   }
 
   void AppendText(const char* text) {
-    if (logging_utils_class_ == 0) return;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jstring text_string = env->NewStringUTF(text);
@@ -179,7 +179,7 @@ class LoggingUtilsData {
   }
 
   bool DidTouch() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     return env->CallStaticBooleanMethod(logging_utils_class_,
@@ -187,7 +187,7 @@ class LoggingUtilsData {
   }
 
   bool SkipUITest() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
@@ -196,7 +196,7 @@ class LoggingUtilsData {
   }
 
   bool SkipNonUITest() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jboolean b = env->CallStaticBooleanMethod(
@@ -205,7 +205,7 @@ class LoggingUtilsData {
   }
 
   bool IsLoggingToFile() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
@@ -219,7 +219,7 @@ class LoggingUtilsData {
   }
 
   bool StartLoggingToFile(const char* path) {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jstring path_string = env->NewStringUTF(path);

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -159,10 +159,10 @@ class LoggingUtilsData {
     logging_utils_start_log_file_ =
         env->GetStaticMethodID(logging_utils_class_, "startLogFile",
                                "(Landroid/app/Activity;Ljava/lang/String;)Z");
-    logging_utils_skip_uitest_log_ = env->GetStaticMethodID(
-        logging_utils_class_, "skipUITestLog", "()Z");
-    logging_utils_skip_nonuitest_log_ = env->GetStaticMethodID(
-        logging_utils_class_, "skipNonUITestLog", "()Z");
+    logging_utils_skip_uitest_log_ =
+        env->GetStaticMethodID(logging_utils_class_, "skipUITestLog", "()Z");
+    logging_utils_skip_nonuitest_log_ =
+        env->GetStaticMethodID(logging_utils_class_, "skipNonUITestLog", "()Z");
 
     env->CallStaticVoidMethod(logging_utils_class_,
                               logging_utils_init_log_window_, GetActivity());
@@ -191,7 +191,7 @@ class LoggingUtilsData {
     JNIEnv* env = GetJniEnv();
     assert(env);
     jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
-                                                   logging_utils_skip_uitest_log_);
+                                              logging_utils_skip_uitest_log_);
     return (bool)b;
   }
 
@@ -199,8 +199,8 @@ class LoggingUtilsData {
     if (logging_utils_class_ == 0) return false;  // haven't been initted yet
     JNIEnv* env = GetJniEnv();
     assert(env);
-    jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
-                                                   logging_utils_skip_nonuitest_log_);
+    jboolean b = env->CallStaticBooleanMethod(
+        logging_utils_class_, logging_utils_skip_nonuitest_log_);
     return (bool)b;
   }
 
@@ -333,9 +333,7 @@ JNIEnv* GetJniEnv() {
   return result == JNI_OK ? env : nullptr;
 }
 
-bool SkipUITest() {
-  return app_framework::g_logging_utils_data->SkipUITest();
-}
+bool SkipUITest() { return app_framework::g_logging_utils_data->SkipUITest(); }
 
 bool SkipNonUITest() {
   return app_framework::g_logging_utils_data->SkipNonUITest();

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -333,6 +333,14 @@ JNIEnv* GetJniEnv() {
   return result == JNI_OK ? env : nullptr;
 }
 
+bool SkipUITest() {
+  return app_framework::g_logging_utils_data->SkipUITest();
+}
+
+bool SkipNonUITest() {
+  return app_framework::g_logging_utils_data->SkipNonUITest();
+}
+
 bool IsLoggingToFile() {
   return app_framework::g_logging_utils_data->IsLoggingToFile();
 }

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -190,7 +190,7 @@ class LoggingUtilsData {
     if (logging_utils_class_ == 0) return false;  // haven't been initted yet
     JNIEnv* env = GetJniEnv();
     assert(env);
-    jboolean b = env->CallStaticObjectMethod(logging_utils_class_,
+    jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
                                                    logging_utils_skip_uitest_log_);
     return (bool)b;
   }
@@ -199,7 +199,7 @@ class LoggingUtilsData {
     if (logging_utils_class_ == 0) return false;  // haven't been initted yet
     JNIEnv* env = GetJniEnv();
     assert(env);
-    jboolean b = env->CallStaticObjectMethod(logging_utils_class_,
+    jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
                                                    logging_utils_skip_nonuitest_log_);
     return (bool)b;
   }

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -159,10 +159,10 @@ class LoggingUtilsData {
     logging_utils_start_log_file_ =
         env->GetStaticMethodID(logging_utils_class_, "startLogFile",
                                "(Landroid/app/Activity;Ljava/lang/String;)Z");
-    logging_utils_skip_uitest_log_ =
-        env->GetStaticMethodID(logging_utils_class_, "skipUITestLog", "()Z");
-    logging_utils_skip_nonuitest_log_ =
-        env->GetStaticMethodID(logging_utils_class_, "skipNonUITestLog", "()Z");
+    logging_utils_should_run_uitests_ =
+        env->GetStaticMethodID(logging_utils_class_, "ShouldRunUITests", "()Z");
+    logging_utils_should_run_nonuitests_ = env->GetStaticMethodID(
+        logging_utils_class_, "ShouldRunNonUITests", "()Z");
 
     env->CallStaticVoidMethod(logging_utils_class_,
                               logging_utils_init_log_window_, GetActivity());
@@ -187,22 +187,22 @@ class LoggingUtilsData {
                                         logging_utils_get_did_touch_);
   }
 
-  bool SkipUITest() {
+  bool ShouldRunUITests() {
     if (logging_utils_class_ == 0)
       return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     return env->CallStaticBooleanMethod(logging_utils_class_,
-                                        logging_utils_skip_uitest_log_);
+                                        logging_utils_should_run_uitests_);
   }
 
-  bool SkipNonUITest() {
+  bool ShouldRunNonUITests() {
     if (logging_utils_class_ == 0)
       return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     return env->CallStaticBooleanMethod(logging_utils_class_,
-                                        logging_utils_skip_nonuitest_log_);
+                                        logging_utils_should_run_nonuitests_);
   }
 
   bool IsLoggingToFile() {
@@ -240,8 +240,8 @@ class LoggingUtilsData {
   jmethodID logging_utils_get_did_touch_;
   jmethodID logging_utils_get_log_file_;
   jmethodID logging_utils_start_log_file_;
-  jmethodID logging_utils_skip_uitest_log_;
-  jmethodID logging_utils_skip_nonuitest_log_;
+  jmethodID logging_utils_should_run_uitests_;
+  jmethodID logging_utils_should_run_nonuitests_;
 };
 
 LoggingUtilsData* g_logging_utils_data;
@@ -336,10 +336,12 @@ JNIEnv* GetJniEnv() {
   return result == JNI_OK ? env : nullptr;
 }
 
-bool SkipUITest() { return app_framework::g_logging_utils_data->SkipUITest(); }
+bool ShouldRunUITests() {
+  return app_framework::g_logging_utils_data->ShouldRunUITests();
+}
 
-bool SkipNonUITest() {
-  return app_framework::g_logging_utils_data->SkipNonUITest();
+bool ShouldRunNonUITests() {
+  return app_framework::g_logging_utils_data->ShouldRunNonUITests();
 }
 
 bool IsLoggingToFile() {

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -160,9 +160,9 @@ class LoggingUtilsData {
         env->GetStaticMethodID(logging_utils_class_, "startLogFile",
                                "(Landroid/app/Activity;Ljava/lang/String;)Z");
     logging_utils_should_run_uitests_ =
-        env->GetStaticMethodID(logging_utils_class_, "ShouldRunUITests", "()Z");
+        env->GetStaticMethodID(logging_utils_class_, "shouldRunUITests", "()Z");
     logging_utils_should_run_nonuitests_ = env->GetStaticMethodID(
-        logging_utils_class_, "ShouldRunNonUITests", "()Z");
+        logging_utils_class_, "shouldRunNonUITests", "()Z");
 
     env->CallStaticVoidMethod(logging_utils_class_,
                               logging_utils_init_log_window_, GetActivity());

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -179,7 +179,8 @@ class LoggingUtilsData {
   }
 
   bool DidTouch() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
+    if (logging_utils_class_ == 0)
+      return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     return env->CallStaticBooleanMethod(logging_utils_class_,
@@ -187,25 +188,26 @@ class LoggingUtilsData {
   }
 
   bool SkipUITest() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
+    if (logging_utils_class_ == 0)
+      return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
-    jboolean b = env->CallStaticBooleanMethod(logging_utils_class_,
-                                              logging_utils_skip_uitest_log_);
-    return (bool)b;
+    return env->CallStaticBooleanMethod(logging_utils_class_,
+                                        logging_utils_skip_uitest_log_);
   }
 
   bool SkipNonUITest() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
+    if (logging_utils_class_ == 0)
+      return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
-    jboolean b = env->CallStaticBooleanMethod(
-        logging_utils_class_, logging_utils_skip_nonuitest_log_);
-    return (bool)b;
+    return env->CallStaticBooleanMethod(logging_utils_class_,
+                                        logging_utils_skip_nonuitest_log_);
   }
 
   bool IsLoggingToFile() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
+    if (logging_utils_class_ == 0)
+      return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
@@ -219,7 +221,8 @@ class LoggingUtilsData {
   }
 
   bool StartLoggingToFile(const char* path) {
-    if (logging_utils_class_ == 0) return false;  // haven't been initialized yet
+    if (logging_utils_class_ == 0)
+      return false;  // haven't been initialized yet
     JNIEnv* env = GetJniEnv();
     assert(env);
     jstring path_string = env->NewStringUTF(path);

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -159,6 +159,10 @@ class LoggingUtilsData {
     logging_utils_start_log_file_ =
         env->GetStaticMethodID(logging_utils_class_, "startLogFile",
                                "(Landroid/app/Activity;Ljava/lang/String;)Z");
+    logging_utils_skip_uitest_log_ = env->GetStaticMethodID(
+        logging_utils_class_, "skipUITestLog", "()Z");
+    logging_utils_skip_nonuitest_log_ = env->GetStaticMethodID(
+        logging_utils_class_, "skipNonUITestLog", "()Z");
 
     env->CallStaticVoidMethod(logging_utils_class_,
                               logging_utils_init_log_window_, GetActivity());
@@ -182,23 +186,36 @@ class LoggingUtilsData {
                                         logging_utils_get_did_touch_);
   }
 
-  bool IsUserInteractionAllowed() {
-    return true;
+  bool SkipUITest() {
+    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    JNIEnv* env = GetJniEnv();
+    assert(env);
+    jboolean b = env->CallStaticObjectMethod(logging_utils_class_,
+                                                   logging_utils_skip_uitest_log_);
+    return (bool)b;
+  }
+
+  bool SkipNonUITest() {
+    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    JNIEnv* env = GetJniEnv();
+    assert(env);
+    jboolean b = env->CallStaticObjectMethod(logging_utils_class_,
+                                                   logging_utils_skip_nonuitest_log_);
+    return (bool)b;
   }
 
   bool IsLoggingToFile() {
-    return true;
-    // if (logging_utils_class_ == 0) return false;  // haven't been initted yet
-    // JNIEnv* env = GetJniEnv();
-    // assert(env);
-    // jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
-    //                                                logging_utils_get_log_file_);
-    // if (file_uri == nullptr) {
-    //   return false;
-    // } else {
-    //   env->DeleteLocalRef(file_uri);
-    //   return true;
-    // }
+    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    JNIEnv* env = GetJniEnv();
+    assert(env);
+    jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
+                                                   logging_utils_get_log_file_);
+    if (file_uri == nullptr) {
+      return false;
+    } else {
+      env->DeleteLocalRef(file_uri);
+      return true;
+    }
   }
 
   bool StartLoggingToFile(const char* path) {
@@ -220,6 +237,8 @@ class LoggingUtilsData {
   jmethodID logging_utils_get_did_touch_;
   jmethodID logging_utils_get_log_file_;
   jmethodID logging_utils_start_log_file_;
+  jmethodID logging_utils_skip_uitest_log_;
+  jmethodID logging_utils_skip_nonuitest_log_;
 };
 
 LoggingUtilsData* g_logging_utils_data;

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -182,18 +182,23 @@ class LoggingUtilsData {
                                         logging_utils_get_did_touch_);
   }
 
+  bool IsUserInteractionAllowed() {
+    return true;
+  }
+
   bool IsLoggingToFile() {
-    if (logging_utils_class_ == 0) return false;  // haven't been initted yet
-    JNIEnv* env = GetJniEnv();
-    assert(env);
-    jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
-                                                   logging_utils_get_log_file_);
-    if (file_uri == nullptr) {
-      return false;
-    } else {
-      env->DeleteLocalRef(file_uri);
-      return true;
-    }
+    return true;
+    // if (logging_utils_class_ == 0) return false;  // haven't been initted yet
+    // JNIEnv* env = GetJniEnv();
+    // assert(env);
+    // jobject file_uri = env->CallStaticObjectMethod(logging_utils_class_,
+    //                                                logging_utils_get_log_file_);
+    // if (file_uri == nullptr) {
+    //   return false;
+    // } else {
+    //   env->DeleteLocalRef(file_uri);
+    //   return true;
+    // }
   }
 
   bool StartLoggingToFile(const char* path) {

--- a/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
+++ b/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
@@ -43,6 +43,8 @@ public class LoggingUtils {
   private static boolean didTouch = false;
   // If a test log file is specified, this is the log file's URI...
   private static Uri logFile = null;
+  private static boolean skipUITest = false;
+  private static boolean skipNonUITest = false;
   // ...and this is the stream to write to.
   private static DataOutputStream logFileStream = null;
 
@@ -101,9 +103,13 @@ public class LoggingUtils {
 
     Intent launchIntent = activity.getIntent();
     // Check if we are running on Firebase Test Lab, and set up a log file if we are.
-    // if (launchIntent.getAction().equals("com.google.intent.action.TEST_LOOP")) {
-    startLogFile(activity, launchIntent.getData().toString());
-    // }
+    if (launchIntent.getAction().equals("com.google.intent.action.TEST_LOOP")) {
+      skipUITest = true;
+      startLogFile(activity, launchIntent.getData().toString());
+    } else if (launchIntent.getAction().equals("com.google.intent.action.UI_TEST")) {
+      skipNonUITest = true;
+      startLogFile(activity, launchIntent.getData().toString());
+    }
   }
 
   /** Adds some text to the log window. */
@@ -159,5 +165,13 @@ public class LoggingUtils {
     } else {
       return null;
     }
+  }
+
+  public static boolean skipUITestLog() {
+    return skipUITest;
+  }
+
+  public static boolean skipNonUITestLog() {
+    return skipNonUITest;
   }
 }

--- a/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
+++ b/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
@@ -101,9 +101,9 @@ public class LoggingUtils {
 
     Intent launchIntent = activity.getIntent();
     // Check if we are running on Firebase Test Lab, and set up a log file if we are.
-    if (launchIntent.getAction().equals("com.google.intent.action.TEST_LOOP")) {
-      startLogFile(activity, launchIntent.getData().toString());
-    }
+    // if (launchIntent.getAction().equals("com.google.intent.action.TEST_LOOP")) {
+    startLogFile(activity, launchIntent.getData().toString());
+    // }
   }
 
   /** Adds some text to the log window. */

--- a/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
+++ b/testing/sample_framework/src/android/java/com/google/firebase/example/LoggingUtils.java
@@ -43,8 +43,8 @@ public class LoggingUtils {
   private static boolean didTouch = false;
   // If a test log file is specified, this is the log file's URI...
   private static Uri logFile = null;
-  private static boolean skipUITest = false;
-  private static boolean skipNonUITest = false;
+  private static boolean shouldRunUITests = true;
+  private static boolean shouldRunNonUITests = true;
   // ...and this is the stream to write to.
   private static DataOutputStream logFileStream = null;
 
@@ -104,10 +104,10 @@ public class LoggingUtils {
     Intent launchIntent = activity.getIntent();
     // Check if we are running on Firebase Test Lab, and set up a log file if we are.
     if (launchIntent.getAction().equals("com.google.intent.action.TEST_LOOP")) {
-      skipUITest = true;
+      shouldRunUITests = false;
       startLogFile(activity, launchIntent.getData().toString());
     } else if (launchIntent.getAction().equals("com.google.intent.action.UI_TEST")) {
-      skipNonUITest = true;
+      shouldRunNonUITests = false;
       startLogFile(activity, launchIntent.getData().toString());
     }
   }
@@ -167,11 +167,11 @@ public class LoggingUtils {
     }
   }
 
-  public static boolean skipUITestLog() {
-    return skipUITest;
+  public static boolean shouldRunUITests() {
+    return shouldRunUITests;
   }
 
-  public static boolean skipNonUITestLog() {
-    return skipNonUITest;
+  public static boolean shouldRunNonUITests() {
+    return shouldRunNonUITests;
   }
 }

--- a/testing/sample_framework/src/app_framework.h
+++ b/testing/sample_framework/src/app_framework.h
@@ -104,6 +104,9 @@ jobject GetActivity();
 jclass FindClass(JNIEnv* env, jobject activity_object, const char* class_name);
 #endif  // defined(__ANDROID__)
 
+// Returns true if the user interaction is allowed.
+bool IsUserInteractionAllowed();
+
 // Returns true if the logger is currently logging to a file.
 bool IsLoggingToFile();
 

--- a/testing/sample_framework/src/app_framework.h
+++ b/testing/sample_framework/src/app_framework.h
@@ -104,8 +104,11 @@ jobject GetActivity();
 jclass FindClass(JNIEnv* env, jobject activity_object, const char* class_name);
 #endif  // defined(__ANDROID__)
 
-// Returns true if the user interaction is allowed.
-bool IsUserInteractionAllowed();
+// Returns true if we skip tests that require interaction, false if not.
+bool SkipUITest();
+
+// Returns true if we skip tests that do not require interaction, false if not.
+bool SkipNonUITest();
 
 // Returns true if the logger is currently logging to a file.
 bool IsLoggingToFile();

--- a/testing/sample_framework/src/app_framework.h
+++ b/testing/sample_framework/src/app_framework.h
@@ -107,7 +107,7 @@ jclass FindClass(JNIEnv* env, jobject activity_object, const char* class_name);
 // Returns ture if we run tests that require interaction.
 bool ShouldRunUITests();
 
-// Returns true if we ru  tests that do not require interaction.
+// Returns true if we run tests that do not require interaction.
 bool ShouldRunNonUITests();
 
 // Returns true if the logger is currently logging to a file.

--- a/testing/sample_framework/src/app_framework.h
+++ b/testing/sample_framework/src/app_framework.h
@@ -104,11 +104,11 @@ jobject GetActivity();
 jclass FindClass(JNIEnv* env, jobject activity_object, const char* class_name);
 #endif  // defined(__ANDROID__)
 
-// Returns true if we skip tests that require interaction, false if not.
-bool SkipUITest();
+// Returns ture if we run tests that require interaction.
+bool ShouldRunUITests();
 
-// Returns true if we skip tests that do not require interaction, false if not.
-bool SkipNonUITest();
+// Returns true if we ru  tests that do not require interaction.
+bool ShouldRunNonUITests();
 
 // Returns true if the logger is currently logging to a file.
 bool IsLoggingToFile();

--- a/testing/sample_framework/src/desktop/desktop_app_framework.cc
+++ b/testing/sample_framework/src/desktop/desktop_app_framework.cc
@@ -213,7 +213,7 @@ std::string ReadTextInput(const char* title, const char* message,
 
 bool ShouldRunUITests() { return true; }
 
-bool ShouldNonUITests() { return true; }
+bool ShouldRunNonUITests() { return true; }
 
 bool IsLoggingToFile() { return false; }
 

--- a/testing/sample_framework/src/desktop/desktop_app_framework.cc
+++ b/testing/sample_framework/src/desktop/desktop_app_framework.cc
@@ -211,6 +211,8 @@ std::string ReadTextInput(const char* title, const char* message,
   return input_line.empty() ? std::string(placeholder) : input_line;
 }
 
+bool IsUserInteractionAllowed() { return false; }
+
 bool IsLoggingToFile() { return false; }
 
 }  // namespace app_framework

--- a/testing/sample_framework/src/desktop/desktop_app_framework.cc
+++ b/testing/sample_framework/src/desktop/desktop_app_framework.cc
@@ -211,7 +211,9 @@ std::string ReadTextInput(const char* title, const char* message,
   return input_line.empty() ? std::string(placeholder) : input_line;
 }
 
-bool IsUserInteractionAllowed() { return false; }
+bool SkipUITest() { return false; }
+
+bool SkipNonUITest() { return false; }
 
 bool IsLoggingToFile() { return false; }
 

--- a/testing/sample_framework/src/desktop/desktop_app_framework.cc
+++ b/testing/sample_framework/src/desktop/desktop_app_framework.cc
@@ -211,9 +211,9 @@ std::string ReadTextInput(const char* title, const char* message,
   return input_line.empty() ? std::string(placeholder) : input_line;
 }
 
-bool SkipUITest() { return false; }
+bool ShouldRunUITests() { return true; }
 
-bool SkipNonUITest() { return false; }
+bool ShouldNonUITests() { return true; }
 
 bool IsLoggingToFile() { return false; }
 

--- a/testing/sample_framework/src/ios/ios_app_framework.mm
+++ b/testing/sample_framework/src/ios/ios_app_framework.mm
@@ -288,9 +288,9 @@ std::string ReadTextInput(const char *title, const char *message, const char *pl
   }
 }
 
-bool SkipUITest() { return g_gameloop_launch; }
+bool ShouldRunUITests() { return !g_gameloop_launch; }
 
-bool SkipNonUITest() { return g_uitest_launch; }
+bool ShouldRunNonUITests() { return !g_uitest_launch; }
 
 bool IsLoggingToFile() { return g_file_url_path; }
 

--- a/testing/sample_framework/src/ios/ios_app_framework.mm
+++ b/testing/sample_framework/src/ios/ios_app_framework.mm
@@ -286,7 +286,9 @@ std::string ReadTextInput(const char *title, const char *message, const char *pl
   }
 }
 
-bool IsLoggingToFile() { return g_file_url_path; }
+bool IsUserInteractionAllowed() { return true; }
+
+bool IsLoggingToFile() { return true; }
 
 bool StartLoggingToFile(const char *file_path) {
   NSURL *home_url = [NSURL fileURLWithPath:NSHomeDirectory()];
@@ -343,14 +345,14 @@ int main(int argc, char *argv[]) {
   setenv("USE_FIRESTORE_EMULATOR", "true", 1);
 #endif
 
-  if ([url.scheme isEqual:kGameLoopUrlPrefix]) {
-    g_gameloop_launch = true;
-    app_framework::StartLoggingToFile(GAMELOOP_DEFAULT_LOG_FILE);
-    return YES;
-  }
-  NSLog(@"The testapp will not log to files since it is not launched by URL %@",
-        kGameLoopUrlPrefix);
-  return NO;
+  // if ([url.scheme isEqual:kGameLoopUrlPrefix]) {
+  g_gameloop_launch = true;
+  app_framework::StartLoggingToFile(GAMELOOP_DEFAULT_LOG_FILE);
+  return YES;
+  // }
+  // NSLog(@"The testapp will not log to files since it is not launched by URL %@",
+  //       kGameLoopUrlPrefix);
+  // return NO;
 }
 
 - (BOOL)application:(UIApplication *)application

--- a/testing/sample_framework/src/ios/ios_app_framework.mm
+++ b/testing/sample_framework/src/ios/ios_app_framework.mm
@@ -42,6 +42,7 @@
 @end
 
 static NSString *const kGameLoopUrlPrefix = @"firebase-game-loop";
+static NSString *const kUITestUrlPrefix = @"firebase-ui-test";
 static NSString *const kGameLoopCompleteUrlScheme = @"firebase-game-loop-complete://";
 static const float kGameLoopSecondsToPauseBeforeQuitting = 5.0f;
 
@@ -62,6 +63,7 @@ static UIView *g_parent_view;
 static UIViewController *g_parent_view_controller;
 static FTAViewController *g_view_controller;
 static bool g_gameloop_launch = false;
+static bool g_uitest_launch = false;
 static NSURL *g_results_url;
 static NSString *g_file_name;
 static NSString *g_file_url_path;
@@ -185,7 +187,7 @@ void AddToTextView(const char *str) {
     NSRange range = NSMakeRange(g_text_view.text.length, 0);
     [g_text_view scrollRangeToVisible:range];
   });
-  if (g_gameloop_launch) {
+  if (g_gameloop_launch || g_uitest_launch) {
     NSData *data = [message dataUsingEncoding:NSUTF8StringEncoding];
     if ([NSFileManager.defaultManager fileExistsAtPath:g_file_url_path]) {
       NSFileHandle *fileHandler = [NSFileHandle fileHandleForUpdatingAtPath:g_file_url_path];
@@ -286,9 +288,11 @@ std::string ReadTextInput(const char *title, const char *message, const char *pl
   }
 }
 
-bool IsUserInteractionAllowed() { return true; }
+bool SkipUITest() { return g_gameloop_launch; }
 
-bool IsLoggingToFile() { return true; }
+bool SkipNonUITest() { return g_uitest_launch; }
+
+bool IsLoggingToFile() { return g_file_url_path; }
 
 bool StartLoggingToFile(const char *file_path) {
   NSURL *home_url = [NSURL fileURLWithPath:NSHomeDirectory()];
@@ -345,14 +349,18 @@ int main(int argc, char *argv[]) {
   setenv("USE_FIRESTORE_EMULATOR", "true", 1);
 #endif
 
-  // if ([url.scheme isEqual:kGameLoopUrlPrefix]) {
-  g_gameloop_launch = true;
-  app_framework::StartLoggingToFile(GAMELOOP_DEFAULT_LOG_FILE);
-  return YES;
-  // }
-  // NSLog(@"The testapp will not log to files since it is not launched by URL %@",
-  //       kGameLoopUrlPrefix);
-  // return NO;
+  if ([url.scheme isEqual:kGameLoopUrlPrefix]) {
+    g_gameloop_launch = true;
+    app_framework::StartLoggingToFile(GAMELOOP_DEFAULT_LOG_FILE);
+    return YES;
+  } else if ([url.scheme isEqual:kUITestUrlPrefix]) {
+    g_uitest_launch = true;
+    app_framework::StartLoggingToFile(GAMELOOP_DEFAULT_LOG_FILE);
+    return YES;
+  }
+  NSLog(@"The testapp will not log to files since it is not launched by URL %@ or %@",
+        kGameLoopUrlPrefix, kUITestUrlPrefix);
+  return NO;
 }
 
 - (BOOL)application:(UIApplication *)application

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -265,7 +265,7 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
 bool FirebaseTest::IsUserInteractionAllowed() {
   // In the trivial case, just check whether we are logging to file. If not,
   // assume interaction is allowed.
-  return !app_framework::IsLoggingToFile();
+  return !app_framework::IsUserInteractionAllowed();
 }
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -262,8 +262,12 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
   return out.str();
 }
 
-bool FirebaseTest::IsUserInteractionAllowed() {
-  return !app_framework::IsUserInteractionAllowed();
+bool FirebaseTest::SkipUITest() {
+  return !app_framework::SkipUITest();
+}
+
+bool FirebaseTest::SkipNonUITest() {
+  return !app_framework::SkipNonUITest();
 }
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -262,9 +262,9 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
   return out.str();
 }
 
-bool FirebaseTest::SkipUITest() { return app_framework::SkipUITest(); }
+bool FirebaseTest::ShouldRunUITests() { return app_framework::ShouldRunUITests(); }
 
-bool FirebaseTest::SkipNonUITest() { return app_framework::SkipNonUITest(); }
+bool FirebaseTest::ShouldRunNonUITests() { return app_framework::ShouldRunNonUITests(); }
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {
   return ::firebase::internal::Base64Encode(input, output);

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -263,11 +263,11 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
 }
 
 bool FirebaseTest::SkipUITest() {
-  return !app_framework::SkipUITest();
+  return app_framework::SkipUITest();
 }
 
 bool FirebaseTest::SkipNonUITest() {
-  return !app_framework::SkipNonUITest();
+  return app_framework::SkipNonUITest();
 }
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -263,8 +263,6 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
 }
 
 bool FirebaseTest::IsUserInteractionAllowed() {
-  // In the trivial case, just check whether we are logging to file. If not,
-  // assume interaction is allowed.
   return !app_framework::IsUserInteractionAllowed();
 }
 

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -262,9 +262,13 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
   return out.str();
 }
 
-bool FirebaseTest::ShouldRunUITests() { return app_framework::ShouldRunUITests(); }
+bool FirebaseTest::ShouldRunUITests() {
+  return app_framework::ShouldRunUITests();
+}
 
-bool FirebaseTest::ShouldRunNonUITests() { return app_framework::ShouldRunNonUITests(); }
+bool FirebaseTest::ShouldRunNonUITests() {
+  return app_framework::ShouldRunNonUITests();
+}
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {
   return ::firebase::internal::Base64Encode(input, output);

--- a/testing/test_framework/src/firebase_test_framework.cc
+++ b/testing/test_framework/src/firebase_test_framework.cc
@@ -262,13 +262,9 @@ std::string FirebaseTest::VariantToString(const firebase::Variant& variant) {
   return out.str();
 }
 
-bool FirebaseTest::SkipUITest() {
-  return app_framework::SkipUITest();
-}
+bool FirebaseTest::SkipUITest() { return app_framework::SkipUITest(); }
 
-bool FirebaseTest::SkipNonUITest() {
-  return app_framework::SkipNonUITest();
-}
+bool FirebaseTest::SkipNonUITest() { return app_framework::SkipNonUITest(); }
 
 bool FirebaseTest::Base64Encode(const std::string& input, std::string* output) {
   return ::firebase::internal::Base64Encode(input, output);

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -39,9 +39,9 @@ namespace firebase_test_framework {
 // Use this macro to skip an entire test if it is an non UI Test and we are
 // not running it in UItest mode (for example, on UI Test workflow).
 #define TEST_DOES_NOT_REQUIRE_USER_INTERACTION                            \
-  if (SkipNonUITest()) {                                                  \
+  if (!ShouldRunNonUITests()) {                                           \
     app_framework::LogInfo(                                               \
-        "Skipping %s, as it is an Non UI Test.",                          \
+        "Skipping %s, as it is a Non UI Test.",                           \
         ::testing::UnitTest::GetInstance()->current_test_info()->name()); \
     GTEST_SKIP();                                                         \
     return;                                                               \
@@ -50,7 +50,7 @@ namespace firebase_test_framework {
 // Use this macro to skip an entire test if it requires interactivity and we are
 // not running in interactive mode (for example, on FTL).
 #define TEST_REQUIRES_USER_INTERACTION                                    \
-  if (SkipUITest()) {                                                     \
+  if (!ShouldRunUITests()) {                                              \
     app_framework::LogInfo(                                               \
         "Skipping %s, as it requires user interaction.",                  \
         ::testing::UnitTest::GetInstance()->current_test_info()->name()); \
@@ -456,11 +456,11 @@ class FirebaseTest : public testing::Test {
   static bool OpenUrlInBrowser(const char* url);
 
   // Returns true if we skip tests that require interaction, false if not.
-  static bool SkipUITest();
+  static bool ShouldRunUITests();
 
   // Returns true if we skip tests that do not require interaction, false if
   // not.
-  static bool SkipNonUITest();
+  static bool ShouldRunNonUITests();
 
   // Encode a binary string to base64. Returns true if the encoding succeeded,
   // false if it failed.

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -455,10 +455,10 @@ class FirebaseTest : public testing::Test {
   // Open a URL in a browser window, for testing only.
   static bool OpenUrlInBrowser(const char* url);
 
-  // Returns true if we skip tests that require interaction, false if not.
+  // Returns true if we run tests that require interaction, false if not.
   static bool ShouldRunUITests();
 
-  // Returns true if we skip tests that do not require interaction, false if
+  // Returns true if we run tests that do not require interaction, false if
   // not.
   static bool ShouldRunNonUITests();
 

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -36,11 +36,11 @@
 
 namespace firebase_test_framework {
 
-// Use this macro to skip an entire test if it is an UI Test and we are
-// not running in UItest mode (for example, on UI Test workflow).
+// Use this macro to skip an entire test if it is an non UI Test and we are
+// not running it in UItest mode (for example, on UI Test workflow).
 #define TEST_NO_USER_INTERACTION                                            \
-  if (IsUserInteractionAllowed()) {                                         \
-    app_framework::LogInfo("Skipping %s, as it is an UI Test.",             \
+  if (SkipNonUITest()) {                                                    \
+    app_framework::LogInfo("Skipping %s, as it is an Non UI Test.",         \
                             test_info_->name());                            \
     GTEST_SKIP();                                                           \
     return;                                                                 \
@@ -49,7 +49,7 @@ namespace firebase_test_framework {
 // Use this macro to skip an entire test if it requires interactivity and we are
 // not running in interactive mode (for example, on FTL).
 #define TEST_REQUIRES_USER_INTERACTION                                      \
-  if (!IsUserInteractionAllowed()) {                                        \
+  if (SkipUITest()) {                                                       \
     app_framework::LogInfo("Skipping %s, as it requires user interaction.", \
                            test_info_->name());                             \
     GTEST_SKIP();                                                           \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -36,6 +36,16 @@
 
 namespace firebase_test_framework {
 
+// Use this macro to skip an entire test if it is an UI Test and we are
+// not running in UItest mode (for example, on UI Test workflow).
+#define TEST_NO_USER_INTERACTION                                            \
+  if (IsUserInteractionAllowed()) {                                         \
+    app_framework::LogInfo("Skipping %s, as it is an UI Test.",             \
+                            test_info_->name());                            \
+    GTEST_SKIP();                                                           \
+    return;
+  }
+
 // Use this macro to skip an entire test if it requires interactivity and we are
 // not running in interactive mode (for example, on FTL).
 #define TEST_REQUIRES_USER_INTERACTION                                      \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -453,8 +453,11 @@ class FirebaseTest : public testing::Test {
   // Open a URL in a browser window, for testing only.
   static bool OpenUrlInBrowser(const char* url);
 
-  // Returns true if we can run tests that require interaction, false if not.
-  static bool IsUserInteractionAllowed();
+  // Returns true if we skip tests that require interaction, false if not.
+  static bool SkipUITest();
+
+  // Returns true if we skip tests that do not require interaction, false if not.
+  static bool SkipNonUITest();
 
   // Encode a binary string to base64. Returns true if the encoding succeeded,
   // false if it failed.

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -38,10 +38,10 @@ namespace firebase_test_framework {
 
 // Use this macro to skip an entire test if it is an non UI Test and we are
 // not running it in UItest mode (for example, on UI Test workflow).
-#define TEST_REQUIRES_USER_INTERACTION                              \
+#define TEST_DOES_NOT_REQUIRE_USER_INTERACTION                      \
   if (SkipNonUITest()) {                                            \
     app_framework::LogInfo("Skipping %s, as it is an Non UI Test.", \
-                           test_info_->name());                     \
+                           ::testing::UnitTest::GetInstance()->current_test_info()->name());                     \
     GTEST_SKIP();                                                   \
     return;                                                         \
   }
@@ -51,7 +51,7 @@ namespace firebase_test_framework {
 #define TEST_REQUIRES_USER_INTERACTION                                      \
   if (SkipUITest()) {                                                       \
     app_framework::LogInfo("Skipping %s, as it requires user interaction.", \
-                           test_info_->name());                             \
+                           ::testing::UnitTest::GetInstance()->current_test_info()->name());                             \
     GTEST_SKIP();                                                           \
     return;                                                                 \
   }

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -43,7 +43,7 @@ namespace firebase_test_framework {
     app_framework::LogInfo("Skipping %s, as it is an UI Test.",             \
                             test_info_->name());                            \
     GTEST_SKIP();                                                           \
-    return;
+    return;                                                                 \
   }
 
 // Use this macro to skip an entire test if it requires interactivity and we are

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -38,22 +38,24 @@ namespace firebase_test_framework {
 
 // Use this macro to skip an entire test if it is an non UI Test and we are
 // not running it in UItest mode (for example, on UI Test workflow).
-#define TEST_DOES_NOT_REQUIRE_USER_INTERACTION                      \
-  if (SkipNonUITest()) {                                            \
-    app_framework::LogInfo("Skipping %s, as it is an Non UI Test.", \
-                           ::testing::UnitTest::GetInstance()->current_test_info()->name());                     \
-    GTEST_SKIP();                                                   \
-    return;                                                         \
+#define TEST_DOES_NOT_REQUIRE_USER_INTERACTION                            \
+  if (SkipNonUITest()) {                                                  \
+    app_framework::LogInfo(                                               \
+        "Skipping %s, as it is an Non UI Test.",                          \
+        ::testing::UnitTest::GetInstance()->current_test_info()->name()); \
+    GTEST_SKIP();                                                         \
+    return;                                                               \
   }
 
 // Use this macro to skip an entire test if it requires interactivity and we are
 // not running in interactive mode (for example, on FTL).
-#define TEST_REQUIRES_USER_INTERACTION                                      \
-  if (SkipUITest()) {                                                       \
-    app_framework::LogInfo("Skipping %s, as it requires user interaction.", \
-                           ::testing::UnitTest::GetInstance()->current_test_info()->name());                             \
-    GTEST_SKIP();                                                           \
-    return;                                                                 \
+#define TEST_REQUIRES_USER_INTERACTION                                    \
+  if (SkipUITest()) {                                                     \
+    app_framework::LogInfo(                                               \
+        "Skipping %s, as it requires user interaction.",                  \
+        ::testing::UnitTest::GetInstance()->current_test_info()->name()); \
+    GTEST_SKIP();                                                         \
+    return;                                                               \
   }
 
 #if TARGET_OS_IPHONE

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -38,12 +38,12 @@ namespace firebase_test_framework {
 
 // Use this macro to skip an entire test if it is an non UI Test and we are
 // not running it in UItest mode (for example, on UI Test workflow).
-#define TEST_NO_USER_INTERACTION                                            \
-  if (SkipNonUITest()) {                                                    \
-    app_framework::LogInfo("Skipping %s, as it is an Non UI Test.",         \
-                            test_info_->name());                            \
-    GTEST_SKIP();                                                           \
-    return;                                                                 \
+#define TEST_NO_USER_INTERACTION                                    \
+  if (SkipNonUITest()) {                                            \
+    app_framework::LogInfo("Skipping %s, as it is an Non UI Test.", \
+                           test_info_->name());                     \
+    GTEST_SKIP();                                                   \
+    return;                                                         \
   }
 
 // Use this macro to skip an entire test if it requires interactivity and we are
@@ -456,7 +456,8 @@ class FirebaseTest : public testing::Test {
   // Returns true if we skip tests that require interaction, false if not.
   static bool SkipUITest();
 
-  // Returns true if we skip tests that do not require interaction, false if not.
+  // Returns true if we skip tests that do not require interaction, false if
+  // not.
   static bool SkipNonUITest();
 
   // Encode a binary string to base64. Returns true if the encoding succeeded,

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -38,7 +38,7 @@ namespace firebase_test_framework {
 
 // Use this macro to skip an entire test if it is an non UI Test and we are
 // not running it in UItest mode (for example, on UI Test workflow).
-#define TEST_NO_USER_INTERACTION                                    \
+#define TEST_REQUIRES_USER_INTERACTION                              \
   if (SkipNonUITest()) {                                            \
     app_framework::LogInfo("Skipping %s, as it is an Non UI Test.", \
                            test_info_->name());                     \


### PR DESCRIPTION
### Description
To support UI Test Automation,
1. Modified `app_framework` and `firebase_test_framework`. Now, we could skip non UI tests with Marco `TEST_NO_USER_INTERACTION `
2. Modified GMA testapps. Skip Android non UI tests with Intent `com.google.intent.action.UI_TEST`; skip iOS non UI tests with URI `firebase-ui-test`.
3. Modified helper apps (in `scripts/gha/ui_testing`). Now, we could run testapps and skip non UI tests with the script.

Will have a followup PR that modify GMA Integration Tests, and enables GMA UI Tests in CI.

***
### Testing
Currently CI passed: https://github.com/firebase/firebase-cpp-sdk/actions/runs/2235993495
UI Tests were tested locally and work as expected.

[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
