### PR TITLE
Propagate the Position Independent Code flag

### DIFF
--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -240,6 +240,9 @@ function(build_external_dependencies)
           -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE})
     endif()
   endif()
+  # Propagate the PIC setting, as the dependencies need to match it
+  set(CMAKE_SUB_CONFIGURE_OPTIONS ${CMAKE_SUB_CONFIGURE_OPTIONS}
+      -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE})
   message(STATUS "Sub-configure options: ${CMAKE_SUB_CONFIGURE_OPTIONS}")
   message(STATUS "Sub-build options: ${CMAKE_SUB_BUILD_OPTIONS}")
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

In CMake, if the caller has set CMAKE_POSITION_INDEPENDENT_CODE, that needs to be propagated to the special early build of the dependencies like boringssl, so that the libraries can link together properly.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building the Unity SDK on Linux with boringssl enabled.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
