### PR TITLE
Handle Access Denied error when cleaning up build directory on Windows

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -79,6 +79,7 @@ import json
 import os
 import platform
 import shutil
+import stat
 import subprocess
 import sys
 import tempfile

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -707,7 +707,7 @@ def _rm_dir_safe(directory_path):
   """Removes directory at given path. No error if dir doesn't exist."""
   logging.info("Deleting %s...", directory_path)
   try:
-    shutil.rmtree(directory_path, onerror=_handle_readonly_file))
+    shutil.rmtree(directory_path, onerror=_handle_readonly_file)
   except OSError as e:
     # There are two known cases where this can happen:
     # The directory doesn't exist (FileNotFoundError)

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -697,11 +697,17 @@ def _run(args, timeout=_DEFAULT_RUN_TIMEOUT_SECONDS, capture_output=False, text=
       check=check)
 
 
+def _handle_readonly_file(func, path, excinfo):
+  """Function passed into shutil.rmtree to handle Access Denied error"""
+  os.chmod(path, stat.S_IWRITE)
+  func(path)  # will re-throw if a different error occurrs
+
+
 def _rm_dir_safe(directory_path):
   """Removes directory at given path. No error if dir doesn't exist."""
   logging.info("Deleting %s...", directory_path)
   try:
-    shutil.rmtree(directory_path)
+    shutil.rmtree(directory_path, onerror=_handle_readonly_file))
   except OSError as e:
     # There are two known cases where this can happen:
     # The directory doesn't exist (FileNotFoundError)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Some of the build artifacts on Windows end up as read-only files, which shutil.rmtree doesn't handle by default. Pass in an onerror handler to make the files writable and try again.

This causes the disk space usage of build_testapps on Windows desktop to drop from 11GB+ to 2.5GB.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Tested in #959 and in this PR's integration tests.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
