### PR TITLE
pthread_condvar.h: Fix ConditionVariable::TimedWait() on 32-bit platforms

### DIFF
--- a/app/src/pthread_condvar.h
+++ b/app/src/pthread_condvar.h
@@ -53,22 +53,6 @@ class ConditionVariable {
     }
   }
 
-  // Waits for the condition variable to go, AND for the predicate to succeed.
-  // Returns false if it times out before both those conditions are met.
-  // Returns true otherwise
-  template <class Predicate>
-  bool TimedWait(pthread_mutex_t* lock, Predicate predicate, int milliseconds) {
-    int64_t end_time_ms = TimespecToMs(MsToAbsoluteTimespec(milliseconds));
-    int64_t current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
-    while (!predicate() && current_time_ms < end_time_ms) {
-      TimedWait(lock, end_time_ms - current_time_ms);
-      current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
-    }
-    // If time isn't up, AND the predicate is true, then we return true.
-    // False otherwise.
-    return current_time_ms < end_time_ms;
-  }
-
   void NotifyOne() { pthread_cond_signal(&cond_); }
   void NotifyAll() { pthread_cond_broadcast(&cond_); }
 

--- a/app/src/pthread_condvar.h
+++ b/app/src/pthread_condvar.h
@@ -58,18 +58,11 @@ class ConditionVariable {
   // Returns true otherwise
   template <class Predicate>
   bool TimedWait(pthread_mutex_t* lock, Predicate predicate, int milliseconds) {
-    timespec end_time, current_time;
-    clock_gettime(CLOCK_REALTIME, &end_time);
-    end_time.tv_nsec += milliseconds * kNanosecondsPerMillisecond;
-    int64_t end_time_ms = TimespecToMs(end_time);
-    NormalizeTimespec(&end_time);
-
-    clock_gettime(CLOCK_REALTIME, &current_time);
-    int64_t current_time_ms = TimespecToMs(current_time);
+    int64_t end_time_ms = TimespecToMs(MsToAbsoluteTimespec(milliseconds));
+    int64_t current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
     while (!predicate() && current_time_ms < end_time_ms) {
       TimedWait(lock, end_time_ms - current_time_ms);
-      clock_gettime(CLOCK_REALTIME, &current_time);
-      current_time_ms = TimespecToMs(current_time);
+      current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
     }
     // If time isn't up, AND the predicate is true, then we return true.
     // False otherwise.

--- a/app/src/pthread_condvar.h
+++ b/app/src/pthread_condvar.h
@@ -53,6 +53,22 @@ class ConditionVariable {
     }
   }
 
+  // Waits for the condition variable to go, AND for the predicate to succeed.
+  // Returns false if it times out before both those conditions are met.
+  // Returns true otherwise
+  template <class Predicate>
+  bool TimedWait(pthread_mutex_t* lock, Predicate predicate, int milliseconds) {
+    int64_t end_time_ms = TimespecToMs(MsToAbsoluteTimespec(milliseconds));
+    int64_t current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
+    while (!predicate() && current_time_ms < end_time_ms) {
+      TimedWait(lock, end_time_ms - current_time_ms);
+      current_time_ms = TimespecToMs(MsToAbsoluteTimespec(0));
+    }
+    // If time isn't up, AND the predicate is true, then we return true.
+    // False otherwise.
+    return current_time_ms < end_time_ms;
+  }
+
   void NotifyOne() { pthread_cond_signal(&cond_); }
   void NotifyAll() { pthread_cond_broadcast(&cond_); }
 

--- a/app/src/time.h
+++ b/app/src/time.h
@@ -63,12 +63,6 @@ inline void Sleep(int64_t milliseconds) {
 }
 
 #if !FIREBASE_PLATFORM_WINDOWS
-// Utility function for normalizing a timespec.
-inline void NormalizeTimespec(timespec* t) {
-  t->tv_sec += t->tv_nsec / kNanosecondsPerSecond;
-  t->tv_nsec %= kNanosecondsPerSecond;
-}
-
 // Utility function, for converting a timespec struct into milliseconds.
 inline int64_t TimespecToMs(timespec tm) {
   return tm.tv_sec * firebase::internal::kMillisecondsPerSecond +

--- a/app/tests/time_test.cc
+++ b/app/tests/time_test.cc
@@ -24,17 +24,6 @@
 namespace {
 
 #ifndef WIN32
-// Test that the normalize function works, for timespecs
-TEST(TimeTests, NormalizeTest) {
-  timespec t;
-  t.tv_sec = 2;
-  t.tv_nsec = firebase::internal::kNanosecondsPerSecond * 5.5;
-  firebase::internal::NormalizeTimespec(&t);
-
-  EXPECT_EQ(t.tv_sec, 7);
-  EXPECT_EQ(t.tv_nsec, firebase::internal::kNanosecondsPerSecond * 0.5);
-}
-
 // Test the various conversions to and from timespecs.
 TEST(TimeTests, ConversionTests) {
   timespec t;


### PR DESCRIPTION
Fix the templated overload of `ConditionVariable::TimedWait()`, which suffers from the same integer overflow bug on 32-bit architectures as `Semaphore::TimedWait(int)` did (which was fixed by https://github.com/firebase/firebase-cpp-sdk/pull/1042). Also, delete `NormalizeTimespec()` since it is no longer used anywhere.