### PR TITLE
Fix #973 Make sure all resources are closed in RegistrationIntentService

### DIFF
--- a/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
+++ b/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
@@ -67,25 +67,6 @@ public class RegistrationIntentService extends JobIntentService {
     sizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
     sizeBuffer.putInt(buffer.length);
 
-    // try (FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0)) {
-    //   // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
-    //   // append to it.
-    //   try (FileLock lock = lockFileStream.getChannel().lock()) {
-    //     try (FileOutputStream outputStream =
-    //             context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND)) {
-    //       // We send both the buffer length and the buffer itself so that we can potentially
-    //       // process more than one event in the case where they get queued up.
-    //       outputStream.write(sizeBuffer.array());
-    //       outputStream.write(buffer);
-    //     } catch (Exception e) {
-    //         e.printStackTrace();
-    //     }
-    //   } catch (Exception e) {
-    //       e.printStackTrace();
-    //   }
-    // } catch (Exception e) {
-    //     e.printStackTrace();
-    // }
     try (FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0);
          // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
          // append to it.

--- a/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
+++ b/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
@@ -66,31 +66,38 @@ public class RegistrationIntentService extends JobIntentService {
     // Write out the buffer length into the first four bytes.
     sizeBuffer.order(ByteOrder.LITTLE_ENDIAN);
     sizeBuffer.putInt(buffer.length);
-    FileLock lock = null;
-    try {
-      // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
-      // append to it.
-      FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0);
-      lock = lockFileStream.getChannel().lock();
 
-      FileOutputStream outputStream =
-          context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND);
-      // We send both the buffer length and the buffer itself so that we can potentially process
-      // more than one event in the case where they get queued up.
+    // try (FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0)) {
+    //   // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
+    //   // append to it.
+    //   try (FileLock lock = lockFileStream.getChannel().lock()) {
+    //     try (FileOutputStream outputStream =
+    //             context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND)) {
+    //       // We send both the buffer length and the buffer itself so that we can potentially
+    //       // process more than one event in the case where they get queued up.
+    //       outputStream.write(sizeBuffer.array());
+    //       outputStream.write(buffer);
+    //     } catch (Exception e) {
+    //         e.printStackTrace();
+    //     }
+    //   } catch (Exception e) {
+    //       e.printStackTrace();
+    //   }
+    // } catch (Exception e) {
+    //     e.printStackTrace();
+    // }
+    try (FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0);
+        // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
+        // append to it.
+        FileLock lock = lockFileStream.getChannel().lock();
+        FileOutputStream outputStream =
+            context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND)) {
+      // We send both the buffer length and the buffer itself so that we can potentially
+      // process more than one event in the case where they get queued up.
       outputStream.write(sizeBuffer.array());
       outputStream.write(buffer);
-      outputStream.close();
     } catch (Exception e) {
-      e.printStackTrace();
-    } finally {
-      // Release the lock.
-      try {
-        if (lock != null) {
-          lock.release();
-        }
-      } catch (Exception e) {
         e.printStackTrace();
-      }
     }
   }
 

--- a/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
+++ b/messaging/src/android/java/com/google/firebase/messaging/cpp/RegistrationIntentService.java
@@ -87,17 +87,17 @@ public class RegistrationIntentService extends JobIntentService {
     //     e.printStackTrace();
     // }
     try (FileOutputStream lockFileStream = context.openFileOutput(MessageWriter.LOCK_FILE, 0);
-        // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
-        // append to it.
-        FileLock lock = lockFileStream.getChannel().lock();
-        FileOutputStream outputStream =
-            context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND)) {
+         // Acquire lock. This prevents the C++ code from consuming and clearing the file while we
+         // append to it.
+         FileLock lock = lockFileStream.getChannel().lock();
+         FileOutputStream outputStream =
+             context.openFileOutput(MessageWriter.STORAGE_FILE, Context.MODE_APPEND)) {
       // We send both the buffer length and the buffer itself so that we can potentially
       // process more than one event in the case where they get queued up.
       outputStream.write(sizeBuffer.array());
       outputStream.write(buffer);
     } catch (Exception e) {
-        e.printStackTrace();
+      e.printStackTrace();
     }
   }
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -82,23 +82,23 @@ All Firebase SDKs          | platform(com.google.firebase:firebase-bom:30.0.0)
 |                          | (Android Bill of Materials)
 Firebase AdMob             | libfirebase_admob.a
 |                          | libfirebase_app.a
-|                          | com.google.firebase:firebase-analytics 
+|                          | com.google.firebase:firebase-analytics
 |                          | (Maven package)
-|                          | com.google.firebase:firebase-ads:19.8.0 
+|                          | com.google.firebase:firebase-ads:19.8.0
 |                          | (Maven package)
 Firebase Analytics         | libfirebase_analytics.a
 |                          | libfirebase_app.a
-|                          | com.google.firebase:firebase-analytics 
+|                          | com.google.firebase:firebase-analytics
 |                          | (Maven package)
 Firebase Authentication    | libfirebase_auth.a
 |                          | libfirebase_app.a
-|                          | com.google.firebase:firebase-analytics 
+|                          | com.google.firebase:firebase-analytics
 |                          | (Maven package)
-|                          | com.google.firebase:firebase-auth 
+|                          | com.google.firebase:firebase-auth
 |                          | (Maven package)
 Firebase Dynamic Links     | libfirebase_dynamic_links.a
 |                          | libfirebase_app.a
-|                          | com.google.firebase:firebase-analytics 
+|                          | com.google.firebase:firebase-analytics
 |                          | (Maven package)
 |                          | com.google.firebase:firebase-dynamic-links
 |                          | (Maven package)
@@ -156,7 +156,7 @@ Firebase Storage           | libfirebase_storage.a
 |                          | (Maven package)
 |                          | com.google.firebase:firebase-auth
 |                          | (Maven package)
-Google Play services module| com.google.android.gms:play-services-base:18.0.1 
+Google Play services module| com.google.android.gms:play-services-base:18.0.1
 |                          | (Maven package)
 
 The Firebase C++ SDK uses an Android BoM (Bill of Materials) to specify a single
@@ -615,6 +615,8 @@ code.
 -   Changes
     - General (Android): Switched over to Android BoM (Bill of Materials)
       for dependency versions. This requires Gradle 5.
+    - Messaging (Android): Fixed #973. Make sure all the resources are closed in
+      `RegistrationIntentService`.
 
 ### 9.1.0
 -   Changes
@@ -710,16 +712,16 @@ code.
         and include support for ARM-based Mac systems.
     -   General (iOS): iOS SDKs are now built using Xcode 12.2.
     -   Messaging (Android): Fixes an issue to receive token when
-        initialize the app. 
+        initialize the app.
         ([#667](https://github.com/firebase/firebase-cpp-sdk/pull/667)).
     -   Auth (Desktop): Fix a crash that would occur if parsing the JSON
         response from the server failed
         ([#692](https://github.com/firebase/firebase-cpp-sdk/pull/692)).
-        
+
 ### 8.5.0
 -   Changes
     -   General: Updating Android and iOS dependencies to the latest.
-    -   General: Fixes an issue with generating Proguard files. 
+    -   General: Fixes an issue with generating Proguard files.
         ([#664](https://github.com/firebase/firebase-cpp-sdk/pull/664)).
 
 ### 8.4.0


### PR DESCRIPTION
Make sure all FileStream and FileLock are closed using AutoClose pattern.

### Description
> Provide details of the change, and generalize the change in the PR title above.

Make sure all the resource are closed RegistrationIntentService using AutoClose and try-with-resources statement.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Using integration test workflow (pending)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
