### PR TITLE
Change macos runners to macos-12. (requires updating xcode to 13.1)

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ on:
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir
   GITHUB_TOKEN: ${{ github.token }}
-  xcodeVersion: "12.4"  # Only affects Mac runners, and only for prerequisites.
+  xcodeVersion: "13.3.1"  # Only affects Mac runners, and only for prerequisites.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -13,7 +13,7 @@ on:
 env:
   CCACHE_DIR: ${{ github.workspace }}/ccache_dir
   GITHUB_TOKEN: ${{ github.token }}
-  xcodeVersion: "13.3.1"  # Only affects Mac runners, and only for prerequisites.
+  xcodeVersion: "13.1"  # Only affects Mac runners, and only for prerequisites.
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event_name }}-${{ github.head_ref || github.ref }}

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -32,9 +32,9 @@ env:
   demumbleVer: "1.1.0"
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"
-  # Xcode version 12.4 is the version we build the SDK with.
+  # Xcode version 13.3.1 is the version we build the SDK with.
   # Our MacOS runners will use the version in /Applications/Xcode_${xcodeVersion}.app
-  xcodeVersion: "12.4"
+  xcodeVersion: "13.3.1"
   # LLVM version with ARM MachO support has no version number yet.
   llvmVer: "5f187f0afaad33013ba03454c4749d99b1362534"
   GITHUB_TOKEN: ${{ github.token }}
@@ -79,13 +79,13 @@ jobs:
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-12]
         include:
         - os: ubuntu-latest
           tools_platform: linux
           # Binutils 2.35.1 released Sep 19, 2020
           binutils_version: "2.35.1"
-        - os: macos-latest
+        - os: macos-12
           tools_platform: darwin
           # Binutils 2.35.1 released Sep 19, 2020
           binutils_version: "2.35.1"
@@ -180,7 +180,7 @@ jobs:
 
   build_and_package_ios_tvos:
     name: build-and-package-ios-tvos
-    runs-on: macos-latest
+    runs-on: macos-12
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     steps:
       - name: Store git credentials for all git commands
@@ -302,7 +302,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
+        os: [windows-latest, ubuntu-latest, macos-12]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86", "arm64"]
         msvc_runtime: ["static", "dynamic"]
@@ -322,7 +322,7 @@ jobs:
           vcpkg_triplet_suffix: "linux"
           additional_build_flags: ""
           sdk_platform: "linux"
-        - os: macos-latest
+        - os: macos-12
           vcpkg_triplet_suffix: "osx"
           additional_build_flags: "--target_format libraries"
           sdk_platform: "darwin"
@@ -330,13 +330,13 @@ jobs:
         exclude:
         - os: windows-latest
           linux_abi: "c++11"
-        - os: macos-latest
+        - os: macos-12
           architecture: "x86"
-        - os: macos-latest
+        - os: macos-12
           msvc_runtime: "dynamic"
-        - os: macos-latest
+        - os: macos-12
           linux_abi: "c++11"
-        - os: macos-latest
+        - os: macos-12
           build_type: "Debug"
         - os: ubuntu-latest
           msvc_runtime: "dynamic"
@@ -497,7 +497,7 @@ jobs:
           suffix: '-x64-Debug-dynamic'
           runs_on_platform: ubuntu-latest
         - sdk_platform: darwin
-          runs_on_platform: macos-latest
+          runs_on_platform: macos-12
         exclude:
         - sdk_platform: windows
           suffix: ''

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -32,9 +32,9 @@ env:
   demumbleVer: "1.1.0"
   # Use SHA256 for hashing files.
   hashCommand: "sha256sum"
-  # Xcode version 13.3.1 is the version we build the SDK with.
+  # Xcode version 13.1 is the version we build the SDK with.
   # Our MacOS runners will use the version in /Applications/Xcode_${xcodeVersion}.app
