### PR TITLE
Disable vcpkg and remove homebrew update

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -110,18 +110,6 @@ jobs:
             rm -rf /tmp/android-ndk-r21e
           fi
 
-      - name: Update homebrew (avoid bintray errors)
-        uses: nick-invision/retry@v2
-        if: startsWith(matrix.os, 'macos')
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            # Temporarily here until Github runners have updated their version of
-            # homebrew. This prevents errors arising from the shut down of
-            # binutils, used by older version of homebrew for hosting packages.
-            brew update
-
       - name: Install prerequisites
         shell: bash
         run: |

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -401,18 +401,6 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
 
-      - name: Update homebrew (avoid bintray errors)
-        uses: nick-invision/retry@v2
-        if: runner.os == 'macOS'
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            # Temporarily here until Github runners have updated their version of
-            # homebrew. This prevents errors arising from the shut down of
-            # binutils, used by older version of homebrew for hosting packages.
-            brew update
-
       - name: Install Desktop SDK prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -531,18 +519,6 @@ jobs:
         uses: actions/setup-python@v2
         with:
           python-version: 3.7
-
-      - name: Update homebrew (avoid bintray errors)
-        uses: nick-invision/retry@v2
-        if: runner.os == 'macOS'
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            # Temporarily here until Github runners have updated their version of
-            # homebrew. This prevents errors arising from the shut down of
-            # binutils, used by older version of homebrew for hosting packages.
-            brew update
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -168,18 +168,6 @@ jobs:
           python-version: ${{ matrix.python_version }}
           architecture: 'x64'
 
-      - name: Update homebrew (avoid bintray errors)
-        uses: nick-invision/retry@v2
-        if: startsWith(matrix.os, 'macos')
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: |
-            # Temporarily here until Github runners have updated their version of
-            # homebrew. This prevents errors arising from the shut down of
-            # binutils, used by older version of homebrew for hosting packages.
-            brew update
-
       - name: Install Desktop SDK prerequisites
         uses: nick-invision/retry@v2
         with:

--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -278,7 +278,7 @@ def parse_cmdline_args():
   parser.add_argument('--build_dir', default='build', help='Output build directory')
   parser.add_argument('--build_tests', action='store_true', help='Build unit tests too')
   parser.add_argument('--verbose', action='store_true', help='Enable verbose CMake builds.')
-  parser.add_argument('--disable_vcpkg', action='store_true', help='Disable vcpkg and just use CMake.')
+  parser.add_argument('--disable_vcpkg', default='True', action='store_true', help='Disable vcpkg and just use CMake.')
   parser.add_argument('--vcpkg_step_only', action='store_true', help='Just install cpp packages using vcpkg and exit.')
   parser.add_argument('--config', default='Release', help='Release/Debug config')
   parser.add_argument('--target', nargs='+', help='A list of CMake build targets (eg: firebase_app firebase_auth)')


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

vcpkg keeps giving errors when trying to update, so disabling it for now.  Likewise homebrew is repeatedly failing to update, and based on the comments about it, it should no longer be needed, as it was working around an issue that was fixed a year ago.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Tests via workflows
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
