### PR TITLE
Fix local server timestamp handling on 32-bit architectures

### DIFF
--- a/database/integration_test/src/integration_test.cc
+++ b/database/integration_test/src/integration_test.cc
@@ -454,8 +454,8 @@ TEST_F(FirebaseDatabaseTest, TestSetAndGetSimpleValues) {
     WaitForCompletion(f7, "GetLongDouble");
 
     // Get the current time to compare to the Timestamp.
-    int64_t current_time_milliseconds =
-        static_cast<int64_t>(time(nullptr)) * 1000L;
+    time_t current_time = time(nullptr)
+    int64_t current_time_milliseconds = current_time * 1000L;
 
     EXPECT_EQ(f1.result()->value().AsString(), kSimpleString);
     EXPECT_EQ(f2.result()->value().AsInt64(), kSimpleInt);

--- a/database/integration_test/src/integration_test.cc
+++ b/database/integration_test/src/integration_test.cc
@@ -454,8 +454,8 @@ TEST_F(FirebaseDatabaseTest, TestSetAndGetSimpleValues) {
     WaitForCompletion(f7, "GetLongDouble");
 
     // Get the current time to compare to the Timestamp.
-    time_t current_time = time(nullptr)
-    int64_t current_time_milliseconds = current_time * 1000L;
+    int64_t current_time_milliseconds =
+        static_cast<int64_t>(time(nullptr)) * 1000L;
 
     EXPECT_EQ(f1.result()->value().AsString(), kSimpleString);
     EXPECT_EQ(f2.result()->value().AsInt64(), kSimpleInt);

--- a/database/src/desktop/core/server_values.cc
+++ b/database/src/desktop/core/server_values.cc
@@ -28,7 +28,7 @@ static const char kNameSubkeyServerValue[] = ".sv";
 
 Variant GenerateServerValues(int64_t server_time_offset) {
   Variant server_values = Variant::EmptyMap();
-  int64_t corrected_time = time(nullptr) * 1000L + server_time_offset;
+  int64_t corrected_time = static_cast<int64_t>(time(nullptr)) * 1000L + server_time_offset;
   server_values.map()["timestamp"] = Variant::FromInt64(corrected_time);
   return server_values;
 }

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -584,6 +584,8 @@ code.
         the Google-Mobile-Ads-SDK Cocoapod, "7.69.0-cppsdk2", to maintain
         compatibility with version 9.x of the Firebase iOS SDK.
     -   Analytics: Removed deprecated event names and parameters.
+    -   Realtime Database (Desktop): Fixed a bug handling server timestamps
+        on 32-bit CPUs.
     -   Storage (Desktop): Set Content-Type HTTP header when uploading with
         custom metadata.
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On 32-bit Linux, time() returns a 32-bit integer. Cast it to 64-bit before doing math on it. This fixes a bug in the RTDB integration tests on x86 devices.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Tested in #931.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
