### PR TITLE
Update simulator min version

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,7 +170,7 @@ TEST_DEVICES = {
   "ios_min": {"type": "real", "model":"iphone8", "version":"11.4"},
   "ios_target": {"type": "real", "model":"iphone8plus", "version":"12.0"},
   "ios_latest": {"type": "real", "model":"iphone11pro", "version":"14.7"},
-  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"13.7"},
+  "simulator_min": {"type": "virtual", "name":"iPhone 8", "version":"13.7"},
   "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"14.5"},
   "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.2"},
   "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"14.3"},

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -170,7 +170,7 @@ TEST_DEVICES = {
   "ios_min": {"type": "real", "model":"iphone8", "version":"11.4"},
   "ios_target": {"type": "real", "model":"iphone8plus", "version":"12.0"},
   "ios_latest": {"type": "real", "model":"iphone11pro", "version":"14.7"},
-  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"12.4"},
+  "simulator_min": {"type": "virtual", "name":"iPhone 6", "version":"13.7"},
   "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"14.5"},
   "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.2"},
   "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"14.3"},


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

iOS 12.4 simulator is not playing nicely with Xcode 13.3.1. Update to use iOS 13.7 instead to unbreak the tests. We still test on iOS 12.x on FTL so this is low risk.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Can only be tested in the expanded matrix.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
