### PR TITLE
Disable flakey auth test on Linux

### DIFF
--- a/auth/tests/CMakeLists.txt
+++ b/auth/tests/CMakeLists.txt
@@ -159,18 +159,20 @@ firebase_cpp_cc_test(
     firebase_testing
 )
 
-firebase_cpp_cc_test(
-  firebase_auth_user_desktop_test
-  SOURCES
-    desktop/user_desktop_test.cc
-  DEPENDS
-    firebase_app_for_testing
-    firebase_auth
-    firebase_auth_desktop_test_util
-    firebase_rest_lib
-    firebase_rest_mocks
-    firebase_testing
-)
+if (MSVC OR APPLE)
+  firebase_cpp_cc_test(
+    firebase_auth_user_desktop_test
+    SOURCES
+      desktop/user_desktop_test.cc
+    DEPENDS
+      firebase_app_for_testing
+      firebase_auth
+      firebase_auth_desktop_test_util
+      firebase_rest_lib
+      firebase_rest_mocks
+      firebase_testing
+  )
+endif()
 
 firebase_cpp_cc_test(
   firebase_auth_request_heartbeat_test


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

firebase_auth_user_desktop_test keeps hanging on the Ubuntu x86 runners.  Disable the tests for now until the root cause can be found.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
