### PR TITLE
Firestore: Remove broken absl flags logic from CMakeLists.txt

### DIFF
--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -377,17 +377,6 @@ else()
   endif()
 endif()
 
-if(NOT ANDROID)
- set(${ADDITIONAL_LIBS} ${ADDITIONAL_LIBS} firestore_core absl_variant)
-else()
- set(${ADDITIONAL_LIBS} ${ADDITIONAL_LIBS}
-     absl_base
-     absl_memory
-     absl_meta
-     absl_optional
-     absl_strings)
-endif()
-
 # Add the Firebase libraries to the target using the function from the SDK.
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 


### PR DESCRIPTION
The removed logic is completely broken. It calls `set(${ADDITIONAL_LIBS}` but should be `set(ADDITIONAL_LIBS`. It's effectively setting some variable that's never used. Therefore, just remove the code since its presence is confusing.