### PR TITLE
semaphore_test.cc: re-enable MultithreadedStressTest

### DIFF
--- a/app/tests/semaphore_test.cc
+++ b/app/tests/semaphore_test.cc
@@ -76,7 +76,7 @@ TEST(SemaphoreTest, TimedWait) {
       0.20 * firebase::internal::kMillisecondsPerSecond);
 }
 
-TEST(SemaphoreTest, DISABLED_MultithreadedStressTest) {
+TEST(SemaphoreTest, MultithreadedStressTest) {
   for (int i = 0; i < 10000; ++i) {
     firebase::Semaphore sem(0);
 


### PR DESCRIPTION
With the fix to Semaphore::TimedWait() in https://github.com/firebase/firebase-cpp-sdk/pull/1021, the MultithreadedStressTest can now be re-enabled.