### PR TITLE
Add RE2 library to desktop packaging & Update MSVC dependencies

### DIFF
--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -193,7 +193,6 @@ readonly deps_hidden_firebase_app="
 */boringssl-build/crypto/${subdir}${prefix}crypto.${ext}
 */boringssl-build/ssl/${subdir}${prefix}ssl.${ext}
 */firestore-build/*/leveldb-build*/${prefix}*.${ext}
-*/firestore-build/*/re2-build*/${prefix}*.${ext}
 */firestore-build/*/snappy-build*/${prefix}*.${ext}
 */firestore-build/*/nanopb-build*/${prefix}*.${ext}
 "
@@ -206,6 +205,7 @@ readonly deps_hidden_firebase_firestore="
 */firestore-build/*/grpc-build/${subdir}${prefix}*.${ext}
 */firestore-build/*/grpc-build/third_party/cares/*${subdir}${prefix}*.${ext}
 */firestore-build/*/grpc-build/third_party/abseil-cpp/*${subdir}${prefix}*.${ext}
+*/firestore-build/*/grpc-build/third_party/re2/*${subdir}${prefix}re2.${ext}
 "
 
 # List of C++ namespaces to be renamed, so as to not conflict with the

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -229,7 +229,7 @@ readonly -a rename_namespaces=(flatbuffers flexbuffers reflection ZLib bssl uWS 
                                grpc_ssl_server_credentials grpc_tls_credential_reload_config
                                grpc_tls_server_authorization_check_config GrpcUdpListener leveldb
                                leveldb_filterpolicy_create_bloom leveldb_writebatch_iterate strings
-                               TlsCredentials TlsServerCredentials tsi snappy re2 re2_internal hooks)
+                               TlsCredentials TlsServerCredentials tsi snappy re2)
 
 # String to prepend to all hidden symbols.
 readonly rename_string=f_b_

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -193,6 +193,7 @@ readonly deps_hidden_firebase_app="
 */boringssl-build/crypto/${subdir}${prefix}crypto.${ext}
 */boringssl-build/ssl/${subdir}${prefix}ssl.${ext}
 */firestore-build/*/leveldb-build*/${prefix}*.${ext}
+*/firestore-build/*/re2-build*/${prefix}*.${ext}
 */firestore-build/*/snappy-build*/${prefix}*.${ext}
 */firestore-build/*/nanopb-build*/${prefix}*.${ext}
 "
@@ -228,7 +229,7 @@ readonly -a rename_namespaces=(flatbuffers flexbuffers reflection ZLib bssl uWS 
                                grpc_ssl_server_credentials grpc_tls_credential_reload_config
                                grpc_tls_server_authorization_check_config GrpcUdpListener leveldb
                                leveldb_filterpolicy_create_bloom leveldb_writebatch_iterate strings
-                               TlsCredentials TlsServerCredentials tsi snappy)
+                               TlsCredentials TlsServerCredentials tsi snappy re2 re2_internal hooks)
 
 # String to prepend to all hidden symbols.
 readonly rename_string=f_b_

--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -196,7 +196,7 @@ else()
       "-framework SystemConfiguration"
     )
   elseif(MSVC)
-    set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32)
+    set(ADDITIONAL_LIBS advapi32 ws2_32 crypt32 dbghelp bcrypt)
   else()
     set(ADDITIONAL_LIBS pthread)
   endif()

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -452,7 +452,7 @@ information):
 Firebase C++ Library | Windows SDK library dependencies
 -------------------- | -----------------------------------------------------
 Authentication       | `advapi32, ws2_32, crypt32`
-Firestore            | `advapi32, ws2_32, crypt32, rpcrt4, ole32, shell32`
+Firestore            | `advapi32, ws2_32, crypt32, rpcrt4, ole32, shell32, dbghelp, bcrypt`
 Functions            | `advapi32, ws2_32, crypt32, rpcrt4, ole32`
 Realtime Database    | `advapi32, ws2_32, crypt32, iphlpapi, psapi, userenv, shell32`
 Remote Config        | `advapi32, ws2_32, crypt32, rpcrt4, ole32`

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -605,9 +605,11 @@ code.
       only using AdMob, Analytics, Remote Config, or Messaging.
     - Functions: Add a new method `GetHttpsCallableFromURL`, to create callables
       with URLs other than cloudfunctions.net.
-    - Analytics (iOS): Added InitiateOnDeviceConversionMeasurementWithEmail function to facilitate the
-      [on-device conversion measurement](https://support.google.com/google-ads/answer/12119136) API.
-    - Firestore (Windows): dbghelp and bcrypt need to be linked against.
+    - Analytics (iOS): Added InitiateOnDeviceConversionMeasurementWithEmail
+      function to facilitate the [on-device conversion
+      measurement](https://support.google.com/google-ads/answer/12119136) API.
+    - Firestore (Desktop): On Windows, you must additionally link against the
+      bcrypt and dbghelp system libraries.
 
 ### 9.0.0
 -   Changes

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -607,6 +607,7 @@ code.
       with URLs other than cloudfunctions.net.
     - Analytics (iOS): Added InitiateOnDeviceConversionMeasurementWithEmail function to facilitate the
       [on-device conversion measurement](https://support.google.com/google-ads/answer/12119136) API.
+    - Firestore (Windows): dbghelp and bcrypt need to be linked against.
 
 ### 9.0.0
 -   Changes


### PR DESCRIPTION
The PR https://github.com/firebase/firebase-ios-sdk/pull/9488 in the firebase-ios-sdk added a dependency on a new third-party library, "re2". This was picked up by the firebase-cpp-sdk in https://github.com/firebase/firebase-cpp-sdk/pull/977.

All of the CI builds and tests worked fine; however, the "blastdoor" post-processing step renamed the `re2` namespace that caused linking error when linking against the packaged SDK (e.g. https://github.com/firebase/firebase-cpp-sdk/runs/6701070693).

This PR fixes the linking error by configuring blastdoor to properly handle re2. This was 100% based on the same thing for the snappy dependency in https://github.com/firebase/firebase-cpp-sdk/pull/885.

Also, in the same PR the versions of grpc and absl were updated, which on Windows requires linking against dbghelp and bcrypt, so add those to the set of libraries in the integration test.