### PR TITLE
Update linter to allow non-const references to match more recent goog…

### DIFF
--- a/scripts/gha/lint_commenter.py
+++ b/scripts/gha/lint_commenter.py
@@ -42,6 +42,7 @@ IGNORE_LINT_WARNINGS = [
   'build/include_subdir',   # doesn't know about our include paths
   'build/c++11',            # ignore "unapproved c++11 header" warning
   'readability/casting',    # allow non-C++ casts in rare occasions
+  'runtime/references',     # allow non-const references
   'whitespace/indent',      # we rely on our code formatter for this...
   'whitespace/line_length'  # ...and for this
 ]


### PR DESCRIPTION
### Description
Remove the "Is this a non-const reference? If so, make const or use a pointer" lint warning.
This lint warning is a leftover from when the google style guide used to forbid non-const references, but it now allows and even recommends non-const references for required output parameters.  ([go/cstyle#Output_Parameters](https://goto.google.com/cstyle#Output_Parameters))
***

### Testing
N/A
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***