### PR TITLE
Firestore: Add SCOPED_TRACE to Await() calls in firestore_integration_test.h/cc

### DIFF
--- a/firestore/integration_test_internal/src/firestore_integration_test.cc
+++ b/firestore/integration_test_internal/src/firestore_integration_test.cc
@@ -237,6 +237,7 @@ DocumentReference FirestoreIntegrationTest::DocumentWithData(
 
 void FirestoreIntegrationTest::WriteDocument(DocumentReference reference,
                                              const MapFieldValue& data) const {
+  SCOPED_TRACE("WriteDocument(" + reference.path() + ")");
   Future<void> future = reference.Set(data);
   Stopwatch stopwatch;
   Await(future);
@@ -247,6 +248,7 @@ void FirestoreIntegrationTest::WriteDocument(DocumentReference reference,
 void FirestoreIntegrationTest::WriteDocuments(
     CollectionReference reference,
     const std::map<std::string, MapFieldValue>& data) const {
+  SCOPED_TRACE("WriteDocuments(" + std::to_string(data.size()) + " documents)");
   for (const auto& kv : data) {
     WriteDocument(reference.Document(kv.first), kv.second);
   }
@@ -254,6 +256,7 @@ void FirestoreIntegrationTest::WriteDocuments(
 
 DocumentSnapshot FirestoreIntegrationTest::ReadDocument(
     const DocumentReference& reference) const {
+  SCOPED_TRACE("ReadDocument(" + reference.path() + ")");
   Future<DocumentSnapshot> future = reference.Get();
   Stopwatch stopwatch;
   const DocumentSnapshot* result = Await(future);
@@ -267,6 +270,7 @@ DocumentSnapshot FirestoreIntegrationTest::ReadDocument(
 
 QuerySnapshot FirestoreIntegrationTest::ReadDocuments(
     const Query& reference) const {
+  SCOPED_TRACE("ReadDocuments()");
   Future<QuerySnapshot> future = reference.Get();
   Stopwatch stopwatch;
   const QuerySnapshot* result = Await(future);
@@ -280,6 +284,7 @@ QuerySnapshot FirestoreIntegrationTest::ReadDocuments(
 
 void FirestoreIntegrationTest::DeleteDocument(
     DocumentReference reference) const {
+  SCOPED_TRACE("DeleteDocument(" + reference.path() + ")");
   Future<void> future = reference.Delete();
   Stopwatch stopwatch;
   Await(future);

--- a/firestore/integration_test_internal/src/firestore_integration_test.cc
+++ b/firestore/integration_test_internal/src/firestore_integration_test.cc
@@ -237,7 +237,8 @@ DocumentReference FirestoreIntegrationTest::DocumentWithData(
 
 void FirestoreIntegrationTest::WriteDocument(DocumentReference reference,
                                              const MapFieldValue& data) const {
-  SCOPED_TRACE("WriteDocument(" + reference.path() + ")");
+  SCOPED_TRACE("FirestoreIntegrationTest::WriteDocument(" + reference.path() +
+               ")");
   Future<void> future = reference.Set(data);
   Stopwatch stopwatch;
   Await(future);
@@ -248,7 +249,8 @@ void FirestoreIntegrationTest::WriteDocument(DocumentReference reference,
 void FirestoreIntegrationTest::WriteDocuments(
     CollectionReference reference,
     const std::map<std::string, MapFieldValue>& data) const {
-  SCOPED_TRACE("WriteDocuments(" + std::to_string(data.size()) + " documents)");
+  SCOPED_TRACE("FirestoreIntegrationTest::WriteDocuments(" +
+               std::to_string(data.size()) + " documents)");
   for (const auto& kv : data) {
     WriteDocument(reference.Document(kv.first), kv.second);
   }
@@ -256,7 +258,8 @@ void FirestoreIntegrationTest::WriteDocuments(
 
 DocumentSnapshot FirestoreIntegrationTest::ReadDocument(
     const DocumentReference& reference) const {
-  SCOPED_TRACE("ReadDocument(" + reference.path() + ")");
+  SCOPED_TRACE("FirestoreIntegrationTest::ReadDocument(" + reference.path() +
+               ")");
   Future<DocumentSnapshot> future = reference.Get();
   Stopwatch stopwatch;
   const DocumentSnapshot* result = Await(future);
@@ -270,7 +273,7 @@ DocumentSnapshot FirestoreIntegrationTest::ReadDocument(
 
 QuerySnapshot FirestoreIntegrationTest::ReadDocuments(
     const Query& reference) const {
-  SCOPED_TRACE("ReadDocuments()");
+  SCOPED_TRACE("FirestoreIntegrationTest::ReadDocuments()");
   Future<QuerySnapshot> future = reference.Get();
   Stopwatch stopwatch;
   const QuerySnapshot* result = Await(future);
@@ -284,7 +287,8 @@ QuerySnapshot FirestoreIntegrationTest::ReadDocuments(
 
 void FirestoreIntegrationTest::DeleteDocument(
     DocumentReference reference) const {
-  SCOPED_TRACE("DeleteDocument(" + reference.path() + ")");
+  SCOPED_TRACE("FirestoreIntegrationTest::DeleteDocument(" + reference.path() +
+               ")");
   Future<void> future = reference.Delete();
   Stopwatch stopwatch;
   Await(future);

--- a/firestore/integration_test_internal/src/firestore_integration_test.h
+++ b/firestore/integration_test_internal/src/firestore_integration_test.h
@@ -319,6 +319,7 @@ class FirestoreIntegrationTest : public testing::Test {
   // Update the specified document and wait for the update to complete.
   template <typename MapType>
   void UpdateDocument(DocumentReference reference, const MapType& data) const {
+    SCOPED_TRACE("UpdateDocument(" + reference.path() + ")");
     Future<void> future = reference.Update(data);
     Await(future);
     EXPECT_EQ(FutureStatus::kFutureStatusComplete, future.status());
@@ -392,9 +393,15 @@ class FirestoreIntegrationTest : public testing::Test {
 
   static std::string DescribeFailedFuture(const FutureBase& future);
 
-  void DisableNetwork() { Await(TestFirestore()->DisableNetwork()); }
+  void DisableNetwork() {
+    SCOPED_TRACE("DisableNetwork");
+    Await(TestFirestore()->DisableNetwork());
+  }
 
-  void EnableNetwork() { Await(TestFirestore()->EnableNetwork()); }
+  void EnableNetwork() {
+    SCOPED_TRACE("EnableNetwork");
+    Await(TestFirestore()->EnableNetwork());
+  }
 
   static FirestoreInternal* GetFirestoreInternal(Firestore* firestore) {
     return firestore->internal_;

--- a/firestore/integration_test_internal/src/firestore_integration_test.h
+++ b/firestore/integration_test_internal/src/firestore_integration_test.h
@@ -319,7 +319,8 @@ class FirestoreIntegrationTest : public testing::Test {
   // Update the specified document and wait for the update to complete.
   template <typename MapType>
   void UpdateDocument(DocumentReference reference, const MapType& data) const {
-    SCOPED_TRACE("UpdateDocument(" + reference.path() + ")");
+    SCOPED_TRACE("FirestoreIntegrationTest::UpdateDocument(" +
+                 reference.path() + ")");
     Future<void> future = reference.Update(data);
     Await(future);
     EXPECT_EQ(FutureStatus::kFutureStatusComplete, future.status());
@@ -394,12 +395,12 @@ class FirestoreIntegrationTest : public testing::Test {
   static std::string DescribeFailedFuture(const FutureBase& future);
 
   void DisableNetwork() {
-    SCOPED_TRACE("DisableNetwork");
+    SCOPED_TRACE("FirestoreIntegrationTest::DisableNetwork()");
     Await(TestFirestore()->DisableNetwork());
   }
 
   void EnableNetwork() {
-    SCOPED_TRACE("EnableNetwork");
+    SCOPED_TRACE("FirestoreIntegrationTest::EnableNetwork()");
     Await(TestFirestore()->EnableNetwork());
   }
 


### PR DESCRIPTION
This will help debug test failures to point more closely to the line of code on which a timeout occurred.