-  xcodeVersion: "13.3.1"
+  xcodeVersion: "13.1"
   # LLVM version with ARM MachO support has no version number yet.
   llvmVer: "5f187f0afaad33013ba03454c4749d99b1362534"
   GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -71,10 +71,10 @@ jobs:
           # msvc_runtime excludes
           - os: ubuntu-latest
             msvc_runtime: "dynamic"
-          - os: macos-latest
+          - os: macos-12
             msvc_runtime: "dynamic"
           # architecture excluees
-          - os: macos-latest
+          - os: macos-12
             architecture: "x86"
           # Xcode excludes -- allow only one on osx and linux
           - os: ubuntu-latest

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -658,7 +658,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: macos-12
+        os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -20,7 +20,7 @@ on:
         required: true
       operating_systems:
         description: 'CSV of VMs to run on'
-        default: 'ubuntu-latest,windows-latest,macos-latest'
+        default: 'ubuntu-latest,windows-latest,macos-12'
         required: true
       desktop_ssl_variants:
         description: 'CSV of desktop SSL variants to use'
@@ -534,7 +534,7 @@ jobs:
   build_ios:
     name: build-ios-macos-latest
     needs: [check_and_prepare]
-    runs-on: macos-latest
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
@@ -599,7 +599,7 @@ jobs:
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
             --ios_sdk ${{ needs.check_and_prepare.outputs.mobile_test_on }} \
