### PR TITLE
GMA - rename AdResult error/success future-completion methods

### DIFF
--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -776,8 +776,9 @@ void CompleteLoadAdCallback(FutureCallbackData<AdResult>* callback_data,
 
   // Invoke a friend of AdResult to have it invoke the AdResult
   // protected constructor with the AdErrorInternal data.
-  GmaInternal::CompleteLoadAdFuture(callback_data, ad_error_internal.code,
-                                    future_error_message, ad_error_internal);
+  GmaInternal::CompleteLoadAdFutureFailure(
+      callback_data, ad_error_internal.code, future_error_message,
+      ad_error_internal);
 }
 
 void CompleteLoadAdAndroidErrorResult(JNIEnv* env, jlong data_ptr,
@@ -882,8 +883,8 @@ void JNI_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
 
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(data_ptr);
-  GmaInternal::CompleteLoadAdFuture(callback_data,
-                                    ResponseInfoInternal({j_response_info}));
+  GmaInternal::CompleteLoadAdFutureSuccess(
+      callback_data, ResponseInfoInternal({j_response_info}));
   env->DeleteLocalRef(j_response_info);
 }
 
@@ -1001,8 +1002,8 @@ void JNI_AdViewHelper_completeLoadedAd(JNIEnv* env, jclass clazz,
   // Complete the Future.
   FutureCallbackData<AdResult>* callback_data =
       reinterpret_cast<FutureCallbackData<AdResult>*>(callback_data_ptr);
-  GmaInternal::CompleteLoadAdFuture(callback_data,
-                                    ResponseInfoInternal({j_response_info}));
+  GmaInternal::CompleteLoadAdFutureSuccess(
+      callback_data, ResponseInfoInternal({j_response_info}));
   env->DeleteLocalRef(j_response_info);
 }
 

--- a/gma/src/common/gma_common.cc
+++ b/gma/src/common/gma_common.cc
@@ -64,7 +64,7 @@ const char* kAdLoadInProgressErrorMessage = "Ad is currently loading.";
 const char* kAdUninitializedErrorMessage = "Ad has not been fully initialized.";
 
 // GmaInternal
