### PR TITLE
Mark AdMob as deprecated

### DIFF
--- a/admob/src/include/firebase/admob.h
+++ b/admob/src/include/firebase/admob.h
@@ -36,20 +36,29 @@ FIREBASE_APP_REGISTER_CALLBACKS_REFERENCE(admob)
 
 namespace firebase {
 
+/// @deprecated
 /// @brief API for AdMob with Firebase.
 ///
 /// The AdMob API allows you to load and display mobile ads using the Google
 /// Mobile Ads SDK. Each ad format has its own header file.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 namespace admob {
 
-/// Initializes AdMob via Firebase.
+/// @deprecated
+/// @brief Initializes AdMob via Firebase.
+///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
 ///
 /// @param app The Firebase app for which to initialize mobile ads.
 ///
@@ -57,16 +66,11 @@ namespace admob {
 /// kInitResultFailedMissingDependency on Android if Google Play services is not
 /// available on the current device and the Google Mobile Ads SDK requires
 /// Google Play services (for example, when using 'play-services-ads-lite').
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app);
 
-/// Initializes AdMob via Firebase with the publisher's AdMob app ID.
+/// @deprecated
+/// @brief Initializes AdMob via Firebase with the publisher's AdMob app ID.
+///
 /// Initializing the Google Mobile Ads SDK with the AdMob app ID at app launch
 /// allows the SDK to fetch app-level settings and perform configuration tasks
 /// as early as possible. This can help reduce latency for the initial ad
@@ -76,6 +80,13 @@ FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app);
 /// option under the settings dropdown (located in the upper right-hand corner).
 /// App IDs have the form ca-app-pub-XXXXXXXXXXXXXXXX~NNNNNNNNNN.
 ///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
+///
 /// @param[in] app The Firebase app for which to initialize mobile ads.
 /// @param[in] admob_app_id The publisher's AdMob app ID.
 ///
@@ -83,18 +94,12 @@ FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app);
 /// kInitResultFailedMissingDependency on Android if Google Play services is not
 /// available on the current device and the Google Mobile Ads SDK requires
 /// Google Play services (for example, when using 'play-services-ads-lite').
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app,
                                           const char* admob_app_id);
 
 #if FIREBASE_PLATFORM_ANDROID || defined(DOXYGEN)
-/// Initializes AdMob without Firebase for Android.
+/// @deprecated
+/// @brief Initializes AdMob without Firebase for Android.
 ///
 /// The arguments to @ref Initialize are platform-specific so the caller must do
 /// something like this:
@@ -106,6 +111,13 @@ FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app,
 /// #endif
 /// @endcode
 ///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
+///
 /// @param[in] jni_env JNIEnv pointer.
 /// @param[in] activity Activity used to start the application.
 ///