-            --artifact_name "ios-macos-latest" \
+            --artifact_name "ios-macos-12" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -607,22 +607,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-ios-macos-latest.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-ios-macos-latest.log.json
+          if [ ! -f build-results-ios-macos-12.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-ios-macos-12.log.json
           fi
       - name: Upload iOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-ios-macos-latest
-          path: testapps-ios-macos-latest
+          name: testapps-ios-macos-12
+          path: testapps-ios-macos-12
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-ios-macos-latest*
+          path: build-results-ios-macos-12*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -643,7 +643,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-ios-macos-latest.log
+          cat build-results-ios-macos-12.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
@@ -651,7 +651,7 @@ jobs:
   build_tvos:
     name: build-tvos-macos-latest
     needs: [check_and_prepare]
-    runs-on: macos-latest
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
@@ -715,7 +715,7 @@ jobs:
           python scripts/gha/build_testapps.py --p tvOS \
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
-            --artifact_name "tvos-macos-latest" \
+            --artifact_name "tvos-macos-12" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -723,22 +723,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-tvos-macos-latest.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-tvos-macos-latest.log.json
+          if [ ! -f build-results-tvos-macos-12.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-tvos-macos-12.log.json
           fi
       - name: Upload tvOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-tvos-macos-latest
-          path: testapps-tvos-macos-latest
+          name: testapps-tvos-macos-12
+          path: testapps-tvos-macos-12
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload tvOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-tvos-macos-latest*
+          path: build-results-tvos-macos-12*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -759,7 +759,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-tvos-macos-latest.log
+          cat build-results-tvos-macos-12.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
@@ -858,7 +858,7 @@ jobs:
   test_android:
     name: test-android-${{ matrix.build_os }}-${{ matrix.android_device }}
     needs: [check_and_prepare, build_android]
-    runs-on: macos-latest
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'Android') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
@@ -963,7 +963,7 @@ jobs:
   test_ios:
     name: test-ios-macos-latest-${{ matrix.ios_device }}
     needs: [check_and_prepare, build_ios]
-    runs-on: macos-latest
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
@@ -980,7 +980,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-ios-macos-latest
+          name: testapps-ios-macos-12
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1009,7 +1009,7 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-macos-latest-${{ matrix.ios_device }}" \
+            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1022,7 +1022,7 @@ jobs:
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
           python scripts/gha/test_lab.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-macos-latest-${{ matrix.ios_device }}" \
+            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
             --code_platform cpp \
             --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Prepare results summary artifact
@@ -1030,15 +1030,15 @@ jobs:
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-ios-macos-latest" && ! -f "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log.json"
+          if [ -d "testapps/testapps-ios-macos-12" && ! -f "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json"
           fi
       - name: Upload iOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}*
+          path: testapps/test-results-ios-macos-12-${{ matrix.ios_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1059,7 +1059,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-ios-macos-latest-${{ matrix.ios_device }}.log"
+          cat "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
@@ -1067,7 +1067,7 @@ jobs:
   test_tvos:
     name: test-tvos-macos-latest-${{ matrix.tvos_device }}
     needs: [check_and_prepare, build_tvos]
-    runs-on: macos-latest
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
     strategy:
       fail-fast: false
@@ -1084,7 +1084,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-tvos-macos-latest
+          name: testapps-tvos-macos-12
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1105,22 +1105,22 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --tvos_device "${{ matrix.tvos_device }}" \
-            --logfile_name "tvos-macos-latest-${{ matrix.tvos_device }}" \
+            --logfile_name "tvos-macos-12-${{ matrix.tvos_device }}" \
             --ci
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-tvos-macos-latest" && ! -f "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log.json"
+          if [ -d "testapps/testapps-tvos-macos-12" && ! -f "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json"
           fi
       - name: Upload tvOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}*
+          path: testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1141,7 +1141,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-tvos-macos-latest-${{ matrix.tvos_device }}.log"
+          cat "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -532,14 +532,12 @@ jobs:
           fi
 
   build_ios:
-    name: build-ios-${{ matrix.os }}
+    name: build-ios-macos-latest
     needs: [check_and_prepare]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
-      matrix:
-        os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -601,7 +599,7 @@ jobs:
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
             --ios_sdk ${{ needs.check_and_prepare.outputs.mobile_test_on }} \
-            --artifact_name "ios-${{ matrix.os }}" \
+            --artifact_name "ios-macos-12" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -609,22 +607,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-ios-${{ matrix.os }}.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-ios-${{ matrix.os }}.log.json
+          if [ ! -f build-results-ios-macos-12.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-ios-macos-12.log.json
           fi
       - name: Upload iOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-ios-${{ matrix.os }}
-          path: testapps-ios-${{ matrix.os }}
+          name: testapps-ios-macos-12
+          path: testapps-ios-macos-12
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-ios-${{ matrix.os }}*
+          path: build-results-ios-macos-12*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -645,20 +643,18 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-ios-${{ matrix.os }}.log
+          cat build-results-ios-macos-12.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
 
   build_tvos:
-    name: build-tvos-${{ matrix.os }}
+    name: build-tvos-macos-latest
     needs: [check_and_prepare]
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
-      matrix:
-        os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -719,7 +715,7 @@ jobs:
           python scripts/gha/build_testapps.py --p tvOS \
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
-            --artifact_name "tvos-${{ matrix.os }}" \
+            --artifact_name "tvos-macos-12" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -727,22 +723,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-tvos-${{ matrix.os }}.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-tvos-${{ matrix.os }}.log.json
+          if [ ! -f build-results-tvos-macos-12.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-tvos-macos-12.log.json
           fi
       - name: Upload tvOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-tvos-${{ matrix.os }}
-          path: testapps-tvos-${{ matrix.os }}
+          name: testapps-tvos-macos-12
+          path: testapps-tvos-macos-12
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload tvOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-tvos-${{ matrix.os }}*
+          path: build-results-tvos-macos-12*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -763,7 +759,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-tvos-${{ matrix.os }}.log
+          cat build-results-tvos-macos-12.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
@@ -965,7 +961,7 @@ jobs:
           fi
 
   test_ios:
-    name: test-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}
+    name: test-ios-macos-latest-${{ matrix.ios_device }}
     needs: [check_and_prepare, build_ios]
     runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
@@ -973,7 +969,6 @@ jobs:
       fail-fast: false
       matrix:
         ios_device: ${{ fromJson(needs.check_and_prepare.outputs.ios_device) }}
-        build_os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -985,7 +980,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-ios-${{ matrix.build_os }}
+          name: testapps-ios-macos-12
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1014,7 +1009,7 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-${{ matrix.build_os }}-${{ matrix.ios_device }}" \
+            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1027,7 +1022,7 @@ jobs:
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
           python scripts/gha/test_lab.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-${{ matrix.build_os }}-${{ matrix.ios_device }}" \
+            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
             --code_platform cpp \
             --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Prepare results summary artifact
@@ -1035,15 +1030,15 @@ jobs:
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-ios-${{ matrix.build_os }}" && ! -f "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log.json"
+          if [ -d "testapps/testapps-ios-macos-12" && ! -f "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json"
           fi
       - name: Upload iOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}*
+          path: testapps/test-results-ios-macos-12-${{ matrix.ios_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1064,13 +1059,13 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log"
+          cat "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
 
   test_tvos:
-    name: test-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}
+    name: test-tvos-macos-latest-${{ matrix.tvos_device }}
     needs: [check_and_prepare, build_tvos]
     runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
@@ -1078,7 +1073,6 @@ jobs:
       fail-fast: false
       matrix:
         tvos_device: ${{ fromJson(needs.check_and_prepare.outputs.tvos_device) }}
-        build_os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -1090,7 +1084,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-tvos-${{ matrix.build_os }}
+          name: testapps-tvos-macos-12
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1111,22 +1105,22 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --tvos_device "${{ matrix.tvos_device }}" \
-            --logfile_name "tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}" \
+            --logfile_name "tvos-macos-12-${{ matrix.tvos_device }}" \
             --ci
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-tvos-${{ matrix.build_os }}" && ! -f "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log.json"
+          if [ -d "testapps/testapps-tvos-macos-12" && ! -f "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json"
           fi
       - name: Upload tvOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}*
+          path: testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1147,7 +1141,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log"
+          cat "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -532,12 +532,14 @@ jobs:
           fi
 
   build_ios:
-    name: build-ios-macos-latest
+    name: build-ios-${{ matrix.os }}
     needs: [check_and_prepare]
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
+      matrix:
+        os: macos-12
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -599,7 +601,7 @@ jobs:
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
             --ios_sdk ${{ needs.check_and_prepare.outputs.mobile_test_on }} \
-            --artifact_name "ios-macos-12" \
+            --artifact_name "ios-${{ matrix.os }}" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -607,22 +609,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-ios-macos-12.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-ios-macos-12.log.json
+          if [ ! -f build-results-ios-${{ matrix.os }}.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-ios-${{ matrix.os }}.log.json
           fi
       - name: Upload iOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-ios-macos-12
-          path: testapps-ios-macos-12
+          name: testapps-ios-${{ matrix.os }}
+          path: testapps-ios-${{ matrix.os }}
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload iOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-ios-macos-12*
+          path: build-results-ios-${{ matrix.os }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -643,18 +645,20 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-ios-macos-12.log
+          cat build-results-ios-${{ matrix.os }}.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
 
   build_tvos:
-    name: build-tvos-macos-latest
+    name: build-tvos-${{ matrix.os }}
     needs: [check_and_prepare]
-    runs-on: macos-12
+    runs-on: ${{ matrix.os }}
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled() && !failure()
     strategy:
       fail-fast: false
+      matrix:
+        os: macos-12
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -715,7 +719,7 @@ jobs:
           python scripts/gha/build_testapps.py --p tvOS \
             --t ${{ needs.check_and_prepare.outputs.apis }}  \
             --output_directory "${{ github.workspace }}" \
-            --artifact_name "tvos-macos-12" \
+            --artifact_name "tvos-${{ matrix.os }}" \
             --noadd_timestamp \
             --short_output_paths \
             ${additional_flags[*]}
@@ -723,22 +727,22 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          if [ ! -f build-results-tvos-macos-12.log.json ]; then
-            echo "__SUMMARY_MISSING__" > build-results-tvos-macos-12.log.json
+          if [ ! -f build-results-tvos-${{ matrix.os }}.log.json ]; then
+            echo "__SUMMARY_MISSING__" > build-results-tvos-${{ matrix.os }}.log.json
           fi
       - name: Upload tvOS integration tests artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
-          name: testapps-tvos-macos-12
-          path: testapps-tvos-macos-12
+          name: testapps-tvos-${{ matrix.os }}
+          path: testapps-tvos-${{ matrix.os }}
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Upload tvOS build results artifact
         uses: actions/upload-artifact@v3
         if: ${{ !cancelled() }}
         with:
           name: log-artifact
-          path: build-results-tvos-macos-12*
+          path: build-results-tvos-${{ matrix.os }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -759,7 +763,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat build-results-tvos-macos-12.log
+          cat build-results-tvos-${{ matrix.os }}.log
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
@@ -961,7 +965,7 @@ jobs:
           fi
 
   test_ios:
-    name: test-ios-macos-latest-${{ matrix.ios_device }}
+    name: test-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}
     needs: [check_and_prepare, build_ios]
     runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'iOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
@@ -969,6 +973,7 @@ jobs:
       fail-fast: false
       matrix:
         ios_device: ${{ fromJson(needs.check_and_prepare.outputs.ios_device) }}
+        build_os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -980,7 +985,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-ios-macos-12
+          name: testapps-ios-${{ matrix.build_os }}
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1009,7 +1014,7 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
+            --logfile_name "ios-${{ matrix.build_os }}-${{ matrix.ios_device }}" \
             --ci
       - name: Install Cloud SDK
         if: steps.get-device-type.outputs.device_type == 'real'
@@ -1022,7 +1027,7 @@ jobs:
           python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}"
           python scripts/gha/test_lab.py --testapp_dir testapps \
             --ios_device "${{ matrix.ios_device }}" \
-            --logfile_name "ios-macos-12-${{ matrix.ios_device }}" \
+            --logfile_name "ios-${{ matrix.build_os }}-${{ matrix.ios_device }}" \
             --code_platform cpp \
             --key_file scripts/gha-encrypted/gcs_key_file.json
       - name: Prepare results summary artifact
@@ -1030,15 +1035,15 @@ jobs:
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-ios-macos-12" && ! -f "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log.json"
+          if [ -d "testapps/testapps-ios-${{ matrix.build_os }}" && ! -f "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log.json"
           fi
       - name: Upload iOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-ios-macos-12-${{ matrix.ios_device }}*
+          path: testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1059,13 +1064,13 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-ios-macos-12-${{ matrix.ios_device }}.log"
+          cat "testapps/test-results-ios-${{ matrix.build_os }}-${{ matrix.ios_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
 
   test_tvos:
-    name: test-tvos-macos-latest-${{ matrix.tvos_device }}
+    name: test-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}
     needs: [check_and_prepare, build_tvos]
     runs-on: macos-12
     if: contains(needs.check_and_prepare.outputs.matrix_platform, 'tvOS') && needs.check_and_prepare.outputs.apis != '' && !cancelled()
@@ -1073,6 +1078,7 @@ jobs:
       fail-fast: false
       matrix:
         tvos_device: ${{ fromJson(needs.check_and_prepare.outputs.tvos_device) }}
+        build_os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
@@ -1084,7 +1090,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           path: testapps
-          name: testapps-tvos-macos-12
+          name: testapps-tvos-${{ matrix.build_os }}
       - name: Setup python
         uses: actions/setup-python@v2
         with:
@@ -1105,22 +1111,22 @@ jobs:
         run: |
           python scripts/gha/test_simulator.py --testapp_dir testapps \
             --tvos_device "${{ matrix.tvos_device }}" \
-            --logfile_name "tvos-macos-12-${{ matrix.tvos_device }}" \
+            --logfile_name "tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}" \
             --ci
       - name: Prepare results summary artifact
         if: ${{ !cancelled() }}
         shell: bash
         run: |
           # If testapps do not exist, then it's a build error not test error. 
-          if [ -d "testapps/testapps-tvos-macos-12" && ! -f "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json" ]; then
-            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log.json"
+          if [ -d "testapps/testapps-tvos-${{ matrix.build_os }}" && ! -f "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log.json" ]; then
+            mkdir -p testapps && echo "__SUMMARY_MISSING__" > "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log.json"
           fi
       - name: Upload tvOS test results artifact
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v3
         with:
           name: log-artifact
-          path: testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}*
+          path: testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}*
           retention-days: ${{ env.artifactRetentionDays }}
       - name: Download log artifacts
         if: ${{ needs.check_and_prepare.outputs.pr_number && failure() && !cancelled() }}
@@ -1141,7 +1147,7 @@ jobs:
         if: ${{ !cancelled() }}
         shell: bash
         run: |
-          cat "testapps/test-results-tvos-macos-12-${{ matrix.tvos_device }}.log"
+          cat "testapps/test-results-tvos-${{ matrix.build_os }}-${{ matrix.tvos_device }}.log"
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -539,7 +539,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: macos-12
+        os: [macos-12]
     steps:
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -35,13 +35,14 @@ jobs:
           echo "::set-output name=matrix_xcode_version::$( python scripts/gha/print_matrix_configuration.py -w ios -k xcode_version ${EXPANDED_MATRIX_PARAM} )"
 
   build:
-    name: ios-macos-latest
-    runs-on: macos-12
+    name: ios-${{ matrix.os }}-${{ matrix.xcode_version }}
+    runs-on: ${{ matrix.os }}
     needs: prepare_matrix
     strategy:
       fail-fast: false
       matrix:
-        xcode_verison: ${{ fromJson(needs.prepare_matrix.outputs.matrix_xcode_version) }}
+        os: [ 'macos-12' ]
+        xcode_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_xcode_version) }}
     steps:
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
@@ -52,7 +53,7 @@ jobs:
 
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
-        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_verison }}.app/Contents/Developer
+        run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer
 
       - uses: actions/checkout@v2
         with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -36,7 +36,7 @@ jobs:
 
   build:
     name: ios-macos-latest
