### PR TITLE
Desktop Heartbeat - Log a heartbeat after app is created, and add LogHeartbeat method

### DIFF
--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -141,7 +141,11 @@ App* App::Create(const AppOptions& options, const char* name) {  // NOLINT
         MakeShared<heartbeat::HeartbeatController>(
             name, *app_common::FindAppLoggerByName(name),
             app->internal_->date_provider_);
+#ifndef SWIG
+    // Log a heartbeat after creating an App. In the Unity SDK this will happen
+    // at a later time, after additional user agents have been registered.
     app->internal_->heartbeat_controller_->LogHeartbeat();
+#endif  // SWIG
   }
   return app;
 }

--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -141,6 +141,7 @@ App* App::Create(const AppOptions& options, const char* name) {  // NOLINT
         MakeShared<heartbeat::HeartbeatController>(
             name, *app_common::FindAppLoggerByName(name),
             app->internal_->date_provider_);
+    app->internal_->heartbeat_controller_->LogHeartbeat();
   }
   return app;
 }

--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -187,6 +187,12 @@ void App::SetDefaultConfigPath(const char* path) {
   }
 }
 
+void App::LogHeartbeat() const {
+  if (internal_ != nullptr && internal_->heartbeat_controller_) {
+    internal_->heartbeat_controller_->LogHeartbeat();
+  }
+}
+
 SharedPtr<heartbeat::HeartbeatController> App::GetHeartbeatController() const {
   if (internal_ != nullptr) {
     return internal_->heartbeat_controller_;

--- a/app/src/heartbeat/heartbeat_controller_desktop.h
+++ b/app/src/heartbeat/heartbeat_controller_desktop.h
@@ -52,6 +52,7 @@ class HeartbeatController {
 
  private:
 #ifdef FIREBASE_TESTING
+  FRIEND_TEST(HeartbeatControllerDesktopTest, PerAppHeartbeatController);
   FRIEND_TEST(HeartbeatControllerDesktopTest, EncodeAndDecode);
   FRIEND_TEST(HeartbeatControllerDesktopTest, CreatePayloadString);
   FRIEND_TEST(HeartbeatControllerDesktopTest, GetExpectedHeartbeatPayload);

--- a/app/src/include/firebase/app.h
+++ b/app/src/include/firebase/app.h
@@ -714,6 +714,9 @@ class App {
 #if FIREBASE_PLATFORM_DESKTOP
   // These methods are only visible to SWIG and internal users of firebase::App.
 
+  /// Logs a heartbeat using the internal HeartbeatController.
+  void LogHeartbeat() const;
+
   /// Get a pointer to the HeartbeatController associated with this app.
   SharedPtr<heartbeat::HeartbeatController> GetHeartbeatController() const;
 #endif  // FIREBASE_PLATFORM_DESKTOP

--- a/app/tests/heartbeat_controller_desktop_test.cc
+++ b/app/tests/heartbeat_controller_desktop_test.cc
@@ -88,18 +88,22 @@ class HeartbeatControllerDesktopTest : public ::testing::Test {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(HeartbeatControllerDesktopTest, PerAppHeartbeatController) {
-  App* firebase_app = testing::CreateApp();
-  ASSERT_NE(firebase_app, nullptr);
-
   // For the sake of testing, clear any pre-existing stored heartbeats.
-  HeartbeatStorageDesktop storage(firebase_app->name(), logger_);
+  HeartbeatStorageDesktop storage(firebase::kDefaultAppName, logger_);
   LoggedHeartbeats empty_heartbeats_struct;
   storage.Write(empty_heartbeats_struct);
 
-  firebase_app->GetHeartbeatController()->LogHeartbeat();
+  // Creating an App should trigger logging of a heartbeat.
+  App* firebase_app = testing::CreateApp();
+  ASSERT_NE(firebase_app, nullptr);
+
   std::string encoded_payload =
       firebase_app->GetHeartbeatController()->GetAndResetStoredHeartbeats();
-  EXPECT_NE(encoded_payload, "");
+  ASSERT_NE(encoded_payload, "");
+  std::string decoded_payload =
+      controller_.DecodeAndDecompress(encoded_payload);
+  // Verify that C++ user agents are included in the heartbeat payload.
+  EXPECT_THAT(decoded_payload, MatchesRegex("^.*fire-cpp.*$"));
   // Deleting the app internally triggers resetting of registered user agents.
   delete firebase_app;
 }

--- a/app/tests/heartbeat_controller_desktop_test.cc
+++ b/app/tests/heartbeat_controller_desktop_test.cc
@@ -94,8 +94,9 @@ TEST_F(HeartbeatControllerDesktopTest, PerAppHeartbeatController) {
   storage.Write(empty_heartbeats_struct);
 
   // Creating an App should trigger logging of a heartbeat.
-  App* firebase_app = testing::CreateApp();
-  ASSERT_NE(firebase_app, nullptr);
+  // The app will be deleted after the test, resetting registered user agents.
+  std::unique_ptr<App> firebase_app(testing::CreateApp());
+  ASSERT_NE(firebase_app.get(), nullptr);
 
   std::string encoded_payload =
       firebase_app->GetHeartbeatController()->GetAndResetStoredHeartbeats();
@@ -104,8 +105,6 @@ TEST_F(HeartbeatControllerDesktopTest, PerAppHeartbeatController) {
       controller_.DecodeAndDecompress(encoded_payload);
   // Verify that C++ user agents are included in the heartbeat payload.
   EXPECT_THAT(decoded_payload, MatchesRegex("^.*fire-cpp.*$"));
-  // Deleting the app internally triggers resetting of registered user agents.
-  delete firebase_app;
 }
 #endif  // FIREBASE_PLATFORM_DESKTOP
 

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -98,11 +98,7 @@ void DestroyFunctionRegistryListener(AuthData* auth_data);
 
 void LogHeartbeat(Auth* const auth) {
   if (auth && auth->auth_data_ && auth->auth_data_->app) {
-    SharedPtr<heartbeat::HeartbeatController> heartbeat_controller =
-        auth->auth_data_->app->GetHeartbeatController();
-    if (heartbeat_controller) {
-      heartbeat_controller->LogHeartbeat();
-    }
+    auth->auth_data_->app->LogHeartbeat();
   }
 }
 

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -52,8 +52,8 @@ class AuthRequestHeartbeatTest : public ::testing::Test {
     // For the sake of testing, clear any pre-existing stored heartbeats.
     LoggedHeartbeats empty_heartbeats_struct;
     storage.Write(empty_heartbeats_struct);
-    // A single heartbeat will be logged when app is created.
-    app_ = std::make_unique<App>(*testing::CreateApp());
+    // Update the unique ptr to point at the created app.
+    app_.reset(testing::CreateApp());
   }
 };
 

--- a/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
+++ b/auth/tests/desktop/rpcs/auth_request_heartbeat_test.cc
@@ -41,24 +41,24 @@ using ::firebase::heartbeat::LoggedHeartbeats;
 
 class AuthRequestHeartbeatTest : public ::testing::Test {
  public:
-  AuthRequestHeartbeatTest() : app_(testing::CreateApp()) {}
+  AuthRequestHeartbeatTest() {}
 
  protected:
   std::unique_ptr<App> app_;
 
   void SetUp() override {
     Logger logger(nullptr);
-    HeartbeatStorageDesktop storage(app_->name(), logger);
+    HeartbeatStorageDesktop storage(firebase::kDefaultAppName, logger);
     // For the sake of testing, clear any pre-existing stored heartbeats.
     LoggedHeartbeats empty_heartbeats_struct;
     storage.Write(empty_heartbeats_struct);
+    // A single heartbeat will be logged when app is created.
+    app_ = std::make_unique<App>(*testing::CreateApp());
   }
 };
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestCreateAuthUriRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   CreateAuthUriRequest request(*app_, "APIKEY", "email");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -70,8 +70,6 @@ TEST_F(AuthRequestHeartbeatTest, TestCreateAuthUriRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestDeleteAccountRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   DeleteAccountRequest request(*app_, "APIKEY");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -83,8 +81,6 @@ TEST_F(AuthRequestHeartbeatTest, TestDeleteAccountRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestGetAccountInfoRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   GetAccountInfoRequest request(*app_, "APIKEY");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -96,8 +92,6 @@ TEST_F(AuthRequestHeartbeatTest, TestGetAccountInfoRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestOobSendEmailRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request =
       GetOobConfirmationCodeRequest::CreateSendEmailVerificationRequest(
           *app_, "APIKEY");
@@ -111,8 +105,6 @@ TEST_F(AuthRequestHeartbeatTest, TestOobSendEmailRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestOobSendPasswordResetRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request =
       GetOobConfirmationCodeRequest::CreateSendPasswordResetEmailRequest(
           *app_, "APIKEY", "email");
@@ -126,8 +118,6 @@ TEST_F(AuthRequestHeartbeatTest, TestOobSendPasswordResetRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestResetPasswordRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   ResetPasswordRequest request(*app_, "APIKEY", "oob", "password");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -139,8 +129,6 @@ TEST_F(AuthRequestHeartbeatTest, TestResetPasswordRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSecureTokenRequestDoesNotHaveHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   SecureTokenRequest request(*app_, "APIKEY", "email");
 
   // SecureTokenRequest should not have heartbeat payload since it is sent
@@ -152,8 +140,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSecureTokenRequestDoesNotHaveHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdatePasswordRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = SetAccountInfoRequest::CreateUpdatePasswordRequest(
       *app_, "APIKEY", "fakepassword");
 
@@ -166,8 +152,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdatePasswordRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateEmailRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request =
       SetAccountInfoRequest::CreateUpdateEmailRequest(*app_, "APIKEY", "email");
 
@@ -180,8 +164,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateEmailRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateProfileRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = SetAccountInfoRequest::CreateUpdateProfileRequest(
       *app_, "APIKEY", "New Name", "new_url");
 
@@ -194,8 +176,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSetInfoUpdateProfileRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSetInfoUnlinkProviderRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = SetAccountInfoRequest::CreateUnlinkProviderRequest(
       *app_, "APIKEY", "provider");
 
@@ -208,8 +188,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSetInfoUnlinkProviderRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestSignUpNewUserRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   SignUpNewUserRequest request(*app_, "APIKEY");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -222,8 +200,6 @@ TEST_F(AuthRequestHeartbeatTest, TestSignUpNewUserRequestHasHeartbeat) {
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest,
        TestVerifyAssertionFromIdTokenRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = VerifyAssertionRequest::FromIdToken(*app_, "APIKEY",
                                                      "provider", "id_token");
 
@@ -237,8 +213,6 @@ TEST_F(AuthRequestHeartbeatTest,
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest,
        TestVerifyAssertionFromAccessTokenRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = VerifyAssertionRequest::FromAccessToken(
       *app_, "APIKEY", "provider", "access_token");
 
@@ -252,8 +226,6 @@ TEST_F(AuthRequestHeartbeatTest,
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest,
        TestVerifyAssertionFromAccessTokenAndOauthRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   auto request = VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
       *app_, "APIKEY", "provider", "access_token", "oauth_secret");
 
@@ -266,8 +238,6 @@ TEST_F(AuthRequestHeartbeatTest,
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestVerifyCustomTokenRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   VerifyCustomTokenRequest request(*app_, "APIKEY", "email");
 
   // The request headers should include both hearbeat payload and GMP App ID.
@@ -279,8 +249,6 @@ TEST_F(AuthRequestHeartbeatTest, TestVerifyCustomTokenRequestHasHeartbeat) {
 
 #if FIREBASE_PLATFORM_DESKTOP
 TEST_F(AuthRequestHeartbeatTest, TestVerifyPasswordRequestHasHeartbeat) {
-  // Log a single heartbeat for today's date.
-  app_->GetHeartbeatController()->LogHeartbeat();
   VerifyPasswordRequest request(*app_, "APIKEY", "abc@email", "pwd");
 
   // The request headers should include both hearbeat payload and GMP App ID.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On desktop, call LogHeartbeat after App is created. This should mean that heartbeats are consistently logged regardless of whether or not auth or firestore is included.
Also define a method called LogHeartbeat in App so that Unity SDK can call that to trigger heartbeat logging without having to interact with the HeartbeatController.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Updated heartbeat controller and auth request unit tests to rely on this automatic call to LogHeartbeat instead of explicitly calling LogHeartbeat in those test cases.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
