### PR TITLE
Update GHA CI Java Version

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -362,6 +362,10 @@ jobs:
         run: |
           npm install -g firebase-tools
       - name: Run Desktop integration tests
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
         run: |
           cp scripts/gha/integration_testing/google-services.json testapps-desktop-ubuntu-latest-openssl/firestore/google-services.json
           firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps-desktop-ubuntu-latest-openssl --logfile_name "desktop-ubuntu-latest-openssl"'

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -361,11 +361,12 @@ jobs:
       - name: Setup Firestore Emulator
         run: |
           npm install -g firebase-tools
-      - name: Run Desktop integration tests
+      - name: Setup java
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'
+      - name: Run Desktop integration tests
         run: |
           cp scripts/gha/integration_testing/google-services.json testapps-desktop-ubuntu-latest-openssl/firestore/google-services.json
           firebase emulators:exec --only firestore --project demo-example 'python scripts/gha/desktop_tester.py --testapp_dir testapps-desktop-ubuntu-latest-openssl --logfile_name "desktop-ubuntu-latest-openssl"'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -893,6 +893,11 @@ jobs:
           command: |
             pip install -r scripts/gha/requirements.txt
             python scripts/gha/restore_secrets.py --passphrase "${{ secrets.TEST_SECRET }}" --artifact "testapps/testapps-desktop-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.ssl_variant }}"
+      - name: Setup java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Run Desktop integration tests
         env:
           USE_FIRESTORE_EMULATOR: true


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The Firebase CLI tools require a java version 11+.  The default GHA runner Java version did not meet this standard.
This change adds an extra workflow step to install a JRE of v17.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2358886238)
[Desktop CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2358635902)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

