### PR TITLE
semaphore.h: handle spurious wakeups in TimedWait() on Linux

### DIFF
--- a/app/src/semaphore.h
+++ b/app/src/semaphore.h
@@ -192,12 +192,6 @@ class Semaphore {
         default:
           assert("sem_timedwait() failed with an unknown error" == 0);
       }
-    } else if (errno == EINTR) {
-        continue;
-      } else {
-        assert(errno == ETIMEDOUT);
-        return false;
-      }
     }
 #endif
   }

--- a/app/src/semaphore.h
+++ b/app/src/semaphore.h
@@ -187,10 +187,13 @@ class Semaphore {
           return false;
         case EINVAL:
           assert("sem_timedwait() failed with EINVAL" == 0);
+          return false;
         case EDEADLK:
           assert("sem_timedwait() failed with EDEADLK" == 0);
+          return false;
         default:
           assert("sem_timedwait() failed with an unknown error" == 0);
+          return false;
       }
     }
 #endif

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -634,6 +634,13 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Changes
+-   Changes
+    - General (Android,Linux): Fixed a concurrency bug where waiting for an
+      event with a timeout could occasionally return prematurely, as if the
+      timeout had occurred
+      ([#1021](https://github.com/firebase/firebase-cpp-sdk/pull/1021)).
+
 ### 9.2.0
 -   Changes
     - GMA: Added the Google Mobile Ads SDK with updated support for AdMob. See


### PR DESCRIPTION
This fixes a latent bug where [`Future::Wait(int timeout_milliseconds)`](https://github.com/firebase/firebase-cpp-sdk/blob/c722ca77e4cbfd38f530f51c205a55d1c76bb212/app/src/include/firebase/future.h#L213) would occasionally return prematurely, when neither the timeout had expired nor the Future been completed. This was due to the implementation of [`Semaphore::TimedWait(int milliseconds)`](https://github.com/firebase/firebase-cpp-sdk/blob/c722ca77e4cbfd38f530f51c205a55d1c76bb212/app/src/semaphore.h#L165-L177) which calls [`sem_timedwait()`](https://linux.die.net/man/3/sem_timedwait) on Linux and Android and neglected to check if the `errno` was `EINTR`, in which case the wait should be restarted. 

This bug surfaced as the integration tests for Firestore's `TransactionTest.TestMaxAttempts` flakily failing due to a call to `Future.Await(int timeout_milliseconds)` returning as if it had timed out when, in fact, no timeout had occurred.

Note that this fix only affects Linux and Android (which runs Linux under the hood).