### PR TITLE
Pass in -j N to cmake  to speed up desktop testapp build.

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -177,9 +177,19 @@ flags.DEFINE_string(
     "arch", "x64",
     "(Desktop only) Which architecture to build: x64 (all) or arm64 (Mac only).")
 
+# Get the number of CPUs for the default value of FLAGS.jobs
+CPU_COUNT = os.cpu_count();
+# If CPU count couldn't be determined, default to 2.
+DEFAULT_CPU_COUNT = 2
+if CPU_COUNT is None: CPU_COUNT = DEFAULT_CPU_COUNT
+# Cap at 4 CPUs.
+MAX_CPU_COUNT = 4
+if CPU_COUNT > MAX_CPU_COUNT: CPU_COUNT = MAX_CPU_COUNT
+
 flags.DEFINE_integer(
-    "jobs", 3,
-    "(Desktop only) If > 0, pass in -j <number> to CMake to parallelize build")
+    "jobs", CPU_COUNT,
+    "(Desktop only) If > 0, pass in -j <number> to make CMake parallelize the"
+    " build. Defaults to the system's CPU count (max %s)." % MAX_CPU_COUNT)
 
 flags.DEFINE_multi_string(
     "cmake_flag", None,
@@ -463,7 +473,7 @@ def _build_desktop(sdk_dir, cmake_flags):
                             ("arm64" if FLAGS.arch == "arm64" else "x86_64")]
   _run(cmake_configure_cmd + cmake_flags)
   _run(["cmake", "--build", ".", "--config", "Debug"] +
-       ["-j", "%s" % FLAGS.jobs] if FLAGS.jobs > 0 else [])
+       ["-j", str(FLAGS.jobs)] if FLAGS.jobs > 0 else [])
 
 
 def _get_desktop_compiler_flags(compiler, compiler_table):

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -177,6 +177,10 @@ flags.DEFINE_string(
     "arch", "x64",
     "(Desktop only) Which architecture to build: x64 (all) or arm64 (Mac only).")
 
+flags.DEFINE_integer(
+    "jobs", 3,
+    "(Desktop only) If > 0, pass in -j <number> to CMake to parallelize build")
+
 flags.DEFINE_multi_string(
     "cmake_flag", None,
     "Pass an additional flag to the CMake configure step."
@@ -458,7 +462,8 @@ def _build_desktop(sdk_dir, cmake_flags):
     cmake_configure_cmd += ["-DCMAKE_OSX_ARCHITECTURES=%s" %
                             ("arm64" if FLAGS.arch == "arm64" else "x86_64")]
   _run(cmake_configure_cmd + cmake_flags)
-  _run(["cmake", "--build", ".", "--config", "Debug"])
+  _run(["cmake", "--build", ".", "--config", "Debug"] +
+       ["-j", "%s" % FLAGS.jobs] if FLAGS.jobs > 0 else [])
 
 
 def _get_desktop_compiler_flags(compiler, compiler_table):


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Pass in "-j <number_of_cpus>" to cmake --build when building desktop testapps.

This should speed up the desktop testapp build. Linux improves from ~50min to ~35min. MacOS improves from ~140min to ~90min. Windows does not change (probably ignores the -j parameter).

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Run integration tests in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
