### PR TITLE
Upgrade node-version to 16 (was 14) in GitHub Actions workflows

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -354,7 +354,7 @@ jobs:
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
-      - name: Set up Node (14)
+      - name: Set up Node (16)
         uses: actions/setup-node@v2
         with:
           node-version: 16.x

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -357,7 +357,7 @@ jobs:
       - name: Set up Node (14)
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Setup Firestore Emulator
         run: |
           npm install -g firebase-tools

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -737,7 +737,7 @@ jobs:
       - name: Set up Node (14)
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Setup Firestore Emulator
         run: |
           npm install -g firebase-tools     
@@ -990,7 +990,7 @@ jobs:
       - name: Set up Node (14)
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Setup java 17 for Firestore emulator
         uses: actions/setup-java@v3
         with:
@@ -1125,7 +1125,7 @@ jobs:
       - name: Set up Node (14)
         uses: actions/setup-node@v2
         with:
-          node-version: 14.x
+          node-version: 16.x
       - name: Setup java for Firestore emulator
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -734,7 +734,7 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           command: scripts/gha/install_test_workflow_prereqs.sh -p Desktop -t true -a '${{ matrix.arch }}' -s '${{ matrix.ssl_variant }}'
-      - name: Set up Node (14)
+      - name: Set up Node (16)
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
@@ -987,7 +987,7 @@ jobs:
       - id: get-device-type
         run: |
           echo "::set-output name=device_type::$( python scripts/gha/print_matrix_configuration.py -d -k ${{ matrix.android_device }} )"
-      - name: Set up Node (14)
+      - name: Set up Node (16)
         uses: actions/setup-node@v2
         with:
           node-version: 16.x
@@ -1122,7 +1122,7 @@ jobs:
       - id: get-device-type
         run: |
           echo "::set-output name=device_type::$( python scripts/gha/print_matrix_configuration.py -d -k ${{ matrix.ios_device }} )"
-      - name: Set up Node (14)
+      - name: Set up Node (16)
         uses: actions/setup-node@v2
         with:
           node-version: 16.x


### PR DESCRIPTION
Upgrade `node-version` to 16 (was 14) in GitHub Actions workflows (`desktop.yml` and `integration_tests.yml`).

Node version 16 is the "long term support" version.

This may also fix intermittent failures of `npm install -g firebase-tools` with the error "npm ERR! cb() never called!"