### PR TITLE
bundle_test.cc: Disable LoadBundleWithDocumentsAlreadyPulledFromBackend

### DIFF
--- a/firestore/integration_test_internal/src/bundle_test.cc
+++ b/firestore/integration_test_internal/src/bundle_test.cc
@@ -295,9 +295,6 @@ TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
 
-  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
-                  "Actions and needs to be investigated (b/233751585)";
-
   Firestore* db = TestFirestore();
   auto collection = db->Collection("coll-1");
   WriteDocuments(collection,

--- a/firestore/integration_test_internal/src/bundle_test.cc
+++ b/firestore/integration_test_internal/src/bundle_test.cc
@@ -142,6 +142,9 @@ class BundleTest : public FirestoreIntegrationTest {
 };
 
 TEST_F(BundleTest, CanLoadBundlesWithoutProgressUpdates) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   auto bundle = CreateTestBundle(db);
 
@@ -152,6 +155,9 @@ TEST_F(BundleTest, CanLoadBundlesWithoutProgressUpdates) {
 }
 
 TEST_F(BundleTest, CanLoadBundlesWithProgressUpdates) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   auto bundle = CreateTestBundle(db);
 
@@ -180,6 +186,9 @@ TEST_F(BundleTest, CanLoadBundlesWithProgressUpdates) {
 }
 
 TEST_F(BundleTest, CanDeleteFirestoreFromProgressUpdate) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   auto bundle = CreateTestBundle(db);
 
@@ -216,6 +225,9 @@ TEST_F(BundleTest, CanDeleteFirestoreFromProgressUpdate) {
 }
 
 TEST_F(BundleTest, LoadBundlesForASecondTimeSkips) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   // TODO(wuandy): This test fails on Windows CI, but
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
@@ -244,6 +256,9 @@ TEST_F(BundleTest, LoadBundlesForASecondTimeSkips) {
 }
 
 TEST_F(BundleTest, LoadInvalidBundlesShouldFail) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   // TODO(wuandy): This test fails on Windows CI, but
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
@@ -273,12 +288,15 @@ TEST_F(BundleTest, LoadInvalidBundlesShouldFail) {
 }
 
 TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   // TODO(wuandy, b/189477267): This test fails on Windows CI, but
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
 
-  GTEST_SKIP() << "This test fails often on Android and iOS in GitHub Actions "
-                  "and needs to be investigated (b/233751585)";
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
 
   Firestore* db = TestFirestore();
   auto collection = db->Collection("coll-1");
@@ -322,6 +340,9 @@ TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
 }
 
 TEST_F(BundleTest, LoadedDocumentsShouldNotBeGarbageCollectedRightAway) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   // TODO(wuandy, b/189477267): This test fails on Windows CI, but
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
@@ -346,6 +367,9 @@ TEST_F(BundleTest, LoadedDocumentsShouldNotBeGarbageCollectedRightAway) {
 }
 
 TEST_F(BundleTest, LoadDocumentsFromOtherProjectsShouldFail) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   auto bundle = CreateBundle("other-project");
   std::vector<LoadBundleTaskProgress> progresses;
@@ -366,6 +390,9 @@ TEST_F(BundleTest, LoadDocumentsFromOtherProjectsShouldFail) {
 }
 
 TEST_F(BundleTest, GetInvalidNamedQuery) {
+  GTEST_SKIP() << "Bundle tests fails often on Android and iOS in GitHub "
+                  "Actions and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   {
     auto future = db->NamedQuery("DOES_NOT_EXIST");

--- a/firestore/integration_test_internal/src/bundle_test.cc
+++ b/firestore/integration_test_internal/src/bundle_test.cc
@@ -277,6 +277,9 @@ TEST_F(BundleTest, LoadBundleWithDocumentsAlreadyPulledFromBackend) {
   // local run is fine. We need to figure out why and re-enable it.
   SKIP_TEST_ON_WINDOWS;
 
+  GTEST_SKIP() << "This test fails often on Android and iOS in GitHub Actions "
+                  "and needs to be investigated (b/233751585)";
+
   Firestore* db = TestFirestore();
   auto collection = db->Collection("coll-1");
   WriteDocuments(collection,


### PR DESCRIPTION
This test is very flaky, so I'm disabling it for now.

Googlers see b/233751585 for details.