### PR TITLE
Fix python interpreter build issues on systems without `python` executable

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DFIREBASE_PYTHON_EXECUTABLE=python
+          cmake .. -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=python
           cmake --build . --target FIREBASE_GENERATED_HEADERS
       - name: Install doxygen
         run: sudo apt-get install doxygen

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake .. -DFIREBASE_PYTHON_EXECUTABLE=python
           cmake --build . --target FIREBASE_GENERATED_HEADERS
       - name: Install doxygen
         run: sudo apt-get install doxygen

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=python -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=python
+          cmake .. -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=python
           cmake --build . --target FIREBASE_GENERATED_HEADERS
       - name: Install doxygen
         run: sudo apt-get install doxygen

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,7 +66,7 @@ jobs:
         run: |
           mkdir build
           cd build
-          cmake .. -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=python
+          cmake .. -DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=python -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=python
           cmake --build . --target FIREBASE_GENERATED_HEADERS
       - name: Install doxygen
         run: sudo apt-get install doxygen

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,17 @@ set(
 
 message(STATUS "Using FIREBASE_PYTHON_EXECUTABLE: ${FIREBASE_PYTHON_EXECUTABLE}")
 
+# Propagate FIREBASE_PYTHON_EXECUTABLE to the firebase-ios-sdk via the
+# FIREBASE_PYTHON_HOST_EXECUTABLE cache variable.
+set(
+  FIREBASE_PYTHON_HOST_EXECUTABLE
+  "${FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter on the host system to use"
+  FORCE
+)
+
 set(FIREBASE_XCODE_TARGET_FORMAT "frameworks" CACHE STRING
                                  "Format to output, 'frameworks' or 'libraries'")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ option(FIREBASE_GITHUB_ACTION_BUILD
 option(FIREBASE_QUICK_TEST
        "Enable quick tests will skip tests which requires access to the SECRET" OFF)
 
-# Find a Python interpreter using the best available mechanism.
 if(${CMAKE_VERSION} VERSION_LESS "3.12")
   include(FindPythonInterp)
   set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,8 +83,22 @@ option(FIREBASE_GITHUB_ACTION_BUILD
 option(FIREBASE_QUICK_TEST
        "Enable quick tests will skip tests which requires access to the SECRET" OFF)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+# Find a Python interpreter using the best available mechanism.
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 set(FIREBASE_XCODE_TARGET_FORMAT "frameworks" CACHE STRING
                                  "Format to output, 'frameworks' or 'libraries'")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,6 +99,8 @@ set(
   "The Python interpreter to use, such as one from a venv"
 )
 
+message(STATUS "Using FIREBASE_PYTHON_EXECUTABLE: ${FIREBASE_PYTHON_EXECUTABLE}")
+
 set(FIREBASE_XCODE_TARGET_FORMAT "frameworks" CACHE STRING
                                  "Format to output, 'frameworks' or 'libraries'")
 

--- a/admob/integration_test/CMakeLists.txt
+++ b/admob/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/analytics/integration_test/CMakeLists.txt
+++ b/analytics/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/app/integration_test/CMakeLists.txt
+++ b/app/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/auth/integration_test/CMakeLists.txt
+++ b/auth/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/build_scripts/ios/build.sh
+++ b/build_scripts/ios/build.sh
@@ -132,6 +132,7 @@ if ${generateMakefiles}; then
             echo "generate Makefiles start"
             mkdir -p ${buildpath}/ios_build_file/${platform}-${arch} && cd ${buildpath}/ios_build_file/${platform}-${arch}
             cmake -DCMAKE_TOOLCHAIN_FILE=${sourcepath}/${toolchain} \
+                -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=$(which python) \
                 -DCMAKE_OSX_ARCHITECTURES=${arch} \
                 -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${buildpath}/${frameworkspath}/${platform}-${arch} \
                 ${sourcepath}

--- a/build_scripts/tvos/build.sh
+++ b/build_scripts/tvos/build.sh
@@ -134,6 +134,7 @@ if ${generateMakefiles}; then
             echo "generate Makefiles start"
             mkdir -p ${buildpath}/tvos_build_file/${platform}-${arch} && cd ${buildpath}/tvos_build_file/${platform}-${arch}
             cmake -DCMAKE_TOOLCHAIN_FILE=${sourcepath}/${toolchain} \
+                  -DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=$(which python) \
                   -DPLATFORM=${tvos_toolchain_platform} \
                   -DCMAKE_ARCHIVE_OUTPUT_DIRECTORY=${buildpath}/${frameworkspath}/${platform}-${arch} \
                 ${sourcepath}

--- a/database/integration_test/CMakeLists.txt
+++ b/database/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/dynamic_links/integration_test/CMakeLists.txt
+++ b/dynamic_links/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -16,8 +16,22 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+# Find a Python interpreter using the best available mechanism.
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-# Find a Python interpreter using the best available mechanism.
 if(${CMAKE_VERSION} VERSION_LESS "3.12")
   include(FindPythonInterp)
   set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -16,8 +16,22 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+# Find a Python interpreter using the best available mechanism.
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -16,7 +16,6 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-# Find a Python interpreter using the best available mechanism.
 if(${CMAKE_VERSION} VERSION_LESS "3.12")
   include(FindPythonInterp)
   set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")

--- a/functions/integration_test/CMakeLists.txt
+++ b/functions/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/gma/integration_test/CMakeLists.txt
+++ b/gma/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/installations/integration_test/CMakeLists.txt
+++ b/installations/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/messaging/integration_test/CMakeLists.txt
+++ b/messaging/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/remote_config/integration_test/CMakeLists.txt
+++ b/remote_config/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.

--- a/scripts/build_desktop_app_with_firebase.py
+++ b/scripts/build_desktop_app_with_firebase.py
@@ -175,6 +175,7 @@ def build_app_with_source(app_dir, sdk_source_dir, build_dir, arch,
   # Cmake configure.
   cmd = ['cmake', '-S', '.', '-B', build_dir]
   cmd.append('-DFIREBASE_CPP_SDK_DIR={0}'.format(sdk_source_dir))
+  cmd.append('-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable)
 
   # If generator is not specified, default for platform is used by cmake, else
   # use the specified value.
@@ -242,6 +243,7 @@ def build_app_with_prebuilt(app_dir, sdk_prebuilt_dir, build_dir, arch,
 
   cmd = ['cmake', '-S', '.', '-B', build_dir]
   cmd.append('-DFIREBASE_CPP_SDK_DIR={0}'.format(sdk_prebuilt_dir))
+  cmd.append('-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable)
 
   if platform.system() == 'Windows':
     if arch == 'x64':

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -162,7 +162,6 @@ def cmake_configure(build_dir, arch, msvc_runtime_library='static', linux_abi='l
 
   # Make sure cmake uses the Python interpreter that has the required
   # libraries installed.
-  cmd.append('-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s' % sys.executable)
   cmd.append('-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable)
 
   # If generator is not specifed, default for platform is used by cmake, else

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -160,6 +160,11 @@ def cmake_configure(build_dir, arch, msvc_runtime_library='static', linux_abi='l
   """
   cmd = ['cmake', '-S', '.', '-B', build_dir]
 
+  # Make sure cmake uses the Python interpreter that has the required
+  # libraries installed.
+  cmd.append('-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s' % sys.executable)
+  cmd.append('-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable)
+
   # If generator is not specifed, default for platform is used by cmake, else
   # use the specified value
   if config:
@@ -193,8 +198,6 @@ def cmake_configure(build_dir, arch, msvc_runtime_library='static', linux_abi='l
     # on different windows machines.
     cmd.append('-A')
     cmd.append('Win32') if arch == 'x86' else cmd.append('x64')
-    # Also, for Windows, specify the path to Python.
-    cmd.append('-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s' % sys.executable)
 
     # Use our special cmake flag to specify /MD vs /MT
     if msvc_runtime_library == "static":

--- a/scripts/gha/build_ios_tvos.py
+++ b/scripts/gha/build_ios_tvos.py
@@ -42,6 +42,7 @@ import multiprocessing
 import os
 import shutil
 import subprocess
+import sys
 import utils
 
 

--- a/scripts/gha/build_ios_tvos.py
+++ b/scripts/gha/build_ios_tvos.py
@@ -465,6 +465,7 @@ def cmake_configure(source_path, build_path, toolchain, archive_output_path,
         (eg: 'TVOS', 'SIMULATOR_TVOS' etc)
   """
   cmd = ['cmake', '-S', source_path, '-B', build_path]
+  cmd.append('-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s' % sys.executable)
   cmd.append('-DCMAKE_TOOLCHAIN_FILE={0}'.format(toolchain))
   cmd.append('-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY={0}'.format(archive_output_path))
   if architecture:

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -262,6 +262,7 @@ def main(argv):
     _run(["pod", "repo", "update"])
 
   cmake_flags = _get_desktop_compiler_flags(FLAGS.compiler, config.compilers)
+  cmake_flags.append("-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=%s" % sys.executable)
   # VCPKG is used to install dependencies for the desktop SDK.
   # Building from source requires building the underlying SDK libraries,
   # so we need to use VCPKG as well.
@@ -284,7 +285,6 @@ def main(argv):
     cmake_flags.extend((
         "-DCMAKE_TOOLCHAIN_FILE=%s" % toolchain_file,
         "-DVCPKG_TARGET_TRIPLET=%s" % utils.get_vcpkg_triplet(arch=vcpkg_arch),
-        "-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable,
     ))
 
   if (_DESKTOP in platforms and FLAGS.packaged_sdk and

--- a/storage/integration_test/CMakeLists.txt
+++ b/storage/integration_test/CMakeLists.txt
@@ -16,8 +16,21 @@
 
 cmake_minimum_required(VERSION 2.8)
 
-set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
-  "The Python interpreter to use, such as one from a venv")
+if(${CMAKE_VERSION} VERSION_LESS "3.12")
+  include(FindPythonInterp)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${PYTHON_EXECUTABLE}")
+else()
+  find_package(Python3 COMPONENTS Interpreter REQUIRED)
+  set(DEFAULT_FIREBASE_PYTHON_EXECUTABLE "${Python3_EXECUTABLE}")
+endif()
+
+set(
+  FIREBASE_PYTHON_EXECUTABLE
+  "${DEFAULT_FIREBASE_PYTHON_EXECUTABLE}"
+  CACHE
+  FILEPATH
+  "The Python interpreter to use, such as one from a venv"
+)
 
 # User settings for Firebase integration tests.
 # Path to Firebase SDK.


### PR DESCRIPTION
Hardcoding `python` as the Python executable doesn't work on new MacBooks (and gLinux) since the `python` executable does not exist, only `python3`. So instead, use cmake's built-in mechanism for finding a Python interpreter, which will find either `python` or `python3`. A similar change was made to the Unity SDK: https://github.com/firebase/firebase-unity-sdk/pull/395.

The scripts that are run on GitHub Actions runners needed to be changed to explicitly specify `-DFIREBASE_PYTHON_EXECUTABLE:FILEPATH=<python path>` to ensure that the Python interpreter into which the dependencies (e.g. absl-py) were installed gets used. Otherwise, FindPythonInterp/find_package(Python3) may choose a different Python interpreter which does _not_ have the dependencies installed and cause the scripts to fail due to the missing dependencies.

I also changed the cmake cache variable `FIREBASE_PYTHON_EXECUTABLE` to set `FIREBASE_PYTHON_HOST_EXECUTABLE`, which is used by the firebase-ios-sdk. Therefore, the GitHub Actions scripts need only set the former cmake cache variable and not the latter.