### PR TITLE
Fix iTests on Packaged Builds - add vcpkg

### DIFF
--- a/scripts/gha/build_desktop.py
+++ b/scripts/gha/build_desktop.py
@@ -278,7 +278,7 @@ def parse_cmdline_args():
   parser.add_argument('--build_dir', default='build', help='Output build directory')
   parser.add_argument('--build_tests', action='store_true', help='Build unit tests too')
   parser.add_argument('--verbose', action='store_true', help='Enable verbose CMake builds.')
-  parser.add_argument('--disable_vcpkg', default='True', action='store_true', help='Disable vcpkg and just use CMake.')
+  parser.add_argument('--disable_vcpkg', default='False', action='store_true', help='Disable vcpkg and just use CMake.')
   parser.add_argument('--vcpkg_step_only', action='store_true', help='Just install cpp packages using vcpkg and exit.')
   parser.add_argument('--config', default='Release', help='Release/Debug config')
   parser.add_argument('--target', nargs='+', help='A list of CMake build targets (eg: firebase_app firebase_auth)')


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Use vcpkg again to fix link errors in our iTests CI built against the packaged SDK.

Example issues in the build: [Integration CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3242318003/jobs/5315415167)


***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

iTest successful runs without Packaged SDK
- [Run #1](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3245050574)

iTest successful runs from Packaged SDK

- [Run #1](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3243491530)
- [Run #2](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3239134547)

Both runs have test failures, but at least they build!

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
