### PR TITLE
GMA - Add ResponseInfo to AdResult

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -744,10 +744,22 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAd) {
   WaitForCompletion(ad_view->Initialize(app_framework::GetWindowContext(),
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
-  WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      ad_view->LoadAd(GetAdRequest());
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
   EXPECT_EQ(ad_view->ad_size().width(), kBannerWidth);
   EXPECT_EQ(ad_view->ad_size().height(), kBannerHeight);
   EXPECT_EQ(ad_view->ad_size().type(), firebase::gma::AdSize::kTypeStandard);
+
   WaitForCompletion(ad_view->Destroy(), "Destroy");
   delete ad_view;
 }
@@ -765,9 +777,19 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
                     "Initialize");
 
   // When the InterstitialAd is initialized, load an ad.
-  firebase::gma::AdRequest request = GetAdRequest();
-  WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
-                    "LoadAd");
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      interstitial->LoadAd(kInterstitialAdUnit, GetAdRequest());
+
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
   delete interstitial;
 }
 
@@ -783,8 +805,19 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
                     "Initialize");
 
   // When the RewardedAd is initialized, load an ad.
-  firebase::gma::AdRequest request = GetAdRequest();
-  WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request), "LoadAd");
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      rewarded->LoadAd(kRewardedAdUnit, GetAdRequest());
+
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
   delete rewarded;
 }
 
@@ -977,6 +1010,36 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadAndShow) {
 }
 
 // Other AdView Tests
