### PR TITLE
semaphore_test.cc: add TimedWaitSpuriousWakeupLinux

### DIFF
--- a/app/tests/semaphore_test.cc
+++ b/app/tests/semaphore_test.cc
@@ -125,7 +125,7 @@ TEST(SemaphoreTest, TimedWaitSpuriousWakeupLinux) {
 }
 #endif  // #if SEMAPHORE_LINUX
 
-TEST(SemaphoreTest, MultithreadedStressTest) {
+TEST(SemaphoreTest, DISABLED_MultithreadedStressTest) {
   for (int i = 0; i < 10000; ++i) {
     firebase::Semaphore sem(0);
 

--- a/app/tests/semaphore_test.cc
+++ b/app/tests/semaphore_test.cc
@@ -107,8 +107,8 @@ TEST(SemaphoreTest, TimedWaitSpuriousWakeupLinux) {
   // Call Semaphore::TimedWait() and keep track of how long it blocks for.
   firebase::Semaphore sem(0);
   auto start_ms = firebase::internal::GetTimestamp();
-  const int timed_wait_timeout = 2 * firebase::internal::kMillisecondsPerSecond;
-  EXPECT_FALSE(sem.TimedWait(timed_wait_timeout));
+  const int kTimedWaitTimeout = 2 * firebase::internal::kMillisecondsPerSecond;
+  EXPECT_FALSE(sem.TimedWait(kTimedWaitTimeout));
   auto finish_ms = firebase::internal::GetTimestamp();
   const int actual_wait_time = static_cast<int>(finish_ms - start_ms);
   EXPECT_TRUE(sigusr1_received.load());
@@ -122,9 +122,9 @@ TEST(SemaphoreTest, TimedWaitSpuriousWakeupLinux) {
 
   // Make sure that Semaphore::TimedWait() blocked for the entire timeout, and,
   // specifically, did NOT return early as a result of the SIGUSR1 interruption.
-  const double wait_time_error_margin =
+  const double kWaitTimeErrorMargin =
       0.20 * firebase::internal::kMillisecondsPerSecond;
-  ASSERT_NEAR(actual_wait_time, timed_wait_timeout, wait_time_error_margin);
+  ASSERT_NEAR(actual_wait_time, kTimedWaitTimeout, kWaitTimeErrorMargin);
 }
 #endif  // #if FIREBASE_PLATFORM_ANDROID || FIREBASE_PLATFORM_LINUX
 

--- a/app/tests/semaphore_test.cc
+++ b/app/tests/semaphore_test.cc
@@ -76,7 +76,7 @@ TEST(SemaphoreTest, TimedWait) {
       0.20 * firebase::internal::kMillisecondsPerSecond);
 }
 
-TEST(SemaphoreTest, DISABLED_MultithreadedStressTest) {
+TEST(SemaphoreTest, MultithreadedStressTest) {
   for (int i = 0; i < 10000; ++i) {
     firebase::Semaphore sem(0);
 


### PR DESCRIPTION
Add a unit test for the Semaphore::TimedWait() spurious wakeup fix in https://github.com/firebase/firebase-cpp-sdk/pull/1021.