-    runs-on: macos-latest
+    runs-on: macos-12
     needs: prepare_matrix
     strategy:
       fail-fast: false

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -25,7 +25,7 @@ env:
 jobs:
   update_dependencies:
     name: update-deps
-    runs-on: macos-latest
+    runs-on: macos-12
     steps:
       - name: Get token for firebase-workflow-trigger
         uses: tibdex/github-app-token@v1

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,8 +170,8 @@ TEST_DEVICES = {
   "ios_min": {"type": "real", "model":"iphone8", "version":"11.4"},
   "ios_target": {"type": "real", "model":"iphone8plus", "version":"12.0"},
   "ios_latest": {"type": "real", "model":"iphone11pro", "version":"14.7"},
-  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"15.4"},
-  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"15.4"},
+  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"15.0"},
+  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"15.0"},
   "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.4"},
   "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"15.0"},
 }

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -72,35 +72,35 @@ MINIMAL_KEY = "minimal"
 PARAMETERS = {
   "desktop": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest"],
+      "os": ["ubuntu-latest", "macos-12"],
       "build_type": ["Release", "Debug"],
       "architecture": ["x64", "x86", "arm64"],
       "msvc_runtime": ["static","dynamic"],
-      "xcode_version": ["12.4"],
+      "xcode_version": ["13.3.1"],
       "python_version": ["3.7"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
-        "xcode_version": ["11.7", "12.4", "12.5.1"],
+        "os": ["ubuntu-latest", "macos-12", "windows-latest"],
+        "xcode_version": ["13.3.1"],
       }
     }
   },
 
   "android": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