-void GmaInternal::CompleteLoadAdFuture(
+void GmaInternal::CompleteLoadAdFutureSuccess(
     FutureCallbackData<AdResult>* callback_data,
     const ResponseInfoInternal& response_info_internal) {
   callback_data->future_data->future_impl.CompleteWithResult(
@@ -73,7 +73,7 @@ void GmaInternal::CompleteLoadAdFuture(
   delete callback_data;
 }
 
-void GmaInternal::CompleteLoadAdFuture(
+void GmaInternal::CompleteLoadAdFutureFailure(
     FutureCallbackData<AdResult>* callback_data, int error_code,
     const std::string& error_message,
     const AdErrorInternal& ad_error_internal) {

--- a/gma/src/common/gma_common.h
+++ b/gma/src/common/gma_common.h
@@ -131,14 +131,15 @@ void CompleteFuture(int error, const char* error_msg,
 class GmaInternal {
  public:
   // Completes an AdResult future with a successful result.
-  static void CompleteLoadAdFuture(FutureCallbackData<AdResult>* callback_data,
-                                   const ResponseInfoInternal& response_info);
+  static void CompleteLoadAdFutureSuccess(
+      FutureCallbackData<AdResult>* callback_data,
+      const ResponseInfoInternal& response_info);
 
-  // Completes an AdResult future given the AdErrorInternal object.
-  static void CompleteLoadAdFuture(FutureCallbackData<AdResult>* callback_data,
-                                   int error_code,
-                                   const std::string& error_message,
-                                   const AdErrorInternal& ad_error_internal);
+  // Completes an AdResult future as an error given the AdErrorInternal object.
+  static void CompleteLoadAdFutureFailure(
+      FutureCallbackData<AdResult>* callback_data, int error_code,
+      const std::string& error_message,
+      const AdErrorInternal& ad_error_internal);
 
   // Constructs and returns an AdError object given an AdErrorInternal object.
   static AdError CreateAdError(const AdErrorInternal& ad_error_internal);

--- a/gma/src/ios/ad_view_internal_ios.mm
+++ b/gma/src/ios/ad_view_internal_ios.mm
@@ -56,12 +56,12 @@ Future<void> AdViewInternalIOS::Initialize(AdParent parent,
     // Guard against parameter object destruction before the async operation
     // executes (below).
     AdParent local_ad_parent = parent;
-    std::string local_ad_unit_id(ad_unit_id);
+    NSString *local_ad_unit_id = @(ad_unit_id);
     ad_size_ = size;
 
     dispatch_async(dispatch_get_main_queue(), ^{
       ad_view_ = [[FADAdView alloc] initWithView:local_ad_parent
-                                        adUnitID:@(local_ad_unit_id.c_str())
+                                        adUnitID:local_ad_unit_id
                                           adSize:ad_size_
                                   internalAdView:this];
     CompleteFuture(kAdErrorCodeNone, nullptr, future_handle, &future_data_);

--- a/gma/src/ios/gma_ios.mm
+++ b/gma/src/ios/gma_ios.mm
@@ -337,8 +337,9 @@ void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
     future_error_message = ad_error_internal.message;
   }
 
-  GmaInternal::CompleteLoadAdFuture(
-      callback_data, ad_error_internal.code, future_error_message, ad_error_internal);
+  GmaInternal::CompleteLoadAdFutureFailure(
+      callback_data, ad_error_internal.code, future_error_message,
+      ad_error_internal);
 }
 
 void CompleteLoadAdInternalSuccess(
@@ -346,8 +347,8 @@ void CompleteLoadAdInternalSuccess(
     const ResponseInfoInternal& response_info_internal) {
   FIREBASE_ASSERT(callback_data);
 
-  GmaInternal::CompleteLoadAdFuture(callback_data, response_info_internal);
-
+  GmaInternal::CompleteLoadAdFutureSuccess(
+      callback_data, response_info_internal);
 }
 
 void CompleteLoadAdInternalError(
@@ -358,8 +359,7 @@ void CompleteLoadAdInternalError(
 
   CompleteAdResultError(callback_data, /*error=*/nullptr,
      /*is_load_ad_error=*/false, error_code, error_message);
- }
-
+}
 
 void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
                            NSError *gad_error, bool is_load_ad_error) {

--- a/gma/src/ios/interstitial_ad_internal_ios.mm
+++ b/gma/src/ios/interstitial_ad_internal_ios.mm
@@ -84,7 +84,7 @@ Future<AdResult> InterstitialAdInternalIOS::LoadAd(
   // Guard against parameter object destruction before the async operation
   // executes (below).
   AdRequest local_ad_request = request;
-  std::string local_ad_unit_id(ad_unit_id);
+  NSString *local_ad_unit_id = @(ad_unit_id);
 
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an gma::AdRequest.
@@ -102,7 +102,7 @@ Future<AdResult> InterstitialAdInternalIOS::LoadAd(
       ad_load_callback_data_ = nil;
     } else {
       // Make the interstitial ad request.
-      [GADInterstitialAd loadWithAdUnitID:@(local_ad_unit_id.c_str())
+      [GADInterstitialAd loadWithAdUnitID:local_ad_unit_id
                                   request:ad_request
                         completionHandler:^(GADInterstitialAd *ad, NSError *error)  // NO LINT
         {

--- a/gma/src/ios/rewarded_ad_internal_ios.mm
+++ b/gma/src/ios/rewarded_ad_internal_ios.mm
@@ -83,7 +83,7 @@ Future<AdResult> RewardedAdInternalIOS::LoadAd(
   // Guard against parameter object destruction before the async operation
   // executes (below).
   AdRequest local_ad_request = request;
-  std::string local_ad_unit_id(ad_unit_id);
+  NSString *local_ad_unit_id = @(ad_unit_id);
 
   dispatch_async(dispatch_get_main_queue(), ^{
     // Create a GADRequest from an gma::AdRequest.
@@ -101,7 +101,7 @@ Future<AdResult> RewardedAdInternalIOS::LoadAd(
       ad_load_callback_data_ = nil;
     } else {
       // Make the rewarded ad request.
-      [GADRewardedAd loadWithAdUnitID:@(local_ad_unit_id.c_str())
+      [GADRewardedAd loadWithAdUnitID:local_ad_unit_id
                               request:ad_request
                     completionHandler:^(GADRewardedAd *ad, NSError *error) {
           if (error) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

- Renamed Internal methods to be more descriptive as to whether they complete the AdResult futures successfully or with an error. 

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

- Manually testing on iOS and Android
- [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2276799851)
 
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
