### PR TITLE
firestore_test.cc: add assertions for snapshots existing

### DIFF
--- a/firestore/integration_test_internal/src/firestore_test.cc
+++ b/firestore/integration_test_internal/src/firestore_test.cc
@@ -121,6 +121,7 @@ TEST_F(FirestoreIntegrationTest, TestCanUpdateAnExistingDocument) {
       MapFieldValue{{"desc", FieldValue::String("NewDescription")},
                     {"owner.email", FieldValue::String("new@xyz.com")}}));
   DocumentSnapshot doc = ReadDocument(document);
+  EXPECT_TRUE(doc.exists());
   EXPECT_THAT(
       doc.GetData(),
       ContainerEq(MapFieldValue{
@@ -151,11 +152,13 @@ TEST_F(FirestoreIntegrationTest, TestCanUpdateAnUnknownDocument) {
   EXPECT_EQ(Error::kErrorUnavailable, future.error());
 
   writer_snapshot = ReadDocument(writer_reference);
+  EXPECT_TRUE(writer_snapshot.exists());
   EXPECT_THAT(writer_snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::String("a")},
                                         {"b", FieldValue::String("b")}}));
   EXPECT_FALSE(writer_snapshot.metadata().is_from_cache());
   DocumentSnapshot reader_snapshot = ReadDocument(reader_reference);
+  EXPECT_TRUE(reader_snapshot.exists());
   EXPECT_THAT(reader_snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::String("a")},
                                         {"b", FieldValue::String("b")}}));
@@ -174,6 +177,7 @@ TEST_F(FirestoreIntegrationTest, TestCanOverwriteAnExistingDocumentUsingSet) {
       {"owner.data",
        FieldValue::Map({{"name", FieldValue::String("Sebastian")}})}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -197,6 +201,7 @@ TEST_F(FirestoreIntegrationTest,
            FieldValue::Map({{"name", FieldValue::String("Sebastian")}})}},
       SetOptions::Merge()));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -230,22 +235,27 @@ TEST_F(FirestoreIntegrationTest, TestCanMergeEmptyObject) {
 
   document.Set(MapFieldValue{});
   DocumentSnapshot snapshot = accumulator.Await();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(), ContainerEq(MapFieldValue{}));
 
   Await(document.Set(MapFieldValue{{"a", FieldValue::Map({})}},
                      SetOptions::MergeFields({"a"})));
   snapshot = accumulator.Await();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Map({})}}));
 
   Await(document.Set(MapFieldValue{{"b", FieldValue::Map({})}},
                      SetOptions::Merge()));
   snapshot = accumulator.Await();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Map({})},
                                         {"b", FieldValue::Map({})}}));
 
-  snapshot = *Await(document.Get(Source::kServer));
+  auto* snapshot_ptr = Await(document.Get(Source::kServer));
+  ASSERT_TRUE(snapshot_ptr);
+  snapshot = *snapshot_ptr;
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Map({})},
                                         {"b", FieldValue::Map({})}}));
