### PR TITLE
Change Firestore external ref to one with patch.exe bugfix

### DIFF
--- a/cmake/external/firestore.cmake
+++ b/cmake/external/firestore.cmake
@@ -20,7 +20,7 @@ endif()
 
 # If the format of the line below changes, then be sure to update
 # https://github.com/firebase/firebase-cpp-sdk/blob/fd054fa016/.github/workflows/update-dependencies.yml#L81
-set(version CocoaPods-9.2.0)
+set(version 632ea8c18bf78fa67bc63d3f32015a976d8caa44)
 
 function(GetReleasedDep)
   message("Getting released firebase-ios-sdk @ ${version}")


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

In the Firestore iOS SDK, the usage of patch.exe crashes on Windows due to CRLF issues. This is fixed in that repo by https://github.com/firebase/firebase-ios-sdk/pull/9941; use that commit in the C++ SDK, since it was not included in the 9.2.0 release. (The commit was branched off of the CocoaPods-9.2.0 tag.)

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Running C++ Packaging workflow.](https://github.com/firebase/firebase-cpp-sdk/actions/workflows/cpp-packaging.yml?query=branch%3Abugfix%2Fwindows-patch-exe)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
