### PR TITLE
Add retry to npm installation of firebase-tools

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -359,8 +359,12 @@ jobs:
         with:
           node-version: 14.x
       - name: Setup Firestore Emulator
-        run: |
-          npm install -g firebase-tools
+        uses: nick-invision/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm install -g firebase-tools     
       - name: Setup java
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -739,8 +739,12 @@ jobs:
         with:
           node-version: 14.x
       - name: Setup Firestore Emulator
-        run: |
-          npm install -g firebase-tools     
+        uses: nick-invision/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm install -g firebase-tools     
       - name: Setup java
         uses: actions/setup-java@v3
         with:
@@ -998,8 +1002,15 @@ jobs:
           java-version: '17'
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm install -g firebase-tools     
+      - name: Start Firestore Emulator
+        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-          npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Setup java 8 for test_simulator.py
         uses: actions/setup-java@v3
@@ -1133,8 +1144,15 @@ jobs:
           java-version: '17'
       - name: Setup Firestore Emulator
         if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm install -g firebase-tools     
+      - name: Start Firestore Emulator
+        if: steps.get-device-type.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-          npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run iOS integration tests on Simulator locally
         timeout-minutes: 120
@@ -1242,8 +1260,15 @@ jobs:
           java-version: '17'
       - name: Setup Firestore Emulator
         if: contains(needs.check_and_prepare.outputs.apis, 'firestore')
+        uses: nick-invision/retry@v2
+        with:
+          shell: bash
+          timeout_minutes: 5
+          max_attempts: 3
+          command: npm install -g firebase-tools     
+      - name: Start Firestore Emulator
+        if: contains(needs.check_and_prepare.outputs.apis, 'firestore')
         run: |
-          npm install -g firebase-tools
           firebase emulators:start --only firestore --project demo-example &
       - name: Run tvOS integration tests on Simulator locally
         timeout-minutes: 90


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Installing firebase-tools requires network connectivity - thus we should retry if it fails.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Run integration tests, ensure no issues installing firebase-tools
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
