### PR TITLE
Fix building integration tests against packaged SDK on Linux x86

### DIFF
--- a/release_build_files/CMakeLists.txt
+++ b/release_build_files/CMakeLists.txt
@@ -58,7 +58,7 @@ else()  # LINUX
     set(LINUX_ABI cxx11)
   endif()
   # Check if we are building for x86
-  if ("${CMAKE_CXX_FLAGS}" MATCHES "-m32")
+  if (" ${CMAKE_CXX_FLAGS} " MATCHES " -m32 ")
     set(LINUX_CPU i386)
   else()
     set(LINUX_CPU x86_64)

--- a/release_build_files/CMakeLists.txt
+++ b/release_build_files/CMakeLists.txt
@@ -46,7 +46,7 @@ elseif(MSVC)
   set(MSVC_VS_VERSION VS2019)
   set(FIREBASE_SDK_LIBDIR
       ${FIREBASE_CPP_SDK_DIR}/libs/windows/${MSVC_VS_VERSION}/${MSVC_RUNTIME_MODE}/${MSVC_CPU}/${MSVC_CONFIG})
-else()
+else()  # LINUX
   # Check whether we are building with CXX11 ABI.
   get_directory_property(CURR_DIRECTORY_DEFS COMPILE_DEFINITIONS)
   if ("${CURR_DIRECTORY_DEFS}" MATCHES "_GLIBCXX_USE_CXX11_ABI=0" OR
@@ -56,8 +56,13 @@ else()
   else()
     set(DISABLE_CXX11 FALSE)
     set(LINUX_ABI cxx11)
-  endif()  
-  set(LINUX_CPU x86_64)
+  endif()
+  # Check if we are building for x86
+  if ("${CMAKE_CXX_FLAGS}" MATCHES "-m32")
+    set(LINUX_CPU i386)
+  else()
+    set(LINUX_CPU x86_64)
+  endif()
   set(FIREBASE_SDK_LIBDIR ${FIREBASE_CPP_SDK_DIR}/libs/linux/${LINUX_CPU}/${LINUX_ABI})
 endif()
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Check whether -m32 was specified in the c++ flags, and if so, link against the i386 version of the Linux libraries.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Tested in #931 along with other cross-architecture changes.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
