### PR TITLE
Add GMA to the list of cron SDKs to build nightly

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -183,7 +183,7 @@ jobs:
         # list. Then we can use fromJson to define the field in the matrix for the tests job.
         if [[ "${{ github.event.schedule }}" == "0 9 * * *" ]]; then
           # at 1am PST / 2am PDT. Running integration tests and generate test report for all testapps except firestore
-          apis="admob,analytics,auth,database,dynamic_links,functions,installations,messaging,remote_config,storage"
+          apis="admob,analytics,auth,database,dynamic_links,functions,gma,installations,messaging,remote_config,storage"
         elif [[ "${{ github.event.schedule }}" == "0 10 * * *" ]]; then
           # at 2am PST / 3am PDT. Running integration tests for firestore and generate test report
           apis="firestore"


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The nightly SDK builds are hardcoded into the workflow. This change updates the list of the nightly builds to include the new GMA SDK.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Ran the[ Integration Test Workflow](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2612125641) to ensure that the syntax of the workflow file is correct.  Firestore failed on tvOS but everything else worked correctly.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***