+
+TEST_F(FirebaseGmaTest, TestAdViewLoadAdEmptyAdRequest) {
+  SKIP_TEST_ON_DESKTOP;
+
+  const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
+  firebase::gma::AdView* ad_view = new firebase::gma::AdView();
+  WaitForCompletion(ad_view->Initialize(app_framework::GetWindowContext(),
+                                        kBannerAdUnit, banner_ad_size),
+                    "Initialize");
+  firebase::gma::AdRequest request;
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      ad_view->LoadAd(request);
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
+  EXPECT_EQ(ad_view->ad_size().width(), kBannerWidth);
+  EXPECT_EQ(ad_view->ad_size().height(), kBannerHeight);
+  EXPECT_EQ(ad_view->ad_size().type(), firebase::gma::AdSize::kTypeStandard);
+
+  WaitForCompletion(ad_view->Destroy(), "Destroy");
+  delete ad_view;
+}
+
 TEST_F(FirebaseGmaTest, TestAdViewLoadAdAnchorAdaptiveAd) {
   SKIP_TEST_ON_DESKTOP;
   using firebase::gma::AdSize;
@@ -1469,6 +1532,34 @@ TEST_F(FirebaseGmaTest, TestAdViewErrorBadExtrasClassName) {
 
 // Other InterstitialAd Tests
 
+TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
+  SKIP_TEST_ON_DESKTOP;
+
+  firebase::gma::InterstitialAd* interstitial =
+      new firebase::gma::InterstitialAd();
+
+  WaitForCompletion(interstitial->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // When the InterstitialAd is initialized, load an ad.
+  firebase::gma::AdRequest request;
+
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      interstitial->LoadAd(kInterstitialAdUnit, request);
+
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
+  delete interstitial;
+}
+
 TEST_F(FirebaseGmaTest, TestInterstitialAdErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;
 
@@ -1610,6 +1701,35 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdErrorBadExtrasClassName) {
 }
 
 // Other RewardedAd Tests.
+
+TEST_F(FirebaseGmaTest, TestRewardedAdLoadEmptyRequest) {
+  SKIP_TEST_ON_DESKTOP;
+
+  // Note: while showing an ad requires user interaction (below),
+  // we test that we can simply load an ad first.
+
+  firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
+
+  WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
+                    "Initialize");
+
+  // When the RewardedAd is initialized, load an ad.
+  firebase::gma::AdRequest request;
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
+      rewarded->LoadAd(kRewardedAdUnit, request);
+
+  WaitForCompletion(load_ad_future, "LoadAd");
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+  ASSERT_NE(result_ptr, nullptr);
+  EXPECT_TRUE(result_ptr->is_successful());
+  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+  EXPECT_FALSE(
+      result_ptr->response_info().mediation_adapter_class_name().empty());
+  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+
+  delete rewarded;
+}
 
 TEST_F(FirebaseGmaTest, TestRewardedAdErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;

--- a/gma/src/android/adapter_response_info_android.cc
+++ b/gma/src/android/adapter_response_info_android.cc
@@ -45,16 +45,21 @@ AdapterResponseInfo::AdapterResponseInfo(
 
   // Construct an AdErrorInternal from the Android SDK AdError object in the
   // AdapterResponseInfo.
-  AdErrorInternal ad_error_internal;
-  ad_error_internal.native_ad_error = env->CallObjectMethod(
-      j_adapter_response_info,
-      adapter_response_info::GetMethodId(adapter_response_info::kGetAdError));
-  FIREBASE_ASSERT(ad_error_internal.native_ad_error);
-  AdError ad_error = AdError(ad_error_internal);
-  if (ad_error.code() != kAdErrorCodeNone) {
-    ad_result_ = AdResult(ad_error);
+  const jobject j_native_ad_error =
+      env->CallObjectMethod(
+        j_adapter_response_info,
+        adapter_response_info::GetMethodId(adapter_response_info::kGetAdError)
+      );
+
+  if( j_native_ad_error != nullptr ) {
+      AdErrorInternal ad_error_internal;
+      ad_error_internal.native_ad_error = j_native_ad_error;
+      AdError ad_error = AdError(ad_error_internal);
+      if (ad_error.code() != kAdErrorCodeNone) {
+        ad_result_ = AdResult(ad_error);
+      }
+    env->DeleteLocalRef(ad_error_internal.native_ad_error);
   }
-  env->DeleteLocalRef(ad_error_internal.native_ad_error);
 
   // The class name of the adapter.
   const jobject j_adapter_class_name =

--- a/gma/src/android/adapter_response_info_android.cc
+++ b/gma/src/android/adapter_response_info_android.cc
@@ -45,19 +45,17 @@ AdapterResponseInfo::AdapterResponseInfo(
 
   // Construct an AdErrorInternal from the Android SDK AdError object in the
   // AdapterResponseInfo.
-  const jobject j_native_ad_error =
-      env->CallObjectMethod(
-        j_adapter_response_info,
-        adapter_response_info::GetMethodId(adapter_response_info::kGetAdError)
-      );
+  const jobject j_native_ad_error = env->CallObjectMethod(
+      j_adapter_response_info,
+      adapter_response_info::GetMethodId(adapter_response_info::kGetAdError));
 
-  if( j_native_ad_error != nullptr ) {
-      AdErrorInternal ad_error_internal;
-      ad_error_internal.native_ad_error = j_native_ad_error;
-      AdError ad_error = AdError(ad_error_internal);
-      if (ad_error.code() != kAdErrorCodeNone) {
-        ad_result_ = AdResult(ad_error);
-      }
+  if (j_native_ad_error != nullptr) {
+    AdErrorInternal ad_error_internal;
+    ad_error_internal.native_ad_error = j_native_ad_error;
+    AdError ad_error = AdError(ad_error_internal);
+    if (ad_error.code() != kAdErrorCodeNone) {
+      ad_result_ = AdResult(ad_error);
+    }
     env->DeleteLocalRef(ad_error_internal.native_ad_error);
   }
 

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -883,7 +883,7 @@ void JNI_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(data_ptr);
   GmaInternal::CompleteLoadAdFuture(callback_data,
-                                    ResponseInfoInternal({ j_response_info }));
+                                    ResponseInfoInternal({j_response_info}));
   env->DeleteLocalRef(j_response_info);
 }
 
@@ -990,7 +990,7 @@ void JNI_AdViewHelper_completeLoadedAd(JNIEnv* env, jclass clazz,
   FIREBASE_ASSERT(callback_data_ptr);
   FIREBASE_ASSERT(ad_view_internal_data_ptr);
   FIREBASE_ASSERT(j_response_info);
-  
+
   internal::AdViewInternalAndroid* ad_view_internal =
       reinterpret_cast<internal::AdViewInternalAndroid*>(
           ad_view_internal_data_ptr);
@@ -1002,7 +1002,7 @@ void JNI_AdViewHelper_completeLoadedAd(JNIEnv* env, jclass clazz,
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(callback_data_ptr);
   GmaInternal::CompleteLoadAdFuture(callback_data,
-                                    ResponseInfoInternal({ j_response_info }));
+                                    ResponseInfoInternal({j_response_info}));
   env->DeleteLocalRef(j_response_info);
 }
 

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -874,12 +874,17 @@ void JNI_completeAdFutureCallback(JNIEnv* env, jclass clazz, jlong data_ptr,
   CompleteAdFutureCallback(env, clazz, data_ptr, error_code, error_message);
 }
 
-void JNI_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr) {
+void JNI_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
+                          jobject j_response_info) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
+  FIREBASE_ASSERT(j_response_info);
+
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(data_ptr);
-  GmaInternal::CompleteLoadAdFuture(callback_data);
+  GmaInternal::CompleteLoadAdFuture(callback_data,
+                                    ResponseInfoInternal({ j_response_info }));
+  env->DeleteLocalRef(j_response_info);
 }
 
 void JNI_completeLoadAdError(JNIEnv* env, jclass clazz, jlong data_ptr,
@@ -979,10 +984,13 @@ void JNI_notifyAdPaidEvent(JNIEnv* env, jclass clazz, jlong data_ptr,
 void JNI_AdViewHelper_completeLoadedAd(JNIEnv* env, jclass clazz,
                                        jlong callback_data_ptr,
                                        jlong ad_view_internal_data_ptr,
-                                       int width, int height) {
+                                       int width, int height,
+                                       jobject j_response_info) {
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(callback_data_ptr);
   FIREBASE_ASSERT(ad_view_internal_data_ptr);
+  FIREBASE_ASSERT(j_response_info);
+  
   internal::AdViewInternalAndroid* ad_view_internal =
       reinterpret_cast<internal::AdViewInternalAndroid*>(
           ad_view_internal_data_ptr);
@@ -990,11 +998,12 @@ void JNI_AdViewHelper_completeLoadedAd(JNIEnv* env, jclass clazz,
   // Invoke a friend of AdViewInternal to update its AdSize's width and height.
   GmaInternal::UpdateAdViewInternalAdSizeDimensions(ad_view_internal, width,
                                                     height);
-
   // Complete the Future.
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(callback_data_ptr);
-  GmaInternal::CompleteLoadAdFuture(callback_data);
+  GmaInternal::CompleteLoadAdFuture(callback_data,
+                                    ResponseInfoInternal({ j_response_info }));
+  env->DeleteLocalRef(j_response_info);
 }
 
 void JNI_AdViewHelper_notifyBoundingBoxChanged(JNIEnv* env, jclass clazz,
@@ -1072,7 +1081,8 @@ bool RegisterNatives() {
   static const JNINativeMethod kAdViewMethods[] = {
       {"completeAdViewFutureCallback", "(JILjava/lang/String;)V",
        reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
-      {"completeAdViewLoadedAd", "(JJII)V",
+      {"completeAdViewLoadedAd",
+       "(JJIILcom/google/android/gms/ads/ResponseInfo;)V",
        reinterpret_cast<void*>(&JNI_AdViewHelper_completeLoadedAd)},
       {"completeAdViewLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",
@@ -1096,7 +1106,8 @@ bool RegisterNatives() {
   static const JNINativeMethod kInterstitialMethods[] = {
       {"completeInterstitialAdFutureCallback", "(JILjava/lang/String;)V",
        reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
-      {"completeInterstitialLoadedAd", "(J)V",
+      {"completeInterstitialLoadedAd",
+       "(JLcom/google/android/gms/ads/ResponseInfo;)V",
        reinterpret_cast<void*>(&JNI_completeLoadedAd)},
       {"completeInterstitialLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",
@@ -1122,7 +1133,8 @@ bool RegisterNatives() {
   static const JNINativeMethod kRewardedAdMethods[] = {
       {"completeRewardedAdFutureCallback", "(JILjava/lang/String;)V",
        reinterpret_cast<void*>(&JNI_completeAdFutureCallback)},
-      {"completeRewardedLoadedAd", "(J)V",
+      {"completeRewardedLoadedAd",
+       "(JLcom/google/android/gms/ads/ResponseInfo;)V",
        reinterpret_cast<void*>(&JNI_completeLoadedAd)},
       {"completeRewardedLoadAdError",
        "(JLcom/google/android/gms/ads/LoadAdError;ILjava/lang/String;)V",

--- a/gma/src/common/gma_common.cc
+++ b/gma/src/common/gma_common.cc
@@ -65,10 +65,11 @@ const char* kAdUninitializedErrorMessage = "Ad has not been fully initialized.";
 
 // GmaInternal
 void GmaInternal::CompleteLoadAdFuture(
-    FutureCallbackData<AdResult>* callback_data) {
+    FutureCallbackData<AdResult>* callback_data,
+    const ResponseInfoInternal& response_info_internal) {
   callback_data->future_data->future_impl.CompleteWithResult(
       callback_data->future_handle, static_cast<int>(kAdErrorCodeNone), "",
-      AdResult());
+      AdResult(ResponseInfo(response_info_internal)));
   delete callback_data;
 }
 
@@ -100,9 +101,13 @@ AdInspectorClosedListener::~AdInspectorClosedListener() {}
 AdResult::AdResult() : is_successful_(true) {}
 AdResult::AdResult(const AdError& ad_error)
     : is_successful_(false), ad_error_(ad_error) {}
+AdResult::AdResult(const ResponseInfo& response_info)
+    : is_successful_(true), response_info_(response_info) {}
+
 AdResult::~AdResult() {}
 bool AdResult::is_successful() const { return is_successful_; }
 const AdError& AdResult::ad_error() const { return ad_error_; }
+const ResponseInfo& AdResult::response_info() const { return response_info_; }
 
 // AdSize
 // Hardcoded values are from publicly available documentation:

--- a/gma/src/common/gma_common.h
+++ b/gma/src/common/gma_common.h
@@ -131,7 +131,8 @@ void CompleteFuture(int error, const char* error_msg,
 class GmaInternal {
  public:
   // Completes an AdResult future with a successful result.
-  static void CompleteLoadAdFuture(FutureCallbackData<AdResult>* callback_data);
+  static void CompleteLoadAdFuture(FutureCallbackData<AdResult>* callback_data,
+                                   const ResponseInfoInternal& response_info);
 
   // Completes an AdResult future given the AdErrorInternal object.
   static void CompleteLoadAdFuture(FutureCallbackData<AdResult>* callback_data,

--- a/gma/src/include/firebase/gma/ad_view.h
+++ b/gma/src/include/firebase/gma/ad_view.h
@@ -228,7 +228,7 @@ class AdView {
   internal::AdViewInternal* internal_;
 };
 
-/// A listener class that developers can extend and pass to a @ref AdView
+/// A listener class that developers can extend and pass to an @ref AdView
 /// object's @ref AdView::SetBoundingBoxListener method to be notified of
 /// changes to the size of the Ad's bounding box.
 class AdViewBoundingBoxListener {
@@ -243,7 +243,7 @@ class AdViewBoundingBoxListener {
   virtual void OnBoundingBoxChanged(AdView* ad_view, BoundingBox box) = 0;
 };
 
-/// @brief The screen location and dimensions of an ad view once it has been
+/// @brief The screen location and dimensions of an AdView once it has been
 /// initialized.
 struct BoundingBox {
   /// Default constructor which initializes all member variables to 0.

--- a/gma/src/include/firebase/gma/types.h
+++ b/gma/src/include/firebase/gma/types.h
@@ -397,7 +397,7 @@ class AdapterResponseInfo {
   /// occurred, and any contextual information about that error.
   ///
   /// @return the error that occurred while rendering the ad.  If no error
-  /// occurred then the AdResults's successful method will return true.
+  /// occurred then the AdResults' successful method will return true.
   AdResult ad_result() const { return ad_result_; }
 
   /// Returns a string representation of a class name that identifies the ad

--- a/gma/src/include/firebase/gma/types.h
+++ b/gma/src/include/firebase/gma/types.h
@@ -397,7 +397,7 @@ class AdapterResponseInfo {
   /// occurred, and any contextual information about that error.
   ///
   /// @return the error that occurred while rendering the ad.  If no error
-  /// occurred then the AdResults' successful method will return true.
+  /// occurred then the AdResult's successful method will return true.
   AdResult ad_result() const { return ad_result_; }
 
   /// Returns a string representation of a class name that identifies the ad

--- a/gma/src/include/firebase/gma/types.h
+++ b/gma/src/include/firebase/gma/types.h
@@ -46,6 +46,7 @@ struct AdapterResponseInfoInternal;
 struct BoundingBox;
 struct ResponseInfoInternal;
 
+class AdapterResponseInfo;
 class AdViewBoundingBoxListener;
 class GmaInternal;
 class AdView;
@@ -234,6 +235,45 @@ class AdError {
   AdErrorInternal* internal_;
 };
 
+/// Information about an ad response.
+class ResponseInfo {
+ public:
+  /// Constructor creates an uninitialized ResponseInfo.
+  ResponseInfo();
+
+  /// Gets the AdaptorResponseInfo objects for the ad response.
+  ///
+  /// @return a vector of AdapterResponseInfo objects containing metadata for
+  ///   each adapter included in the ad response.
+  const std::vector<AdapterResponseInfo>& adapter_responses() const {
+    return adapter_responses_;
+  }
+
+  /// A class name that identifies the ad network that returned the ad.
+  /// Returns an empty string if the ad failed to load.
+  const std::string& mediation_adapter_class_name() const {
+    return mediation_adapter_class_name_;
+  }
+
+  /// Gets the response ID string for the loaded ad.  Returns an empty
+  /// string if the ad fails to load.
+  const std::string& response_id() const { return response_id_; }
+
+  /// Gets a log friendly string version of this object.
+  const std::string& ToString() const { return to_string_; }
+
+ private:
+  friend class AdError;
+  friend class GmaInternal;
+
+  explicit ResponseInfo(const ResponseInfoInternal& internal);
+
+  std::vector<AdapterResponseInfo> adapter_responses_;
+  std::string mediation_adapter_class_name_;
+  std::string response_id_;
+  std::string to_string_;
+};
+
 /// Information about the result of an ad operation.
 class AdResult {
  public:
@@ -255,13 +295,29 @@ class AdResult {
   /// information.
   const AdError& ad_error() const;
 
+  /// For debugging and logging purposes, successfully loaded ads provide a
+  /// ResponseInfo object which contains information about the adapter which
+  /// loaded the ad. If the ad failed to load then the object returned from
+  /// this method will have default values. Information about the error
+  /// should be retrieved via @ref AdResult::ad_error() instead.
+  const ResponseInfo& response_info() const;
+
  private:
+  friend class GmaInternal;
+
+  /// Constructor invoked upon successful ad load. This contains response
+  /// information from the adapter which loaded the ad.
+  explicit AdResult(const ResponseInfo& response_info);
+
   /// Denotes if the @ref AdResult represents a success or an error.
   bool is_successful_;
 
   /// Information about the error.  Will be a default-constructed @ref AdError
   /// if this result represents a success.
   AdError ad_error_;
+
+  /// Information from the adapter which loaded the ad.
+  ResponseInfo response_info_;
 };
 
 /// A snapshot of a mediation adapter's initialization status.
@@ -739,44 +795,6 @@ class PaidEventListener {
 
   /// Called when an ad is estimated to have earned money.
   virtual void OnPaidEvent(const AdValue& value) {}
-};
-
-/// Information about an ad response.
-class ResponseInfo {
- public:
-  /// Constructor creates an uninitialized ResponseInfo.
-  ResponseInfo();
-
-  /// Gets the AdaptorResponseInfo objects for the ad response.
-  ///
-  /// @return a vector of AdapterResponseInfo objects containing metadata for
-  ///   each adapter included in the ad response.
-  const std::vector<AdapterResponseInfo>& adapter_responses() const {
-    return adapter_responses_;
-  }
-
-  /// A class name that identifies the ad network that returned the ad.
-  /// Returns an empty string if the ad failed to load.
-  const std::string& mediation_adapter_class_name() const {
-    return mediation_adapter_class_name_;
-  }
-
-  /// Gets the response ID string for the loaded ad.  Returns an empty
-  /// string if the ad fails to load.
-  const std::string& response_id() const { return response_id_; }
-
-  /// Gets a log friendly string version of this object.
-  const std::string& ToString() const { return to_string_; }
-
- private:
-  friend class AdError;
-
-  explicit ResponseInfo(const ResponseInfoInternal& internal);
-
-  std::vector<AdapterResponseInfo> adapter_responses_;
-  std::string mediation_adapter_class_name_;
-  std::string response_id_;
-  std::string to_string_;
 };
 
 /// @brief Global configuration that will be used for every @ref AdRequest.

--- a/gma/src/ios/FADAdView.mm
+++ b/gma/src/ios/FADAdView.mm
@@ -275,7 +275,7 @@ firebase::gma::AdView::Position _position;
   NSInteger width = (NSInteger) (floor(bannerView.intrinsicContentSize.width));
   NSInteger height = (NSInteger) (floor(bannerView.intrinsicContentSize.height));
   _adLoaded = YES;
-  _cppAdView->AdViewDidReceiveAd(width, height);
+  _cppAdView->AdViewDidReceiveAd(width, height, bannerView.responseInfo);
   gma::BoundingBox bounding_box = self.boundingBox;
 }
 - (void)bannerView:(nonnull GADBannerView *)bannerView didFailToReceiveAdWithError:(nonnull NSError *)error {

--- a/gma/src/ios/ad_view_internal_ios.h
+++ b/gma/src/ios/ad_view_internal_ios.h
@@ -54,7 +54,7 @@ class AdViewInternalIOS : public AdViewInternal {
   }
 
 #ifdef __OBJC__
-  void AdViewDidReceiveAd(int width, int height);
+  void AdViewDidReceiveAd(int width, int height, GADResponseInfo *gad_response_info);
   void AdViewDidFailToReceiveAdWithError(NSError *gad_error);
 #endif  // __OBJC__
 

--- a/gma/src/ios/ad_view_internal_ios.mm
+++ b/gma/src/ios/ad_view_internal_ios.mm
@@ -47,7 +47,6 @@ Future<void> AdViewInternalIOS::Initialize(AdParent parent,
     future_data_.future_impl.SafeAlloc<void>(kAdViewFnInitialize);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
-
   if(initialized_) {
     CompleteFuture(kAdErrorCodeAlreadyInitialized,
       kAdAlreadyInitializedErrorMessage, future_handle, &future_data_);

--- a/gma/src/ios/adapter_response_info_ios.mm
+++ b/gma/src/ios/adapter_response_info_ios.mm
@@ -34,13 +34,15 @@ AdapterResponseInfo::AdapterResponseInfo(
   const AdapterResponseInfoInternal& internal) : ad_result_() {
   FIREBASE_ASSERT(internal.ad_network_response_info);
 
-  AdErrorInternal ad_error_internal;
-  ad_error_internal.native_ad_error = internal.ad_network_response_info.error;
-  AdError ad_error = AdError(ad_error_internal);
-  if(ad_error.code() != kAdErrorCodeNone) {
-    ad_result_ = AdResult(AdError(ad_error_internal));
+  if(internal.ad_network_response_info.error != nil) {
+    AdErrorInternal ad_error_internal;
+    ad_error_internal.native_ad_error = internal.ad_network_response_info.error;
+    AdError ad_error = AdError(ad_error_internal);
+    if(ad_error.code() != kAdErrorCodeNone) {
+      ad_result_ = AdResult(AdError(ad_error_internal));
+    }
   }
-  
+
   adapter_class_name_ = util::NSStringToString(
     internal.ad_network_response_info.adNetworkClassName);
   

--- a/gma/src/ios/gma_ios.h
+++ b/gma/src/ios/gma_ios.h
@@ -30,9 +30,14 @@ extern "C" {
 namespace firebase {
 namespace gma {
 
+// Completes AdResult futures for successful ad loads.
+void CompleteLoadAdInternalSuccess(
+  FutureCallbackData<AdResult>* callback_data,
+  const ResponseInfoInternal& response_info_internal);
+
 // Resolves LoadAd errors that exist in the C++ SDK before they reach the iOS
 // SDK.
-void CompleteLoadAdInternalResult(
+void CompleteLoadAdInternalError(
   FutureCallbackData<AdResult>* callback_data, AdErrorCode error_code,
   const char* error_message);
 

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/AdViewHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/AdViewHelper.java
@@ -33,6 +33,7 @@ import com.google.android.gms.ads.AdValue;
 import com.google.android.gms.ads.AdView;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnPaidEventListener;
+import com.google.android.gms.ads.ResponseInfo;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
@@ -535,8 +536,8 @@ public class AdViewHelper implements ViewTreeObserver.OnPreDrawListener {
         }
         if (mLoadAdCallbackDataPtr != CPP_NULLPTR) {
           AdSize adSize = mAdView.getAdSize();
-          completeAdViewLoadedAd(
-              mLoadAdCallbackDataPtr, mAdViewInternalPtr, adSize.getWidth(), adSize.getHeight());
+          completeAdViewLoadedAd(mLoadAdCallbackDataPtr, mAdViewInternalPtr, adSize.getWidth(),
+              adSize.getHeight(), mAdView.getResponseInfo());
           mLoadAdCallbackDataPtr = CPP_NULLPTR;
         }
         // Only update the bounding box if the banner view is already visible.
@@ -606,8 +607,8 @@ public class AdViewHelper implements ViewTreeObserver.OnPreDrawListener {
   /**
    * Native callback invoked upon successfully loading an ad.
    */
-  public static native void completeAdViewLoadedAd(
-      long nativeInternalPtr, long mAdViewInternalPtr, int width, int height);
+  public static native void completeAdViewLoadedAd(long nativeInternalPtr, long mAdViewInternalPtr,
+      int width, int height, ResponseInfo responseInfo);
 
   /**
    * Native callback upon encountering an error loading an Ad Request. Returns

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/InterstitialAdHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/InterstitialAdHelper.java
@@ -24,6 +24,7 @@ import com.google.android.gms.ads.AdValue;
 import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnPaidEventListener;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.interstitial.InterstitialAd;
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback;
 
@@ -278,7 +279,7 @@ public class InterstitialAdHelper {
         mInterstitial.setFullScreenContentCallback(listener);
         mInterstitial.setOnPaidEventListener(listener);
         if (mLoadAdCallbackDataPtr != CPP_NULLPTR) {
-          completeInterstitialLoadedAd(mLoadAdCallbackDataPtr);
+          completeInterstitialLoadedAd(mLoadAdCallbackDataPtr, ad.getResponseInfo());
           mLoadAdCallbackDataPtr = CPP_NULLPTR;
         }
       }
@@ -294,7 +295,8 @@ public class InterstitialAdHelper {
   /**
    * Native callback invoked upon successfully loading an ad.
    */
-  public static native void completeInterstitialLoadedAd(long nativeInternalPtr);
+  public static native void completeInterstitialLoadedAd(
+      long nativeInternalPtr, ResponseInfo responseInfo);
 
   /**
    * Native callback upon encountering an error loading an Ad Request. Returns

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/RewardedAdHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/RewardedAdHelper.java
@@ -25,6 +25,7 @@ import com.google.android.gms.ads.FullScreenContentCallback;
 import com.google.android.gms.ads.LoadAdError;
 import com.google.android.gms.ads.OnPaidEventListener;
 import com.google.android.gms.ads.OnUserEarnedRewardListener;
+import com.google.android.gms.ads.ResponseInfo;
 import com.google.android.gms.ads.rewarded.RewardItem;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
@@ -301,7 +302,7 @@ public class RewardedAdHelper {
           RewardedAdFullScreenContentListener listener = new RewardedAdFullScreenContentListener();
           mRewarded.setFullScreenContentCallback(listener);
           mRewarded.setOnPaidEventListener(listener);
-          completeRewardedLoadedAd(mLoadAdCallbackDataPtr);
+          completeRewardedLoadedAd(mLoadAdCallbackDataPtr, mRewarded.getResponseInfo());
           mLoadAdCallbackDataPtr = CPP_NULLPTR;
         }
       }
@@ -317,7 +318,8 @@ public class RewardedAdHelper {
   /**
    * Native callback invoked upon successfully loading an ad.
    */
-  public static native void completeRewardedLoadedAd(long nativeInternalPtr);
+  public static native void completeRewardedLoadedAd(
+      long nativeInternalPtr, ResponseInfo responseInfo);
 
   /**
    * Native callback upon encountering an error loading an Ad Request. Returns


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GMA ResponseInfo object can be obtained on any and result, whether it's an AdError or a successful AdLoad.  However, currently the C++ API only makes this accessible on error objects.

This will allow our customers to query which mediation adapter loaded an ad.

Additional Changes:
- [iOS] fixed a problem on Load Ad operations for all ad types if the parameters passed into the method were destroyed before the ayschronous ad load operation is scheduled.
- [iOS] Renamed the methods which complete ad load futures to clarify code paths which handle errors and successes.
- A few doxygen changes based on feedback from DevRel.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

- Local testing on iOS and Android.
- Added new tests to ensure the ResponseInfo object is populated on successful ad loads.
- Added tests where AdRequest objects leave scope, and are destroyed, for LoadAd operations.
- Added tests which pass-in empty AdRequest objects on ad loads to ensure we correctly handle the marshalling of empty parameters.
- [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2264384922).

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
