### PR TITLE
Send App Id when Firestore SDK delivers heartbeat

### DIFF
--- a/firestore/src/main/create_firebase_metadata_provider_desktop.cc
+++ b/firestore/src/main/create_firebase_metadata_provider_desktop.cc
@@ -23,8 +23,9 @@ namespace firestore {
 
 using remote::FirebaseMetadataProvider;
 
-std::unique_ptr<FirebaseMetadataProvider> CreateFirebaseMetadataProvider(App&) {
-  return absl::make_unique<FirebaseMetadataProviderCpp>();
+std::unique_ptr<FirebaseMetadataProvider> CreateFirebaseMetadataProvider(
+    App& app) {
+  return absl::make_unique<FirebaseMetadataProviderCpp>(app);
 }
 
 }  // namespace firestore

--- a/firestore/src/main/firebase_metadata_provider_desktop.cc
+++ b/firestore/src/main/firebase_metadata_provider_desktop.cc
@@ -22,6 +22,9 @@
 namespace firebase {
 namespace firestore {
 
+FirebaseMetadataProviderCpp::FirebaseMetadataProviderCpp(const App& app)
+    : gmp_app_id_(app.options().app_id()) {}
+
 void FirebaseMetadataProviderCpp::UpdateMetadata(grpc::ClientContext& context) {
   HeartbeatInfo::Code heartbeat = HeartbeatInfo::GetHeartbeatCode("fire-fst");
 
@@ -34,6 +37,10 @@ void FirebaseMetadataProviderCpp::UpdateMetadata(grpc::ClientContext& context) {
   }
 
   context.AddMetadata(kXFirebaseClientHeader, App::GetUserAgent());
+
+  if (!gmp_app_id_.empty()) {
+    context.AddMetadata(kXFirebaseGmpIdHeader, gmp_app_id_);
+  }
 }
 
 }  // namespace firestore

--- a/firestore/src/main/firebase_metadata_provider_desktop.h
+++ b/firestore/src/main/firebase_metadata_provider_desktop.h
@@ -17,7 +17,10 @@
 #ifndef FIREBASE_FIRESTORE_SRC_MAIN_FIREBASE_METADATA_PROVIDER_DESKTOP_H_
 #define FIREBASE_FIRESTORE_SRC_MAIN_FIREBASE_METADATA_PROVIDER_DESKTOP_H_
 
+#include <string>
+
 #include "Firestore/core/src/remote/firebase_metadata_provider.h"
+#include "app/src/include/firebase/app.h"
 
 #if defined(__ANDROID__)
 #error "This header should not be used on Android."
@@ -29,7 +32,12 @@ namespace firestore {
 
 class FirebaseMetadataProviderCpp : public remote::FirebaseMetadataProvider {
  public:
+  explicit FirebaseMetadataProviderCpp(const App& app);
+
   void UpdateMetadata(grpc::ClientContext& context) override;
+
+ private:
+  std::string gmp_app_id_;
 };
 
 }  // namespace firestore


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Send GMP App Id along with Firestore requests for desktop platform similar to for Apple platform.

https://github.com/firebase/firebase-ios-sdk/blob/eb30b6fdd809cbfe3a9eb7f3ccf1dd46326bef2d/Firestore/core/src/remote/firebase_metadata_provider_apple.mm#L66.

This is required for the backend to process heartbeat properly for desktop usage.

**
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

The test was done manually by checking backend log and verified that app id was received properly after this patch.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
