### PR TITLE
Remove vcpkg from testapp builder

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -262,6 +262,10 @@ def main(argv):
     _run(["pod", "repo", "update"])
 
   cmake_flags = _get_desktop_compiler_flags(FLAGS.compiler, config.compilers)
+  if _DESKTOP in platforms and not FLAGS.packaged_sdk:
+    cmake_flags.extend((
+        "-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable,
+    ))
 
   if (_DESKTOP in platforms and FLAGS.packaged_sdk and
       utils.is_linux_os() and FLAGS.arch == "x86"):

--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -262,30 +262,6 @@ def main(argv):
     _run(["pod", "repo", "update"])
 
   cmake_flags = _get_desktop_compiler_flags(FLAGS.compiler, config.compilers)
-  # VCPKG is used to install dependencies for the desktop SDK.
-  # Building from source requires building the underlying SDK libraries,
-  # so we need to use VCPKG as well.
-  if _DESKTOP in platforms and not FLAGS.packaged_sdk:
-    vcpkg_arch = FLAGS.arch
-    installer = os.path.join(repo_dir, "scripts", "gha", "build_desktop.py")
-    # --gha_build may be required to enable x86 Linux GitHub workarounds.
-    additional_flags = ["--gha_build"] if FLAGS.gha_build else []
-    _run([sys.executable, installer, "--vcpkg_step_only", "--arch", vcpkg_arch]
-         + additional_flags)
-    toolchain_file = os.path.join(
-        repo_dir, "external", "vcpkg", "scripts", "buildsystems", "vcpkg.cmake")
-    if utils.is_mac_os() and FLAGS.arch == "arm64":
-      toolchain_file = os.path.join(
-          repo_dir, "external", "vcpkg", "scripts", "buildsystems", "macos_arm64.cmake")
-    if utils.is_linux_os() and FLAGS.arch == "x86":
-      toolchain_file = os.path.join(
-          repo_dir, "external", "vcpkg", "scripts", "buildsystems", "linux_32.cmake")
-
-    cmake_flags.extend((
-        "-DCMAKE_TOOLCHAIN_FILE=%s" % toolchain_file,
-        "-DVCPKG_TARGET_TRIPLET=%s" % utils.get_vcpkg_triplet(arch=vcpkg_arch),
-        "-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable,
-    ))
 
   if (_DESKTOP in platforms and FLAGS.packaged_sdk and
       utils.is_linux_os() and FLAGS.arch == "x86"):


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

vcpkg has been having errors finding the toolchain files, and should not be necessary for the build, so remove it from the testapp builder logic.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

https://github.com/firebase/firebase-cpp-sdk/actions/runs/3099919285
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