@@ -113,16 +125,11 @@ FIREBASE_DEPRECATED InitResult Initialize(const ::firebase::App& app,
 /// kInitResultFailedMissingDependency on Android if Google Play services is not
 /// available on the current device and the AdMob SDK requires
 /// Google Play services (for example when using 'play-services-ads-lite').
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize(JNIEnv* jni_env, jobject activity);
 
-/// Initializes AdMob via Firebase with the publisher's AdMob app ID.
+/// @deprecated
+/// @brief Initializes AdMob via Firebase with the publisher's AdMob app ID.
+///
 /// Initializing the Google Mobile Ads SDK with the AdMob app ID at app launch
 /// allows the SDK to fetch app-level settings and perform configuration tasks
 /// as early as possible. This can help reduce latency for the initial ad
@@ -142,6 +149,13 @@ FIREBASE_DEPRECATED InitResult Initialize(JNIEnv* jni_env, jobject activity);
 /// #endif
 /// @endcode
 ///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
+///
 /// @param[in] jni_env JNIEnv pointer.
 /// @param[in] activity Activity used to start the application.
 /// @param[in] admob_app_id The publisher's AdMob app ID.
@@ -150,29 +164,25 @@ FIREBASE_DEPRECATED InitResult Initialize(JNIEnv* jni_env, jobject activity);
 /// kInitResultFailedMissingDependency on Android if Google Play services is not
 /// available on the current device and the AdMob SDK requires
 /// Google Play services (for example when using 'play-services-ads-lite').
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize(JNIEnv* jni_env, jobject activity,
                                           const char* admob_app_id);
 #endif  // defined(__ANDROID__) || defined(DOXYGEN)
 #if !FIREBASE_PLATFORM_ANDROID || defined(DOXYGEN)
-/// Initializes AdMob without Firebase for iOS.
+/// @deprecated
+/// @brief Initializes AdMob without Firebase for iOS.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize();
 
-/// Initializes AdMob with the publisher's AdMob app ID and without Firebase for
-/// iOS.
+/// @deprecated
+/// @brief Initializes AdMob with the publisher's AdMob app ID and without
+/// Firebase for iOS.
+///
 /// Initializing the Google Mobile Ads SDK with the AdMob app ID at app launch
 /// allows the SDK to fetch app-level settings and perform configuration tasks
 /// as early as possible. This can help reduce latency for the initial ad
@@ -182,28 +192,29 @@ FIREBASE_DEPRECATED InitResult Initialize();
 /// option under the settings dropdown (located in the upper right-hand corner).
 /// App IDs have the form ca-app-pub-XXXXXXXXXXXXXXXX~NNNNNNNNNN.
 ///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
+///
 /// @param[in] admob_app_id The publisher's AdMob app ID.
 ///
 /// @return kInitResultSuccess if initialization succeeded
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED InitResult Initialize(const char* admob_app_id);
 #endif  // !defined(__ANDROID__) || defined(DOXYGEN)
 
+/// @deprecated
 /// @brief Terminate AdMob.
 ///
 /// Frees resources associated with AdMob that were allocated during
 /// @ref firebase::admob::Initialize().
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED void Terminate();

--- a/admob/src/include/firebase/admob/banner_view.h
+++ b/admob/src/include/firebase/admob/banner_view.h
@@ -29,6 +29,7 @@ namespace internal {
 class BannerViewInternal;
 }  // namespace internal
 
+/// @deprecated
 /// @brief Loads and displays AdMob banner ads.
 ///
 /// Each BannerView object corresponds to a single AdMob banner placement. There
@@ -69,10 +70,10 @@ class BannerViewInternal;
 /// }
 /// @endcode
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 class BannerView {
@@ -80,12 +81,13 @@ class BannerView {
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-  /// The presentation state of a @ref BannerView.
+  /// @deprecated
+  /// @brief The presentation state of a @ref BannerView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   enum PresentationState {
@@ -109,12 +111,13 @@ class BannerView {
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-  /// The possible screen positions for a @ref BannerView.
+  /// @deprecated
+  /// @brief The possible screen positions for a @ref BannerView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   enum Position {
@@ -135,26 +138,43 @@ class BannerView {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
-  /// A listener class that developers can extend and pass to a @ref BannerView
-  /// object's @ref SetListener method to be notified of changes to the
-  /// presentation state and bounding box.
+  /// @deprecated
+  /// @brief A listener class that developers can extend and pass to a @ref
+  /// BannerView object's @ref SetListener method to be notified of changes to
+  /// the presentation state and bounding box.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   class Listener {
    public:
-    /// This method is called when the @ref BannerView object's presentation
-    /// state changes.
+    /// @deprecated
+    /// @brief This method is called when the @ref BannerView object's
+    /// presentation state changes.
+    ///
+    /// <b>Deprecated</b>. The functionality in the
+    /// <code>firebase::admob</code> namespace has been replaced by the Google
+    /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+    /// to transition to the new SDK in our <a
+    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+    /// guide</a>.
     /// @param[in] banner_view The banner view whose presentation state changed.
     /// @param[in] state The new presentation state.
     virtual void OnPresentationStateChanged(BannerView* banner_view,
                                             PresentationState state) = 0;
-    /// This method is called when the @ref BannerView object's bounding box
-    /// changes.
+    /// @deprecated
+    /// @brief This method is called when the @ref BannerView object's bounding
+    /// box changes.
+    ///
+    /// <b>Deprecated</b>. The functionality in the
+    /// <code>firebase::admob</code> namespace has been replaced by the Google
+    /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+    /// to transition to the new SDK in our <a
+    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+    /// guide</a>.
     /// @param[in] banner_view The banner view whose bounding box changed.
     /// @param[in] box The new bounding box.
     virtual void OnBoundingBoxChanged(BannerView* banner_view,
@@ -162,251 +182,265 @@ class BannerView {
     virtual ~Listener();
   };
 
-  /// Creates an uninitialized @ref BannerView object.
+  /// @deprecated
+  /// @brief Creates an uninitialized @ref BannerView object.
   ///
   /// @ref Initialize must be called before the object is used.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED BannerView();
 
   ~BannerView();
 
-  /// Initializes the @ref BannerView object.
+  /// @deprecated
+  /// @brief Initializes the @ref BannerView object.
   ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] parent The platform-specific UI element that will host the ad.
   /// @param[in] ad_unit_id The ad unit ID to use when requesting ads.
   /// @param[in] size The desired ad size for the banner.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Initialize(AdParent parent,
                                               const char* ad_unit_id,
                                               AdSize size);
 
-  /// Returns a @ref Future that has the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future that has the status of the last call to
   /// @ref Initialize.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> InitializeLastResult() const;
 
-  /// Begins an asynchronous request for an ad. If successful, the ad
+  /// @deprecated
+  /// @brief Begins an asynchronous request for an ad. If successful, the ad
   /// will automatically be displayed in the BannerView.
   ///
-  /// @param[in] request An AdRequest struct with information about the request
-  ///                    to be made (such as targeting info).
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] request An AdRequest struct with information about the request
+  ///                    to be made (such as targeting info).
   FIREBASE_DEPRECATED Future<void> LoadAd(const AdRequest& request);
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref LoadAd.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> LoadAdLastResult() const;
 
-  /// Hides the BannerView.
+  /// @deprecated
+  /// @brief Hides the BannerView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Hide();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Hide.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> HideLastResult() const;
 
-  /// Shows the @ref BannerView.
+  /// @deprecated
+  /// @brief Shows the @ref BannerView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Show();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Show.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> ShowLastResult() const;
 
-  /// Pauses the @ref BannerView. Should be called whenever the C++ engine
-  /// pauses or the application loses focus.
+  /// @deprecated
+  /// @brief Pauses the @ref BannerView. Should be called whenever the C++
+  /// engine pauses or the application loses focus.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Pause();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Pause.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> PauseLastResult() const;
 
-  /// Resumes the @ref BannerView after pausing.
+  /// @deprecated
+  /// @brief Resumes the @ref BannerView after pausing.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Resume();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Resume.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> ResumeLastResult() const;
 
-  /// Cleans up and deallocates any resources used by the @ref BannerView.
+  /// @deprecated
+  /// @brief Cleans up and deallocates any resources used by the @ref
+  /// BannerView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Destroy();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Destroy.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> DestroyLastResult() const;
 
-  /// Moves the @ref BannerView so that its top-left corner is located at
+  /// @deprecated
+  /// @brief Moves the @ref BannerView so that its top-left corner is located at
   /// (x, y). Coordinates are in pixels from the top-left corner of the screen.
   ///
-  /// When built for Android, the library will not display an ad on top of or
-  /// beneath an Activity's status bar. If a call to MoveTo would result in an
-  /// overlap, the @ref BannerView is placed just below the status bar, so no
-  /// overlap occurs.
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] x The desired horizontal coordinate.
   /// @param[in] y The desired vertical coordinate.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> MoveTo(int x, int y);
 
-  /// Moves the @ref BannerView so that it's located at the given pre-defined
-  /// position.
-  /// @param[in] position The pre-defined position to which to move the
-  ///                     @ref BannerView.
+  /// @deprecated
+  /// @brief Moves the @ref BannerView so that it's located at the given
+  /// pre-defined position.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] position The pre-defined position to which to move the
+  ///                     @ref BannerView.
   FIREBASE_DEPRECATED Future<void> MoveTo(Position position);
 
-  /// Returns a @ref Future containing the status of the last call to either
-  /// version of @ref MoveTo.
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
+  /// either version of @ref MoveTo.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> MoveToLastResult() const;
 
-  /// Returns the current presentation state of the @ref BannerView.
-  /// @return The current presentation state.
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// @deprecated
+  /// @brief Returns the current presentation state of the @ref BannerView.z
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @return The current presentation state.
   FIREBASE_DEPRECATED PresentationState presentation_state() const;
 
-  /// Retrieves the @ref BannerView's current onscreen size and location.
-  /// @return The current size and location. Values are in pixels, and location
-  ///         coordinates originate from the top-left corner of the screen.
+  /// @deprecated
+  /// @brief Retrieves the @ref BannerView's current onscreen size and location.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED BoundingBox bounding_box() const;
 
-  /// Sets the @ref Listener for this object.
-  /// @param[in] listener A valid BannerView::Listener to receive callbacks.
+  /// @deprecated
+  /// @brief Sets the @ref Listener for this object.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] listener A valid BannerView::Listener to receive callbacks.
   FIREBASE_DEPRECATED void SetListener(Listener* listener);
 
  private:

--- a/admob/src/include/firebase/admob/interstitial_ad.h
+++ b/admob/src/include/firebase/admob/interstitial_ad.h
@@ -29,6 +29,7 @@ namespace internal {
 class InterstitialAdInternal;
 }  // namespace internal
 
+/// @deprecated
 /// @brief Loads and displays AdMob interstitial ads.
 ///
 /// @ref InterstitialAd is a single-use object that can load and show a
@@ -75,10 +76,10 @@ class InterstitialAdInternal;
 /// }
 /// @endcode
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 class InterstitialAd {
@@ -86,12 +87,13 @@ class InterstitialAd {
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-  /// The presentation states of an @ref InterstitialAd.
+  /// @deprecated
+  /// @brief The presentation states of an @ref InterstitialAd.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the
+  /// <code>firebase::admob</code> namespace has been replaced by the Google
+  /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+  /// to transition to the new SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   enum PresentationState {
@@ -106,141 +108,155 @@ class InterstitialAd {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/InterstitialAdHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
-  /// A listener class that developers can extend and pass to an
+  /// @deprecated
+  /// @brief A listener class that developers can extend and pass to an
   /// @ref InterstitialAd object's @ref SetListener method to be notified of
-  /// presentation state changes. This is useful for changes caused by user
-  /// interaction, such as when the user closes an interstitial.
+  /// presentation state changes.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// This is useful for changes caused by user interaction, such as when the
+  /// user closes an interstitial.
+  ///
+  /// <b>Deprecated</b>. The functionality in the
+  /// <code>firebase::admob</code> namespace has been replaced by the Google
+  /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+  /// to transition to the new SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   class Listener {
    public:
-    /// This method is called when the @ref InterstitialAd object's presentation
-    /// state changes.
+    /// @deprecated
+    /// @brief This method is called when the @ref InterstitialAd object's
+    /// presentation state changes.
+    ///
+    /// <b>Deprecated</b>. The functionality in the
+    /// <code>firebase::admob</code> namespace has been replaced by the Google
+    /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+    /// to transition to the new SDK in our <a
+    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+    /// guide</a>.
     /// @param[in] interstitial_ad The interstitial ad whose presentation state
     ///                            changed.
     /// @param[in] state The new presentation state.
-    ///
-    /// @deprecated The functionality in the firebase::admob namespace has been
-    /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-    /// how to transition to the new SDK in our
-    /// <a
-    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-    /// guide</a>.
     virtual void OnPresentationStateChanged(InterstitialAd* interstitial_ad,
                                             PresentationState state) = 0;
     virtual ~Listener();
   };
 
-  /// Creates an uninitialized @ref InterstitialAd object.
+  /// @deprecated
+  /// @brief Creates an uninitialized @ref InterstitialAd object.
   /// @ref Initialize must be called before the object is used.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED InterstitialAd();
 
   ~InterstitialAd();
 
-  /// Initialize the @ref InterstitialAd object.
-  /// @param[in] parent The platform-specific UI element that will host the ad.
-  /// @param[in] ad_unit_id The ad unit ID to use in loading the ad.
+  /// @deprecated
+  /// @brief Initialize the @ref InterstitialAd object.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] parent The platform-specific UI element that will host the ad.
+  /// @param[in] ad_unit_id The ad unit ID to use in loading the ad.
   FIREBASE_DEPRECATED Future<void> Initialize(AdParent parent,
                                               const char* ad_unit_id);
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Initialize.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> InitializeLastResult() const;
 
-  /// Begins an asynchronous request for an ad. The
-  /// @ref InterstitialAd::presentation_state method can be used to track the
-  /// progress of the request.
-  /// @param[in] request An AdRequest struct with information about the request
-  ///                    to be made (such as targeting info).
+  /// @deprecated
+  /// @brief Begins an asynchronous request for an ad.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// The @ref InterstitialAd::presentation_state method can be used to track
+  /// the progress of the request.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] request An AdRequest struct with information about the request
+  ///                    to be made (such as targeting info).
   FIREBASE_DEPRECATED Future<void> LoadAd(const AdRequest& request);
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref LoadAd.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> LoadAdLastResult() const;
 
-  /// Shows the @ref InterstitialAd. This should not be called unless an ad has
-  /// already been loaded.
+  /// @deprecated
+  /// @brief Shows the @ref InterstitialAd. This should not be called unless an
+  /// ad has already been loaded.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Show();
 
-  /// Returns a @ref Future containing the status of the last call to @ref Show.
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
+  /// @ref Show.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED Future<void> ShowLastResult() const;
 
-  /// Returns the current presentation state of the @ref InterstitialAd.
+  /// @deprecated
+  /// @brief Returns the current presentation state of the @ref InterstitialAd.
   ///
-  /// @return The current presentation state.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @return The current presentation state.
   FIREBASE_DEPRECATED PresentationState presentation_state() const;
 
-  /// Sets the @ref Listener for this @ref InterstitialAd.
-  /// @param[in] listener A valid InterstititalAd::Listener to receive
-  ///                     callbacks.
+  /// @deprecated
+  /// @brief Sets the @ref Listener for this @ref InterstitialAd.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] listener A valid InterstititalAd::Listener to receive
+  ///                     callbacks.
   FIREBASE_DEPRECATED void SetListener(Listener* listener);
 
  private:

--- a/admob/src/include/firebase/admob/native_express_ad_view.h
+++ b/admob/src/include/firebase/admob/native_express_ad_view.h
@@ -29,6 +29,7 @@ namespace internal {
 class NativeExpressAdViewInternal;
 }  // namespace internal
 
+/// @deprecated
 /// @brief Loads and displays ads from AdMob Native Ads Express.
 ///
 /// Each NativeExpressAdView object corresponds to a single AdMob Native Express
@@ -69,27 +70,26 @@ class NativeExpressAdViewInternal;
 /// }
 /// @endcode
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>. Native Express Ads has been discontinued, and are no longer
-/// served.
+/// guide</a>.
 class NativeExpressAdView {
  public:
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-  /// The presentation state of a @ref NativeExpressAdView.
+  /// @deprecated
+  /// @brief The presentation state of a @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   enum PresentationState {
     /// NativeExpressAdView is currently hidden.
     kPresentationStateHidden = 0,
@@ -112,15 +112,15 @@ class NativeExpressAdView {
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-  /// The possible screen positions for a @ref NativeExpressAdView.
+  /// @deprecated
+  /// @brief The possible screen positions for a @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   enum Position {
     /// Top of the screen, horizontally centered.
     kPositionTop = 0,
@@ -139,321 +139,326 @@ class NativeExpressAdView {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
-  /// A listener class that developers can extend and pass to a
+  /// @deprecated
+  /// @brief A listener class that developers can extend and pass to a
   /// @ref NativeExpressAdView object's @ref SetListener method to be notified
   /// of changes to the presentation state and bounding box.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   class Listener {
    public:
-    /// This method is called when the @ref NativeExpressAdView object's
+    /// @deprecated
+    /// @brief This method is called when the @ref NativeExpressAdView object's
     /// presentation state changes.
+    ///
+    /// <b>Deprecated</b>. The functionality in the
+    /// <code>firebase::admob</code> namespace has been replaced by the Google
+    /// Mobile Ads SDK in the <code>firebase::gma</code> namespace. Learn how
+    /// to transition to the new SDK in our <a
+    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+    /// guide</a>.
     /// @param[in] ad_view The native express ad view whose presentation state
     ///                    changed.
     /// @param[in] state The new presentation state.
-    ///
-    /// @deprecated The functionality in the firebase::admob namespace has been
-    /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-    /// how to transition to the new SDK in our
-    /// <a
-    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-    /// guide</a>. Native Express Ads has been discontinued, and are no longer
-    /// served.
     FIREBASE_DEPRECATED virtual void OnPresentationStateChanged(
         NativeExpressAdView* ad_view, PresentationState state) = 0;
-    /// This method is called when the @ref NativeExpressAdView object's
+
+    /// @deprecated
+    /// @brief This method is called when the @ref NativeExpressAdView object's
     /// bounding box changes.
+    ///
+    /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+    /// namespace has been replaced by the Google Mobile Ads SDK in the
+    /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+    /// SDK in our <a
+    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+    /// guide</a>.
     /// @param[in] ad_view The native express ad view whose bounding box
     ///                    changed.
     /// @param[in] box The new bounding box.
-    ///
-    /// @deprecated The functionality in the firebase::admob namespace has been
-    /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-    /// how to transition to the new SDK in our
-    /// <a
-    /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-    /// guide</a>. Native Express Ads has been discontinued, and are no longer
-    /// served.
     FIREBASE_DEPRECATED virtual void OnBoundingBoxChanged(
         NativeExpressAdView* ad_view, BoundingBox box) = 0;
 
     virtual ~Listener();
   };
 
-  /// Creates an uninitialized @ref NativeExpressAdView object.
+  /// @deprecated
+  /// @brief Creates an uninitialized @ref NativeExpressAdView object.
+  ///
   /// @ref Initialize must be called before the object is used.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED NativeExpressAdView();
 
   ~NativeExpressAdView();
 
-  /// Initializes the @ref NativeExpressAdView object.
+  /// @deprecated
+  /// @brief Initializes the @ref NativeExpressAdView object.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] parent The platform-specific UI element that will host the ad.
   /// @param[in] ad_unit_id The ad unit ID to use when requesting ads.
   /// @param[in] size The desired ad size for the native express ad.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED Future<void> Initialize(AdParent parent,
                                               const char* ad_unit_id,
                                               AdSize size);
 
-  /// Returns a @ref Future that has the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future that has the status of the last call to
   /// @ref Initialize.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> InitializeLastResult() const;
 
-  /// Begins an asynchronous request for an ad. If successful, the ad will
-  /// automatically be displayed in the NativeExpressAdView.
+  /// @deprecated
+  /// @brief Begins an asynchronous request for an ad. If successful, the ad
+  /// will automatically be displayed in the NativeExpressAdView.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] request An AdRequest struct with information about the request
   ///                    to be made (such as targeting info).
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED Future<void> LoadAd(const AdRequest& request);
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref LoadAd.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> LoadAdLastResult() const;
 
-  /// Hides the NativeExpressAdView.
+  /// @deprecated
+  /// @brief Hides the NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Hide();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Hide.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> HideLastResult() const;
 
-  /// Shows the @ref NativeExpressAdView.
+  /// @deprecated
+  /// @brief Shows the @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Show();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Show.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> ShowLastResult() const;
 
-  /// Pauses the @ref NativeExpressAdView. Should be called whenever the C++
-  /// engine pauses or the application loses focus.
+  /// @deprecated
+  /// @brief Pauses the @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// Should be called whenever the C++ engine pauses or the application loses
+  /// focus.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Pause();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Pause.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> PauseLastResult() const;
 
-  /// Resumes the @ref NativeExpressAdView after pausing.
+  /// @deprecated
+  /// @brief Resumes the @ref NativeExpressAdView after pausing.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Resume();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Resume.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> ResumeLastResult() const;
 
-  /// Cleans up and deallocates any resources used by the
+  /// @deprecated
+  /// @brief Cleans up and deallocates any resources used by the
   /// @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> Destroy();
 
-  /// Returns a @ref Future containing the status of the last call to
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
   /// @ref Destroy.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> DestroyLastResult() const;
 
-  /// Moves the @ref NativeExpressAdView so that its top-left corner is located
-  /// at (x, y). Coordinates are in pixels from the top-left corner of the
-  /// screen.
+  /// @deprecated
+  /// @brief Moves the @ref NativeExpressAdView so that its top-left corner is
+  /// located at (x, y). Coordinates are in pixels from the top-left corner of
+  /// the screen.
   ///
   /// When built for Android, the library will not display an ad on top of or
   /// beneath an Activity's status bar. If a call to MoveTo would result in an
   /// overlap, the @ref NativeExpressAdView is placed just below the status bar,
   /// so no overlap occurs.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] x The desired horizontal coordinate.
   /// @param[in] y The desired vertical coordinate.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED Future<void> MoveTo(int x, int y);
 
-  /// Moves the @ref NativeExpressAdView so that it's located at the given
-  /// pre-defined position.
+  /// @deprecated
+  /// @brief Moves the @ref NativeExpressAdView so that it's located at the
+  /// given pre-defined position.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] position The pre-defined position to which to move the
   ///                     @ref NativeExpressAdView.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED Future<void> MoveTo(Position position);
 
-  /// Returns a @ref Future containing the status of the last call to either
-  /// version of @ref MoveTo.
+  /// @deprecated
+  /// @brief Returns a @ref Future containing the status of the last call to
+  /// either version of @ref MoveTo.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
   FIREBASE_DEPRECATED Future<void> MoveToLastResult() const;
 
-  /// Returns the current presentation state of the @ref NativeExpressAdView.
-  /// @return The current presentation state.
+  /// @deprecated
+  /// @brief Returns the current presentation state of the
+  /// @ref NativeExpressAdView.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
+  /// guide</a>.
+  /// @return The current presentation state.
   FIREBASE_DEPRECATED PresentationState GetPresentationState() const;
 
-  /// Retrieves the @ref NativeExpressAdView's current onscreen size and
+  /// @deprecated
+  /// @brief Retrieves the @ref NativeExpressAdView's current onscreen size and
   /// location.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @return The current size and location. Values are in pixels, and location
   ///         coordinates originate from the top-left corner of the screen.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED BoundingBox GetBoundingBox() const;
 
-  /// Sets the @ref Listener for this object.
+  /// @deprecated
+  /// @brief Sets the @ref Listener for this object.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
+  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+  /// guide</a>.
   /// @param[in] listener A valid NativeExpressAdView::Listener to receive
   /// callbacks.
-  ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
-  /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-  /// guide</a>. Native Express Ads has been discontinued, and are no longer
-  /// served.
   FIREBASE_DEPRECATED void SetListener(Listener* listener);
 
  private:

--- a/admob/src/include/firebase/admob/rewarded_video.h
+++ b/admob/src/include/firebase/admob/rewarded_video.h
@@ -30,6 +30,7 @@ class Mutex;
 
 namespace admob {
 
+/// @deprecated
 /// @brief Loads and displays rewarded video ads via AdMob mediation.
 ///
 /// The rewarded_video namespace contains methods to load and display rewarded
@@ -91,23 +92,22 @@ namespace admob {
 /// }
 /// @endcode
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
-namespace rewarded_video {
-
+/// guide</a>.namespace rewarded_video {
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-/// The possible presentation states for rewarded video.
+/// @deprecated
+/// @brief The possible presentation states for rewarded video.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 enum PresentationState {
@@ -128,13 +128,14 @@ enum PresentationState {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/RewardedVideoHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
+/// @deprecated
 /// @brief A reward to be given to the user in exchange for watching a rewarded
 /// video ad.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 struct RewardItem {
@@ -144,44 +145,48 @@ struct RewardItem {
   std::string reward_type;
 };
 
-/// A listener class that developers can extend and pass to @ref SetListener
-/// to be notified of rewards and changes to the presentation state.
+/// @deprecated
+/// @brief A listener class that developers can extend and pass to @ref
+/// SetListener to be notified of rewards and changes to the presentation state.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 class Listener {
  public:
-  /// Invoked when the user should be given a reward for watching an ad.
-  /// @param[in] reward The user's reward.
+  /// @deprecated
+  /// @brief Invoked when the user should be given a reward for watching an ad.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] reward The user's reward.
   FIREBASE_DEPRECATED virtual void OnRewarded(RewardItem reward) = 0;
 
-  /// Invoked when the presentation state of the ad changes.
-  /// @param[in] state The new presentation state.
+  /// @deprecated
+  /// @brief Invoked when the presentation state of the ad changes.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param[in] state The new presentation state.
   FIREBASE_DEPRECATED virtual void OnPresentationStateChanged(
       PresentationState state) = 0;
 
   virtual ~Listener();
 };
 
-/// A polling-based listener that developers can instantiate and pass to
+/// @deprecated
+/// @brief A polling-based listener that developers can instantiate and pass to
 /// @ref SetListener in order to queue rewards for later retrieval.
 ///
 /// The @ref PollReward method should be used to retrieve awards granted by the
@@ -189,52 +194,62 @@ class Listener {
 /// @ref rewarded_video::presentation_state can be used to poll the current
 /// presentation state, so no additional method has been added for it.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 class PollableRewardListener : public Listener {
  public:
-  /// Default constructor.
+  /// @deprecated
+  /// @brief Default constructor.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED PollableRewardListener();
   ~PollableRewardListener();
 
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// @deprecated
+  /// @brief Invoked when the user should be given a reward for watching an ad.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED void OnRewarded(RewardItem reward);
 
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// @deprecated
+  /// @brief nvoked when the presentation state of the ad changes.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
   FIREBASE_DEPRECATED void OnPresentationStateChanged(PresentationState state);
 
-  /// Pop the oldest queued reward, and copy its data into the provided
-  /// RewardItem. If no reward is available, the struct is unchanged.
-  /// @param reward Pointer to a struct that reward data can be copied into.
-  /// @returns true if a reward was popped and data was copied, false otherwise.
+  /// @deprecated
+  /// @brief Pop the oldest queued reward, and copy its data into the provided
+  /// RewardItem.
   ///
-  /// @deprecated The functionality in the firebase::admob namespace has been
-  /// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-  /// how to transition to the new SDK in our
-  /// <a
+  /// If no reward is available, the struct is unchanged.
+  ///
+  /// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+  /// namespace has been replaced by the Google Mobile Ads SDK in the
+  /// <code>firebase::gma</code> namespace. Learn how to transition to the new
+  /// SDK in our <a
   /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
   /// guide</a>.
+  /// @param reward Pointer to a struct that reward data can be copied into.
+  /// @returns true if a reward was popped and data was copied, false otherwise.
   FIREBASE_DEPRECATED bool PollReward(RewardItem* reward);
 
  private:
@@ -244,154 +259,170 @@ class PollableRewardListener : public Listener {
   std::queue<RewardItem> rewards_;
 };
 
-/// Initializes rewarded video. This must be the first method invoked in
+/// @deprecated
+/// @brief Initializes rewarded video. This must be the first method invoked in
 /// this namespace.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> Initialize();
 
-/// Returns a @ref Future that has the status of the last call to
+/// @deprecated
+/// @brief Returns a @ref Future that has the status of the last call to
 /// @ref Initialize.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> InitializeLastResult();
 
-/// Begins an asynchronous request for an ad.
+/// @deprecated
+/// @brief Begins an asynchronous request for an ad.
+///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
 /// @param[in] ad_unit_id The ad unit ID to use in the request.
 /// @param[in] request An AdRequest struct with information about the request
 ///                    to be made (such as targeting info).
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
-/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
-/// guide</a>.
 FIREBASE_DEPRECATED Future<void> LoadAd(const char* ad_unit_id,
                                         const AdRequest& request);
 
-/// Returns a @ref Future containing the status of the last call to
+/// @deprecated
+/// @brief Returns a @ref Future containing the status of the last call to
 /// @ref LoadAd.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> LoadAdLastResult();
 
-/// Shows an ad, assuming one has loaded. @ref LoadAd must be called before this
-/// method.
-/// @param[in] parent An @ref AdParent that is a reference to an iOS
-///                   UIView or an Android Activity.
+/// @deprecated
+/// @brief Shows an ad, assuming one has loaded.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// @ref LoadAd must be called before this method.
+///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
+/// @param[in] parent An @ref AdParent that is a reference to an iOS
+///                   UIView or an Android Activity.
 FIREBASE_DEPRECATED Future<void> Show(AdParent parent);
 
-/// Returns a @ref Future containing the status of the last call to
+/// @deprecated
+/// @brief Returns a @ref Future containing the status of the last call to
 /// @ref Show.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> ShowLastResult();
 
-/// Pauses any background processing associated with rewarded video. Should
-/// be called whenever the C++ engine pauses or the application loses focus.
+/// @deprecated
+/// @brief Pauses any background processing associated with rewarded video.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// Should be called whenever the C++ engine pauses or the application loses
+/// focus.
+///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> Pause();
 
-/// Returns a @ref Future containing the status of the last call to
+/// @deprecated
+/// @brief Returns a @ref Future containing the status of the last call to
 /// @ref Pause.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> PauseLastResult();
 
-/// Resumes the rewarded video system after pausing.
+/// @deprecated
+/// @brief Resumes the rewarded video system after pausing.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> Resume();
 
-/// Returns a @ref Future containing the status of the last call to
+/// @deprecated
+/// @brief Returns a @ref Future containing the status of the last call to
 /// @ref Resume.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED Future<void> ResumeLastResult();
 
-/// Cleans up and deallocates any resources used by rewarded video.
+/// @deprecated
+/// @brief Cleans up and deallocates any resources used by rewarded video.
+///
 /// No other methods in rewarded_video should be called once this method has
 /// been invoked. The system is closed for business at that point.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 FIREBASE_DEPRECATED void Destroy();
 
-/// Returns the current presentation state, indicating if an ad is visible or
-/// if a video has started playing.
+/// @deprecated
+/// @brief Returns the current presentation state, indicating if an ad is
+/// visible or if a video has started playing.
 ///
-/// @return The current presentation state.
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
+/// @return The current presentation state.
 FIREBASE_DEPRECATED PresentationState presentation_state();
 
-/// Sets the @ref Listener that should receive callbacks.
-/// @param[in] listener A valid Listener.
+/// @deprecated
+/// @brief Sets the @ref Listener that should receive callbacks.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
+/// @param[in] listener A valid Listener.
 FIREBASE_DEPRECATED void SetListener(Listener* listener);
 
 }  // namespace rewarded_video

--- a/admob/src/include/firebase/admob/types.h
+++ b/admob/src/include/firebase/admob/types.h
@@ -31,13 +31,23 @@ extern "C" {
 namespace firebase {
 namespace admob {
 
-/// This is a platform specific datatype that is required to create an AdMob ad.
+/// @deprecated
+/// @brief This is a platform specific datatype that is required to create an
+/// AdMob ad.
 ///
 /// The following defines the datatype on each platform:
 /// <ul>
 ///   <li>Android: A `jobject` which references an Android Activity.</li>
 ///   <li>iOS: An `id` which references an iOS UIView.</li>
 /// </ul>
+///
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
+/// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
+/// guide</a>.
+///
 #if FIREBASE_PLATFORM_ANDROID
 /// An Android Activity from Java.
 typedef jobject AdParent;
@@ -53,12 +63,13 @@ typedef void *AdParent;
 #ifdef INTERNAL_EXPERIMENTAL
 // LINT.IfChange
 #endif  // INTERNAL_EXPERIMENTAL
-/// Error codes returned by Future::error().
+/// @deprecated
+/// @brief Error codes returned by Future::error().
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 enum AdMobError {
@@ -88,22 +99,24 @@ enum AdMobError {
 // LINT.ThenChange(//depot_firebase_cpp/admob/client/cpp/src_java/com/google/firebase/admob/internal/cpp/ConstantsHelper.java)
 #endif  // INTERNAL_EXPERIMENTAL
 
+/// @deprecated
 /// @brief Types of ad sizes.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 enum AdSizeType { kAdSizeStandard = 0 };
 
+/// @deprecated
 /// @brief An ad size value to be used in requesting ads.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 struct AdSize {
@@ -115,14 +128,14 @@ struct AdSize {
   int width;
 };
 
+/// @deprecated
 /// @brief Gender information used as part of the
 /// @ref firebase::admob::AdRequest struct.
 ///
-///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 enum Gender {
@@ -134,13 +147,14 @@ enum Gender {
   kGenderFemale
 };
 
+/// @deprecated
 /// @brief Indicates whether an ad request is considered tagged for
 /// child-directed treatment.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 enum ChildDirectedTreatmentState {
@@ -152,13 +166,14 @@ enum ChildDirectedTreatmentState {
   kChildDirectedTreatmentStateNotTagged
 };
 
+/// @deprecated
 /// @brief Generic Key-Value container used for the "extras" values in an
 /// @ref firebase::admob::AdRequest.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 struct KeyValuePair {
@@ -168,12 +183,13 @@ struct KeyValuePair {
   const char *value;
 };
 
+/// @deprecated
 /// @brief The information needed to request an ad.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 struct AdRequest {
@@ -209,13 +225,14 @@ struct AdRequest {
   ChildDirectedTreatmentState tagged_for_child_directed_treatment;
 };
 
+/// @deprecated
 /// @brief The screen location and dimensions of an ad view once it has been
 /// initialized.
 ///
-/// @deprecated The functionality in the firebase::admob namespace has been
-/// replaced by the Google Mobile Ads SDK in the firebase::gma SDK.  Learn
-/// how to transition to the new SDK in our
-/// <a
+/// <b>Deprecated</b>. The functionality in the <code>firebase::admob</code>
+/// namespace has been replaced by the Google Mobile Ads SDK in the
+/// <code>firebase::gma</code> namespace. Learn how to transition to the new
+/// SDK in our <a
 /// href="https://firebase.google.com/docs/admob/cpp/migration-guide">migration
 /// guide</a>.
 struct BoundingBox {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Updates to the header files in admob/src/include/firebase/admob:
 - mark all methods, classes and functions as deprecated.
 - link to the upcoming migration guide.  URL is correct but the document isn't public yet.
 - add FIREBASE_DEPRECATED macro prefix to each method and function.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

 - Local integration test runs on iOS and Android
 - Integration Test CI
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
Release notes update will be added when feature/admob_2021 is merged.