### PR TITLE
Run setup-java for Firestore emulator in GitHub Actions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1140,11 +1140,21 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - name: Setup java 17 for Firestore emulator
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
           npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
+      - name: Setup java 8 for test_simulator.py
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
       - name: Run Android integration tests on Emulator locally
         timeout-minutes: 120
         if: steps.get-device-type.outputs.device_type == 'virtual'
@@ -1245,6 +1255,11 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14.x
+      - name: Setup java for Firestore emulator
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
@@ -1344,6 +1359,11 @@ jobs:
           timeout_minutes: 1
           max_attempts: 3
           command: pip install -r scripts/gha/requirements.txt
+      - name: Setup java for Firestore emulator
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '17'
       - name: Setup Firestore Emulator
         if: contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |


### PR DESCRIPTION
Fix a problem where the Firestore integration tests were flakily failing in GitHub Actions runners due to the Firestore emulator failing to start.

If the GitHub Actions runner selected for integration testing had JDK 8 installed then the Firestore emulator would fail to start because recent releases of the Firestore emulator require JDK 11 or newer. This would cause the tests that attempt to communicate with the Firestore emulator to understandably fail.

The fix is to explicitly install JDK 11 (or newer) on GitHub Actions runners using the `setup-java` action, instead of relying on the java version that happened to be installed on the runner.

Googlers can see b/233751585 for details.