### PR TITLE
Set core.longpaths=true in git in GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -62,6 +62,10 @@ jobs:
           git config --global credential.helper 'store --file /tmp/git-credentials'
           echo 'https://${{ github.token }}@github.com' > /tmp/git-credentials
 
+      - name: Enable Git Long-paths Support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Check expanded matrix config
         if: github.event.inputs.expanded_matrix == '1'
         run: |

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -101,6 +101,10 @@ jobs:
           git config --global credential.helper 'store --file /tmp/git-credentials'
           echo 'https://${{ github.token }}@github.com' > /tmp/git-credentials
 
+      - name: Enable Git Long-paths Support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
+
       - name: Setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode_version }}.app/Contents/Developer

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -277,6 +277,9 @@ jobs:
         run: |
           git config --global credential.helper 'store --file /tmp/git-credentials'
           echo 'https://${{ github.token }}@github.com' > /tmp/git-credentials
+      - name: Enable Git Long-paths Support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
       - name: Set env vars (Linux)
         if: startsWith(matrix.os, 'ubuntu')
         run: echo "VCPKG_TRIPLET=x64-linux" >> $GITHUB_ENV
@@ -471,6 +474,9 @@ jobs:
         run: |
           git config --global credential.helper 'store --file /tmp/git-credentials'
           echo 'https://${{ github.token }}@github.com' > /tmp/git-credentials
+      - name: Enable Git Long-paths Support
+        if: runner.os == 'Windows'
+        run: git config --system core.longpaths true
       - name: Add msbuild to PATH (Windows)
         if: startsWith(matrix.os, 'windows')
         uses: microsoft/setup-msbuild@v1.0.2


### PR DESCRIPTION
Android builds in Windows GitHub Actions runners was curiously failing with "firestore_errors.h file not found" errors (e.g. https://github.com/firebase/firebase-cpp-sdk/runs/6387651127). It turned out that this was because the cloning of the https://github.com/firebase/firebase-ios-sdk repository was failing due to such a deeply-nested filesystem hierarchy that it exceeded the maximum path lengths.

The fix in this PR enables "long paths" support in Git to disable this troublesome limitation by running

```
git config --system core.longpaths true
```

Here is one explanation of this fix: https://stackoverflow.com/a/72187507

Credit for this fix goes completely to @wu-hui (https://github.com/firebase/firebase-cpp-sdk/pull/967). I'm merely porting it to the `main` branch.