### PR TITLE
Add an API flag to restore_secrets script

### DIFF
--- a/scripts/gha/restore_secrets.py
+++ b/scripts/gha/restore_secrets.py
@@ -24,6 +24,8 @@ python restore_secrets.py --passphrase_file [--repo_dir <path_to_repo>]
 --passphrase_file: Specify a file to read the passphrase from (only reads the
     first line). Use "-" (without quotes) for stdin.
 --repo_dir: Path to C++ SDK Github repository. Defaults to current directory.
+--api: Specify a particular product API and retrieve only that api's
+    secret.
 
 This script will perform the following:
 
@@ -51,6 +53,7 @@ flags.DEFINE_string("passphrase", None, "The passphrase itself.")
 flags.DEFINE_string("passphrase_file", None,
                     "Path to file with passphrase. Use \"-\" (without quotes) for stdin.")
 flags.DEFINE_string("artifact", None, "Artifact Path, google-services.json will be placed here.")
+flags.DEFINE_string("api", None, "Retrieve secret for the particular SDK only.")
 
 
 def main(argv):
@@ -69,17 +72,24 @@ def main(argv):
   else:
     raise ValueError("Must supply passphrase or passphrase_file arg.")
 
+  if FLAGS.api:
+    print("Retrieving secret for product api: ", FLAGS.api)
+
   secrets_dir = os.path.join(repo_dir, "scripts", "gha-encrypted")
   encrypted_files = _find_encrypted_files(secrets_dir)
   print("Found these encrypted files:\n%s" % "\n".join(encrypted_files))
 
   for path in encrypted_files:
     if "google-services" in path or "GoogleService" in path:
-      print("Encrypted Google Service file found: %s" % path)
       # We infer the destination from the file's directory, example:
       # /scripts/gha-encrypted/auth/google-services.json.gpg turns into
       # /<repo_dir>/auth/integration_test/google-services.json
       api = os.path.basename(os.path.dirname(path))
+      if FLAGS.api:
+        if FLAGS.api != api:
+          print("Skipping secret found in product api", api)
+          continue
+      print("Encrypted Google Service file found: %s" % path)
       file_name = os.path.basename(path).replace(".gpg", "")
       dest_paths = [os.path.join(repo_dir, api, "integration_test", file_name)]
       if FLAGS.artifact:
@@ -107,17 +117,19 @@ def main(argv):
   if FLAGS.artifact:
     return
 
-  print("Attempting to patch Dynamic Links uri prefix.")
-  uri_path = os.path.join(secrets_dir, "dynamic_links", "uri_prefix.txt.gpg")
-  uri_prefix = _decrypt(uri_path, passphrase)
-  dlinks_project = os.path.join(repo_dir, "dynamic_links", "integration_test")
-  _patch_main_src(dlinks_project, "REPLACE_WITH_YOUR_URI_PREFIX", uri_prefix)
+  if not FLAGS.api or FLAGS.api == "dynamic_links":
+    print("Attempting to patch Dynamic Links uri prefix.")
+    uri_path = os.path.join(secrets_dir, "dynamic_links", "uri_prefix.txt.gpg")
+    uri_prefix = _decrypt(uri_path, passphrase)
+    dlinks_project = os.path.join(repo_dir, "dynamic_links", "integration_test")
+    _patch_main_src(dlinks_project, "REPLACE_WITH_YOUR_URI_PREFIX", uri_prefix)
 
-  print("Attempting to patch Messaging server key.")
-  server_key_path = os.path.join(secrets_dir, "messaging", "server_key.txt.gpg")
-  server_key = _decrypt(server_key_path, passphrase)
-  messaging_project = os.path.join(repo_dir, "messaging", "integration_test")
-  _patch_main_src(messaging_project, "REPLACE_WITH_YOUR_SERVER_KEY", server_key)
+  if not FLAGS.api or FLAGS.api == "messaging":
+    print("Attempting to patch Messaging server key.")
+    server_key_path = os.path.join(secrets_dir, "messaging", "server_key.txt.gpg")
+    server_key = _decrypt(server_key_path, passphrase)
+    messaging_project = os.path.join(repo_dir, "messaging", "integration_test")
+    _patch_main_src(messaging_project, "REPLACE_WITH_YOUR_SERVER_KEY", server_key)
 
   print("Attempting to decrypt GCS service account key file.")
   decrypted_key_file = os.path.join(secrets_dir, "gcs_key_file.json")


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Whenever I do local development I run restore_secrets, which updates all of the Google Services data for all of the products. This pollutes my local branch since normally I'm only working on one product.

This change adds an optional `api` flag so that you can checkout the secrets for only one product at a time.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

- Local testing.
- [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2502019096)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
