### PR TITLE
Fix lint error by removing brace initialization syntax from strings.

### DIFF
--- a/auth/src/desktop/auth_providers/google_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/google_auth_provider.cc
@@ -27,7 +27,7 @@ Credential GoogleAuthProvider::GetCredential(const char* const id_token,
                                              const char* const access_token) {
   if (id_token && id_token[0] != '\0') {
     return Credential{
-      new CredentialImpl{new GoogleAuthCredential(id_token, std::string())}};
+        new CredentialImpl{new GoogleAuthCredential(id_token, std::string())}};
   } else if (access_token) {
     return Credential{new CredentialImpl{
         new GoogleAuthCredential(std::string(), access_token)}};

--- a/auth/src/desktop/auth_providers/google_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/google_auth_provider.cc
@@ -27,13 +27,13 @@ Credential GoogleAuthProvider::GetCredential(const char* const id_token,
                                              const char* const access_token) {
   if (id_token && id_token[0] != '\0') {
     return Credential{
-        new CredentialImpl{new GoogleAuthCredential(id_token, std::string{})}};
+      new CredentialImpl{new GoogleAuthCredential(id_token, std::string())}};
   } else if (access_token) {
     return Credential{new CredentialImpl{
-        new GoogleAuthCredential(std::string{}, access_token)}};
+        new GoogleAuthCredential(std::string(), access_token)}};
   } else {
     return Credential{new CredentialImpl{
-        new GoogleAuthCredential(std::string{}, std::string{})}};
+        new GoogleAuthCredential(std::string(), std::string())}};
   }
 }
 

--- a/auth/src/desktop/rpcs/verify_assertion_request.cc
+++ b/auth/src/desktop/rpcs/verify_assertion_request.cc
@@ -35,7 +35,7 @@ VerifyAssertionRequest::VerifyAssertionRequest(const char* const api_key,
   application_data_->requestUri = url;
 
   if (provider_id) {
-    post_body_ = std::string{"providerId="} + provider_id;
+    post_body_ = std::string("providerId=") + provider_id;
   } else {
     LogError("No provider id given");
   }
@@ -55,13 +55,13 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromIdToken(
       new VerifyAssertionRequest{api_key, provider_id});
 
   if (id_token) {
-    request->post_body_ += std::string{"&id_token="} + id_token;
+    request->post_body_ += std::string("&id_token=") + id_token;
   } else {
     LogError("No id token given");
   }
 
   if (nonce) {
-    request->post_body_ += std::string{"&nonce="} + nonce;
+    request->post_body_ += std::string("&nonce=") + nonce;
   }
 
   request->application_data_->postBody = request->post_body_;
@@ -83,13 +83,13 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAccessToken(
       new VerifyAssertionRequest{api_key, provider_id});
 
   if (access_token) {
-    request->post_body_ += std::string{"&access_token="} + access_token;
+    request->post_body_ += std::string("&access_token=") + access_token;
   } else {
     LogError("No access token given");
   }
 
   if (nonce) {
-    request->post_body_ += std::string{"&nonce="} + nonce;
+    request->post_body_ += std::string("&nonce=") + nonce;
   }
 
   request->application_data_->postBody = request->post_body_;
@@ -105,12 +105,12 @@ VerifyAssertionRequest::FromAccessTokenAndOAuthSecret(
       new VerifyAssertionRequest{api_key, provider_id});
 
   if (access_token) {
-    request->post_body_ += std::string{"&access_token="} + access_token;
+    request->post_body_ += std::string("&access_token=") + access_token;
   } else {
     LogError("No access token given");
   }
   if (oauth_secret) {
-    request->post_body_ += std::string{"&oauth_token_secret="} + oauth_secret;
+    request->post_body_ += std::string("&oauth_token_secret=") + oauth_secret;
   } else {
     LogError("No OAuth secret given");
   }
@@ -130,7 +130,7 @@ std::unique_ptr<VerifyAssertionRequest> VerifyAssertionRequest::FromAuthCode(
       new VerifyAssertionRequest{api_key, provider_id});
 
   if (auth_code) {
-    request->post_body_ += std::string{"&code="} + auth_code;
+    request->post_body_ += std::string("&code=") + auth_code;
   } else {
     LogError("No server auth code given");
   }

--- a/auth/tests/desktop/fakes.cc
+++ b/auth/tests/desktop/fakes.cc
@@ -66,7 +66,7 @@ std::string GetUrlForApi(const std::string& api_key,
   const char* const base_url =
       "https://www.googleapis.com/identitytoolkit/v3/"
       "relyingparty/";
-  return std::string{base_url} + api_method + "?key=" + api_key;
+  return std::string(base_url) + api_method + "?key=" + api_key;
 }
 
 std::string FakeSuccessfulResponse(const std::string& body) {

--- a/firestore/integration_test_internal/src/util/integration_test_util.cc
+++ b/firestore/integration_test_internal/src/util/integration_test_util.cc
@@ -49,7 +49,7 @@ App* GetApp(const char* name, const std::string& override_project_id) {
   // unit tests achieve this by using fake options:
   // https://github.com/firebase/firebase-ios-sdk/blob/9a5afbffc17bb63b7bb7f51b9ea9a6a9e1c88a94/Firestore/core/test/firebase/firestore/testutil/app_testing.mm#L29
 
-  if (name == nullptr || std::string{name} == kDefaultAppName) {
+  if (name == nullptr || std::string(name) == kDefaultAppName) {
 #if defined(__ANDROID__)
     return App::Create(app_framework::GetJniEnv(),
                        app_framework::GetActivity());


### PR DESCRIPTION
### Description
The linter does not like the std::string{} brace initialization syntax and spits out errors. This fixes those errors.

***
### Testing
PR checks run to ensure the build has not broken.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