+      "os": ["ubuntu-latest", "macos-12", "windows-latest"],
       "architecture": ["x64"],
       "python_version": ["3.7"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-latest", "macos-latest", "windows-latest"]
+        "os": ["ubuntu-latest", "macos-12", "windows-latest"]
       }
     }
   },
 
   "integration_tests": {
     "matrix": {
-      "os": ["ubuntu-latest", "macos-latest", "windows-latest"],
+      "os": ["ubuntu-latest", "macos-12", "windows-latest"],
       "platform": ["Desktop", "Android", "iOS", "tvOS"],
       "ssl_lib": ["openssl"],
       "android_device": ["android_target", "emulator_target"],
@@ -112,7 +112,7 @@ PARAMETERS = {
       "msvc_runtime": ["dynamic"],
       "cpp_compiler_windows": ["VisualStudio2019"],
       "cpp_compiler_linux": ["clang-11.0"],
-      "xcode_version": ["12.4"],  # only the first one is used
+      "xcode_version": ["13.3.1"],  # only the first one is used
       "ndk_version": ["r22b"],
       "platform_version": ["28"],
       "build_tools_version": ["28.0.3"],
@@ -138,10 +138,10 @@ PARAMETERS = {
 
   "ios": {
     "matrix": {
-      "xcode_version": ["12.4"],
+      "xcode_version": ["13.3.1"],
 
       EXPANDED_KEY: {
-        "xcode_version": ["12.4", "12.5.1"]
+        "xcode_version": ["13.3.1"]
       }
     }
   },

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,10 +170,10 @@ TEST_DEVICES = {
   "ios_min": {"type": "real", "model":"iphone8", "version":"11.4"},
   "ios_target": {"type": "real", "model":"iphone8plus", "version":"12.0"},
   "ios_latest": {"type": "real", "model":"iphone11pro", "version":"14.7"},
-  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"11.4"},
-  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"12.0"},
-  "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"14.4"},
-  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"14.3"},
+  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"15.4"},
+  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"15.4"},
+  "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.4"},
+  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"15.0"},
 }
  
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -76,12 +76,12 @@ PARAMETERS = {
       "build_type": ["Release", "Debug"],
       "architecture": ["x64", "x86", "arm64"],
       "msvc_runtime": ["static","dynamic"],
-      "xcode_version": ["13.3.1"],
+      "xcode_version": ["13.1"],
       "python_version": ["3.7"],
 
       EXPANDED_KEY: {
         "os": ["ubuntu-latest", "macos-12", "windows-latest"],
-        "xcode_version": ["13.3.1"],
+        "xcode_version": ["13.1"],
       }
     }
   },
