### PR TITLE
Replace jcenter(), long deprecated, with mavenCentral().

### DIFF
--- a/admob/admob_resources/build.gradle
+++ b/admob/admob_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/admob/build.gradle
+++ b/admob/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/admob/integration_test/build.gradle
+++ b/admob/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/analytics/integration_test/build.gradle
+++ b/analytics/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/app_resources/build.gradle
+++ b/app/app_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/google_api_resources/build.gradle
+++ b/app/google_api_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/integration_test/build.gradle
+++ b/app/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/invites_resources/build.gradle
+++ b/app/invites_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/app/test_resources/build.gradle
+++ b/app/test_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/auth/auth_resources/build.gradle
+++ b/auth/auth_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/auth/integration_test/build.gradle
+++ b/auth/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/database/database_resources/build.gradle
+++ b/database/database_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/database/integration_test/build.gradle
+++ b/database/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/dynamic_links/build.gradle
+++ b/dynamic_links/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/dynamic_links/integration_test/build.gradle
+++ b/dynamic_links/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/firestore/firestore_resources/build.gradle
+++ b/firestore/firestore_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/firestore/integration_test/build.gradle
+++ b/firestore/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/firestore/integration_test_internal/build.gradle
+++ b/firestore/integration_test_internal/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/functions/integration_test/build.gradle
+++ b/functions/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/installations/build.gradle
+++ b/installations/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/installations/integration_test/build.gradle
+++ b/installations/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/messaging/integration_test/build.gradle
+++ b/messaging/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/messaging/messaging_java/build.gradle
+++ b/messaging/messaging_java/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -30,7 +30,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/remote_config/build.gradle
+++ b/remote_config/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/remote_config/integration_test/build.gradle
+++ b/remote_config/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/scripts/gha/integration_testing/gameloop_android/build.gradle
+++ b/scripts/gha/integration_testing/gameloop_android/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.kotlin_version = "1.3.72"
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath "com.android.tools.build:gradle:4.0.1"
@@ -17,7 +17,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,7 +24,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/storage/integration_test/build.gradle
+++ b/storage/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/storage/storage_resources/build.gradle
+++ b/storage/storage_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -27,7 +27,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

jcenter() is no longer online. Use mavenCentral() instead.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Integration tests run in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
