### PR TITLE
Add stdin option to restore_secrets for secure passphrase entry.

### DIFF
--- a/scripts/gha/restore_secrets.py
+++ b/scripts/gha/restore_secrets.py
@@ -22,7 +22,7 @@ python restore_secrets.py --passphrase_file [--repo_dir <path_to_repo>]
 --passphrase: Passphrase to decrypt the files. This option is insecure on a
     multi-user machine; use the --passphrase_file option instead.
 --passphrase_file: Specify a file to read the passphrase from (only reads the
-    first line).
+    first line). Use "-" (without quotes) for stdin.
 --repo_dir: Path to C++ SDK Github repository. Defaults to current directory.
 
 This script will perform the following:
@@ -48,7 +48,8 @@ FLAGS = flags.FLAGS
 
 flags.DEFINE_string("repo_dir", os.getcwd(), "Path to C++ SDK Github repo.")
 flags.DEFINE_string("passphrase", None, "The passphrase itself.")
-flags.DEFINE_string("passphrase_file", None, "Path to file with passphrase.")
+flags.DEFINE_string("passphrase_file", None,
+                    "Path to file with passphrase. Use \"-\" (without quotes) for stdin.")
 flags.DEFINE_string("artifact", None, "Artifact Path, google-services.json will be placed here.")
 
 
@@ -60,6 +61,8 @@ def main(argv):
   # The passphrase is sensitive, do not log.
   if FLAGS.passphrase:
     passphrase = FLAGS.passphrase
+  elif FLAGS.passphrase_file == "-":
+    passphrase = input()
   elif FLAGS.passphrase_file:
     with open(FLAGS.passphrase_file, "r") as f:
       passphrase = f.readline().strip()


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add stdin option to restore_secrets for secure passphrase entry. (Standard POSIX custom is for the filename "-" to refer to standard input.)

This allows us to avoid passing in a passphrase on the command line, which can be insecure on a multi-user machine (which a self-hosted runner could be).
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Tested in #931.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