@@ -112,7 +112,7 @@ PARAMETERS = {
       "msvc_runtime": ["dynamic"],
       "cpp_compiler_windows": ["VisualStudio2019"],
       "cpp_compiler_linux": ["clang-11.0"],
-      "xcode_version": ["13.3.1"],  # only the first one is used
+      "xcode_version": ["13.1"],  # only the first one is used
       "ndk_version": ["r22b"],
       "platform_version": ["28"],
       "build_tools_version": ["28.0.3"],
@@ -138,10 +138,10 @@ PARAMETERS = {
 
   "ios": {
     "matrix": {
-      "xcode_version": ["13.3.1"],
+      "xcode_version": ["13.1"],
 
       EXPANDED_KEY: {
-        "xcode_version": ["13.3.1"]
+        "xcode_version": ["13.1"]
       }
     }
   },

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,10 +170,10 @@ TEST_DEVICES = {
   "ios_min": {"type": "real", "model":"iphone8", "version":"11.4"},
   "ios_target": {"type": "real", "model":"iphone8plus", "version":"12.0"},
   "ios_latest": {"type": "real", "model":"iphone11pro", "version":"14.7"},
-  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"15.0"},
-  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"15.0"},
+  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"12.4"},
+  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"14.5"},
   "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.4"},
-  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"15.0"},
+  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"14.3"},
 }
  
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update macos runners to use macos-12 (public beta) instead of macos-latest (equivalent to macos-11).

This change requires updating to Xcode 13.1 as a stopgap solution; we will update to Xcode 13.2.1 or Xcode 13.3.1 in a subsequently-merged PR. Updating to Xcode 13 necessitates updating iOS simulator versions as well.

Note: skipping release notes check, because the subsequent PR (#915) updates the release notes with the new Xcode version requirement.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Integration test run in the PR.
C++ packaging step here: https://github.com/firebase/firebase-cpp-sdk/actions/runs/2260453371
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
