### PR TITLE
Add heartbeat payload as a header to auth requests

### DIFF
--- a/app/src/app_common.cc
+++ b/app/src/app_common.cc
@@ -169,6 +169,8 @@ const char* kBuildSource = "custom_built";
 // clang-format=on
 
 const char* kApiClientHeader = "x-firebase-client";
+const char* kXFirebaseClientLogTypeHeader = "x-firebase-client-log-type";
+const char* kXFirebaseGmpIdHeader = "X-Firebase-GMPID";
 
 SystemLogger g_system_logger;  // NOLINT
 

--- a/app/src/app_common.cc
+++ b/app/src/app_common.cc
@@ -169,7 +169,6 @@ const char* kBuildSource = "custom_built";
 // clang-format=on
 
 const char* kApiClientHeader = "x-firebase-client";
-const char* kXFirebaseClientLogTypeHeader = "x-firebase-client-log-type";
 const char* kXFirebaseGmpIdHeader = "X-Firebase-GMPID";
 
 SystemLogger g_system_logger;  // NOLINT

--- a/app/src/app_common.h
+++ b/app/src/app_common.h
@@ -43,8 +43,10 @@ extern const char* kCppRuntimeOrStl;
 extern const char* kCpuArchitecture;
 extern const char* kBuildSource;
 
-// Extended API client header for Google user agent strings.
+// Request headers used by platform monitoring.
 extern const char* kApiClientHeader;
+extern const char* kXFirebaseClientLogTypeHeader;
+extern const char* kXFirebaseGmpIdHeader;
 
 // Add an app to the set of apps.
 App* AddApp(App* app, std::map<std::string, InitResult>* results);

--- a/app/src/app_common.h
+++ b/app/src/app_common.h
@@ -45,7 +45,6 @@ extern const char* kBuildSource;
 
 // Request headers used by platform monitoring.
 extern const char* kApiClientHeader;
-extern const char* kXFirebaseClientLogTypeHeader;
 extern const char* kXFirebaseGmpIdHeader;
 
 // Add an app to the set of apps.

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -429,7 +429,8 @@ Future<User*> Auth::CreateUserWithEmailAndPassword(const char* const email,
 
   typedef SignUpNewUserRequest RequestT;
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), email, password, ""));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), email, password,
+                   ""));
 
   return CallAsync(auth_data_, promise, std::move(request),
                    PerformSignInFlow<SignUpNewUserResponse>);

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -347,7 +347,7 @@ Future<User*> Auth::SignInWithCustomToken(const char* const custom_token) {
   // Note: std::make_unique is not supported by Visual Studio 2012, which is
   // among our target compilers.
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(GetApiKey(*auth_data_), custom_token));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), custom_token));
 
   return CallAsync(auth_data_, promise, std::move(request),
                    PerformSignInFlow<VerifyCustomTokenResponse>);
@@ -397,7 +397,7 @@ Future<User*> Auth::SignInAnonymously() {
 
   typedef SignUpNewUserRequest RequestT;
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(GetApiKey(*auth_data_)));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_)));
 
   return CallAsync(auth_data_, promise, std::move(request),
                    PerformSignInFlow<SignUpNewUserResponse>);
@@ -413,7 +413,7 @@ Future<User*> Auth::SignInWithEmailAndPassword(const char* const email,
 
   typedef VerifyPasswordRequest RequestT;
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(GetApiKey(*auth_data_), email, password));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), email, password));
 
   return CallAsync(auth_data_, promise, std::move(request),
                    PerformSignInFlow<VerifyPasswordResponse>);
@@ -429,7 +429,7 @@ Future<User*> Auth::CreateUserWithEmailAndPassword(const char* const email,
 
   typedef SignUpNewUserRequest RequestT;
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(GetApiKey(*auth_data_), email, password, ""));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), email, password, ""));
 
   return CallAsync(auth_data_, promise, std::move(request),
                    PerformSignInFlow<SignUpNewUserResponse>);
@@ -453,7 +453,7 @@ Future<Auth::FetchProvidersResult> Auth::FetchProvidersForEmail(
 
   typedef CreateAuthUriRequest RequestT;
   auto request = std::unique_ptr<RequestT>(  // NOLINT
-      new RequestT(GetApiKey(*auth_data_), email));
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_), email));
 
   const auto callback =
       [](AuthDataHandle<FetchProvidersResult, RequestT>* handle) {
@@ -486,7 +486,7 @@ Future<void> Auth::SendPasswordResetEmail(const char* email) {
 
   typedef GetOobConfirmationCodeRequest RequestT;
   auto request = RequestT::CreateSendPasswordResetEmailRequest(
-      GetApiKey(*auth_data_), email, language_code);
+      *auth_data_->app, GetApiKey(*auth_data_), email, language_code);
 
   const auto callback = [](AuthDataHandle<void, RequestT>* handle) {
     const auto response =

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -17,8 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 
-#include "auth/src/desktop/auth_constants.h"
 #include "app/src/include/firebase/app.h"
+#include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
@@ -32,7 +32,7 @@ class FacebookAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kFacebookAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
+      ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
         app, api_key, GetProvider().c_str(), access_token_.c_str());
   }

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -31,9 +31,9 @@ class FacebookAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kFacebookAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
+      const App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
-        api_key, GetProvider().c_str(), access_token_.c_str());
+        app, api_key, GetProvider().c_str(), access_token_.c_str());
   }
 
  private:

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/facebook_auth_credential.h
+++ b/auth/src/desktop/auth_providers/facebook_auth_credential.h
@@ -18,6 +18,7 @@
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_FACEBOOK_AUTH_CREDENTIAL_H_
 
 #include "auth/src/desktop/auth_constants.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
@@ -31,7 +32,7 @@ class FacebookAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kFacebookAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
         app, api_key, GetProvider().c_str(), access_token_.c_str());
   }

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -17,9 +17,9 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
 namespace firebase {
@@ -32,7 +32,7 @@ class GitHubAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGitHubAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
+      ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
         app, api_key, GetProvider().c_str(), token_.c_str());
   }

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -31,9 +31,9 @@ class GitHubAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGitHubAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
+      const App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
-        api_key, GetProvider().c_str(), token_.c_str());
+        app, api_key, GetProvider().c_str(), token_.c_str());
   }
 
  private:

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -19,6 +19,7 @@
 
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
 namespace firebase {
@@ -31,7 +32,7 @@ class GitHubAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGitHubAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessToken(
         app, api_key, GetProvider().c_str(), token_.c_str());
   }

--- a/auth/src/desktop/auth_providers/github_auth_credential.h
+++ b/auth/src/desktop/auth_providers/github_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GITHUB_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -20,6 +20,7 @@
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -31,7 +32,7 @@ class GoogleAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGoogleAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     if (!id_token_.empty()) {
       return VerifyAssertionRequest::FromIdToken(app, api_key, GetProvider().c_str(),
                                                  id_token_.c_str());

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -17,10 +17,10 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -32,10 +32,10 @@ class GoogleAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGoogleAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
+      ::firebase::App& app, const char* const api_key) const override {
     if (!id_token_.empty()) {
-      return VerifyAssertionRequest::FromIdToken(app, api_key, GetProvider().c_str(),
-                                                 id_token_.c_str());
+      return VerifyAssertionRequest::FromIdToken(
+          app, api_key, GetProvider().c_str(), id_token_.c_str());
     } else {
       return VerifyAssertionRequest::FromAccessToken(
           app, api_key, GetProvider().c_str(), access_token_.c_str());

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -31,13 +31,13 @@ class GoogleAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kGoogleAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
+      const App& app, const char* const api_key) const override {
     if (!id_token_.empty()) {
-      return VerifyAssertionRequest::FromIdToken(api_key, GetProvider().c_str(),
+      return VerifyAssertionRequest::FromIdToken(app, api_key, GetProvider().c_str(),
                                                  id_token_.c_str());
     } else {
       return VerifyAssertionRequest::FromAccessToken(
-          api_key, GetProvider().c_str(), access_token_.c_str());
+          app, api_key, GetProvider().c_str(), access_token_.c_str());
     }
   }
 

--- a/auth/src/desktop/auth_providers/google_auth_credential.h
+++ b/auth/src/desktop/auth_providers/google_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_GOOGLE_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -17,10 +17,10 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -32,12 +32,12 @@ class OAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return provider_id_; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
+      ::firebase::App& app, const char* const api_key) const override {
     const char* raw_nonce =
         (!raw_nonce_.empty()) ? raw_nonce_.c_str() : nullptr;
     if (!id_token_.empty()) {
-      return VerifyAssertionRequest::FromIdToken(app, api_key, provider_id_.c_str(),
-                                                 id_token_.c_str(), raw_nonce);
+      return VerifyAssertionRequest::FromIdToken(
+          app, api_key, provider_id_.c_str(), id_token_.c_str(), raw_nonce);
     } else {
       return VerifyAssertionRequest::FromAccessToken(
           app, api_key, provider_id_.c_str(), access_token_.c_str(), raw_nonce);

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_OAUTH_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -20,6 +20,7 @@
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -31,7 +32,7 @@ class OAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return provider_id_; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     const char* raw_nonce =
         (!raw_nonce_.empty()) ? raw_nonce_.c_str() : nullptr;
     if (!id_token_.empty()) {

--- a/auth/src/desktop/auth_providers/oauth_auth_credential.h
+++ b/auth/src/desktop/auth_providers/oauth_auth_credential.h
@@ -31,15 +31,15 @@ class OAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return provider_id_; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
+      const App& app, const char* const api_key) const override {
     const char* raw_nonce =
         (!raw_nonce_.empty()) ? raw_nonce_.c_str() : nullptr;
     if (!id_token_.empty()) {
-      return VerifyAssertionRequest::FromIdToken(api_key, provider_id_.c_str(),
+      return VerifyAssertionRequest::FromIdToken(app, api_key, provider_id_.c_str(),
                                                  id_token_.c_str(), raw_nonce);
     } else {
       return VerifyAssertionRequest::FromAccessToken(
-          api_key, provider_id_.c_str(), access_token_.c_str(), raw_nonce);
+          app, api_key, provider_id_.c_str(), access_token_.c_str(), raw_nonce);
     }
   }
 

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -31,8 +31,8 @@ class PlayGamesAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kPlayGamesAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
-    return VerifyAssertionRequest::FromAuthCode(api_key, GetProvider().c_str(),
+      const App& app, const char* const api_key) const override {
+    return VerifyAssertionRequest::FromAuthCode(app, api_key, GetProvider().c_str(),
                                                 server_auth_code_.c_str());
   }
 

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -17,10 +17,10 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -32,9 +32,9 @@ class PlayGamesAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kPlayGamesAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
-    return VerifyAssertionRequest::FromAuthCode(app, api_key, GetProvider().c_str(),
-                                                server_auth_code_.c_str());
+      ::firebase::App& app, const char* const api_key) const override {
+    return VerifyAssertionRequest::FromAuthCode(
+        app, api_key, GetProvider().c_str(), server_auth_code_.c_str());
   }
 
  private:

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -20,6 +20,7 @@
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -31,7 +32,7 @@ class PlayGamesAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kPlayGamesAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAuthCode(app, api_key, GetProvider().c_str(),
                                                 server_auth_code_.c_str());
   }

--- a/auth/src/desktop/auth_providers/playgames_auth_credential.h
+++ b/auth/src/desktop/auth_providers/playgames_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_PLAYGAMES_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -19,6 +19,7 @@
 
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
 namespace firebase {
@@ -31,7 +32,7 @@ class TwitterAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kTwitterAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* const api_key) const override {
+       ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
         app, api_key, GetProvider().c_str(), token_.c_str(), secret_.c_str());
   }

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -17,9 +17,9 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_AUTH_PROVIDERS_TWITTER_AUTH_CREDENTIAL_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_constants.h"
 #include "auth/src/desktop/identity_provider_credential.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
 namespace firebase {
@@ -32,7 +32,7 @@ class TwitterAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kTwitterAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* const api_key) const override {
+      ::firebase::App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
         app, api_key, GetProvider().c_str(), token_.c_str(), secret_.c_str());
   }

--- a/auth/src/desktop/auth_providers/twitter_auth_credential.h
+++ b/auth/src/desktop/auth_providers/twitter_auth_credential.h
@@ -31,9 +31,9 @@ class TwitterAuthCredential : public IdentityProviderCredential {
   std::string GetProvider() const override { return kTwitterAuthProviderId; }
 
   std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* const api_key) const override {
+      const App& app, const char* const api_key) const override {
     return VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
-        api_key, GetProvider().c_str(), token_.c_str(), secret_.c_str());
+        app, api_key, GetProvider().c_str(), token_.c_str(), secret_.c_str());
   }
 
  private:

--- a/auth/src/desktop/credential_util.cc
+++ b/auth/src/desktop/credential_util.cc
@@ -30,7 +30,7 @@ std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
       static_cast<const CredentialImpl*>(raw_credential_impl);
   const auto* idp_credential = static_cast<const IdentityProviderCredential*>(
       credential_impl->auth_credential.get());
-  return idp_credential->CreateVerifyAssertionRequest(GetApiKey(auth_data));
+  return idp_credential->CreateVerifyAssertionRequest(*auth_data.app, GetApiKey(auth_data));
 }
 
 std::unique_ptr<rest::Request> CreateRequestFromCredential(
@@ -45,7 +45,7 @@ std::unique_ptr<rest::Request> CreateRequestFromCredential(
       return nullptr;
     }
     return std::unique_ptr<rest::Request>(  // NOLINT
-        new VerifyPasswordRequest(GetApiKey(*auth_data),
+        new VerifyPasswordRequest(*auth_data->app, GetApiKey(*auth_data),
                                   email_credential->GetEmail().c_str(),
                                   email_credential->GetPassword().c_str()));
   }

--- a/auth/src/desktop/credential_util.cc
+++ b/auth/src/desktop/credential_util.cc
@@ -30,7 +30,8 @@ std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
       static_cast<const CredentialImpl*>(raw_credential_impl);
   const auto* idp_credential = static_cast<const IdentityProviderCredential*>(
       credential_impl->auth_credential.get());
-  return idp_credential->CreateVerifyAssertionRequest(*auth_data.app, GetApiKey(auth_data));
+  return idp_credential->CreateVerifyAssertionRequest(*auth_data.app,
+                                                      GetApiKey(auth_data));
 }
 
 std::unique_ptr<rest::Request> CreateRequestFromCredential(

--- a/auth/src/desktop/identity_provider_credential.h
+++ b/auth/src/desktop/identity_provider_credential.h
@@ -40,7 +40,7 @@ namespace auth {
 class IdentityProviderCredential : public AuthCredential {
  public:
   virtual std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const char* api_key) const = 0;
+      const App& app, const char* api_key) const = 0;
 };
 
 }  // namespace auth

--- a/auth/src/desktop/identity_provider_credential.h
+++ b/auth/src/desktop/identity_provider_credential.h
@@ -19,6 +19,7 @@
 
 #include "auth/src/desktop/auth_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -40,7 +41,7 @@ namespace auth {
 class IdentityProviderCredential : public AuthCredential {
  public:
   virtual std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-      const App& app, const char* api_key) const = 0;
+       ::firebase::App& app, const char* api_key) const = 0;
 };
 
 }  // namespace auth

