### PR TITLE
Update GMA iOS Dependency to 9.7.0

### DIFF
--- a/gma/integration_test/Podfile
+++ b/gma/integration_test/Podfile
@@ -5,7 +5,7 @@ use_frameworks! :linkage => :static
 
 target 'integration_test' do
   pod 'Firebase/Analytics', '9.3.0'
-  pod 'Google-Mobile-Ads-SDK', '9.4.0'
+  pod 'Google-Mobile-Ads-SDK', '9.7.0'
 end
 
 post_install do |installer|

--- a/gma/src/ios/ad_view_internal_ios.mm
+++ b/gma/src/ios/ad_view_internal_ios.mm
@@ -123,7 +123,7 @@ Future<AdResult> AdViewInternalIOS::LoadAd(const AdRequest& request) {
       ad_load_callback_data_ = nil;
     } else {
       // Make the AdView ad request.
-      [ad_view_ loadRequest:ad_request];
+      [(GADBannerView*)ad_view_ loadRequest: ad_request];
     }
   });
   return future;

--- a/ios_pod/Podfile
+++ b/ios_pod/Podfile
@@ -5,7 +5,7 @@ use_frameworks!
 target 'GetPods' do
   pod 'Firebase/Core', '9.3.0'
 
-  pod 'Google-Mobile-Ads-SDK', '9.4.0'
+  pod 'Google-Mobile-Ads-SDK', '9.7.0'
   pod 'Firebase/Analytics', '9.3.0'
   pod 'Firebase/Auth', '9.3.0'
   pod 'Firebase/Crashlytics', '9.3.0'

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -248,7 +248,7 @@ Firebase Functions         | firebase_functions.xcframework
 Google Mobile Ads          | firebase_gma.xcframework
 |                          | firebase.xcframework
 |                          | Firebase/Analytics Cocoapod (9.3.0)
-|                          | Google-Mobile-Ads-SDK Cocoapod (9.4.0)
+|                          | Google-Mobile-Ads-SDK Cocoapod (9.7.0)
 Firebase Installations     | firebase_installations.xcframework
 |                          | firebase.xcframework
 |                          | FirebaseInstallations Cocoapod (9.3.0)
@@ -316,7 +316,7 @@ Firebase Functions         | libfirebase_functions.a
 Google Mobile Ads          | libfirebase_gma.a
 |                          | libfirebase_app.a
 |                          | Firebase/Analytics Cocoapod (9.3.0)
-|                          | Google-Mobile-Ads-SDK Cocoapod (9.4.0)
+|                          | Google-Mobile-Ads-SDK Cocoapod (9.7.0)
 Firebase Installations     | libfirebase_installations.a
 |                          | libfirebase_app.a
 |                          | FirebaseInstallations Cocoapod (9.3.0)
@@ -634,6 +634,10 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming
+-   Changes
+    - GMA: Updated iOS dependency to Google Mobile Ads SDK version 9.7.0.
+
 ### 9.3.0
 -   Changes
     - General (Android,Linux): Fixed a concurrency bug where waiting for an


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update the Google Mobile Ads dependency to `9.7.0`.
Fixed an ambiguous selector to in the AdView implementation on iOS.

***
### Testing
Tested manually on simulator and iOS device.
[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2782925220)
[Packaged CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2782978740) -> [Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/2783951512)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
