### PR TITLE
update gradle version

### DIFF
--- a/admob/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/admob/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/admob/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/admob/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/analytics/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/analytics/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/analytics/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/analytics/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/app/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/app/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/app/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/app/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/auth/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/auth/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/auth/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/auth/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/database/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/database/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/database/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/database/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/dynamic_links/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/dynamic_links/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/dynamic_links/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/dynamic_links/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/firestore/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/firestore/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/firestore/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/firestore/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/firestore/integration_test_internal/gradle/wrapper/gradle-wrapper.properties
+++ b/firestore/integration_test_internal/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/firestore/integration_test_internal/gradle/wrapper/gradle-wrapper.properties
+++ b/firestore/integration_test_internal/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/functions/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/functions/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/functions/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/functions/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/installations/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/installations/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/installations/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/installations/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/messaging/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/messaging/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/messaging/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/messaging/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/remote_config/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/remote_config/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/remote_config/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/remote_config/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/scripts/gha/integration_testing/gameloop_android/gradle/wrapper/gradle-wrapper.properties
+++ b/scripts/gha/integration_testing/gameloop_android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/scripts/gha/integration_testing/gameloop_android/gradle/wrapper/gradle-wrapper.properties
+++ b/scripts/gha/integration_testing/gameloop_android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/storage/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/storage/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-5.6.4-all.zip

--- a/storage/integration_test/gradle/wrapper/gradle-wrapper.properties
+++ b/storage/integration_test/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https://services.gradle.org/distributions/gradle-6.5.1-all.zip


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update from a very old Gradle version (4.10.1) to a slightly less old version (5.6.4) to fix some Android build errors, as new Firebase Android dependencies require a newer version.

Gradle 6.x and up cause a build error in our Proguard generator that will need to be addressed before updating further.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
