### PR TITLE
Firestore: Remove copies in FieldValueInternal to reduce global refs consumption.

### DIFF
--- a/firestore/src/android/field_value_android.cc
+++ b/firestore/src/android/field_value_android.cc
@@ -156,7 +156,7 @@ FieldValueInternal::FieldValueInternal(GeoPoint value)
   object_ = GeoPointInternal::Create(env, value);
 }
 
-FieldValueInternal::FieldValueInternal(std::vector<FieldValue> value)
+FieldValueInternal::FieldValueInternal(const std::vector<FieldValue>& value)
     : cached_type_(Type::kArray) {
   Env env = GetEnv();
   Local<ArrayList> list = ArrayList::Create(env, value.size());
@@ -167,7 +167,7 @@ FieldValueInternal::FieldValueInternal(std::vector<FieldValue> value)
   object_ = list;
 }
 
-FieldValueInternal::FieldValueInternal(MapFieldValue value)
+FieldValueInternal::FieldValueInternal(const MapFieldValue& value)
     : cached_type_(Type::kMap) {
   Env env = GetEnv();
   Local<HashMap> map = HashMap::Create(env);

--- a/firestore/src/android/field_value_android.h
+++ b/firestore/src/android/field_value_android.h
@@ -64,8 +64,14 @@ class FieldValueInternal {
   FieldValueInternal(const uint8_t* value, size_t size);
   explicit FieldValueInternal(DocumentReference value);
   explicit FieldValueInternal(GeoPoint value);
-  explicit FieldValueInternal(std::vector<FieldValue> value);
-  explicit FieldValueInternal(MapFieldValue value);
+  // Deviate from the iOS signatures of the following two constructors. The iOS
+  // versions take values into which the caller moves, to elide a copy. In
+  // Android, this actually *costs* an extra copy when calling from
+  // `DocumentReferenceInternal::Set()`, doubling the number of global
+  // references needed. Using const references in Android avoids this extra,
+  // costly copy (https://github.com/firebase/quickstart-unity/issues/1303).
+  explicit FieldValueInternal(const std::vector<FieldValue>& value);
+  explicit FieldValueInternal(const MapFieldValue& value);
 
   Type type() const;
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -634,6 +634,12 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming
+-   Changes
+    - Firestore (Android): Reduce the number of JNI global references consumed
+      when creating or updating documents
+      ([#1111](https://github.com/firebase/firebase-cpp-sdk/pull/1111)).
+
 ### 10.0.0
 -   Changes
     - General (Android): Update to Firebase Android BoM version 31.0.0.


### PR DESCRIPTION
In `field_value_android.h`, change the `std::vector<FieldValue>` and `MapFieldValue` constructors to take const references, instead of values. This reduces by half the number of global references needed when `DocumentReference::Set()`, `DocumentReference::Update()`, and `CollectionReference::Add()` are called on Android.

Since these 3 methods are part of the public interface and take const references as their arguments, they are not able to `std::move` these values into the `FieldValueInternal` constructor, thus requiring copies. On Android, these copies necessitate doubling the number of JNI global references in use, making it much easier to hit the 51,200 hard limit.

This is the first part of a proper fix for the global refs exhaustion issue reported in https://github.com/firebase/quickstart-unity/issues/1303 and https://github.com/firebase/quickstart-unity/issues/1193#issuecomment-1242203289 (Googlers see b/251869890 for more details). This should help alleviate the immediate problems being experienced by these customers. A proper fix is much more complicated and will take time to implement. Hopefully the improvement in this PR will be sufficient to unblock those customers.