--- a/auth/src/desktop/identity_provider_credential.h
+++ b/auth/src/desktop/identity_provider_credential.h
@@ -17,9 +17,9 @@
 
 #include <memory>
 
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/auth_credential.h"
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -41,7 +41,7 @@ namespace auth {
 class IdentityProviderCredential : public AuthCredential {
  public:
   virtual std::unique_ptr<VerifyAssertionRequest> CreateVerifyAssertionRequest(
-       ::firebase::App& app, const char* api_key) const = 0;
+      ::firebase::App& app, const char* api_key) const = 0;
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -15,6 +15,7 @@
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 #include <assert.h>
+#include <string>
 
 #include "app/src/app_common.h"
 #include "app/src/include/firebase/app.h"
@@ -26,7 +27,7 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest(App* app, const char* schema, bool deliver_heartbeat) : RequestJson(schema) {
+AuthRequest::AuthRequest(const App& app, const char* schema, bool deliver_heartbeat) : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid
   // dependencies upon other parts of this library.  This complication is due to
   // the way the tests are currently configured where each library has minimal
@@ -56,12 +57,11 @@ AuthRequest::AuthRequest(App* app, const char* schema, bool deliver_heartbeat) :
     add_header("User-Agent", auth_user_agent.c_str());
     add_header("X-Client-Version", extended_auth_user_agent.c_str());
   }
-  if (deliver_heartbeat && app) {
-    std::string payload = app->GetAndResetStoredDesktopHeartbeats();
-    std::string gmp_app_id = app->options().app_id()
+  if (deliver_heartbeat) {
+    std::string payload = app.GetAndResetStoredDesktopHeartbeats();
+    std::string gmp_app_id = app.options().app_id()
     if (payload) {
       add_header(app_common::kApiClientHeader, payload);
-      add_header(app_common::kXFirebaseClientLogTypeHeader, "2");
       add_header(app_common::kXFirebaseGmpIdHeader, gmp_app_id);
     } else {
       add_header(app_common::kApiClientHeader, App::GetUserAgent());

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest(const ::firebase::App& app,const char* schema,
+AuthRequest::AuthRequest(const ::firebase::App& app, const char* schema,
                          bool deliver_heartbeat)
     : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest(const ::firebase::App& app, const char* schema,
+AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
                          bool deliver_heartbeat)
     : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -15,6 +15,7 @@
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 #include <assert.h>
+
 #include <string>
 
 #include "app/src/app_common.h"
@@ -27,7 +28,9 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest( ::firebase::App& app, const char* schema, bool deliver_heartbeat) : RequestJson(schema) {
+AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
+                         bool deliver_heartbeat)
+    : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid
   // dependencies upon other parts of this library.  This complication is due to
   // the way the tests are currently configured where each library has minimal

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
+AuthRequest::AuthRequest(const ::firebase::App& app,const char* schema,
                          bool deliver_heartbeat)
     : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid
@@ -66,11 +66,7 @@ AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
     if (!payload.empty()) {
       add_header(app_common::kApiClientHeader, payload.c_str());
       add_header(app_common::kXFirebaseGmpIdHeader, gmp_app_id.c_str());
-    } else {
-      add_header(app_common::kApiClientHeader, App::GetUserAgent());
     }
-  } else {
-    add_header(app_common::kApiClientHeader, App::GetUserAgent());
   }
 }
 

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -56,6 +56,7 @@ AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
                                sdk + "/" + version + "/" + "FirebaseCore-" +
                                sdk_type;
   }
+  // TODO(b/244643516): Remove the User-Agent and X-Client-Version headers.
   if (!auth_user_agent.empty()) {
     add_header("User-Agent", auth_user_agent.c_str());
     add_header("X-Client-Version", extended_auth_user_agent.c_str());

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -27,7 +27,7 @@ namespace auth {
 // Key name for header when sending language code data.
 const char* kHeaderFirebaseLocale = "X-Firebase-Locale";
 
-AuthRequest::AuthRequest(const App& app, const char* schema, bool deliver_heartbeat) : RequestJson(schema) {
+AuthRequest::AuthRequest( ::firebase::App& app, const char* schema, bool deliver_heartbeat) : RequestJson(schema) {
   // The user agent strings are cached in static variables here to avoid
   // dependencies upon other parts of this library.  This complication is due to
   // the way the tests are currently configured where each library has minimal
@@ -59,10 +59,10 @@ AuthRequest::AuthRequest(const App& app, const char* schema, bool deliver_heartb
   }
   if (deliver_heartbeat) {
     std::string payload = app.GetAndResetStoredDesktopHeartbeats();
-    std::string gmp_app_id = app.options().app_id()
-    if (payload) {
-      add_header(app_common::kApiClientHeader, payload);
-      add_header(app_common::kXFirebaseGmpIdHeader, gmp_app_id);
+    std::string gmp_app_id = app.options().app_id();
+    if (!payload.empty()) {
+      add_header(app_common::kApiClientHeader, payload.c_str());
+      add_header(app_common::kXFirebaseGmpIdHeader, gmp_app_id.c_str());
     } else {
       add_header(app_common::kApiClientHeader, App::GetUserAgent());
     }

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -30,10 +30,10 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(const char* schema, bool deliver_heartbeat);
+  explicit AuthRequest(const App& app, const char* schema, bool deliver_heartbeat);
 
-  explicit AuthRequest(const unsigned char* schema, bool deliver_heartbeat)
-      : AuthRequest(reinterpret_cast<const char*>(schema), deliver_heartbeat) {}
+  explicit AuthRequest(const App& app, const unsigned char* schema, bool deliver_heartbeat)
+      : AuthRequest(app, reinterpret_cast<const char*>(schema), deliver_heartbeat) {}
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -18,8 +18,8 @@
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_AUTH_REQUEST_H_
 
 #include "app/rest/request_json.h"
-#include "auth/request_generated.h"
 #include "app/src/include/firebase/app.h"
+#include "auth/request_generated.h"
 #include "auth/request_resource.h"
 
 namespace firebase {
@@ -31,10 +31,13 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest( ::firebase::App& app, const char* schema, bool deliver_heartbeat);
+  explicit AuthRequest(::firebase::App& app, const char* schema,
+                       bool deliver_heartbeat);
 
-  explicit AuthRequest( ::firebase::App& app, const unsigned char* schema, bool deliver_heartbeat)
-      : AuthRequest(app, reinterpret_cast<const char*>(schema), deliver_heartbeat) {}
+  explicit AuthRequest(::firebase::App& app, const unsigned char* schema,
+                       bool deliver_heartbeat)
+      : AuthRequest(app, reinterpret_cast<const char*>(schema),
+                    deliver_heartbeat) {}
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -31,10 +31,10 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(::firebase::App& app, const char* schema,
+  explicit AuthRequest(const ::firebase::App& app,const char* schema,
                        bool deliver_heartbeat);
 
-  explicit AuthRequest(::firebase::App& app, const unsigned char* schema,
+  explicit AuthRequest(const ::firebase::App& app,const unsigned char* schema,
                        bool deliver_heartbeat)
       : AuthRequest(app, reinterpret_cast<const char*>(schema),
                     deliver_heartbeat) {}

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -30,10 +30,10 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(const char* schema);
+  explicit AuthRequest(const char* schema, bool deliver_heartbeat);
 
-  explicit AuthRequest(const unsigned char* schema)
-      : AuthRequest(reinterpret_cast<const char*>(schema)) {}
+  explicit AuthRequest(const unsigned char* schema, bool deliver_heartbeat)
+      : AuthRequest(reinterpret_cast<const char*>(schema), deliver_heartbeat) {}
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -31,10 +31,10 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(const ::firebase::App& app,const char* schema,
+  explicit AuthRequest(const ::firebase::App& app, const char* schema,
                        bool deliver_heartbeat);
 
-  explicit AuthRequest(const ::firebase::App& app,const unsigned char* schema,
+  explicit AuthRequest(const ::firebase::App& app, const unsigned char* schema,
                        bool deliver_heartbeat)
       : AuthRequest(app, reinterpret_cast<const char*>(schema),
                     deliver_heartbeat) {}

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -31,10 +31,12 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(const ::firebase::App& app, const char* schema,
+  // App is a non-const parameter because this constructor might modify App's
+  // internal HeartbeatController by logging or fetching heartbeats.
+  AuthRequest(::firebase::App& app, const char* schema,
                        bool deliver_heartbeat);
 
-  explicit AuthRequest(const ::firebase::App& app, const unsigned char* schema,
+  AuthRequest(::firebase::App& app, const unsigned char* schema,
                        bool deliver_heartbeat)
       : AuthRequest(app, reinterpret_cast<const char*>(schema),
                     deliver_heartbeat) {}

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -19,6 +19,7 @@
 
 #include "app/rest/request_json.h"
 #include "auth/request_generated.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/request_resource.h"
 
 namespace firebase {
@@ -30,9 +31,9 @@ extern const char* kHeaderFirebaseLocale;
 class AuthRequest
     : public firebase::rest::RequestJson<fbs::Request, fbs::RequestT> {
  public:
-  explicit AuthRequest(const App& app, const char* schema, bool deliver_heartbeat);
+  explicit AuthRequest( ::firebase::App& app, const char* schema, bool deliver_heartbeat);
 
-  explicit AuthRequest(const App& app, const unsigned char* schema, bool deliver_heartbeat)
+  explicit AuthRequest( ::firebase::App& app, const unsigned char* schema, bool deliver_heartbeat)
       : AuthRequest(app, reinterpret_cast<const char*>(schema), deliver_heartbeat) {}
 };
 

--- a/auth/src/desktop/rpcs/auth_request.h
+++ b/auth/src/desktop/rpcs/auth_request.h
@@ -33,11 +33,10 @@ class AuthRequest
  public:
   // App is a non-const parameter because this constructor might modify App's
   // internal HeartbeatController by logging or fetching heartbeats.
-  AuthRequest(::firebase::App& app, const char* schema,
-                       bool deliver_heartbeat);
+  AuthRequest(::firebase::App& app, const char* schema, bool deliver_heartbeat);
 
   AuthRequest(::firebase::App& app, const unsigned char* schema,
-                       bool deliver_heartbeat)
+              bool deliver_heartbeat)
       : AuthRequest(app, reinterpret_cast<const char*>(schema),
                     deliver_heartbeat) {}
 };

--- a/auth/src/desktop/rpcs/create_auth_uri_request.cc
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.cc
@@ -20,9 +20,9 @@
 namespace firebase {
 namespace auth {
 
-CreateAuthUriRequest::CreateAuthUriRequest(const char* api_key,
+CreateAuthUriRequest::CreateAuthUriRequest(const App& app, const char* api_key,
                                            const char* identifier)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/create_auth_uri_request.cc
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.cc
@@ -16,11 +16,12 @@
 
 #include "app/src/assert.h"
 #include "app/src/log.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-CreateAuthUriRequest::CreateAuthUriRequest(const App& app, const char* api_key,
+CreateAuthUriRequest::CreateAuthUriRequest( ::firebase::App& app, const char* api_key,
                                            const char* identifier)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/create_auth_uri_request.cc
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.cc
@@ -22,7 +22,7 @@ namespace auth {
 
 CreateAuthUriRequest::CreateAuthUriRequest(const char* api_key,
                                            const char* identifier)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/create_auth_uri_request.cc
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.cc
@@ -15,13 +15,14 @@
 #include "auth/src/desktop/rpcs/create_auth_uri_request.h"
 
 #include "app/src/assert.h"
-#include "app/src/log.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/log.h"
 
 namespace firebase {
 namespace auth {
 
-CreateAuthUriRequest::CreateAuthUriRequest( ::firebase::App& app, const char* api_key,
+CreateAuthUriRequest::CreateAuthUriRequest(::firebase::App& app,
+                                           const char* api_key,
                                            const char* identifier)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest(const ::firebase::App& app, const char* api_key,
+  CreateAuthUriRequest(::firebase::App& app, const char* api_key,
                        const char* identifier);
 };
 

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -17,17 +17,18 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_CREATE_AUTH_URI_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_CREATE_AUTH_URI_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest( ::firebase::App& app, const char* api_key, const char* identifier);
+  CreateAuthUriRequest(::firebase::App& app, const char* api_key,
+                       const char* identifier);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -20,13 +20,14 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest(const App& app, const char* api_key, const char* identifier);
+  CreateAuthUriRequest( ::firebase::App& app, const char* api_key, const char* identifier);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest(const ::firebase::App& app,const char* api_key,
+  CreateAuthUriRequest(const ::firebase::App& app, const char* api_key,
                        const char* identifier);
 };
 

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -26,7 +26,7 @@ namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest(const char* api_key, const char* identifier);
+  CreateAuthUriRequest(const App& app, const char* api_key, const char* identifier);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/create_auth_uri_request.h
+++ b/auth/src/desktop/rpcs/create_auth_uri_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class CreateAuthUriRequest : public AuthRequest {
  public:
-  CreateAuthUriRequest(::firebase::App& app, const char* api_key,
+  CreateAuthUriRequest(const ::firebase::App& app,const char* api_key,
                        const char* identifier);
 };
 

--- a/auth/src/desktop/rpcs/delete_account_request.cc
+++ b/auth/src/desktop/rpcs/delete_account_request.cc
@@ -15,11 +15,12 @@
 #include "auth/src/desktop/rpcs/delete_account_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-DeleteAccountRequest::DeleteAccountRequest(const App& app, const char* const api_key)
+DeleteAccountRequest::DeleteAccountRequest( ::firebase::App& app, const char* const api_key)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 

--- a/auth/src/desktop/rpcs/delete_account_request.cc
+++ b/auth/src/desktop/rpcs/delete_account_request.cc
@@ -19,8 +19,8 @@
 namespace firebase {
 namespace auth {
 
-DeleteAccountRequest::DeleteAccountRequest(const char* const api_key)
-    : AuthRequest(request_resource_data, true) {
+DeleteAccountRequest::DeleteAccountRequest(const App& app, const char* const api_key)
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/delete_account_request.cc
+++ b/auth/src/desktop/rpcs/delete_account_request.cc
@@ -20,7 +20,7 @@ namespace firebase {
 namespace auth {
 
 DeleteAccountRequest::DeleteAccountRequest(const char* const api_key)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/delete_account_request.cc
+++ b/auth/src/desktop/rpcs/delete_account_request.cc
@@ -20,7 +20,8 @@
 namespace firebase {
 namespace auth {
 
-DeleteAccountRequest::DeleteAccountRequest( ::firebase::App& app, const char* const api_key)
+DeleteAccountRequest::DeleteAccountRequest(::firebase::App& app,
+                                           const char* const api_key)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -21,13 +21,14 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(const App& app, const char* api_key);
+  explicit DeleteAccountRequest( ::firebase::App& app, const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -28,7 +28,8 @@ namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(const ::firebase::App& app,const char* api_key);
+  explicit DeleteAccountRequest(const ::firebase::App& app,
+                                const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -28,8 +28,7 @@ namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(::firebase::App& app,
-                                const char* api_key);
+  explicit DeleteAccountRequest(::firebase::App& app, const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -28,7 +28,7 @@ namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(::firebase::App& app, const char* api_key);
+  explicit DeleteAccountRequest(const ::firebase::App& app,const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(const char* api_key);
+  explicit DeleteAccountRequest(const App& app, const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -28,7 +28,7 @@ namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest(const ::firebase::App& app,
+  explicit DeleteAccountRequest(::firebase::App& app,
                                 const char* api_key);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/delete_account_request.h
+++ b/auth/src/desktop/rpcs/delete_account_request.h
@@ -17,18 +17,18 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_DELETE_ACCOUNT_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_DELETE_ACCOUNT_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class DeleteAccountRequest : public AuthRequest {
  public:
-  explicit DeleteAccountRequest( ::firebase::App& app, const char* api_key);
+  explicit DeleteAccountRequest(::firebase::App& app, const char* api_key);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {

--- a/auth/src/desktop/rpcs/get_account_info_request.cc
+++ b/auth/src/desktop/rpcs/get_account_info_request.cc
@@ -20,14 +20,14 @@ namespace firebase {
 namespace auth {
 
 GetAccountInfoRequest::GetAccountInfoRequest(const char* const api_key)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   SetUrl(api_key);
   UpdatePostFields();
 }
 
 GetAccountInfoRequest::GetAccountInfoRequest(const char* const api_key,
                                              const char* const id_token)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   SetUrl(api_key);
   SetIdToken(id_token);
   UpdatePostFields();

--- a/auth/src/desktop/rpcs/get_account_info_request.cc
+++ b/auth/src/desktop/rpcs/get_account_info_request.cc
@@ -20,13 +20,15 @@
 namespace firebase {
 namespace auth {
 
-GetAccountInfoRequest::GetAccountInfoRequest( ::firebase::App& app, const char* const api_key)
+GetAccountInfoRequest::GetAccountInfoRequest(::firebase::App& app,
+                                             const char* const api_key)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   UpdatePostFields();
 }
 
-GetAccountInfoRequest::GetAccountInfoRequest( ::firebase::App& app, const char* const api_key,
+GetAccountInfoRequest::GetAccountInfoRequest(::firebase::App& app,
+                                             const char* const api_key,
                                              const char* const id_token)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);

--- a/auth/src/desktop/rpcs/get_account_info_request.cc
+++ b/auth/src/desktop/rpcs/get_account_info_request.cc
@@ -15,17 +15,18 @@
 #include "auth/src/desktop/rpcs/get_account_info_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-GetAccountInfoRequest::GetAccountInfoRequest(const App& app, const char* const api_key)
+GetAccountInfoRequest::GetAccountInfoRequest( ::firebase::App& app, const char* const api_key)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   UpdatePostFields();
 }
 
-GetAccountInfoRequest::GetAccountInfoRequest(const App& app, const char* const api_key,
+GetAccountInfoRequest::GetAccountInfoRequest( ::firebase::App& app, const char* const api_key,
                                              const char* const id_token)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);

--- a/auth/src/desktop/rpcs/get_account_info_request.cc
+++ b/auth/src/desktop/rpcs/get_account_info_request.cc
@@ -19,15 +19,15 @@
 namespace firebase {
 namespace auth {
 
-GetAccountInfoRequest::GetAccountInfoRequest(const char* const api_key)
-    : AuthRequest(request_resource_data, true) {
+GetAccountInfoRequest::GetAccountInfoRequest(const App& app, const char* const api_key)
+    : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   UpdatePostFields();
 }
 
-GetAccountInfoRequest::GetAccountInfoRequest(const char* const api_key,
+GetAccountInfoRequest::GetAccountInfoRequest(const App& app, const char* const api_key,
                                              const char* const id_token)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   SetIdToken(id_token);
   UpdatePostFields();

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -28,8 +28,8 @@ namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(::firebase::App& app, const char* api_key);
-  GetAccountInfoRequest(::firebase::App& app, const char* api_key,
+  explicit GetAccountInfoRequest(const ::firebase::App& app,const char* api_key);
+  GetAccountInfoRequest(const ::firebase::App& app,const char* api_key,
                         const char* id_token);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -17,19 +17,20 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_GET_ACCOUNT_INFO_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_GET_ACCOUNT_INFO_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest( ::firebase::App& app, const char* api_key);
-  GetAccountInfoRequest( ::firebase::App& app, const char* api_key, const char* id_token);
+  explicit GetAccountInfoRequest(::firebase::App& app, const char* api_key);
+  GetAccountInfoRequest(::firebase::App& app, const char* api_key,
+                        const char* id_token);
 
   void SetIdToken(const char* const id_token) {
     // This is actually access token, named ID token for backward compatibility.

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -28,8 +28,7 @@ namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(::firebase::App& app,
-                                 const char* api_key);
+  explicit GetAccountInfoRequest(::firebase::App& app, const char* api_key);
   GetAccountInfoRequest(::firebase::App& app, const char* api_key,
                         const char* id_token);
 

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -21,14 +21,15 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(const App& app, const char* api_key);
-  GetAccountInfoRequest(const App& app, const char* api_key, const char* id_token);
+  explicit GetAccountInfoRequest( ::firebase::App& app, const char* api_key);
+  GetAccountInfoRequest( ::firebase::App& app, const char* api_key, const char* id_token);
 
   void SetIdToken(const char* const id_token) {
     // This is actually access token, named ID token for backward compatibility.

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -27,8 +27,8 @@ namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(const char* api_key);
-  GetAccountInfoRequest(const char* api_key, const char* id_token);
+  explicit GetAccountInfoRequest(const App& app, const char* api_key);
+  GetAccountInfoRequest(const App& app, const char* api_key, const char* id_token);
 
   void SetIdToken(const char* const id_token) {
     // This is actually access token, named ID token for backward compatibility.

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -28,8 +28,9 @@ namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(const ::firebase::App& app,const char* api_key);
-  GetAccountInfoRequest(const ::firebase::App& app,const char* api_key,
+  explicit GetAccountInfoRequest(const ::firebase::App& app,
+                                 const char* api_key);
+  GetAccountInfoRequest(const ::firebase::App& app, const char* api_key,
                         const char* id_token);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/get_account_info_request.h
+++ b/auth/src/desktop/rpcs/get_account_info_request.h
@@ -28,9 +28,9 @@ namespace auth {
 
 class GetAccountInfoRequest : public AuthRequest {
  public:
-  explicit GetAccountInfoRequest(const ::firebase::App& app,
+  explicit GetAccountInfoRequest(::firebase::App& app,
                                  const char* api_key);
-  GetAccountInfoRequest(const ::firebase::App& app, const char* api_key,
+  GetAccountInfoRequest(::firebase::App& app, const char* api_key,
                         const char* id_token);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
@@ -21,7 +21,7 @@ namespace auth {
 
 GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
     const char* api_key)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
@@ -21,7 +21,7 @@ namespace firebase {
 namespace auth {
 
 GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
-     ::firebase::App& app, const char* api_key)
+    ::firebase::App& app, const char* api_key)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
@@ -37,7 +37,7 @@ GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
-     ::firebase::App& app, const char* api_key, const char* language_code) {
+    ::firebase::App& app, const char* api_key, const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
       new GetOobConfirmationCodeRequest(app, api_key));
   request->application_data_->requestType = "VERIFY_EMAIL";
@@ -50,7 +50,8 @@ GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendPasswordResetEmailRequest(
-     ::firebase::App& app, const char* api_key, const char* email, const char* language_code) {
+    ::firebase::App& app, const char* api_key, const char* email,
+    const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
       new GetOobConfirmationCodeRequest(app, api_key));
   request->application_data_->requestType = "PASSWORD_RESET";

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
@@ -20,8 +20,8 @@ namespace firebase {
 namespace auth {
 
 GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
-    const char* api_key)
-    : AuthRequest(request_resource_data, true) {
+    const App& app, const char* api_key)
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =
@@ -36,7 +36,7 @@ GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
-    const char* api_key, const char* language_code) {
+    const App& app, const char* api_key, const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
       new GetOobConfirmationCodeRequest(api_key));
   request->application_data_->requestType = "VERIFY_EMAIL";
@@ -49,9 +49,9 @@ GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendPasswordResetEmailRequest(
-    const char* api_key, const char* email, const char* language_code) {
+    const App& app, const char* api_key, const char* email, const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
-      new GetOobConfirmationCodeRequest(api_key));
+      new GetOobConfirmationCodeRequest(app, api_key));
   request->application_data_->requestType = "PASSWORD_RESET";
   if (language_code != nullptr) {
     request->add_header(kHeaderFirebaseLocale, language_code);

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.cc
@@ -15,12 +15,13 @@
 #include "auth/src/desktop/rpcs/get_oob_confirmation_code_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
-    const App& app, const char* api_key)
+     ::firebase::App& app, const char* api_key)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
@@ -36,9 +37,9 @@ GetOobConfirmationCodeRequest::GetOobConfirmationCodeRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
-    const App& app, const char* api_key, const char* language_code) {
+     ::firebase::App& app, const char* api_key, const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
-      new GetOobConfirmationCodeRequest(api_key));
+      new GetOobConfirmationCodeRequest(app, api_key));
   request->application_data_->requestType = "VERIFY_EMAIL";
   if (language_code != nullptr) {
     request->add_header(kHeaderFirebaseLocale, language_code);
@@ -49,7 +50,7 @@ GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
 
 std::unique_ptr<GetOobConfirmationCodeRequest>
 GetOobConfirmationCodeRequest::CreateSendPasswordResetEmailRequest(
-    const App& app, const char* api_key, const char* email, const char* language_code) {
+     ::firebase::App& app, const char* api_key, const char* email, const char* language_code) {
   auto request = std::unique_ptr<GetOobConfirmationCodeRequest>(  // NOLINT
       new GetOobConfirmationCodeRequest(app, api_key));
   request->application_data_->requestType = "PASSWORD_RESET";

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -23,6 +23,7 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -30,11 +31,11 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(const App& app, const char* api_key,
+  CreateSendEmailVerificationRequest( ::firebase::App& app, const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(const App& app, const char* api_key, const char* email,
+  CreateSendPasswordResetEmailRequest( ::firebase::App& app, const char* api_key, const char* email,
                                       const char* language_code = nullptr);
 
   void SetIdToken(const char* const id_token) {
@@ -47,7 +48,7 @@ class GetOobConfirmationCodeRequest : public AuthRequest {
   }
 
  private:
-  explicit GetOobConfirmationCodeRequest(const App& app, const char* api_key);
+  explicit GetOobConfirmationCodeRequest( ::firebase::App& app, const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -19,11 +19,11 @@
 
 #include <memory>
 
+#include "app/src/include/firebase/app.h"
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -31,11 +31,12 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest( ::firebase::App& app, const char* api_key,
+  CreateSendEmailVerificationRequest(::firebase::App& app, const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest( ::firebase::App& app, const char* api_key, const char* email,
+  CreateSendPasswordResetEmailRequest(::firebase::App& app, const char* api_key,
+                                      const char* email,
                                       const char* language_code = nullptr);
 
   void SetIdToken(const char* const id_token) {
@@ -48,7 +49,8 @@ class GetOobConfirmationCodeRequest : public AuthRequest {
   }
 
  private:
-  explicit GetOobConfirmationCodeRequest( ::firebase::App& app, const char* api_key);
+  explicit GetOobConfirmationCodeRequest(::firebase::App& app,
+                                         const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -31,13 +31,12 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(::firebase::App& app,
-                                     const char* api_key,
+  CreateSendEmailVerificationRequest(::firebase::App& app, const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(::firebase::App& app,
-                                      const char* api_key, const char* email,
+  CreateSendPasswordResetEmailRequest(::firebase::App& app, const char* api_key,
+                                      const char* email,
                                       const char* language_code = nullptr);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -31,12 +31,12 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(const ::firebase::App& app,
+  CreateSendEmailVerificationRequest(::firebase::App& app,
                                      const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(const ::firebase::App& app,
+  CreateSendPasswordResetEmailRequest(::firebase::App& app,
                                       const char* api_key, const char* email,
                                       const char* language_code = nullptr);
 

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -30,11 +30,11 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(const char* api_key,
+  CreateSendEmailVerificationRequest(const App& app, const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(const char* api_key, const char* email,
+  CreateSendPasswordResetEmailRequest(const App& app, const char* api_key, const char* email,
                                       const char* language_code = nullptr);
 
   void SetIdToken(const char* const id_token) {
@@ -47,7 +47,7 @@ class GetOobConfirmationCodeRequest : public AuthRequest {
   }
 
  private:
-  explicit GetOobConfirmationCodeRequest(const char* api_key);
+  explicit GetOobConfirmationCodeRequest(const App& app, const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -31,11 +31,11 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(::firebase::App& app, const char* api_key,
+  CreateSendEmailVerificationRequest(const ::firebase::App& app,const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(::firebase::App& app, const char* api_key,
+  CreateSendPasswordResetEmailRequest(const ::firebase::App& app,const char* api_key,
                                       const char* email,
                                       const char* language_code = nullptr);
 

--- a/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
+++ b/auth/src/desktop/rpcs/get_oob_confirmation_code_request.h
@@ -31,12 +31,13 @@ namespace auth {
 class GetOobConfirmationCodeRequest : public AuthRequest {
  public:
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendEmailVerificationRequest(const ::firebase::App& app,const char* api_key,
+  CreateSendEmailVerificationRequest(const ::firebase::App& app,
+                                     const char* api_key,
                                      const char* language_code = nullptr);
 
   static std::unique_ptr<GetOobConfirmationCodeRequest>
-  CreateSendPasswordResetEmailRequest(const ::firebase::App& app,const char* api_key,
-                                      const char* email,
+  CreateSendPasswordResetEmailRequest(const ::firebase::App& app,
+                                      const char* api_key, const char* email,
                                       const char* language_code = nullptr);
 
   void SetIdToken(const char* const id_token) {

--- a/auth/src/desktop/rpcs/reset_password_request.cc
+++ b/auth/src/desktop/rpcs/reset_password_request.cc
@@ -20,10 +20,10 @@
 namespace firebase {
 namespace auth {
 
-ResetPasswordRequest::ResetPasswordRequest(const char* api_key,
+ResetPasswordRequest::ResetPasswordRequest(const App& app, const char* api_key,
                                            const char* oob_code,
                                            const char* new_password)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/reset_password_request.cc
+++ b/auth/src/desktop/rpcs/reset_password_request.cc
@@ -16,11 +16,12 @@
 
 #include "app/src/assert.h"
 #include "app/src/log.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-ResetPasswordRequest::ResetPasswordRequest(const App& app, const char* api_key,
+ResetPasswordRequest::ResetPasswordRequest( ::firebase::App& app, const char* api_key,
                                            const char* oob_code,
                                            const char* new_password)
     : AuthRequest(app, request_resource_data, true) {

--- a/auth/src/desktop/rpcs/reset_password_request.cc
+++ b/auth/src/desktop/rpcs/reset_password_request.cc
@@ -15,13 +15,14 @@
 #include "auth/src/desktop/rpcs/reset_password_request.h"
 
 #include "app/src/assert.h"
-#include "app/src/log.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/log.h"
 
 namespace firebase {
 namespace auth {
 
-ResetPasswordRequest::ResetPasswordRequest( ::firebase::App& app, const char* api_key,
+ResetPasswordRequest::ResetPasswordRequest(::firebase::App& app,
+                                           const char* api_key,
                                            const char* oob_code,
                                            const char* new_password)
     : AuthRequest(app, request_resource_data, true) {

--- a/auth/src/desktop/rpcs/reset_password_request.cc
+++ b/auth/src/desktop/rpcs/reset_password_request.cc
@@ -23,7 +23,7 @@ namespace auth {
 ResetPasswordRequest::ResetPasswordRequest(const char* api_key,
                                            const char* oob_code,
                                            const char* new_password)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest(::firebase::App& app, const char* api_key,
+  ResetPasswordRequest(const ::firebase::App& app,const char* api_key,
                        const char* oob_code, const char* new_password);
 };
 

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest(const ::firebase::App& app,const char* api_key,
+  ResetPasswordRequest(const ::firebase::App& app, const char* api_key,
                        const char* oob_code, const char* new_password);
 };
 

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -17,18 +17,18 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_RESET_PASSWORD_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_RESET_PASSWORD_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest( ::firebase::App& app, const char* api_key, const char* oob_code,
-                       const char* new_password);
+  ResetPasswordRequest(::firebase::App& app, const char* api_key,
+                       const char* oob_code, const char* new_password);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -26,7 +26,7 @@ namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest(const char* api_key, const char* oob_code,
+  ResetPasswordRequest(const App& app, const char* api_key, const char* oob_code,
                        const char* new_password);
 };
 

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest(const ::firebase::App& app, const char* api_key,
+  ResetPasswordRequest(::firebase::App& app, const char* api_key,
                        const char* oob_code, const char* new_password);
 };
 

--- a/auth/src/desktop/rpcs/reset_password_request.h
+++ b/auth/src/desktop/rpcs/reset_password_request.h
@@ -20,13 +20,14 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class ResetPasswordRequest : public AuthRequest {
  public:
-  ResetPasswordRequest(const App& app, const char* api_key, const char* oob_code,
+  ResetPasswordRequest( ::firebase::App& app, const char* api_key, const char* oob_code,
                        const char* new_password);
 };
 

--- a/auth/src/desktop/rpcs/secure_token_request.cc
+++ b/auth/src/desktop/rpcs/secure_token_request.cc
@@ -20,9 +20,9 @@
 namespace firebase {
 namespace auth {
 
-SecureTokenRequest::SecureTokenRequest(const char* api_key,
+SecureTokenRequest::SecureTokenRequest(const App& app, const char* api_key,
                                        const char* refresh_token)
-    : AuthRequest(request_resource_data, false) {
+    : AuthRequest(app, request_resource_data, false) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] = "https://securetoken.googleapis.com/v1/token?key=";

--- a/auth/src/desktop/rpcs/secure_token_request.cc
+++ b/auth/src/desktop/rpcs/secure_token_request.cc
@@ -16,11 +16,12 @@
 
 #include "app/src/assert.h"
 #include "app/src/log.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-SecureTokenRequest::SecureTokenRequest(const App& app, const char* api_key,
+SecureTokenRequest::SecureTokenRequest( ::firebase::App& app, const char* api_key,
                                        const char* refresh_token)
     : AuthRequest(app, request_resource_data, false) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/secure_token_request.cc
+++ b/auth/src/desktop/rpcs/secure_token_request.cc
@@ -22,7 +22,7 @@ namespace auth {
 
 SecureTokenRequest::SecureTokenRequest(const char* api_key,
                                        const char* refresh_token)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, false) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] = "https://securetoken.googleapis.com/v1/token?key=";

--- a/auth/src/desktop/rpcs/secure_token_request.cc
+++ b/auth/src/desktop/rpcs/secure_token_request.cc
@@ -15,13 +15,14 @@
 #include "auth/src/desktop/rpcs/secure_token_request.h"
 
 #include "app/src/assert.h"
-#include "app/src/log.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/log.h"
 
 namespace firebase {
 namespace auth {
 
-SecureTokenRequest::SecureTokenRequest( ::firebase::App& app, const char* api_key,
+SecureTokenRequest::SecureTokenRequest(::firebase::App& app,
+                                       const char* api_key,
                                        const char* refresh_token)
     : AuthRequest(app, request_resource_data, false) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -17,10 +17,10 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_SECURE_TOKEN_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_SECURE_TOKEN_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -28,7 +28,8 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest( ::firebase::App& app, const char* api_key, const char* refresh_token);
+  SecureTokenRequest(::firebase::App& app, const char* api_key,
+                     const char* refresh_token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -27,7 +27,7 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest(const char* api_key, const char* refresh_token);
+  SecureTokenRequest(const App& app, const char* api_key, const char* refresh_token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -28,7 +28,7 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest(const ::firebase::App& app,const char* api_key,
+  SecureTokenRequest(const ::firebase::App& app, const char* api_key,
                      const char* refresh_token);
 };
 

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -28,7 +28,7 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest(const ::firebase::App& app, const char* api_key,
+  SecureTokenRequest(::firebase::App& app, const char* api_key,
                      const char* refresh_token);
 };
 

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -20,6 +20,7 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
@@ -27,7 +28,7 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest(const App& app, const char* api_key, const char* refresh_token);
+  SecureTokenRequest( ::firebase::App& app, const char* api_key, const char* refresh_token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/secure_token_request.h
+++ b/auth/src/desktop/rpcs/secure_token_request.h
@@ -28,7 +28,7 @@ namespace auth {
 class SecureTokenRequest : public AuthRequest {
  public:
   // Set request by using refresh token.
-  SecureTokenRequest(::firebase::App& app, const char* api_key,
+  SecureTokenRequest(const ::firebase::App& app,const char* api_key,
                      const char* refresh_token);
 };
 

--- a/auth/src/desktop/rpcs/set_account_info_request.cc
+++ b/auth/src/desktop/rpcs/set_account_info_request.cc
@@ -20,7 +20,8 @@
 namespace firebase {
 namespace auth {
 
-SetAccountInfoRequest::SetAccountInfoRequest( ::firebase::App& app, const char* const api_key)
+SetAccountInfoRequest::SetAccountInfoRequest(::firebase::App& app,
+                                             const char* const api_key)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
@@ -37,7 +38,8 @@ SetAccountInfoRequest::SetAccountInfoRequest( ::firebase::App& app, const char* 
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUpdateEmailRequest( ::firebase::App& app, const char* const api_key,
+SetAccountInfoRequest::CreateUpdateEmailRequest(::firebase::App& app,
+                                                const char* const api_key,
                                                 const char* const email) {
   auto request = CreateRequest(app, api_key);
   if (email) {
@@ -51,7 +53,7 @@ SetAccountInfoRequest::CreateUpdateEmailRequest( ::firebase::App& app, const cha
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdatePasswordRequest(
-     ::firebase::App& app, const char* const api_key, const char* const password,
+    ::firebase::App& app, const char* const api_key, const char* const password,
     const char* const language_code) {
   auto request = CreateRequest(app, api_key);
   if (language_code != nullptr) {
@@ -68,7 +70,7 @@ SetAccountInfoRequest::CreateUpdatePasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
-     ::firebase::App& app, const char* const api_key, const char* const email,
+    ::firebase::App& app, const char* const api_key, const char* const email,
     const char* const password) {
   auto request = CreateRequest(app, api_key);
   if (email) {
@@ -87,8 +89,8 @@ SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdateProfileRequest(
-     ::firebase::App& app, const char* const api_key, const char* const set_display_name,
-    const char* const set_photo_url) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const set_display_name, const char* const set_photo_url) {
   auto request = CreateRequest(app, api_key);
 
   // It's fine for either set_photo_url or set_photo_url to be null.
@@ -115,7 +117,8 @@ SetAccountInfoRequest::CreateUpdateProfileRequest(
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUnlinkProviderRequest( ::firebase::App& app, const char* const api_key,
+SetAccountInfoRequest::CreateUnlinkProviderRequest(::firebase::App& app,
+                                                   const char* const api_key,
                                                    const char* const provider) {
   auto request = CreateRequest(app, api_key);
   if (provider) {
@@ -127,7 +130,7 @@ SetAccountInfoRequest::CreateUnlinkProviderRequest( ::firebase::App& app, const 
 }
 
 std::unique_ptr<SetAccountInfoRequest> SetAccountInfoRequest::CreateRequest(
-     ::firebase::App& app, const char* const api_key) {
+    ::firebase::App& app, const char* const api_key) {
   return std::unique_ptr<SetAccountInfoRequest>(
       new SetAccountInfoRequest(app, api_key));  // NOLINT
 }

--- a/auth/src/desktop/rpcs/set_account_info_request.cc
+++ b/auth/src/desktop/rpcs/set_account_info_request.cc
@@ -20,7 +20,7 @@ namespace firebase {
 namespace auth {
 
 SetAccountInfoRequest::SetAccountInfoRequest(const char* const api_key)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_dat, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/set_account_info_request.cc
+++ b/auth/src/desktop/rpcs/set_account_info_request.cc
@@ -15,12 +15,13 @@
 #include "auth/src/desktop/rpcs/set_account_info_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-SetAccountInfoRequest::SetAccountInfoRequest(const App& app, const char* const api_key)
-    : AuthRequest(app, request_resource_dat, true) {
+SetAccountInfoRequest::SetAccountInfoRequest( ::firebase::App& app, const char* const api_key)
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =
@@ -36,7 +37,7 @@ SetAccountInfoRequest::SetAccountInfoRequest(const App& app, const char* const a
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUpdateEmailRequest(const App& app, const char* const api_key,
+SetAccountInfoRequest::CreateUpdateEmailRequest( ::firebase::App& app, const char* const api_key,
                                                 const char* const email) {
   auto request = CreateRequest(app, api_key);
   if (email) {
@@ -50,7 +51,7 @@ SetAccountInfoRequest::CreateUpdateEmailRequest(const App& app, const char* cons
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdatePasswordRequest(
-    const App& app, const char* const api_key, const char* const password,
+     ::firebase::App& app, const char* const api_key, const char* const password,
     const char* const language_code) {
   auto request = CreateRequest(app, api_key);
   if (language_code != nullptr) {
@@ -67,7 +68,7 @@ SetAccountInfoRequest::CreateUpdatePasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
-    const App& app, const char* const api_key, const char* const email,
+     ::firebase::App& app, const char* const api_key, const char* const email,
     const char* const password) {
   auto request = CreateRequest(app, api_key);
   if (email) {
@@ -86,7 +87,7 @@ SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdateProfileRequest(
-    const App& app, const char* const api_key, const char* const set_display_name,
+     ::firebase::App& app, const char* const api_key, const char* const set_display_name,
     const char* const set_photo_url) {
   auto request = CreateRequest(app, api_key);
 
@@ -114,7 +115,7 @@ SetAccountInfoRequest::CreateUpdateProfileRequest(
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUnlinkProviderRequest(const App& app, const char* const api_key,
+SetAccountInfoRequest::CreateUnlinkProviderRequest( ::firebase::App& app, const char* const api_key,
                                                    const char* const provider) {
   auto request = CreateRequest(app, api_key);
   if (provider) {
@@ -126,7 +127,7 @@ SetAccountInfoRequest::CreateUnlinkProviderRequest(const App& app, const char* c
 }
 
 std::unique_ptr<SetAccountInfoRequest> SetAccountInfoRequest::CreateRequest(
-    const App& app, const char* const api_key) {
+     ::firebase::App& app, const char* const api_key) {
   return std::unique_ptr<SetAccountInfoRequest>(
       new SetAccountInfoRequest(app, api_key));  // NOLINT
 }

--- a/auth/src/desktop/rpcs/set_account_info_request.cc
+++ b/auth/src/desktop/rpcs/set_account_info_request.cc
@@ -19,8 +19,8 @@
 namespace firebase {
 namespace auth {
 
-SetAccountInfoRequest::SetAccountInfoRequest(const char* const api_key)
-    : AuthRequest(request_resource_dat, true) {
+SetAccountInfoRequest::SetAccountInfoRequest(const App& app, const char* const api_key)
+    : AuthRequest(app, request_resource_dat, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =
@@ -36,9 +36,9 @@ SetAccountInfoRequest::SetAccountInfoRequest(const char* const api_key)
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUpdateEmailRequest(const char* const api_key,
+SetAccountInfoRequest::CreateUpdateEmailRequest(const App& app, const char* const api_key,
                                                 const char* const email) {
-  auto request = CreateRequest(api_key);
+  auto request = CreateRequest(app, api_key);
   if (email) {
     request->application_data_->email = email;
   } else {
@@ -50,9 +50,9 @@ SetAccountInfoRequest::CreateUpdateEmailRequest(const char* const api_key,
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdatePasswordRequest(
-    const char* const api_key, const char* const password,
+    const App& app, const char* const api_key, const char* const password,
     const char* const language_code) {
-  auto request = CreateRequest(api_key);
+  auto request = CreateRequest(app, api_key);
   if (language_code != nullptr) {
     request->add_header(kHeaderFirebaseLocale, language_code);
   }
@@ -67,9 +67,9 @@ SetAccountInfoRequest::CreateUpdatePasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
-    const char* const api_key, const char* const email,
+    const App& app, const char* const api_key, const char* const email,
     const char* const password) {
-  auto request = CreateRequest(api_key);
+  auto request = CreateRequest(app, api_key);
   if (email) {
     request->application_data_->email = email;
   } else {
@@ -86,9 +86,9 @@ SetAccountInfoRequest::CreateLinkWithEmailAndPasswordRequest(
 
 std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdateProfileRequest(
-    const char* const api_key, const char* const set_display_name,
+    const App& app, const char* const api_key, const char* const set_display_name,
     const char* const set_photo_url) {
-  auto request = CreateRequest(api_key);
+  auto request = CreateRequest(app, api_key);
 
   // It's fine for either set_photo_url or set_photo_url to be null.
   if (set_display_name) {
@@ -114,9 +114,9 @@ SetAccountInfoRequest::CreateUpdateProfileRequest(
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUnlinkProviderRequest(const char* const api_key,
+SetAccountInfoRequest::CreateUnlinkProviderRequest(const App& app, const char* const api_key,
                                                    const char* const provider) {
-  auto request = CreateRequest(api_key);
+  auto request = CreateRequest(app, api_key);
   if (provider) {
     request->application_data_->deleteProvider.push_back(provider);
   }
@@ -126,9 +126,9 @@ SetAccountInfoRequest::CreateUnlinkProviderRequest(const char* const api_key,
 }
 
 std::unique_ptr<SetAccountInfoRequest> SetAccountInfoRequest::CreateRequest(
-    const char* const api_key) {
+    const App& app, const char* const api_key) {
   return std::unique_ptr<SetAccountInfoRequest>(
-      new SetAccountInfoRequest(api_key));  // NOLINT
+      new SetAccountInfoRequest(app, api_key));  // NOLINT
 }
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -31,18 +31,18 @@ namespace auth {
 class SetAccountInfoRequest : public AuthRequest {
  public:
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateEmailRequest(
-      const char* api_key, const char* email);
+      const App& app, const char* api_key, const char* email);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdatePasswordRequest(
-      const char* api_key, const char* password,
-      const char* language_code = nullptr);
+      const App& app, const char* api_key, const char* password,
+      const App& app, const char* language_code = nullptr);
   static std::unique_ptr<SetAccountInfoRequest>
-  CreateLinkWithEmailAndPasswordRequest(const char* api_key, const char* email,
+  CreateLinkWithEmailAndPasswordRequest(const App& app, const char* api_key, const char* email,
                                         const char* password);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateProfileRequest(
-      const char* api_key, const char* set_display_name,
+      const App& app, const char* api_key, const char* set_display_name,
       const char* set_photo_url);
   static std::unique_ptr<SetAccountInfoRequest> CreateUnlinkProviderRequest(
-      const char* api_key, const char* provider);
+      const App& app, const char* api_key, const char* provider);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -54,9 +54,9 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(const char* api_key);
+  explicit SetAccountInfoRequest(const App& app, const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
-      const char* api_key);
+      const App& app, const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -20,10 +20,10 @@
 #include <memory>
 #include <string>
 
+#include "app/src/include/firebase/app.h"
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -32,18 +32,19 @@ namespace auth {
 class SetAccountInfoRequest : public AuthRequest {
  public:
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateEmailRequest(
-       ::firebase::App& app, const char* api_key, const char* email);
+      ::firebase::App& app, const char* api_key, const char* email);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdatePasswordRequest(
-       ::firebase::App& app, const char* api_key, const char* password,
-       const char* language_code = nullptr);
+      ::firebase::App& app, const char* api_key, const char* password,
+      const char* language_code = nullptr);
   static std::unique_ptr<SetAccountInfoRequest>
-  CreateLinkWithEmailAndPasswordRequest( ::firebase::App& app, const char* api_key, const char* email,
+  CreateLinkWithEmailAndPasswordRequest(::firebase::App& app,
+                                        const char* api_key, const char* email,
                                         const char* password);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateProfileRequest(
-       ::firebase::App& app, const char* api_key, const char* set_display_name,
+      ::firebase::App& app, const char* api_key, const char* set_display_name,
       const char* set_photo_url);
   static std::unique_ptr<SetAccountInfoRequest> CreateUnlinkProviderRequest(
-       ::firebase::App& app, const char* api_key, const char* provider);
+      ::firebase::App& app, const char* api_key, const char* provider);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -55,9 +56,9 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest( ::firebase::App& app, const char* api_key);
+  explicit SetAccountInfoRequest(::firebase::App& app, const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
-       ::firebase::App& app, const char* api_key);
+      ::firebase::App& app, const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -56,8 +56,7 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(::firebase::App& app,
-                                 const char* api_key);
+  explicit SetAccountInfoRequest(::firebase::App& app, const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
       ::firebase::App& app, const char* api_key);
 };

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -56,7 +56,7 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(const ::firebase::App& app,
+  explicit SetAccountInfoRequest(::firebase::App& app,
                                  const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
       ::firebase::App& app, const char* api_key);

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -23,6 +23,7 @@
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -31,18 +32,18 @@ namespace auth {
 class SetAccountInfoRequest : public AuthRequest {
  public:
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateEmailRequest(
-      const App& app, const char* api_key, const char* email);
+       ::firebase::App& app, const char* api_key, const char* email);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdatePasswordRequest(
-      const App& app, const char* api_key, const char* password,
-      const App& app, const char* language_code = nullptr);
+       ::firebase::App& app, const char* api_key, const char* password,
+       const char* language_code = nullptr);
   static std::unique_ptr<SetAccountInfoRequest>
-  CreateLinkWithEmailAndPasswordRequest(const App& app, const char* api_key, const char* email,
+  CreateLinkWithEmailAndPasswordRequest( ::firebase::App& app, const char* api_key, const char* email,
                                         const char* password);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdateProfileRequest(
-      const App& app, const char* api_key, const char* set_display_name,
+       ::firebase::App& app, const char* api_key, const char* set_display_name,
       const char* set_photo_url);
   static std::unique_ptr<SetAccountInfoRequest> CreateUnlinkProviderRequest(
-      const App& app, const char* api_key, const char* provider);
+       ::firebase::App& app, const char* api_key, const char* provider);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -54,9 +55,9 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(const App& app, const char* api_key);
+  explicit SetAccountInfoRequest( ::firebase::App& app, const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
-      const App& app, const char* api_key);
+       ::firebase::App& app, const char* api_key);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -56,7 +56,8 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(const ::firebase::App& app,const char* api_key);
+  explicit SetAccountInfoRequest(const ::firebase::App& app,
+                                 const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
       ::firebase::App& app, const char* api_key);
 };

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -56,7 +56,7 @@ class SetAccountInfoRequest : public AuthRequest {
   }
 
  private:
-  explicit SetAccountInfoRequest(::firebase::App& app, const char* api_key);
+  explicit SetAccountInfoRequest(const ::firebase::App& app,const char* api_key);
   static std::unique_ptr<SetAccountInfoRequest> CreateRequest(
       ::firebase::App& app, const char* api_key);
 };

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.cc
@@ -20,14 +20,16 @@
 namespace firebase {
 namespace auth {
 
-SignUpNewUserRequest::SignUpNewUserRequest( ::firebase::App& app, const char* api_key)
+SignUpNewUserRequest::SignUpNewUserRequest(::firebase::App& app,
+                                           const char* api_key)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   application_data_->returnSecureToken = true;
   UpdatePostFields();
 }
 
-SignUpNewUserRequest::SignUpNewUserRequest( ::firebase::App& app, const char* api_key,
+SignUpNewUserRequest::SignUpNewUserRequest(::firebase::App& app,
+                                           const char* api_key,
                                            const char* email,
                                            const char* password,
                                            const char* display_name)

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.cc
@@ -19,18 +19,18 @@
 namespace firebase {
 namespace auth {
 
-SignUpNewUserRequest::SignUpNewUserRequest(const char* api_key)
-    : AuthRequest(request_resource_data, true) {
+SignUpNewUserRequest::SignUpNewUserRequest(const App& app, const char* api_key)
+    : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   application_data_->returnSecureToken = true;
   UpdatePostFields();
 }
 
-SignUpNewUserRequest::SignUpNewUserRequest(const char* api_key,
+SignUpNewUserRequest::SignUpNewUserRequest(const App& app, const char* api_key,
                                            const char* email,
                                            const char* password,
                                            const char* display_name)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   // It's fine for any of the additional parameters to be null, in case it's an
   // anonymous sign up.

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.cc
@@ -15,18 +15,19 @@
 #include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-SignUpNewUserRequest::SignUpNewUserRequest(const App& app, const char* api_key)
+SignUpNewUserRequest::SignUpNewUserRequest( ::firebase::App& app, const char* api_key)
     : AuthRequest(app, request_resource_data, true) {
   SetUrl(api_key);
   application_data_->returnSecureToken = true;
   UpdatePostFields();
 }
 
-SignUpNewUserRequest::SignUpNewUserRequest(const App& app, const char* api_key,
+SignUpNewUserRequest::SignUpNewUserRequest( ::firebase::App& app, const char* api_key,
                                            const char* email,
                                            const char* password,
                                            const char* display_name)

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.cc
@@ -20,7 +20,7 @@ namespace firebase {
 namespace auth {
 
 SignUpNewUserRequest::SignUpNewUserRequest(const char* api_key)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   SetUrl(api_key);
   application_data_->returnSecureToken = true;
   UpdatePostFields();
@@ -30,7 +30,7 @@ SignUpNewUserRequest::SignUpNewUserRequest(const char* api_key,
                                            const char* email,
                                            const char* password,
                                            const char* display_name)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   SetUrl(api_key);
   // It's fine for any of the additional parameters to be null, in case it's an
   // anonymous sign up.

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -30,10 +30,10 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(const char* api_key);
+  explicit SignUpNewUserRequest(const App& app, const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest(const char* api_key, const char* email,
+  SignUpNewUserRequest(const App& app, const char* api_key, const char* email,
                        const char* password, const char* display_name);
 
  private:

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -31,11 +31,11 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(const ::firebase::App& app,
+  explicit SignUpNewUserRequest(::firebase::App& app,
                                 const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest(const ::firebase::App& app, const char* api_key,
+  SignUpNewUserRequest(::firebase::App& app, const char* api_key,
                        const char* email, const char* password,
                        const char* display_name);
 

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -17,9 +17,9 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_NEW_USER_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_NEW_USER_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -31,11 +31,12 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest( ::firebase::App& app, const char* api_key);
+  explicit SignUpNewUserRequest(::firebase::App& app, const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest( ::firebase::App& app, const char* api_key, const char* email,
-                       const char* password, const char* display_name);
+  SignUpNewUserRequest(::firebase::App& app, const char* api_key,
+                       const char* email, const char* password,
+                       const char* display_name);
 
  private:
   void SetUrl(const char* api_key);

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -31,10 +31,10 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(::firebase::App& app, const char* api_key);
+  explicit SignUpNewUserRequest(const ::firebase::App& app,const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest(::firebase::App& app, const char* api_key,
+  SignUpNewUserRequest(const ::firebase::App& app,const char* api_key,
                        const char* email, const char* password,
                        const char* display_name);
 

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -31,8 +31,7 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(::firebase::App& app,
-                                const char* api_key);
+  explicit SignUpNewUserRequest(::firebase::App& app, const char* api_key);
 
   // initializer for sign-in with email and password.
   SignUpNewUserRequest(::firebase::App& app, const char* api_key,

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -19,6 +19,7 @@
 
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -30,10 +31,10 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(const App& app, const char* api_key);
+  explicit SignUpNewUserRequest( ::firebase::App& app, const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest(const App& app, const char* api_key, const char* email,
+  SignUpNewUserRequest( ::firebase::App& app, const char* api_key, const char* email,
                        const char* password, const char* display_name);
 
  private:

--- a/auth/src/desktop/rpcs/sign_up_new_user_request.h
+++ b/auth/src/desktop/rpcs/sign_up_new_user_request.h
@@ -31,10 +31,11 @@ namespace auth {
 class SignUpNewUserRequest : public AuthRequest {
  public:
   // Initializer for anonymous sign-in.
-  explicit SignUpNewUserRequest(const ::firebase::App& app,const char* api_key);
+  explicit SignUpNewUserRequest(const ::firebase::App& app,
+                                const char* api_key);
 
   // initializer for sign-in with email and password.
-  SignUpNewUserRequest(const ::firebase::App& app,const char* api_key,
+  SignUpNewUserRequest(const ::firebase::App& app, const char* api_key,
                        const char* email, const char* password,
                        const char* display_name);
 

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -55,7 +55,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
     const char* const provider_id, const char* const id_token,
     const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+      new VerifyAssertionRequest {app, api_key, provider_id});
 
   if (id_token) {
     request->post_body_ += std::string{"&id_token="} + id_token;
@@ -84,7 +84,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
     const char* const provider_id, const char* const access_token,
     const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+      new VerifyAssertionRequest {app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -107,7 +107,7 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
     const char* const provider_id, const char* const access_token,
     const char* const oauth_secret) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+      new VerifyAssertionRequest {app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -133,7 +133,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const auth_code) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+      new VerifyAssertionRequest {app, api_key, provider_id});
 
   if (auth_code) {
     request->post_body_ += std::string{"&code="} + auth_code;

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -54,8 +54,8 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const id_token,
     const char* nonce) {
-  auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+  auto request = std::unique_ptr<VerifyAssertionRequest>(
+      new VerifyAssertionRequest{app, api_key, provider_id});  // NOLINT
 
   if (id_token) {
     request->post_body_ += std::string{"&id_token="} + id_token;
@@ -83,8 +83,8 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const access_token,
     const char* nonce) {
-  auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+  auto request = std::unique_ptr<VerifyAssertionRequest>(
+      new VerifyAssertionRequest{app, api_key, provider_id});  // NOLINT
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -106,8 +106,8 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const access_token,
     const char* const oauth_secret) {
-  auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+  auto request = std::unique_ptr<VerifyAssertionRequest>(
+      new VerifyAssertionRequest{app, api_key, provider_id});  // NOLINT
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -132,8 +132,8 @@ static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const auth_code) {
-  auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{app, api_key, provider_id});
+  auto request = std::unique_ptr<VerifyAssertionRequest>(
+      new VerifyAssertionRequest{app, api_key, provider_id});  // NOLINT
 
   if (auth_code) {
     request->post_body_ += std::string{"&code="} + auth_code;

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -19,9 +19,9 @@
 namespace firebase {
 namespace auth {
 
-VerifyAssertionRequest::VerifyAssertionRequest(const char* const api_key,
+VerifyAssertionRequest::VerifyAssertionRequest(const App& app, const char* const api_key,
                                                const char* const provider_id)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =
@@ -43,16 +43,16 @@ VerifyAssertionRequest::VerifyAssertionRequest(const char* const api_key,
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const id_token) {
-  return FromIdToken(api_key, provider_id, id_token, /*nonce=*/nullptr);
+  return FromIdToken(app, api_key, provider_id, id_token, /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const id_token, const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (id_token) {
     request->post_body_ += std::string{"&id_token="} + id_token;
@@ -70,17 +70,17 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token) {
-  return FromAccessToken(api_key, provider_id, access_token,
+  return FromAccessToken(app, api_key, provider_id, access_token,
                          /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token, const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -99,10 +99,10 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
 
 std::unique_ptr<VerifyAssertionRequest>
 VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token, const char* const oauth_secret) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -121,13 +121,13 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
 }
 
 static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-    const char* api_key, const char* provider_id, const char* auth_code);
+    const App& app, const char* api_key, const char* provider_id, const char* auth_code);
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
-    const char* const api_key, const char* const provider_id,
+    const App& app, const char* const api_key, const char* const provider_id,
     const char* const auth_code) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest{api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (auth_code) {
     request->post_body_ += std::string{"&code="} + auth_code;

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -20,7 +20,8 @@
 namespace firebase {
 namespace auth {
 
-VerifyAssertionRequest::VerifyAssertionRequest( ::firebase::App& app, const char* const api_key,
+VerifyAssertionRequest::VerifyAssertionRequest(::firebase::App& app,
+                                               const char* const api_key,
                                                const char* const provider_id)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
@@ -44,14 +45,15 @@ VerifyAssertionRequest::VerifyAssertionRequest( ::firebase::App& app, const char
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const id_token) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const id_token) {
   return FromIdToken(app, api_key, provider_id, id_token, /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const id_token, const char* nonce) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const id_token,
+    const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
 
@@ -71,15 +73,16 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const access_token) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const access_token) {
   return FromAccessToken(app, api_key, provider_id, access_token,
                          /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const access_token, const char* nonce) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const access_token,
+    const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
 
@@ -100,8 +103,9 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
 
 std::unique_ptr<VerifyAssertionRequest>
 VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const access_token, const char* const oauth_secret) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const access_token,
+    const char* const oauth_secret) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
 
@@ -122,11 +126,12 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
 }
 
 static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-     ::firebase::App& app, const char* api_key, const char* provider_id, const char* auth_code);
+    ::firebase::App& app, const char* api_key, const char* provider_id,
+    const char* auth_code);
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
-     ::firebase::App& app, const char* const api_key, const char* const provider_id,
-    const char* const auth_code) {
+    ::firebase::App& app, const char* const api_key,
+    const char* const provider_id, const char* const auth_code) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
 

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -21,7 +21,7 @@ namespace auth {
 
 VerifyAssertionRequest::VerifyAssertionRequest(const char* const api_key,
                                                const char* const provider_id)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -55,7 +55,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
     const char* const provider_id, const char* const id_token,
     const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest {app, api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (id_token) {
     request->post_body_ += std::string{"&id_token="} + id_token;
@@ -84,7 +84,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
     const char* const provider_id, const char* const access_token,
     const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest {app, api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -107,7 +107,7 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
     const char* const provider_id, const char* const access_token,
     const char* const oauth_secret) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest {app, api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (access_token) {
     request->post_body_ += std::string{"&access_token="} + access_token;
@@ -133,7 +133,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
     ::firebase::App& app, const char* const api_key,
     const char* const provider_id, const char* const auth_code) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
-      new VerifyAssertionRequest {app, api_key, provider_id});
+      new VerifyAssertionRequest{app, api_key, provider_id});
 
   if (auth_code) {
     request->post_body_ += std::string{"&code="} + auth_code;

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -15,11 +15,12 @@
 #include "auth/src/desktop/rpcs/verify_assertion_request.h"
 
 #include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-VerifyAssertionRequest::VerifyAssertionRequest(const App& app, const char* const api_key,
+VerifyAssertionRequest::VerifyAssertionRequest( ::firebase::App& app, const char* const api_key,
                                                const char* const provider_id)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
@@ -43,13 +44,13 @@ VerifyAssertionRequest::VerifyAssertionRequest(const App& app, const char* const
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const id_token) {
   return FromIdToken(app, api_key, provider_id, id_token, /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const id_token, const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
@@ -70,14 +71,14 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token) {
   return FromAccessToken(app, api_key, provider_id, access_token,
                          /*nonce=*/nullptr);
 }
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token, const char* nonce) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
@@ -99,7 +100,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
 
 std::unique_ptr<VerifyAssertionRequest>
 VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const access_token, const char* const oauth_secret) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});
@@ -121,10 +122,10 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
 }
 
 static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-    const App& app, const char* api_key, const char* provider_id, const char* auth_code);
+     ::firebase::App& app, const char* api_key, const char* provider_id, const char* auth_code);
 
 std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
-    const App& app, const char* const api_key, const char* const provider_id,
+     ::firebase::App& app, const char* const api_key, const char* const provider_id,
     const char* const auth_code) {
   auto request = std::unique_ptr<VerifyAssertionRequest>(  // NOLINT
       new VerifyAssertionRequest{app, api_key, provider_id});

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -60,7 +60,7 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest(const ::firebase::App& app, const char* api_key,
+  VerifyAssertionRequest(::firebase::App& app, const char* api_key,
                          const char* provider_id);
 
   std::string post_body_;

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -60,7 +60,7 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest(const ::firebase::App& app,const char* api_key,
+  VerifyAssertionRequest(const ::firebase::App& app, const char* api_key,
                          const char* provider_id);
 
   std::string post_body_;

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -23,6 +23,7 @@
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -31,20 +32,20 @@ namespace auth {
 class VerifyAssertionRequest : public AuthRequest {
  public:
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-      const App& app, const char* api_key, const char* provider_id, const char* id_token);
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* id_token);
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-      const App& app, const char* api_key, const char* provider_id, const char* id_token,
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* id_token,
       const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-      const App& app, const char* api_key, const char* provider_id, const char* access_token);
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-      const App& app, const char* api_key, const char* provider_id, const char* access_token,
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token,
       const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessTokenAndOAuthSecret(
-      const App& app, const char* api_key, const char* provider_id, const char* access_token,
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token,
       const char* oauth_secret);
   static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-      const App& app, const char* api_key, const char* provider_id, const char* auth_code);
+       ::firebase::App& app, const char* api_key, const char* provider_id, const char* auth_code);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -56,7 +57,7 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest(const App& app, const char* api_key, const char* provider_id);
+  VerifyAssertionRequest( ::firebase::App& app, const char* api_key, const char* provider_id);
 
   std::string post_body_;
 };

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -31,20 +31,20 @@ namespace auth {
 class VerifyAssertionRequest : public AuthRequest {
  public:
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-      const char* api_key, const char* provider_id, const char* id_token);
+      const App& app, const char* api_key, const char* provider_id, const char* id_token);
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-      const char* api_key, const char* provider_id, const char* id_token,
+      const App& app, const char* api_key, const char* provider_id, const char* id_token,
       const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-      const char* api_key, const char* provider_id, const char* access_token);
+      const App& app, const char* api_key, const char* provider_id, const char* access_token);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-      const char* api_key, const char* provider_id, const char* access_token,
+      const App& app, const char* api_key, const char* provider_id, const char* access_token,
       const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessTokenAndOAuthSecret(
-      const char* api_key, const char* provider_id, const char* access_token,
+      const App& app, const char* api_key, const char* provider_id, const char* access_token,
       const char* oauth_secret);
   static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-      const char* api_key, const char* provider_id, const char* auth_code);
+      const App& app, const char* api_key, const char* provider_id, const char* auth_code);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -56,7 +56,7 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest(const char* api_key, const char* provider_id);
+  VerifyAssertionRequest(const App& app, const char* api_key, const char* provider_id);
 
   std::string post_body_;
 };

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -60,7 +60,7 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest(::firebase::App& app, const char* api_key,
+  VerifyAssertionRequest(const ::firebase::App& app,const char* api_key,
                          const char* provider_id);
 
   std::string post_body_;

--- a/auth/src/desktop/rpcs/verify_assertion_request.h
+++ b/auth/src/desktop/rpcs/verify_assertion_request.h
@@ -20,10 +20,10 @@
 #include <memory>
 #include <string>
 
+#include "app/src/include/firebase/app.h"
 #include "app/src/log.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -32,20 +32,23 @@ namespace auth {
 class VerifyAssertionRequest : public AuthRequest {
  public:
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* id_token);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* id_token);
   static std::unique_ptr<VerifyAssertionRequest> FromIdToken(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* id_token,
-      const char* nonce);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* id_token, const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* access_token);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessToken(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token,
-      const char* nonce);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* access_token, const char* nonce);
   static std::unique_ptr<VerifyAssertionRequest> FromAccessTokenAndOAuthSecret(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* access_token,
-      const char* oauth_secret);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* access_token, const char* oauth_secret);
   static std::unique_ptr<VerifyAssertionRequest> FromAuthCode(
-       ::firebase::App& app, const char* api_key, const char* provider_id, const char* auth_code);
+      ::firebase::App& app, const char* api_key, const char* provider_id,
+      const char* auth_code);
 
   void SetIdToken(const char* const id_token) {
     if (id_token) {
@@ -57,7 +60,8 @@ class VerifyAssertionRequest : public AuthRequest {
   }
 
  private:
-  VerifyAssertionRequest( ::firebase::App& app, const char* api_key, const char* provider_id);
+  VerifyAssertionRequest(::firebase::App& app, const char* api_key,
+                         const char* provider_id);
 
   std::string post_body_;
 };

--- a/auth/src/desktop/rpcs/verify_custom_token_request.cc
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.cc
@@ -22,7 +22,7 @@ namespace auth {
 
 VerifyCustomTokenRequest::VerifyCustomTokenRequest(const char* api_key,
                                                    const char* token)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/verify_custom_token_request.cc
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.cc
@@ -15,13 +15,14 @@
 #include "auth/src/desktop/rpcs/verify_custom_token_request.h"
 
 #include "app/src/assert.h"
-#include "app/src/log.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/log.h"
 
 namespace firebase {
 namespace auth {
 
-VerifyCustomTokenRequest::VerifyCustomTokenRequest( ::firebase::App& app, const char* api_key,
+VerifyCustomTokenRequest::VerifyCustomTokenRequest(::firebase::App& app,
+                                                   const char* api_key,
                                                    const char* token)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/verify_custom_token_request.cc
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.cc
@@ -20,9 +20,9 @@
 namespace firebase {
 namespace auth {
 
-VerifyCustomTokenRequest::VerifyCustomTokenRequest(const char* api_key,
+VerifyCustomTokenRequest::VerifyCustomTokenRequest(const App& app, const char* api_key,
                                                    const char* token)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/verify_custom_token_request.cc
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.cc
@@ -16,11 +16,12 @@
 
 #include "app/src/assert.h"
 #include "app/src/log.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-VerifyCustomTokenRequest::VerifyCustomTokenRequest(const App& app, const char* api_key,
+VerifyCustomTokenRequest::VerifyCustomTokenRequest( ::firebase::App& app, const char* api_key,
                                                    const char* token)
     : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest(const ::firebase::App& app,const char* api_key,
+  VerifyCustomTokenRequest(const ::firebase::App& app, const char* api_key,
                            const char* token);
 };
 

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -19,6 +19,7 @@
 
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -26,7 +27,7 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest(const App& app, const char* api_key, const char* token);
+  VerifyCustomTokenRequest( ::firebase::App& app, const char* api_key, const char* token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -26,7 +26,7 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest(const char* api_key, const char* token);
+  VerifyCustomTokenRequest(const App& app, const char* api_key, const char* token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest(const ::firebase::App& app, const char* api_key,
+  VerifyCustomTokenRequest(::firebase::App& app, const char* api_key,
                            const char* token);
 };
 

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest(::firebase::App& app, const char* api_key,
+  VerifyCustomTokenRequest(const ::firebase::App& app,const char* api_key,
                            const char* token);
 };
 

--- a/auth/src/desktop/rpcs/verify_custom_token_request.h
+++ b/auth/src/desktop/rpcs/verify_custom_token_request.h
@@ -17,9 +17,9 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_VERIFY_CUSTOM_TOKEN_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_VERIFY_CUSTOM_TOKEN_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
-#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
 
 namespace firebase {
@@ -27,7 +27,8 @@ namespace auth {
 
 class VerifyCustomTokenRequest : public AuthRequest {
  public:
-  VerifyCustomTokenRequest( ::firebase::App& app, const char* api_key, const char* token);
+  VerifyCustomTokenRequest(::firebase::App& app, const char* api_key,
+                           const char* token);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/verify_password_request.cc
+++ b/auth/src/desktop/rpcs/verify_password_request.cc
@@ -16,11 +16,12 @@
 
 #include "app/src/assert.h"
 #include "app/src/log.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-VerifyPasswordRequest::VerifyPasswordRequest(const App& app, const char* api_key,
+VerifyPasswordRequest::VerifyPasswordRequest( ::firebase::App& app, const char* api_key,
                                              const char* email,
                                              const char* password)
     : AuthRequest(app, request_resource_data, true) {

--- a/auth/src/desktop/rpcs/verify_password_request.cc
+++ b/auth/src/desktop/rpcs/verify_password_request.cc
@@ -20,10 +20,10 @@
 namespace firebase {
 namespace auth {
 
-VerifyPasswordRequest::VerifyPasswordRequest(const char* api_key,
+VerifyPasswordRequest::VerifyPasswordRequest(const App& app, const char* api_key,
                                              const char* email,
                                              const char* password)
-    : AuthRequest(request_resource_data, true) {
+    : AuthRequest(app, request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/verify_password_request.cc
+++ b/auth/src/desktop/rpcs/verify_password_request.cc
@@ -23,7 +23,7 @@ namespace auth {
 VerifyPasswordRequest::VerifyPasswordRequest(const char* api_key,
                                              const char* email,
                                              const char* password)
-    : AuthRequest(request_resource_data) {
+    : AuthRequest(request_resource_data, true) {
   FIREBASE_ASSERT_RETURN_VOID(api_key);
 
   const char api_host[] =

--- a/auth/src/desktop/rpcs/verify_password_request.cc
+++ b/auth/src/desktop/rpcs/verify_password_request.cc
@@ -15,13 +15,14 @@
 #include "auth/src/desktop/rpcs/verify_password_request.h"
 
 #include "app/src/assert.h"
-#include "app/src/log.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/log.h"
 
 namespace firebase {
 namespace auth {
 
-VerifyPasswordRequest::VerifyPasswordRequest( ::firebase::App& app, const char* api_key,
+VerifyPasswordRequest::VerifyPasswordRequest(::firebase::App& app,
+                                             const char* api_key,
                                              const char* email,
                                              const char* password)
     : AuthRequest(app, request_resource_data, true) {

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest(const ::firebase::App& app, const char* api_key,
+  VerifyPasswordRequest(::firebase::App& app, const char* api_key,
                         const char* email, const char* password);
 };
 

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -17,18 +17,18 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_VERIFY_PASSWORD_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_VERIFY_PASSWORD_REQUEST_H_
 
+#include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest( ::firebase::App& app, const char* api_key, const char* email,
-                        const char* password);
+  VerifyPasswordRequest(::firebase::App& app, const char* api_key,
+                        const char* email, const char* password);
 };
 
 }  // namespace auth

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -26,7 +26,7 @@ namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest(const char* api_key, const char* email,
+  VerifyPasswordRequest(const App& app, const char* api_key, const char* email,
                         const char* password);
 };
 

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest(const ::firebase::App& app,const char* api_key,
+  VerifyPasswordRequest(const ::firebase::App& app, const char* api_key,
                         const char* email, const char* password);
 };
 

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -20,13 +20,14 @@
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"
 #include "auth/src/desktop/rpcs/auth_request.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest(const App& app, const char* api_key, const char* email,
+  VerifyPasswordRequest( ::firebase::App& app, const char* api_key, const char* email,
                         const char* password);
 };
 

--- a/auth/src/desktop/rpcs/verify_password_request.h
+++ b/auth/src/desktop/rpcs/verify_password_request.h
@@ -27,7 +27,7 @@ namespace auth {
 
 class VerifyPasswordRequest : public AuthRequest {
  public:
-  VerifyPasswordRequest(::firebase::App& app, const char* api_key,
+  VerifyPasswordRequest(const ::firebase::App& app,const char* api_key,
                         const char* email, const char* password);
 };
 

--- a/auth/src/desktop/sign_in_flow.cc
+++ b/auth/src/desktop/sign_in_flow.cc
@@ -27,7 +27,7 @@ GetAccountInfoResult GetAccountInfo(const GetAccountInfoRequest& request) {
 
 GetAccountInfoResult GetAccountInfo(const AuthData& auth_data,
                                     const std::string& access_token) {
-  const GetAccountInfoRequest request(GetApiKey(auth_data),
+  const GetAccountInfoRequest request(auth_data.app, GetApiKey(auth_data),
                                       access_token.c_str());
   return GetAccountInfo(request);
 }

--- a/auth/src/desktop/sign_in_flow.cc
+++ b/auth/src/desktop/sign_in_flow.cc
@@ -27,7 +27,7 @@ GetAccountInfoResult GetAccountInfo(const GetAccountInfoRequest& request) {
 
 GetAccountInfoResult GetAccountInfo(const AuthData& auth_data,
                                     const std::string& access_token) {
-  const GetAccountInfoRequest request(auth_data.app, GetApiKey(auth_data),
+  const GetAccountInfoRequest request(*auth_data.app, GetApiKey(auth_data),
                                       access_token.c_str());
   return GetAccountInfo(request);
 }

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -133,7 +133,7 @@ GetTokenResult EnsureFreshToken(AuthData* const auth_data,
     return GetTokenResult(old_token.token());
   }
 
-  const SecureTokenRequest request(auth_data->app, GetApiKey(*auth_data),
+  const SecureTokenRequest request(*auth_data->app, GetApiKey(*auth_data),
                                    refresh_token.c_str());
   auto response = GetResponse<SecureTokenResponse>(request);
   if (!response.IsSuccessful()) {
@@ -271,7 +271,7 @@ Future<ResultT> DoLinkWithEmailAndPassword(
 
   typedef SetAccountInfoRequest RequestT;
   auto request = RequestT::CreateLinkWithEmailAndPasswordRequest(
-      *auth_data_->app, GetApiKey(*auth_data), email_credential->GetEmail().c_str(),
+      *auth_data->app, GetApiKey(*auth_data), email_credential->GetEmail().c_str(),
       email_credential->GetPassword().c_str());
 
   return CallAsyncWithFreshToken(auth_data, promise, std::move(request),
@@ -329,7 +329,7 @@ Future<ResultT> DoLinkCredential(Promise<ResultT> promise,
   // apply to PerformSignIn, which is why it's not used here).
   return CallAsyncWithFreshToken(
       auth_data, promise,
-      CreateVerifyAssertionRequest(auth_data->app, *auth_data, raw_credential),
+      CreateVerifyAssertionRequest(*auth_data, raw_credential),
       [](AuthDataHandle<ResultT, VerifyAssertionRequest>* const handle) {
         FIREBASE_ASSERT_RETURN_VOID(handle && handle->request);
 
@@ -802,7 +802,7 @@ Future<void> User::UpdateUserProfile(const UserProfile& profile) {
 
   typedef SetAccountInfoRequest RequestT;
   auto request = RequestT::CreateUpdateProfileRequest(
-      GetApiKey(*auth_data_->app, profile.display_name, profile.photo_url);
+      *auth_data_->app, GetApiKey(*auth_data_), profile.display_name, profile.photo_url);
 
   return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
                                  PerformSetAccountInfoFlow<void>);

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -16,6 +16,7 @@
 
 #include <fstream>
 #include <memory>
+#include <utility>
 
 #include "app/rest/transport_builder.h"
 #include "app/rest/util.h"

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -271,7 +271,8 @@ Future<ResultT> DoLinkWithEmailAndPassword(
 
   typedef SetAccountInfoRequest RequestT;
   auto request = RequestT::CreateLinkWithEmailAndPasswordRequest(
-      *auth_data->app, GetApiKey(*auth_data), email_credential->GetEmail().c_str(),
+      *auth_data->app, GetApiKey(*auth_data),
+      email_credential->GetEmail().c_str(),
       email_credential->GetPassword().c_str());
 
   return CallAsyncWithFreshToken(auth_data, promise, std::move(request),
@@ -727,9 +728,9 @@ Future<void> User::Reload() {
   }
 
   typedef GetAccountInfoRequest RequestT;
-  auto request =
-      std::unique_ptr<RequestT>(new RequestT(*auth_data_->app, GetApiKey(*auth_data_),
-                                             id_token.c_str()));  // NOLINT
+  auto request = std::unique_ptr<RequestT>(
+      new RequestT(*auth_data_->app, GetApiKey(*auth_data_),
+                   id_token.c_str()));  // NOLINT
 
   const auto callback = [](AuthDataHandle<void, RequestT>* const handle) {
     const GetAccountInfoResult account_info = GetAccountInfo(*handle->request);
@@ -765,8 +766,8 @@ Future<void> User::UpdateEmail(const char* const email) {
   }
 
   typedef SetAccountInfoRequest RequestT;
-  auto request =
-      RequestT::CreateUpdateEmailRequest(*auth_data_->app, GetApiKey(*auth_data_), email);
+  auto request = RequestT::CreateUpdateEmailRequest(
+      *auth_data_->app, GetApiKey(*auth_data_), email);
   return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
                                  PerformSetAccountInfoFlow<void>);
 }
@@ -787,8 +788,8 @@ Future<void> User::UpdatePassword(const char* const password) {
   }
 
   typedef SetAccountInfoRequest RequestT;
-  auto request = RequestT::CreateUpdatePasswordRequest(*auth_data_->app, GetApiKey(*auth_data_),
-                                                       password, language_code);
+  auto request = RequestT::CreateUpdatePasswordRequest(
+      *auth_data_->app, GetApiKey(*auth_data_), password, language_code);
 
   return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
                                  PerformSetAccountInfoFlow<void>);
@@ -802,7 +803,8 @@ Future<void> User::UpdateUserProfile(const UserProfile& profile) {
 
   typedef SetAccountInfoRequest RequestT;
   auto request = RequestT::CreateUpdateProfileRequest(
-      *auth_data_->app, GetApiKey(*auth_data_), profile.display_name, profile.photo_url);
+      *auth_data_->app, GetApiKey(*auth_data_), profile.display_name,
+      profile.photo_url);
 
   return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
                                  PerformSetAccountInfoFlow<void>);
@@ -830,8 +832,8 @@ Future<User*> User::Unlink(const char* const provider) {
   }
 
   typedef SetAccountInfoRequest RequestT;
-  auto request =
-      RequestT::CreateUnlinkProviderRequest(*auth_data_->app, GetApiKey(*auth_data_), provider);
+  auto request = RequestT::CreateUnlinkProviderRequest(
+      *auth_data_->app, GetApiKey(*auth_data_), provider);
 
   return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
                                  PerformSetAccountInfoFlow<User*>);

--- a/auth/tests/CMakeLists.txt
+++ b/auth/tests/CMakeLists.txt
@@ -173,6 +173,15 @@ firebase_cpp_cc_test(
 )
 
 firebase_cpp_cc_test(
+  firebase_auth_request_heartbeat_test
+  SOURCES
+    desktop/rpcs/auth_request_heartbeat_test.cc
+  DEPENDS
+    firebase_auth
+    firebase_testing
+)
+
+firebase_cpp_cc_test(
   firebase_auth_create_auth_uri_test
   SOURCES
     desktop/rpcs/create_auth_uri_test.cc

--- a/auth/tests/desktop/auth_desktop_test.cc
+++ b/auth/tests/desktop/auth_desktop_test.cc
@@ -469,6 +469,7 @@ TEST_F(AuthDesktopTest, TestGetAccountInfo) {
   // Call the function and verify results.
   AuthData auth_data;
   AuthImpl auth;
+  auth_data.app = firebase_app_.get();
   auth_data.auth_impl = &auth;
   auth.api_key = "APIKEY";
   const GetAccountInfoResult result =

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -1,0 +1,79 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+
+#include "app/rest/transport_builder.h"
+#include "app/src/app_common.h"
+#include "app/src/heartbeat/date_provider.h"
+#include "app/src/heartbeat/heartbeat_controller_desktop.h"
+#include "app/src/heartbeat/heartbeat_storage_desktop.h"
+#include "app/src/include/firebase/app.h"
+#include "app/tests/include/firebase/app_for_testing.h"
+#include "auth/src/desktop/rpcs/create_auth_uri_request.h"
+#include "auth/src/desktop/rpcs/secure_token_request.h"
+#include "gtest/gtest.h"
+
+namespace firebase {
+namespace auth {
+
+using ::firebase::heartbeat::HeartbeatController;
+using ::firebase::heartbeat::HeartbeatStorageDesktop;
+using ::firebase::heartbeat::LoggedHeartbeats;
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST(CreateAuthUriTest, TestAuthRequestHasHeartbeatPayload) {
+  std::unique_ptr<App> app(testing::CreateApp());
+  ::firebase::heartbeat::DateProviderImpl date_provider;
+  Logger logger(nullptr);
+  HeartbeatStorageDesktop storage(app->name(), logger);
+  HeartbeatController controller(app->name(), logger, date_provider);
+  // For the sake of testing, clear any pre-existing stored heartbeats.
+  LoggedHeartbeats empty_heartbeats_struct;
+  storage.Write(empty_heartbeats_struct);
+  // Then log a single heartbeat for today's date.
+  controller.LogHeartbeat();
+  CreateAuthUriRequest request(*app, "APIKEY", "email");
+
+  // The payload will be encoded and the date will be today's date
+  // But it should at least be non-empty.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST(CreateAuthUriTest, TestSecureTokenRequestDoesNotHaveHeartbeatPayload) {
+  std::unique_ptr<App> app(testing::CreateApp());
+  ::firebase::heartbeat::DateProviderImpl date_provider;
+  Logger logger(nullptr);
+  HeartbeatStorageDesktop storage(app->name(), logger);
+  HeartbeatController controller(app->name(), logger, date_provider);
+  // For the sake of testing, clear any pre-existing stored heartbeats.
+  LoggedHeartbeats empty_heartbeats_struct;
+  storage.Write(empty_heartbeats_struct);
+  // Then log a single heartbeat for today's date.
+  controller.LogHeartbeat();
+  SecureTokenRequest request(*app, "APIKEY", "email");
+
+  // SecureTokenRequest should not have heartbeat payload since it is sent
+  // to a backend that does not support the payload.
+  EXPECT_EQ("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("", request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+}  // namespace auth
+}  // namespace firebase

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -16,8 +16,6 @@
 
 #include "app/rest/transport_builder.h"
 #include "app/src/app_common.h"
-#include "app/src/heartbeat/date_provider.h"
-#include "app/src/heartbeat/heartbeat_controller_desktop.h"
 #include "app/src/heartbeat/heartbeat_storage_desktop.h"
 #include "app/src/include/firebase/app.h"
 #include "app/tests/include/firebase/app_for_testing.h"
@@ -28,22 +26,19 @@
 namespace firebase {
 namespace auth {
 
-using ::firebase::heartbeat::HeartbeatController;
 using ::firebase::heartbeat::HeartbeatStorageDesktop;
 using ::firebase::heartbeat::LoggedHeartbeats;
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST(AuthRequestHeartbeatTest, TestAuthRequestHasHeartbeatPayload) {
   std::unique_ptr<App> app(testing::CreateApp());
-  ::firebase::heartbeat::DateProviderImpl date_provider;
   Logger logger(nullptr);
   HeartbeatStorageDesktop storage(app->name(), logger);
-  HeartbeatController controller(app->name(), logger, date_provider);
   // For the sake of testing, clear any pre-existing stored heartbeats.
   LoggedHeartbeats empty_heartbeats_struct;
   storage.Write(empty_heartbeats_struct);
   // Then log a single heartbeat for today's date.
-  controller.LogHeartbeat();
+  app->LogDesktopHeartbeat();
   CreateAuthUriRequest request(*app, "APIKEY", "email");
 
   // The payload will be encoded and the date will be today's date
@@ -58,15 +53,13 @@ TEST(AuthRequestHeartbeatTest, TestAuthRequestHasHeartbeatPayload) {
 TEST(AuthRequestHeartbeatTest,
      TestSecureTokenRequestDoesNotHaveHeartbeatPayload) {
   std::unique_ptr<App> app(testing::CreateApp());
-  ::firebase::heartbeat::DateProviderImpl date_provider;
   Logger logger(nullptr);
   HeartbeatStorageDesktop storage(app->name(), logger);
-  HeartbeatController controller(app->name(), logger, date_provider);
   // For the sake of testing, clear any pre-existing stored heartbeats.
   LoggedHeartbeats empty_heartbeats_struct;
   storage.Write(empty_heartbeats_struct);
   // Then log a single heartbeat for today's date.
-  controller.LogHeartbeat();
+  app->LogDesktopHeartbeat();
   SecureTokenRequest request(*app, "APIKEY", "email");
 
   // SecureTokenRequest should not have heartbeat payload since it is sent

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -33,7 +33,7 @@ using ::firebase::heartbeat::HeartbeatStorageDesktop;
 using ::firebase::heartbeat::LoggedHeartbeats;
 
 #if FIREBASE_PLATFORM_DESKTOP
-TEST(CreateAuthUriTest, TestAuthRequestHasHeartbeatPayload) {
+TEST(AuthRequestHeartbeatTest, TestAuthRequestHasHeartbeatPayload) {
   std::unique_ptr<App> app(testing::CreateApp());
   ::firebase::heartbeat::DateProviderImpl date_provider;
   Logger logger(nullptr);
@@ -55,7 +55,8 @@ TEST(CreateAuthUriTest, TestAuthRequestHasHeartbeatPayload) {
 #endif  // FIREBASE_PLATFORM_DESKTOP
 
 #if FIREBASE_PLATFORM_DESKTOP
-TEST(CreateAuthUriTest, TestSecureTokenRequestDoesNotHaveHeartbeatPayload) {
+TEST(AuthRequestHeartbeatTest,
+     TestSecureTokenRequestDoesNotHaveHeartbeatPayload) {
   std::unique_ptr<App> app(testing::CreateApp());
   ::firebase::heartbeat::DateProviderImpl date_provider;
   Logger logger(nullptr);

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -20,7 +20,16 @@
 #include "app/src/include/firebase/app.h"
 #include "app/tests/include/firebase/app_for_testing.h"
 #include "auth/src/desktop/rpcs/create_auth_uri_request.h"
+#include "auth/src/desktop/rpcs/delete_account_request.h"
+#include "auth/src/desktop/rpcs/get_account_info_request.h"
+#include "auth/src/desktop/rpcs/get_oob_confirmation_code_request.h"
+#include "auth/src/desktop/rpcs/reset_password_request.h"
 #include "auth/src/desktop/rpcs/secure_token_request.h"
+#include "auth/src/desktop/rpcs/set_account_info_request.h"
+#include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
+#include "auth/src/desktop/rpcs/verify_assertion_request.h"
+#include "auth/src/desktop/rpcs/verify_custom_token_request.h"
+#include "auth/src/desktop/rpcs/verify_password_request.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -29,20 +38,29 @@ namespace auth {
 using ::firebase::heartbeat::HeartbeatStorageDesktop;
 using ::firebase::heartbeat::LoggedHeartbeats;
 
-#if FIREBASE_PLATFORM_DESKTOP
-TEST(AuthRequestHeartbeatTest, TestAuthRequestHasHeartbeatPayload) {
-  std::unique_ptr<App> app(testing::CreateApp());
-  Logger logger(nullptr);
-  HeartbeatStorageDesktop storage(app->name(), logger);
-  // For the sake of testing, clear any pre-existing stored heartbeats.
-  LoggedHeartbeats empty_heartbeats_struct;
-  storage.Write(empty_heartbeats_struct);
-  // Then log a single heartbeat for today's date.
-  app->LogDesktopHeartbeat();
-  CreateAuthUriRequest request(*app, "APIKEY", "email");
+class AuthRequestHeartbeatTest : public ::testing::Test {
+ public:
+  AuthRequestHeartbeatTest() : app_(testing::CreateApp()) {}
 
-  // The payload will be encoded and the date will be today's date
-  // But it should at least be non-empty.
+ protected:
+  std::unique_ptr<App> app_;
+
+  void SetUp() override {
+    Logger logger(nullptr);
+    HeartbeatStorageDesktop storage(app_->name(), logger);
+    // For the sake of testing, clear any pre-existing stored heartbeats.
+    LoggedHeartbeats empty_heartbeats_struct;
+    storage.Write(empty_heartbeats_struct);
+  }
+};
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestCreateAuthUriRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  CreateAuthUriRequest request(*app_, "APIKEY", "email");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
   EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
   EXPECT_EQ("com.google.firebase.testing",
             request.options().header[app_common::kXFirebaseGmpIdHeader]);
@@ -50,22 +68,224 @@ TEST(AuthRequestHeartbeatTest, TestAuthRequestHasHeartbeatPayload) {
 #endif  // FIREBASE_PLATFORM_DESKTOP
 
 #if FIREBASE_PLATFORM_DESKTOP
-TEST(AuthRequestHeartbeatTest,
-     TestSecureTokenRequestDoesNotHaveHeartbeatPayload) {
-  std::unique_ptr<App> app(testing::CreateApp());
-  Logger logger(nullptr);
-  HeartbeatStorageDesktop storage(app->name(), logger);
-  // For the sake of testing, clear any pre-existing stored heartbeats.
-  LoggedHeartbeats empty_heartbeats_struct;
-  storage.Write(empty_heartbeats_struct);
-  // Then log a single heartbeat for today's date.
-  app->LogDesktopHeartbeat();
-  SecureTokenRequest request(*app, "APIKEY", "email");
+TEST_F(AuthRequestHeartbeatTest, TestDeleteAccountRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  DeleteAccountRequest request(*app_, "APIKEY");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestGetAccountInfoRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  GetAccountInfoRequest request(*app_, "APIKEY");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestOobSendEmailRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request =
+      GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
+          *app_, "APIKEY");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestOobSendPasswordResetRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request =
+      GetOobConfirmationCodeRequest::CreateSendPasswordResetEmailRequest(
+          *app_, "APIKEY", "email");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestResetPasswordRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  ResetPasswordRequest request(*app_, "APIKEY", "oob", "password");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSecureTokenRequestDoesNotHaveHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  SecureTokenRequest request(*app_, "APIKEY", "email");
 
   // SecureTokenRequest should not have heartbeat payload since it is sent
   // to a backend that does not support the payload.
   EXPECT_EQ("", request.options().header[app_common::kApiClientHeader]);
   EXPECT_EQ("", request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdatePasswordRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = SetAccountInfoRequest::CreateUpdatePasswordRequest(
+      *app_, "APIKEY", "fakepassword");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateEmailRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request =
+      SetAccountInfoRequest::CreateUpdateEmailRequest(*app_, "APIKEY", "email");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateProfileRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = SetAccountInfoRequest::CreateUpdateProfileRequest(
+      *app_, "APIKEY", "New Name", "new_url");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSetInfoUnlinkProviderRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = SetAccountInfoRequest::CreateUnlinkProviderRequest(
+      *app_, "APIKEY", "provider");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestSignUpNewUserRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  SignUpNewUserRequest request(*app_, "APIKEY");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest,
+       TestVerifyAssertionFromIdTokenRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = VerifyAssertionRequest::FromIdToken(*app_, "APIKEY",
+                                                     "provider", "id_token");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest,
+       TestVerifyAssertionFromAccessTokenRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = VerifyAssertionRequest::FromAccessToken(
+      *app_, "APIKEY", "provider", "access_token");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest,
+       TestVerifyAssertionFromAccessTokenAndOauthRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  auto request = VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
+      *app_, "APIKEY", "provider", "access_token", "oauth_secret");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request->options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request->options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestVerifyCustomTokenRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  VerifyCustomTokenRequest request(*app_, "APIKEY", "email");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
+}
+#endif  // FIREBASE_PLATFORM_DESKTOP
+
+#if FIREBASE_PLATFORM_DESKTOP
+TEST_F(AuthRequestHeartbeatTest, TestVerifyPasswordRequestHasHeartbeat) {
+  // Log a single heartbeat for today's date.
+  app_->LogDesktopHeartbeat();
+  VerifyPasswordRequest request(*app_, "APIKEY", "abc@email", "pwd");
+
+  // The request headers should include both hearbeat payload and GMP App ID.
+  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
+  EXPECT_EQ("com.google.firebase.testing",
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
 }
 #endif  // FIREBASE_PLATFORM_DESKTOP
 

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -50,6 +50,7 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
       request.options().post_fields);
 }
 
+#if FIREBASE_PLATFORM_DESKTOP
 TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
   std::unique_ptr<App> app(testing::CreateApp());
   ::firebase::heartbeat::DateProviderImpl date_provider;
@@ -69,6 +70,7 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
   EXPECT_EQ("com.google.firebase.testing",
             request.options().header[app_common::kXFirebaseGmpIdHeader]);
 }
+#endif  // FIREBASE_PLATFORM_DESKTOP
 
 // Test CreateAuthUriResponse
 TEST(CreateAuthUriTest, TestCreateAuthUriResponse) {

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -40,7 +40,7 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
       "}\n",
       request.options().post_fields);
   EXPECT_EQ("ACTUAL_PAYLOAD",
-      request.options().header[app_common::kApiClientHeader]);
+            request.options().header[app_common::kApiClientHeader]);
 }
 
 TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
@@ -58,7 +58,7 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
       "}\n",
       request.options().post_fields);
   EXPECT_EQ("ACTUAL_PAYLOAD",
-      request.options().header[app_common::kApiClientHeader]);
+            request.options().header[app_common::kApiClientHeader]);
 }
 
 // Test CreateAuthUriResponse

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Test CreateAuthUriRequest
 TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  CreateAuthUriRequest request("APIKEY", "email");
+  CreateAuthUriRequest request(*app, "APIKEY", "email");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "createAuthUri?key=APIKEY",

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -67,7 +67,7 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
   // But it should at least be non-empty.
   EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
   EXPECT_EQ("com.google.firebase.testing",
-        request.options().header[app_common::kXFirebaseGmpIdHeader]);
+            request.options().header[app_common::kXFirebaseGmpIdHeader]);
 }
 
 // Test CreateAuthUriResponse

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -39,6 +39,26 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
       "  continueUri: \"http://localhost\"\n"
       "}\n",
       request.options().post_fields);
+  EXPECT_EQ("ACTUAL_PAYLOAD",
+      request.options().header[app_common::kApiClientHeader]);
+}
+
+TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
+  std::unique_ptr<App> app(testing::CreateApp());
+  // Clear heartbeat storage, then call auth getter to log a heartbeat
+  CreateAuthUriRequest request(*app, "APIKEY", "email");
+  EXPECT_EQ(
+      "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
+      "createAuthUri?key=APIKEY",
+      request.options().url);
+  EXPECT_EQ(
+      "{\n"
+      "  identifier: \"email\",\n"
+      "  continueUri: \"http://localhost\"\n"
+      "}\n",
+      request.options().post_fields);
+  EXPECT_EQ("ACTUAL_PAYLOAD",
+      request.options().header[app_common::kApiClientHeader]);
 }
 
 // Test CreateAuthUriResponse

--- a/auth/tests/desktop/rpcs/create_auth_uri_test.cc
+++ b/auth/tests/desktop/rpcs/create_auth_uri_test.cc
@@ -16,9 +16,6 @@
 
 #include "app/rest/transport_builder.h"
 #include "app/src/app_common.h"
-#include "app/src/heartbeat/date_provider.h"
-#include "app/src/heartbeat/heartbeat_controller_desktop.h"
-#include "app/src/heartbeat/heartbeat_storage_desktop.h"
 #include "app/src/include/firebase/app.h"
 #include "app/tests/include/firebase/app_for_testing.h"
 #include "auth/src/desktop/rpcs/create_auth_uri_request.h"
@@ -28,11 +25,6 @@
 
 namespace firebase {
 namespace auth {
-
-using ::firebase::heartbeat::HeartbeatController;
-using ::firebase::heartbeat::HeartbeatStorageDesktop;
-using ::firebase::heartbeat::LoggedHeartbeats;
-using ::testing::Return;
 
 // Test CreateAuthUriRequest
 TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
@@ -49,28 +41,6 @@ TEST(CreateAuthUriTest, TestCreateAuthUriRequest) {
       "}\n",
       request.options().post_fields);
 }
-
-#if FIREBASE_PLATFORM_DESKTOP
-TEST(CreateAuthUriTest, TestCreateAuthUriRequestWithHeartbeatPayload) {
-  std::unique_ptr<App> app(testing::CreateApp());
-  ::firebase::heartbeat::DateProviderImpl date_provider;
-  Logger logger(nullptr);
-  HeartbeatStorageDesktop storage(app->name(), logger);
-  HeartbeatController controller(app->name(), logger, date_provider);
-  // For the sake of testing, clear any pre-existing stored heartbeats.
-  LoggedHeartbeats empty_heartbeats_struct;
-  storage.Write(empty_heartbeats_struct);
-  // Then log a single heartbeat for today's date.
-  controller.LogHeartbeat();
-  CreateAuthUriRequest request(*app, "APIKEY", "email");
-
-  // The payload will be encoded and the date will be today's date
-  // But it should at least be non-empty.
-  EXPECT_NE("", request.options().header[app_common::kApiClientHeader]);
-  EXPECT_EQ("com.google.firebase.testing",
-            request.options().header[app_common::kXFirebaseGmpIdHeader]);
-}
-#endif  // FIREBASE_PLATFORM_DESKTOP
 
 // Test CreateAuthUriResponse
 TEST(CreateAuthUriTest, TestCreateAuthUriResponse) {

--- a/auth/tests/desktop/rpcs/delete_account_test.cc
+++ b/auth/tests/desktop/rpcs/delete_account_test.cc
@@ -29,7 +29,7 @@ namespace auth {
 // Test DeleteAccountRequest
 TEST(DeleteAccountTest, TestDeleteAccountRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  DeleteAccountRequest request("APIKEY");
+  DeleteAccountRequest request(*app, "APIKEY");
   request.SetIdToken("token");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"

--- a/auth/tests/desktop/rpcs/get_account_info_test.cc
+++ b/auth/tests/desktop/rpcs/get_account_info_test.cc
@@ -29,7 +29,7 @@ namespace auth {
 // Test GetAccountInfoRequest
 TEST(GetAccountInfoTest, TestGetAccountInfoRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  GetAccountInfoRequest request("APIKEY", "token");
+  GetAccountInfoRequest request(*app, "APIKEY", "token");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "getAccountInfo?key=APIKEY",

--- a/auth/tests/desktop/rpcs/get_oob_confirmation_code_test.cc
+++ b/auth/tests/desktop/rpcs/get_oob_confirmation_code_test.cc
@@ -32,7 +32,7 @@ typedef GetOobConfirmationCodeResponse ResponseT;
 // Test SetVerifyEmailRequest
 TEST(GetOobConfirmationCodeTest, SendVerifyEmailRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateSendEmailVerificationRequest("APIKEY");
+  auto request = RequestT::CreateSendEmailVerificationRequest(*app, "APIKEY");
   request->SetIdToken("token");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
@@ -49,7 +49,7 @@ TEST(GetOobConfirmationCodeTest, SendVerifyEmailRequest) {
 TEST(GetOobConfirmationCodeTest, SendPasswordResetEmailRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      RequestT::CreateSendPasswordResetEmailRequest("APIKEY", "email");
+      RequestT::CreateSendPasswordResetEmailRequest(*app, "APIKEY", "email");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "getOobConfirmationCode?key=APIKEY",

--- a/auth/tests/desktop/rpcs/reset_password_test.cc
+++ b/auth/tests/desktop/rpcs/reset_password_test.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Test ResetPasswordRequest
 TEST(ResetPasswordTest, TestResetPasswordRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  ResetPasswordRequest request("APIKEY", "oob", "password");
+  ResetPasswordRequest request(*app, "APIKEY", "oob", "password");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "resetPassword?key=APIKEY",

--- a/auth/tests/desktop/rpcs/secure_token_test.cc
+++ b/auth/tests/desktop/rpcs/secure_token_test.cc
@@ -29,7 +29,7 @@ namespace auth {
 // Test SignUpNewUserRequest using refresh token
 TEST(SecureTokenTest, TestSetRefreshRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  SecureTokenRequest request("APIKEY", "token123");
+  SecureTokenRequest request(*app, "APIKEY", "token123");
   EXPECT_EQ("https://securetoken.googleapis.com/v1/token?key=APIKEY",
             request.options().url);
   EXPECT_EQ(

--- a/auth/tests/desktop/rpcs/set_account_info_test.cc
+++ b/auth/tests/desktop/rpcs/set_account_info_test.cc
@@ -31,7 +31,7 @@ typedef SetAccountInfoResponse ResponseT;
 // Test SetAccountInfoRequest
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateEmail) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateUpdateEmailRequest("APIKEY", "fakeemail");
+  auto request = RequestT::CreateUpdateEmailRequest(*app, "APIKEY", "fakeemail");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -50,7 +50,7 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateEmail) {
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdatePassword) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      RequestT::CreateUpdatePasswordRequest("APIKEY", "fakepassword");
+      RequestT::CreateUpdatePasswordRequest(*app, "APIKEY", "fakepassword");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -69,7 +69,7 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdatePassword) {
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_Full) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      RequestT::CreateUpdateProfileRequest("APIKEY", "New Name", "new_url");
+      RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "New Name", "new_url");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -89,7 +89,7 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_Full) {
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_Partial) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      RequestT::CreateUpdateProfileRequest("APIKEY", nullptr, "new_url");
+      RequestT::CreateUpdateProfileRequest(*app, "APIKEY", nullptr, "new_url");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -107,7 +107,7 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_Partial) {
 
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_DeleteFields) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateUpdateProfileRequest("APIKEY", "", "");
+  auto request = RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "", "");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -129,7 +129,7 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_DeleteFields) {
 TEST(SetAccountInfoTest,
      TestSetAccountInfoRequest_UpdateProfile_DeleteAndUpdate) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateUpdateProfileRequest("APIKEY", "", "new_url");
+  auto request = RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "", "new_url");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -151,7 +151,7 @@ TEST(SetAccountInfoTest,
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_Unlink) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      RequestT::CreateUnlinkProviderRequest("APIKEY", "fakeprovider");
+      RequestT::CreateUnlinkProviderRequest(*app, "APIKEY", "fakeprovider");
   request->SetIdToken("token");
 
   EXPECT_EQ(

--- a/auth/tests/desktop/rpcs/set_account_info_test.cc
+++ b/auth/tests/desktop/rpcs/set_account_info_test.cc
@@ -31,7 +31,8 @@ typedef SetAccountInfoResponse ResponseT;
 // Test SetAccountInfoRequest
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateEmail) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateUpdateEmailRequest(*app, "APIKEY", "fakeemail");
+  auto request =
+      RequestT::CreateUpdateEmailRequest(*app, "APIKEY", "fakeemail");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -68,8 +69,8 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdatePassword) {
 
 TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_Full) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request =
-      RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "New Name", "new_url");
+  auto request = RequestT::CreateUpdateProfileRequest(*app, "APIKEY",
+                                                      "New Name", "new_url");
   request->SetIdToken("token");
 
   EXPECT_EQ(
@@ -129,7 +130,8 @@ TEST(SetAccountInfoTest, TestSetAccountInfoRequest_UpdateProfile_DeleteFields) {
 TEST(SetAccountInfoTest,
      TestSetAccountInfoRequest_UpdateProfile_DeleteAndUpdate) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "", "new_url");
+  auto request =
+      RequestT::CreateUpdateProfileRequest(*app, "APIKEY", "", "new_url");
   request->SetIdToken("token");
 
   EXPECT_EQ(

--- a/auth/tests/desktop/rpcs/sign_up_new_user_test.cc
+++ b/auth/tests/desktop/rpcs/sign_up_new_user_test.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Test SignUpNewUserRequest for making anonymous signin
 TEST(SignUpNewUserTest, TestAnonymousSignInRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  SignUpNewUserRequest request("APIKEY");
+  SignUpNewUserRequest request(*app, "APIKEY");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "signupNewUser?key=APIKEY",
@@ -43,7 +43,7 @@ TEST(SignUpNewUserTest, TestAnonymousSignInRequest) {
 // Test SignUpNewUserRequest for using password signin
 TEST(SignUpNewUserTest, TestEmailPasswordSignInRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  SignUpNewUserRequest request("APIKEY", "e@mail", "pwd", "rabbit");
+  SignUpNewUserRequest request(*app, "APIKEY", "e@mail", "pwd", "rabbit");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "signupNewUser?key=APIKEY",

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -15,11 +15,12 @@
 #include "app/rest/transport_builder.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_response.h"
+#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-bool GetNewUserLocalIdAndIdToken(const App& app, const char* const api_key,
+bool GetNewUserLocalIdAndIdToken( ::firebase::App& app, const char* const api_key,
                                  std::string* local_id, std::string* id_token) {
   SignUpNewUserRequest request(app, api_key);
   SignUpNewUserResponse response;
@@ -35,7 +36,7 @@ bool GetNewUserLocalIdAndIdToken(const App& app, const char* const api_key,
   return true;
 }
 
-bool GetNewUserLocalIdAndRefreshToken(const App& app, const char* const api_key,
+bool GetNewUserLocalIdAndRefreshToken( ::firebase::App& app, const char* const api_key,
                                       std::string* local_id,
                                       std::string* refresh_token) {
   SignUpNewUserRequest request(app, api_key);
@@ -52,7 +53,7 @@ bool GetNewUserLocalIdAndRefreshToken(const App& app, const char* const api_key,
   return true;
 }
 
-std::string SignUpNewUserAndGetIdToken(const App& app, const char* const api_key,
+std::string SignUpNewUserAndGetIdToken( ::firebase::App& app, const char* const api_key,
                                        const char* const email) {
   SignUpNewUserRequest request(app, api_key, email, "fake_password", "");
   SignUpNewUserResponse response;

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -17,6 +17,8 @@
 #include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_response.h"
 
+#include "firebase/auth/tests/desktop/rpcs/test_util.h"
+
 namespace firebase {
 namespace auth {
 

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -19,9 +19,9 @@
 namespace firebase {
 namespace auth {
 
-bool GetNewUserLocalIdAndIdToken(const char* const api_key,
+bool GetNewUserLocalIdAndIdToken(const App& app, const char* const api_key,
                                  std::string* local_id, std::string* id_token) {
-  SignUpNewUserRequest request(api_key);
+  SignUpNewUserRequest request(app, api_key);
   SignUpNewUserResponse response;
 
   firebase::rest::CreateTransport()->Perform(request, &response);
@@ -35,10 +35,10 @@ bool GetNewUserLocalIdAndIdToken(const char* const api_key,
   return true;
 }
 
-bool GetNewUserLocalIdAndRefreshToken(const char* const api_key,
+bool GetNewUserLocalIdAndRefreshToken(const App& app, const char* const api_key,
                                       std::string* local_id,
                                       std::string* refresh_token) {
-  SignUpNewUserRequest request(api_key);
+  SignUpNewUserRequest request(app, api_key);
   SignUpNewUserResponse response;
 
   firebase::rest::CreateTransport()->Perform(request, &response);
@@ -52,9 +52,9 @@ bool GetNewUserLocalIdAndRefreshToken(const char* const api_key,
   return true;
 }
 
-std::string SignUpNewUserAndGetIdToken(const char* const api_key,
+std::string SignUpNewUserAndGetIdToken(const App& app, const char* const api_key,
                                        const char* const email) {
-  SignUpNewUserRequest request(api_key, email, "fake_password", "");
+  SignUpNewUserRequest request(app, api_key, email, "fake_password", "");
   SignUpNewUserResponse response;
 
   firebase::rest::CreateTransport()->Perform(request, &response);

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -13,14 +13,15 @@
 // limitations under the License.
 
 #include "app/rest/transport_builder.h"
+#include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_response.h"
-#include "app/src/include/firebase/app.h"
 
 namespace firebase {
 namespace auth {
 
-bool GetNewUserLocalIdAndIdToken( ::firebase::App& app, const char* const api_key,
+bool GetNewUserLocalIdAndIdToken(::firebase::App& app,
+                                 const char* const api_key,
                                  std::string* local_id, std::string* id_token) {
   SignUpNewUserRequest request(app, api_key);
   SignUpNewUserResponse response;
@@ -36,7 +37,8 @@ bool GetNewUserLocalIdAndIdToken( ::firebase::App& app, const char* const api_ke
   return true;
 }
 
-bool GetNewUserLocalIdAndRefreshToken( ::firebase::App& app, const char* const api_key,
+bool GetNewUserLocalIdAndRefreshToken(::firebase::App& app,
+                                      const char* const api_key,
                                       std::string* local_id,
                                       std::string* refresh_token) {
   SignUpNewUserRequest request(app, api_key);
@@ -53,7 +55,8 @@ bool GetNewUserLocalIdAndRefreshToken( ::firebase::App& app, const char* const a
   return true;
 }
 
-std::string SignUpNewUserAndGetIdToken( ::firebase::App& app, const char* const api_key,
+std::string SignUpNewUserAndGetIdToken(::firebase::App& app,
+                                       const char* const api_key,
                                        const char* const email) {
   SignUpNewUserRequest request(app, api_key, email, "fake_password", "");
   SignUpNewUserResponse response;

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "firebase/auth/tests/desktop/rpcs/test_util.h"
+#include "auth/tests/desktop/rpcs/test_util.h"
 
 #include "app/rest/transport_builder.h"
 #include "app/src/include/firebase/app.h"

--- a/auth/tests/desktop/rpcs/test_util.cc
+++ b/auth/tests/desktop/rpcs/test_util.cc
@@ -12,12 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "firebase/auth/tests/desktop/rpcs/test_util.h"
+
 #include "app/rest/transport_builder.h"
 #include "app/src/include/firebase/app.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_request.h"
 #include "auth/src/desktop/rpcs/sign_up_new_user_response.h"
-
-#include "firebase/auth/tests/desktop/rpcs/test_util.h"
 
 namespace firebase {
 namespace auth {

--- a/auth/tests/desktop/rpcs/verify_assertion_test.cc
+++ b/auth/tests/desktop/rpcs/verify_assertion_test.cc
@@ -38,13 +38,13 @@ namespace auth {
 TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromIdToken) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request =
-      VerifyAssertionRequest::FromIdToken("APIKEY", "provider", "id_token");
+      VerifyAssertionRequest::FromIdToken(*app, "APIKEY", "provider", "id_token");
   CheckUrl(*request);
 }
 
 TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromAccessToken) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = VerifyAssertionRequest::FromAccessToken("APIKEY", "provider",
+  auto request = VerifyAssertionRequest::FromAccessToken(*app, "APIKEY", "provider",
                                                          "access_token");
   CheckUrl(*request);
 }
@@ -52,7 +52,7 @@ TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromAccessToken) {
 TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromAccessTokenAndSecret) {
   std::unique_ptr<App> app(testing::CreateApp());
   auto request = VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
-      "APIKEY", "provider", "access_token", "oauth_secret");
+      *app, "APIKEY", "provider", "access_token", "oauth_secret");
   CheckUrl(*request);
 }
 

--- a/auth/tests/desktop/rpcs/verify_assertion_test.cc
+++ b/auth/tests/desktop/rpcs/verify_assertion_test.cc
@@ -37,15 +37,15 @@ namespace auth {
 // Test VerifyAssertionRequest
 TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromIdToken) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request =
-      VerifyAssertionRequest::FromIdToken(*app, "APIKEY", "provider", "id_token");
+  auto request = VerifyAssertionRequest::FromIdToken(*app, "APIKEY", "provider",
+                                                     "id_token");
   CheckUrl(*request);
 }
 
 TEST(VerifyAssertionTest, TestVerifyAssertionRequest_FromAccessToken) {
   std::unique_ptr<App> app(testing::CreateApp());
-  auto request = VerifyAssertionRequest::FromAccessToken(*app, "APIKEY", "provider",
-                                                         "access_token");
+  auto request = VerifyAssertionRequest::FromAccessToken(
+      *app, "APIKEY", "provider", "access_token");
   CheckUrl(*request);
 }
 

--- a/auth/tests/desktop/rpcs/verify_custom_token_test.cc
+++ b/auth/tests/desktop/rpcs/verify_custom_token_test.cc
@@ -29,7 +29,7 @@ namespace auth {
 // Test VerifyCustomTokenRequest
 TEST(VerifyCustomTokenTest, TestVerifyCustomTokenRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  VerifyCustomTokenRequest request("APIKEY", "token123");
+  VerifyCustomTokenRequest request(*app, "APIKEY", "token123");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "verifyCustomToken?key=APIKEY",

--- a/auth/tests/desktop/rpcs/verify_password_test.cc
+++ b/auth/tests/desktop/rpcs/verify_password_test.cc
@@ -28,7 +28,7 @@ namespace auth {
 // Test VerifyPasswordRequest
 TEST(VerifyPasswordTest, TestVerifyPasswordRequest) {
   std::unique_ptr<App> app(testing::CreateApp());
-  VerifyPasswordRequest request("APIKEY", "abc@email", "pwd");
+  VerifyPasswordRequest request(*app, "APIKEY", "abc@email", "pwd");
   EXPECT_EQ(
       "https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
       "verifyPassword?key=APIKEY",


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update AuthRequest constructor to take an App& and a bool of whether or not to add heartbeat payload
For all AuthRequest subclasses except for SecureTokenRequest, this bool is true
If a non-empty heartbeat payload is fetched, it is added to the request headers

Most of the files in this change are plumbing to pass App& into the various constructors of subclasses of AuthRequest
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Existing unit and integration tests verify that no code is broken.
I will manually run integration tests to verify that the generated header is correctly processed by backends.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
