### PR TITLE
time.h: fix integer overflow in MsToAbsoluteTimespec() on 32-bit architectures

### DIFF
--- a/app/src/time.h
+++ b/app/src/time.h
@@ -95,7 +95,7 @@ inline timespec MsToAbsoluteTimespec(int milliseconds) {
       (milliseconds * internal::kNanosecondsPerMillisecond);
 
   t.tv_sec = nanoseconds / internal::kNanosecondsPerSecond;
-  t.tv_nsec = nanoseconds - (t.tv_sec * internal::kNanosecondsPerSecond);
+  t.tv_nsec = nanoseconds % internal::kNanosecondsPerSecond;
   return t;
 }
 

--- a/app/src/time.h
+++ b/app/src/time.h
@@ -18,6 +18,8 @@
 #define FIREBASE_APP_SRC_TIME_H_
 #include <cassert>
 #include <cstdint>
+#include <iostream>
+#include <string>
 
 #include "app/src/include/firebase/internal/platform.h"
 
@@ -89,8 +91,13 @@ inline timespec MsToTimespec(int milliseconds) {
 inline timespec MsToAbsoluteTimespec(int milliseconds) {
   timespec t;
   clock_gettime(CLOCK_REALTIME, &t);
-  t.tv_nsec += milliseconds * internal::kNanosecondsPerMillisecond;
-  NormalizeTimespec(&t);
+
+  const int64_t nanoseconds =
+      t.tv_nsec + (t.tv_sec * internal::kNanosecondsPerSecond) +
+      (milliseconds * internal::kNanosecondsPerMillisecond);
+
+  t.tv_sec = nanoseconds / internal::kNanosecondsPerSecond;
+  t.tv_nsec = nanoseconds - (t.tv_sec * internal::kNanosecondsPerSecond);
   return t;
 }
 

--- a/app/src/time.h
+++ b/app/src/time.h
@@ -18,8 +18,6 @@
 #define FIREBASE_APP_SRC_TIME_H_
 #include <cassert>
 #include <cstdint>
-#include <iostream>
-#include <string>
 
 #include "app/src/include/firebase/internal/platform.h"
 

--- a/app/tests/time_test.cc
+++ b/app/tests/time_test.cc
@@ -62,6 +62,14 @@ TEST(TimeTests, ComparisonTests) {
   EXPECT_EQ(firebase::internal::TimespecCmp(t1, t1), 0);
   EXPECT_EQ(firebase::internal::TimespecCmp(t2, t2), 0);
 }
+
+TEST(TimeTests, MsToAbsoluteTimespecTest) {
+  const timespec t1 = firebase::internal::MsToAbsoluteTimespec(0);
+  const timespec t2 = firebase::internal::MsToAbsoluteTimespec(10000);
+  const int64_t ms1 = firebase::internal::TimespecToMs(t1);
+  const int64_t ms2 = firebase::internal::TimespecToMs(t2);
+  ASSERT_NEAR(ms1, ms2 - 10000, 300);
+}
 #endif
 
 // Test GetTimestamp function

--- a/app/tests/time_test.cc
+++ b/app/tests/time_test.cc
@@ -63,6 +63,8 @@ TEST(TimeTests, ComparisonTests) {
   EXPECT_EQ(firebase::internal::TimespecCmp(t2, t2), 0);
 }
 
+// This test verifies the fix for the old integer overflow bug on 32-bit
+// architectures: https://github.com/firebase/firebase-cpp-sdk/pull/1042.
 TEST(TimeTests, MsToAbsoluteTimespecTest) {
   const timespec t1 = firebase::internal::MsToAbsoluteTimespec(0);
   const timespec t2 = firebase::internal::MsToAbsoluteTimespec(10000);

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -641,7 +641,9 @@ code.
       ([#989](https://github.com/firebase/firebase-cpp-sdk/issues/989)).
     - GMA (iOS): Updated iOS dependency to Google Mobile Ads SDK version 9.7.0.
     - General (Android,iOS,Linux,macOS 32-bit): Fixed an integer overflow which
-      could result in a crash when waiting for a `Future` with a timeout.
+      could result in a crash or premature return when waiting for a `Future`
+      with a timeout
+      ([#1042](https://github.com/firebase/firebase-cpp-sdk/pull/1042)).
 
 ### 9.3.0
 -   Changes

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -640,6 +640,8 @@ code.
       cause duplicate symbol linker errors in conjunction with other libraries
       ([#989](https://github.com/firebase/firebase-cpp-sdk/issues/989)).
     - GMA (iOS): Updated iOS dependency to Google Mobile Ads SDK version 9.7.0.
+    - General (Android,iOS,Linux,macOS 32-bit): Fixed an integer overflow which
+      could result in a crash when waiting for a `Future` with a timeout.
 
 ### 9.3.0
 -   Changes


### PR DESCRIPTION
This PR fixes a long-standing bug in `MsToAbsoluteTimespec(int milliseconds)` which would result in an integer overflow if invoked with a sufficiently-large "milliseconds". The bug manifested on 32-bit architectures because the `tv_sec` and `tv_nsec` members of `timespec` are 4 bytes each (32 bits), where on 64-bit architectures they are 8 bytes each (64 bits), and did not suffer from the overflow.

The problem was that in `MsToAbsoluteTimespec(int milliseconds)` it would add the given milliseconds, after converting to nanoseconds, to the `tv_nsec` member, and then call a helper function to normalize the values; however, when being invoked with a `milliseconds` value of `10000` (10 seconds) this would cause `tv_nsec` to overflow and wrap around to a negative value. When this malformed `timespec` was later specified to `sem_timedwait()` in `Semaphore::TimedWait()` it would cause the function call to fail immediately with `EINVAL`.

The fix in this PR is to instead do all of the math with an `int64_t` and then calculate the `tv_sec` and `tv_nsec` values from it. By doing all of the math with a 64-bit integer, no overflow occurs.

This fix will also fix a bunch of Firestore's transaction tests which are currently failing on 32-bit architectures due to this bug when they call `Future::Await(10000)`.

Here is one example of a testapp crash due to this bug on an x86 Android emulator. Here is the implementation of `MsToAbsoluteTimespec()` with the bug: https://github.com/firebase/firebase-cpp-sdk/blob/05890ac602e1d493bddaeb3ae0cd9085741f078d/app/src/time.h#L89-L95

In this test, the `milliseconds` argument was `10000` (10 seconds) and the `timespec t` had the following values after the following lines:
* After line 91: tv_sec=1659589211 tv_nsec=799274196
* After line 92: tv_sec=1659589211 tv_nsec=-2085627692
* After line 93: tv_sec=1659589209 tv_nsec=-85627692

You can see that `tv_nsec` is negative, which is invalid.