@@ -294,6 +304,7 @@ TEST_F(FirestoreIntegrationTest, TestCanDeleteFieldUsingMergeFields) {
                                       {"foo", FieldValue::Delete()}})}},
       SetOptions::MergeFields({"foo", "inner", "nested.foo"})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -341,6 +352,7 @@ TEST_F(FirestoreIntegrationTest, TestMergeReplacesArrays) {
                              {{"data", FieldValue::String("new")}})})}},
       SetOptions::Merge()));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -366,6 +378,7 @@ TEST_F(FirestoreIntegrationTest,
                             {"email", FieldValue::String("new@xyz.com")}})}},
       SetOptions::MergeFieldPaths({{"desc"}, {"owner.data", "name"}})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -405,6 +418,7 @@ TEST_F(FirestoreIntegrationTest, TestFieldsNotInFieldMaskAreIgnored) {
                                  {"owner", FieldValue::String("Sebastian")}},
                    SetOptions::MergeFields({"desc"})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -426,6 +440,7 @@ TEST_F(FirestoreIntegrationTest, TestFieldDeletesNotInFieldMaskAreIgnored) {
                                  {"owner", FieldValue::Delete()}},
                    SetOptions::MergeFields({"desc"})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -447,6 +462,7 @@ TEST_F(FirestoreIntegrationTest, TestFieldTransformsNotInFieldMaskAreIgnored) {
                                  {"owner", FieldValue::ServerTimestamp()}},
                    SetOptions::MergeFields({"desc"})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -467,6 +483,7 @@ TEST_F(FirestoreIntegrationTest, TestCanSetEmptyFieldMask) {
       MapFieldValue{{"desc", FieldValue::String("NewDescription")}},
       SetOptions::MergeFields({})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -491,6 +508,7 @@ TEST_F(FirestoreIntegrationTest, TestCanSpecifyFieldsMultipleTimesInFieldMask) {
                             {"email", FieldValue::String("new@new.com")}})}},
       SetOptions::MergeFields({"owner.name", "owner", "owner"})));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -509,6 +527,7 @@ TEST_F(FirestoreIntegrationTest, TestCanDeleteAFieldWithAnUpdate) {
                         {"email", FieldValue::String("abc@xyz.com")}})}}));
   Await(document.Update(MapFieldValue{{"owner.email", FieldValue::Delete()}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{
                   {"desc", FieldValue::String("Description")},
@@ -524,6 +543,7 @@ TEST_F(FirestoreIntegrationTest, TestCanUpdateFieldsWithDots) {
   Await(document.Update({{FieldPath{"a.b"}, FieldValue::String("new")}}));
   Await(document.Update({{FieldPath{"c.d"}, FieldValue::String("new")}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a.b", FieldValue::String("new")},
                                         {"c.d", FieldValue::String("new")},
@@ -539,6 +559,7 @@ TEST_F(FirestoreIntegrationTest, TestCanUpdateNestedFields) {
   Await(document.Update({{"a.b", FieldValue::String("new")}}));
   Await(document.Update({{"c.d", FieldValue::String("new")}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{
                   {"a", FieldValue::Map({{"b", FieldValue::String("new")}})},
@@ -559,6 +580,7 @@ TEST_F(FirestoreIntegrationTest, TestCanUpdateFieldsWithMultipleDeletes) {
                          {FieldPath{"key3"}, FieldValue::Delete()},
                          {FieldPath{"key5"}, FieldValue::Delete()}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(), ContainerEq(MapFieldValue{
                                       {"key2", FieldValue::String("value2")},
                                       {"key4", FieldValue::String("value4")}}));
@@ -568,6 +590,7 @@ TEST_F(FirestoreIntegrationTest, TestDeleteDocument) {
   DocumentReference document = Collection("rooms").Document("eros");
   WriteDocument(document, MapFieldValue{{"value", FieldValue::String("bar")}});
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"value", FieldValue::String("bar")}}));
 
@@ -605,6 +628,7 @@ TEST_F(FirestoreIntegrationTest,
   DocumentReference document = Collection("rooms").Document();
   Await(document.Set(MapFieldValue{{"foo", FieldValue::Double(1.0)}}));
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"foo", FieldValue::Double(1.0)}}));
 }
@@ -773,7 +797,9 @@ TEST_F(FirestoreIntegrationTest, TestListenCanBeCalledMultipleTimes) {
             });
       });
 
-  EXPECT_THAT(test_data.WaitForDocumentSnapshot().GetData(),
+  DocumentSnapshot snapshot1 = test_data.WaitForDocumentSnapshot();
+  EXPECT_TRUE(snapshot1.exists());
+  EXPECT_THAT(snapshot1.GetData(),
               ContainerEq(MapFieldValue{{"foo", FieldValue::String("bar")}}));
 }
 
@@ -800,10 +826,12 @@ TEST_F(FirestoreIntegrationTest, TestDocumentSnapshotEventsForAdd) {
   WriteDocument(document, MapFieldValue{{"a", FieldValue::Double(1.0)}});
   Await(listener, 3);
   DocumentSnapshot snapshot = listener.last_result(1);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_TRUE(snapshot.metadata().has_pending_writes());
   snapshot = listener.last_result();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -821,6 +849,7 @@ TEST_F(FirestoreIntegrationTest, TestDocumentSnapshotEventsForChange) {
       listener.AttachTo(&document, MetadataChanges::kInclude);
   Await(listener);
   DocumentSnapshot snapshot = listener.last_result();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -829,11 +858,13 @@ TEST_F(FirestoreIntegrationTest, TestDocumentSnapshotEventsForChange) {
   UpdateDocument(document, MapFieldValue{{"a", FieldValue::Double(2.0)}});
   Await(listener, 3);
   snapshot = listener.last_result(1);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(2.0)}}));
   EXPECT_TRUE(snapshot.metadata().has_pending_writes());
   EXPECT_FALSE(snapshot.metadata().is_from_cache());
   snapshot = listener.last_result();
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(snapshot.GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(2.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -891,12 +922,14 @@ TEST_F(FirestoreIntegrationTest, TestQuerySnapshotEventsForAdd) {
   WriteDocument(document, MapFieldValue{{"a", FieldValue::Double(1.0)}});
   Await(listener, 3);
   QuerySnapshot snapshot = listener.last_result(1);
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_TRUE(snapshot.metadata().has_pending_writes());
   snapshot = listener.last_result();
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -914,7 +947,8 @@ TEST_F(FirestoreIntegrationTest, TestQuerySnapshotEventsForChange) {
       listener.AttachTo(&collection, MetadataChanges::kInclude);
   Await(listener);
   QuerySnapshot snapshot = listener.last_result();
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -922,12 +956,14 @@ TEST_F(FirestoreIntegrationTest, TestQuerySnapshotEventsForChange) {
   WriteDocument(document, MapFieldValue{{"a", FieldValue::Double(2.0)}});
   Await(listener, 3);
   snapshot = listener.last_result(1);
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(2.0)}}));
   EXPECT_TRUE(snapshot.metadata().has_pending_writes());
   snapshot = listener.last_result();
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(2.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -945,7 +981,8 @@ TEST_F(FirestoreIntegrationTest, TestQuerySnapshotEventsForDelete) {
       listener.AttachTo(&collection, MetadataChanges::kInclude);
   Await(listener);
   QuerySnapshot snapshot = listener.last_result();
-  EXPECT_EQ(1, snapshot.size());
+  ASSERT_EQ(1, snapshot.size());
+  EXPECT_TRUE(snapshot.documents()[0].exists());
   EXPECT_THAT(snapshot.documents()[0].GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   EXPECT_FALSE(snapshot.metadata().has_pending_writes());
@@ -979,10 +1016,12 @@ TEST_F(FirestoreIntegrationTest,
   ListenerRegistration registration = listener.AttachTo(&document);
   WriteDocument(document, MapFieldValue{{"a", FieldValue::Double(1.0)}});
   Await(listener);
+  EXPECT_TRUE(listener.last_result().exists());
   EXPECT_THAT(listener.last_result().GetData(),
               ContainerEq(MapFieldValue{{"a", FieldValue::Double(1.0)}}));
   WriteDocument(document, MapFieldValue{{"b", FieldValue::Double(1.0)}});
   Await(listener);
+  EXPECT_TRUE(listener.last_result().exists());
   EXPECT_THAT(listener.last_result().GetData(),
               ContainerEq(MapFieldValue{{"b", FieldValue::Double(1.0)}}));
   registration.Remove();
@@ -1100,6 +1139,7 @@ TEST_F(FirestoreIntegrationTest, TestCanQueueWritesWhileOffline) {
 
   // Assert
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -1126,6 +1166,7 @@ TEST_F(FirestoreIntegrationTest, TestCanGetDocumentsWhileOffline) {
 
   // The network is offline and we return a cached result.
   DocumentSnapshot snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -1139,6 +1180,7 @@ TEST_F(FirestoreIntegrationTest, TestCanGetDocumentsWhileOffline) {
   Await(TestFirestore()->EnableNetwork());
   Await(pending_write);
   snapshot = ReadDocument(document);
+  EXPECT_TRUE(snapshot.exists());
   EXPECT_THAT(
       snapshot.GetData(),
       ContainerEq(MapFieldValue{
@@ -1298,6 +1340,7 @@ TEST_F(FirestoreIntegrationTest, RestartFirestoreLeadsToNewInstance) {
   DocumentReference doc2 = db2->Document(doc_path);
   const DocumentSnapshot* snapshot2 = Await(doc2.Get(Source::kCache));
   ASSERT_NE(snapshot2, nullptr);
+  EXPECT_TRUE(snapshot2->exists());
   EXPECT_THAT(snapshot2->GetData(),
               ContainerEq(MapFieldValue{{"foo", FieldValue::String("bar")}}));
 
@@ -1378,6 +1421,7 @@ TEST_F(FirestoreIntegrationTest, CanClearPersistenceTestHarnessVerification) {
   DocumentReference document_2 = db_2->Document(path);
   Future<DocumentSnapshot> get_future = document_2.Get(Source::kCache);
   DocumentSnapshot snapshot_2 = *Await(get_future);
+  EXPECT_TRUE(snapshot_2.exists());
   EXPECT_THAT(snapshot_2.GetData(),
               ContainerEq(MapFieldValue{{"foo", FieldValue::Integer(42)}}));
 }


### PR DESCRIPTION
This additional assertions will help debug future test failures. Also, some EXPECT_EQ were changed to ASSERT_EQ if they were checking the length of a result size, so that if the size is too small then it will avoid dereferencing non-existing elements from the result set.