### PR TITLE
GMA iTest NoFill tetry and loadAd tests disabled on Simulator

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -243,6 +243,11 @@ void LogAdResultIfError(const firebase::gma::AdResult* ad_result) {
   }
 }
 
+// Attempts to load an AdView configured with the provided listeners.
+// If the service returns a NoFill error, then this function will continue to
+// reattempt the load ad until kMaxNoFillRetries is reached. If
+// kMaxNoFillRetries has been reached, either via this invocation or
+// preveiously, then this function returns the AdResult with the loadAd failure.
 firebase::gma::AdView* loadAdView(
     const firebase::gma::AdSize& ad_size,
     const firebase::gma::AdRequest& request,
@@ -280,6 +285,11 @@ firebase::gma::AdView* loadAdView(
   return ad_view;
 }
 
+// Attempts to load an AdView. If the service returns a NoFill error, then
+// this function will continue to reattempt the load ad until kMaxNoFillRetries
+// is reached. If kMaxNoFillRetries has been reached, either via this invocation
+// or preveiously, then this function returns the AdResult with the loadAd
+// failure.
 firebase::gma::AdView* loadAdView(
     const firebase::gma::AdSize& ad_size,
     const firebase::gma::AdRequest& request,
@@ -287,6 +297,11 @@ firebase::gma::AdView* loadAdView(
   return loadAdView(ad_size, request, load_ad_future, nullptr, nullptr);
 }
 
+// Attempts to load an InterstitialAd. If the service returns a NoFill error,
+// then this function will continue to reattempt the load ad until
+// kMaxNoFillRetries is reached. If kMaxNoFillRetries has been reached, either
+// via this invocation or preveiously, then this function returns the AdResult
+// with the loadAd failure.
 firebase::gma::InterstitialAd* loadInterstitialAd(
     const firebase::gma::AdRequest& request,
     firebase::Future<firebase::gma::AdResult>& load_ad_future) {
@@ -317,6 +332,11 @@ firebase::gma::InterstitialAd* loadInterstitialAd(
   return interstitial;
 }
 
+// Attempts to load a RewardedAd. If the service returns a NoFill error, then
+// this function will continue to reattempt the load ad until kMaxNoFillRetries
+// is reached. If kMaxNoFillRetries has been reached, either via this invocation
+// or preveiously, then this function returns the AdResult with the loadAd
+// failure.
 firebase::gma::RewardedAd* loadRewardedAd(
     const firebase::gma::AdRequest& request,
     firebase::Future<firebase::gma::AdResult>& load_ad_future) {
@@ -401,16 +421,16 @@ void FirebaseGmaTest::TearDown() { FirebaseTest::TearDown(); }
 firebase::gma::AdRequest FirebaseGmaTest::GetAdRequest() {
   firebase::gma::AdRequest request;
 
-  for (auto extras_iter = kGmaAdapterExtras.begin();
-       extras_iter != kGmaAdapterExtras.end(); ++extras_iter) {
-    request.add_extra(kAdNetworkExtrasClassName, extras_iter->first.c_str(),
-                      extras_iter->second.c_str());
-  }
-
   // Additional keywords to be used in targeting.
   for (auto keyword_iter = kKeywords.begin(); keyword_iter != kKeywords.end();
        ++keyword_iter) {
     request.add_keyword((*keyword_iter).c_str());
+  }
+
+  for (auto extras_iter = kGmaAdapterExtras.begin();
+       extras_iter != kGmaAdapterExtras.end(); ++extras_iter) {
+    request.add_extra(kAdNetworkExtrasClassName, extras_iter->first.c_str(),
+                      extras_iter->second.c_str());
   }
 
   // Content URL
@@ -1536,17 +1556,17 @@ TEST_F(FirebaseGmaTest, TestAdView) {
 #endif
   }
 
-  
   WaitForCompletion(ad_view->Destroy(), "Destroy AdView");
   delete ad_view;
   PauseForVisualInspectionAndCallbacks();
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     // And finally, the last bounding box change, when the AdView is deleted,
     // should have invalid values (-1,-1, -1, -1).
-    EXPECT_TRUE(bounding_box_listener.bounding_box_changes_.back().x == -1 &&
-                bounding_box_listener.bounding_box_changes_.back().y == -1 &&
-                bounding_box_listener.bounding_box_changes_.back().width == -1 &&
-                bounding_box_listener.bounding_box_changes_.back().height == -1);
+    EXPECT_TRUE(
+        bounding_box_listener.bounding_box_changes_.back().x == -1 &&
+        bounding_box_listener.bounding_box_changes_.back().y == -1 &&
+        bounding_box_listener.bounding_box_changes_.back().width == -1 &&
+        bounding_box_listener.bounding_box_changes_.back().height == -1);
   }
 
   load_ad_future.Release();

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -195,7 +195,7 @@ class FirebaseGmaPreInitializationTests : public FirebaseGmaTest {
 firebase::App* FirebaseGmaTest::shared_app_ = nullptr;
 
 void PauseForVisualInspectionAndCallbacks() {
-  app_framework::ProcessEvents(1000);
+  app_framework::ProcessEvents(500);
 }
 
 bool HasReachedMaxNoAdFillRetryLimit() {
@@ -1001,7 +1001,7 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
 
 // Interactive test section.  These have been placed up front so that the
 // tester doesn't get bored waiting for them.
-TEST_F(FirebaseGmaUITest, DISABLED_TestAdViewAdOpenedAdClosed) {
+TEST_F(FirebaseGmaUITest, TestAdViewAdOpenedAdClosed) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
@@ -1069,7 +1069,7 @@ TEST_F(FirebaseGmaUITest, DISABLED_TestAdViewAdOpenedAdClosed) {
   delete ad_view;
 }
 
-TEST_F(FirebaseGmaUITest, DISABLED_TestInterstitialAdLoadAndShow) {
+TEST_F(FirebaseGmaUITest, TestInterstitialAdLoadAndShow) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
@@ -1123,7 +1123,7 @@ TEST_F(FirebaseGmaUITest, DISABLED_TestInterstitialAdLoadAndShow) {
   delete interstitial;
 }
 
-TEST_F(FirebaseGmaUITest, DISABLED_TestRewardedAdLoadAndShow) {
+TEST_F(FirebaseGmaUITest, TestRewardedAdLoadAndShow) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
@@ -1554,6 +1554,7 @@ TEST_F(FirebaseGmaTest, TestAdView) {
 
 TEST_F(FirebaseGmaTest, TestAdViewErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_SIMULATOR;
 
   firebase::gma::AdView* ad_view = new firebase::gma::AdView();
 
@@ -1722,6 +1723,7 @@ TEST_F(FirebaseGmaTest, TestAdViewErrorBadExtrasClassName) {
 
 TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_SIMULATOR;
 
   firebase::gma::AdRequest request;
   firebase::Future<firebase::gma::AdResult> load_ad_future;
@@ -1747,6 +1749,7 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
 
 TEST_F(FirebaseGmaTest, TestInterstitialAdErrorNotInitialized) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_SIMULATOR;
 
   firebase::gma::InterstitialAd* interstitial_ad =
       new firebase::gma::InterstitialAd();

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -86,6 +86,7 @@ namespace firebase_test_framework {
 // SKIP_TEST_ON_LINUX
 // SKIP_TEST_ON_WINDOWS
 // SKIP_TEST_ON_MACOS
+// SKIP_TEST_ON_SIMULATOR
 //
 // Also includes a special macro SKIP_TEST_IF_USING_STLPORT if compiling for
 // Android STLPort, which does not fully support C++11.
@@ -177,6 +178,26 @@ namespace firebase_test_framework {
 #else
 #define SKIP_TEST_ON_ANDROID ((void)0)
 #endif  // defined(ANDROID)
+
+#if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE && TARGET_OS_SIMULATOR
+#define SKIP_TEST_ON_SIMULATOR                                          \
+  {                                                                     \
+    app_framework::LogInfo("Skipping %s on iOS simulator.",             \
+      test_info_->name());                                              \
+    GTEST_SKIP();                                                       \
+    return;                                                             \
+  }
+#elif defined(ANDROID) && (defined(__x86_64__) || defined(__i386__))
+#define SKIP_TEST_ON_SIMULATOR                                          \
+  {                                                                     \
+    app_framework::LogInfo("Skipping %s on Android simulator.",         \
+      test_info_->name());                                              \
+    GTEST_SKIP();                                                       \
+    return;                                                             \
+  }
+#else
+#define SKIP_TEST_ON_SIMULATOR ((void)0)
+#endif
 
 #if defined(STLPORT)
 #define SKIP_TEST_IF_USING_STLPORT                                             \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -180,20 +180,20 @@ namespace firebase_test_framework {
 #endif  // defined(ANDROID)
 
 #if defined(TARGET_OS_IPHONE) && TARGET_OS_IPHONE && TARGET_OS_SIMULATOR
-#define SKIP_TEST_ON_SIMULATOR                                          \
-  {                                                                     \
-    app_framework::LogInfo("Skipping %s on iOS simulator.",             \
-      test_info_->name());                                              \
-    GTEST_SKIP();                                                       \
-    return;                                                             \
+#define SKIP_TEST_ON_SIMULATOR                              \
+  {                                                         \
+    app_framework::LogInfo("Skipping %s on iOS simulator.", \
+                           test_info_->name());             \
+    GTEST_SKIP();                                           \
+    return;                                                 \
   }
 #elif defined(ANDROID) && (defined(__x86_64__) || defined(__i386__))
-#define SKIP_TEST_ON_SIMULATOR                                          \
-  {                                                                     \
-    app_framework::LogInfo("Skipping %s on Android simulator.",         \
-      test_info_->name());                                              \
-    GTEST_SKIP();                                                       \
-    return;                                                             \
+#define SKIP_TEST_ON_SIMULATOR                                  \
+  {                                                             \
+    app_framework::LogInfo("Skipping %s on Android simulator.", \
+                           test_info_->name());                 \
+    GTEST_SKIP();                                               \
+    return;                                                     \
   }
 #else
 #define SKIP_TEST_ON_SIMULATOR ((void)0)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Numerous updates to the GMA Integration Tests to increase CI stability:
- Added detection of NoFill and BackOff errors sent by the AdMob service.  The iTest will pause and retry the add load in these situations.  The maximum number of retires has been limited to 15.
- Added a `SKIP_TEST_ON_SIMULATOR` to the Firebase App Test Framework.
- Due to the higher chance of NoFill errors occuring when running on local simulators, all LoadAd operations are skipped on simulators.


***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Local Tests on Android / iOS Simulators, and Android / iOS real devices.
[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2455731843)
[Packaging CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2455732913) - [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2456473095)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
