### PR TITLE
Fix inconsistent feature request issue prefix

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -13,8 +13,6 @@ template_path=.github/ISSUE_TEMPLATE/feature-request.md
 -->
 ### [READ] Guidelines
 
-When filing a feature request please make sure the issue title starts with "FR:".
-
 A good feature request ideally
 * is either immediately obvious (i.e. "Add Sign in with Apple support"), or
 * starts with a use case that is not achievable with the existing Firebase API and


### PR DESCRIPTION
Hey wonderful Firebase folks,

I'd noticed that the Feature Request template added [FR] to the title but then asked that the title instead start with "FR:". So, I figured I'd toss up a quick PR as a concrete proposal of one way to fix the inconsistency.

Figured you all would at least want a friendly heads. [FR] and no further description seemed more consistent with the other templates, so that's what I did in the PR. But of course, it doesn't matter to me what you choose. 

Cheers!
Chris
(ex-Googler)