### PR TITLE
In RTDB, create app data directory if it doesn't exist. Modify AppDataDir to create the whole path if needed.

### DIFF
--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -474,11 +474,13 @@ void Repo::DeferredInitialization() {
     database_path += "/";
     database_path += url_domain;
 
-    std::string app_data_path = AppDataDir(database_path.c_str());
+    std::string app_data_path_error;
+    std::string app_data_path = AppDataDir(database_path.c_str(),
+                                           /* should_create = */ true, &error);
     if (app_data_path.empty()) {
       logger_->LogError(
-          "Could not initialize persistence: Unable to find app data "
-          "directory.");
+          "Could not initialize persistence: App data directory error: %s",
+          app_data_path_error.c_str());
       return;
     }
 

--- a/database/src/desktop/core/repo.cc
+++ b/database/src/desktop/core/repo.cc
@@ -475,8 +475,9 @@ void Repo::DeferredInitialization() {
     database_path += url_domain;
 
     std::string app_data_path_error;
-    std::string app_data_path = AppDataDir(database_path.c_str(),
-                                           /* should_create = */ true, &error);
+    std::string app_data_path =
+        AppDataDir(database_path.c_str(),
+                   /* should_create = */ true, &app_data_path_error);
     if (app_data_path.empty()) {
       logger_->LogError(
           "Could not initialize persistence: App data directory error: %s",

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -615,6 +615,8 @@ code.
 -   Changes
     - General (Android): Switched over to Android BoM (Bill of Materials)
       for dependency versions. This requires Gradle 5.
+    - Database (Desktop): If the app data directory doesn't exist, create it.
+      This fixes an issue with disk persistence on Linux.
 
 ### 9.1.0
 -   Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On Linux, if the XDG_DATA_HOME directory doesn't exist, RTDB disk persistence will fail to initialize. This fixes ensures that if the directory doesn't exist, the app will create it. (Fix for #913.)

Previously, only the last part of the path would be created; but if the user did not have a `.local/share` directory this would still silently fail. This change modifies the behavior to create any missing components from the full app data path.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Manually run integration test on Linux with $XDG_DATA_HOME set to an arbitrary directory. Confirmed that directory was created and used for RTDB persistence:
```
~/firebase-cpp-sdk/database/integration_test/build$ rm -rf hello
~/firebase-cpp-sdk/database/integration_test/build$ XDG_DATA_HOME=hello/there/how/are/you ./integration_test | grep -v ^DEBUG:
[==========] Running 30 tests from 2 test suites.
[----------] Global test environment set-up.
[----------] 1 test from TimestampIsNear
[ RUN      ] TimestampIsNear.Matcher
[       OK ] TimestampIsNear.Matcher (0 ms)
[----------] 1 test from TimestampIsNear (0 ms total)

[----------] 29 tests from FirebaseDatabaseTest
[ RUN      ] FirebaseDatabaseTest.TestInitializeAndTerminate
[       OK ] FirebaseDatabaseTest.TestInitializeAndTerminate (100 ms)
[ RUN      ] FirebaseDatabaseTest.TestSignIn
[       OK ] FirebaseDatabaseTest.TestSignIn (100 ms)
[ RUN      ] FirebaseDatabaseTest.TestCreateWorkingPath
INFO: Database URL: https://cpp-database-test-app.firebaseio.com/integration_test_data/-N4clNXcLXtKFu3PRwsF
[       OK ] FirebaseDatabaseTest.TestCreateWorkingPath (444 ms)
[ RUN      ] FirebaseDatabaseTest.TestSetAndGetSimpleValues
[       OK ] FirebaseDatabaseTest.TestSetAndGetSimpleValues (646 ms)
[ RUN      ] FirebaseDatabaseTest.TestLargeWrite
[       OK ] FirebaseDatabaseTest.TestLargeWrite (3172 ms)
[ RUN      ] FirebaseDatabaseTest.TestReadingFromPersistanceWhileOffline
[       OK ] FirebaseDatabaseTest.TestReadingFromPersistanceWhileOffline (1786 ms)
[ RUN      ] FirebaseDatabaseTest.TestRunTransaction
[       OK ] FirebaseDatabaseTest.TestRunTransaction (744 ms)
[ RUN      ] FirebaseDatabaseTest.TestUpdateChildren
[       OK ] FirebaseDatabaseTest.TestUpdateChildren (845 ms)
[ RUN      ] FirebaseDatabaseTest.TestQueryFiltering
WARNING: [pc_7] Using an unspecified index. Consider adding '".indexOn": "subkey"' at integration_test_data/-N4clPUcfwFZgDX2JpnE/TestQueryFiltering to your security and Firebase Database rules for better performance
WARNING: [pc_7] Using an unspecified index. Consider adding '".indexOn": ".value"' at integration_test_data/-N4clPUcfwFZgDX2JpnE/TestQueryFiltering to your security and Firebase Database rules for better performance
[       OK ] FirebaseDatabaseTest.TestQueryFiltering (1849 ms)
[ RUN      ] FirebaseDatabaseTest.TestAddAndRemoveListenerRace
[       OK ] FirebaseDatabaseTest.TestAddAndRemoveListenerRace (694 ms)
[ RUN      ] FirebaseDatabaseTest.TestValueListener
[       OK ] FirebaseDatabaseTest.TestValueListener (3946 ms)
[ RUN      ] FirebaseDatabaseTest.TestChildListener
[       OK ] FirebaseDatabaseTest.TestChildListener (4648 ms)
[ RUN      ] FirebaseDatabaseTest.TestOnDisconnect
[       OK ] FirebaseDatabaseTest.TestOnDisconnect (2447 ms)
[ RUN      ] FirebaseDatabaseTest.TestInvalidatingReferencesWhenDeletingDatabase
[       OK ] FirebaseDatabaseTest.TestInvalidatingReferencesWhenDeletingDatabase (644 ms)
[ RUN      ] FirebaseDatabaseTest.TestInvalidatingReferencesWhenDeletingApp
WARNING: Auth object 0x516d0ed0 should be deleted before the App 0x516d37d0 it depends upon.
WARNING: Database object 0x516da010 should be deleted before the App 0x516d37d0 it depends upon.
[       OK ] FirebaseDatabaseTest.TestInvalidatingReferencesWhenDeletingApp (651 ms)
[ RUN      ] FirebaseDatabaseTest.TestInfoConnected
[       OK ] FirebaseDatabaseTest.TestInfoConnected (3945 ms)
[ RUN      ] FirebaseDatabaseTest.TestGetReferenceWillNullArgument
[       OK ] FirebaseDatabaseTest.TestGetReferenceWillNullArgument (100 ms)
[ RUN      ] FirebaseDatabaseTest.TestGetReferenceFromUrlWithNullArgument
[       OK ] FirebaseDatabaseTest.TestGetReferenceFromUrlWithNullArgument (100 ms)
[ RUN      ] FirebaseDatabaseTest.TestDatabaseReferenceChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestDatabaseReferenceChildWithNullArgument (276 ms)
[ RUN      ] FirebaseDatabaseTest.TestDataSnapshotChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestDataSnapshotChildWithNullArgument (443 ms)
[ RUN      ] FirebaseDatabaseTest.TestDataSnapshotHasChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestDataSnapshotHasChildWithNullArgument (443 ms)
[ RUN      ] FirebaseDatabaseTest.TestMutableDataChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestMutableDataChildWithNullArgument (444 ms)
[ RUN      ] FirebaseDatabaseTest.TestMutableDataHasChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestMutableDataHasChildWithNullArgument (445 ms)
[ RUN      ] FirebaseDatabaseTest.TestQueryOrderByChildWithNullArgument
[       OK ] FirebaseDatabaseTest.TestQueryOrderByChildWithNullArgument (281 ms)
[ RUN      ] FirebaseDatabaseTest.TestQueryStartAtWithNullArgument
[       OK ] FirebaseDatabaseTest.TestQueryStartAtWithNullArgument (273 ms)
[ RUN      ] FirebaseDatabaseTest.TestQueryEndAtWithNullArgument
[       OK ] FirebaseDatabaseTest.TestQueryEndAtWithNullArgument (276 ms)
[ RUN      ] FirebaseDatabaseTest.TestQueryEqualToWithNullArgument
[       OK ] FirebaseDatabaseTest.TestQueryEqualToWithNullArgument (277 ms)
[ RUN      ] FirebaseDatabaseTest.TestValueListenerWithNullArgument
[       OK ] FirebaseDatabaseTest.TestValueListenerWithNullArgument (278 ms)
[ RUN      ] FirebaseDatabaseTest.TestChildListenerWithNullArgument
[       OK ] FirebaseDatabaseTest.TestChildListenerWithNullArgument (100 ms)
[----------] 29 tests from FirebaseDatabaseTest (30412 ms total)

[----------] Global test environment tear-down
[==========] 30 tests from 2 test suites ran. (31044 ms total)
[  PASSED  ] 30 tests.
~/firebase-cpp-sdk/database/integration_test/build$ find hello
hello
hello/there
hello/there/how
hello/there/how/are
hello/there/how/are/you
hello/there/how/are/you/com.google.firebase.cpp.database.testapp
hello/there/how/are/you/com.google.firebase.cpp.database.testapp/cpp-database-test-app.firebaseio.com
```

While tests were running, in another shell:
```
~/firebase-cpp-sdk/database/integration_test/build$ ls -la hello/there/how/are/you/com.google.firebase.cpp.database.testapp/cpp-database-test-app.firebaseio.com
total 1060
drwx------ 2 jsimantov primarygroup    4096 Jun 15 12:17 .
drwx------ 3 jsimantov primarygroup    4096 Jun 15 12:09 ..
-rw-r----- 1 jsimantov primarygroup     312 Jun 15 12:17 000005.ldb
-rw-r----- 1 jsimantov primarygroup    1933 Jun 15 12:17 000008.ldb
-rw-r----- 1 jsimantov primarygroup 1049398 Jun 15 12:17 000009.log
-rw-r----- 1 jsimantov primarygroup      16 Jun 15 12:17 CURRENT
-rw-r----- 1 jsimantov primarygroup       0 Jun 15 12:17 LOCK
-rw-r----- 1 jsimantov primarygroup     325 Jun 15 12:17 LOG
-rw-r----- 1 jsimantov primarygroup     324 Jun 15 12:17 LOG.old
-rw-r----- 1 jsimantov primarygroup     236 Jun 15 12:17 MANIFEST-000007
```
***

Also tested with XDG_DATA_HOME set to an absolute path, e.g. `$(pwd)/hello/world` and `/tmp/test/directory`.

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
