### PR TITLE
Make the app check debug provider use an internal class

### DIFF
--- a/app_check/CMakeLists.txt
+++ b/app_check/CMakeLists.txt
@@ -18,6 +18,7 @@
 set(common_SRCS
   src/common/app_check.cc
   src/common/common.h
+  src/common/debug_provider_common.cc
   src/include/firebase/app_check.h
   src/include/firebase/app_check/debug_provider.h
   src/include/firebase/app_check/play_integrity_provider.h
@@ -32,6 +33,7 @@ set(android_SRCS
   src/android/app_check_android.h
   # Supported providers
   src/android/debug_provider_android.cc
+  src/android/debug_provider_android.h
   src/android/play_integrity_provider_android.cc
   src/android/safety_net_provider_android.cc
   # Unsupported providers
@@ -46,6 +48,7 @@ set(ios_SRCS
   # Supported providers
   src/ios/app_attest_provider_ios.mm
   src/ios/debug_provider_ios.mm
+  src/ios/debug_provider_ios.h
   src/ios/device_check_provider_ios.mm
   # Unsupported providers
   src/stub/play_integrity_provider_stub.cc
@@ -58,6 +61,7 @@ set(desktop_SRCS
   src/desktop/app_check_desktop.h
   # Supported providers
   src/desktop/debug_provider_desktop.cc
+  src/desktop/debug_provider_desktop.h
   # Unsupported providers
   src/stub/app_attest_provider_stub.cc
   src/stub/device_check_provider_stub.cc

--- a/app_check/src/android/debug_provider_android.cc
+++ b/app_check/src/android/debug_provider_android.cc
@@ -12,28 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "app_check/src/android/debug_provider_android.h"
+
 #include "firebase/app_check/debug_provider.h"
 
 namespace firebase {
 namespace app_check {
+namespace internal {
 
-static DebugAppCheckProviderFactory* g_debug_app_check_provider_factory =
-    nullptr;
+DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
 
-DebugAppCheckProviderFactory* DebugAppCheckProviderFactory::GetInstance() {
-  if (!g_debug_app_check_provider_factory) {
-    g_debug_app_check_provider_factory = new DebugAppCheckProviderFactory();
-  }
-  return g_debug_app_check_provider_factory;
-}
+DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
 
-DebugAppCheckProviderFactory::DebugAppCheckProviderFactory() {}
-
-DebugAppCheckProviderFactory::~DebugAppCheckProviderFactory() {}
-
-AppCheckProvider* DebugAppCheckProviderFactory::CreateProvider(App* app) {
+AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) {
   return nullptr;
 }
 
+}  // namespace internal
 }  // namespace app_check
 }  // namespace firebase

--- a/app_check/src/android/debug_provider_android.cc
+++ b/app_check/src/android/debug_provider_android.cc
@@ -24,7 +24,8 @@ DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
 
 DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
 
-AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) {
+AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(
+    App* app) {
   return nullptr;
 }
 

--- a/app_check/src/android/debug_provider_android.h
+++ b/app_check/src/android/debug_provider_android.h
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "app_check/src/ios/debug_provider_ios.h"
+#ifndef FIREBASE_APP_CHECK_SRC_ANDROID_DEBUG_PROVIDER_ANDROID_H_
+#define FIREBASE_APP_CHECK_SRC_ANDROID_DEBUG_PROVIDER_ANDROID_H_
 
-#include "firebase/app_check/debug_provider.h"
+#include "firebase/app_check.h"
 
 namespace firebase {
 namespace app_check {
 namespace internal {
 
-DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
+class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
+ public:
+  DebugAppCheckProviderFactoryInternal();
 
-DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
+  virtual ~DebugAppCheckProviderFactoryInternal();
 
-AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) { return nullptr; }
+  AppCheckProvider* CreateProvider(App* app) override;
+};
 
 }  // namespace internal
 }  // namespace app_check
 }  // namespace firebase
+
+#endif  // FIREBASE_APP_CHECK_SRC_ANDROID_DEBUG_PROVIDER_ANDROID_H_

--- a/app_check/src/common/debug_provider_common.cc
+++ b/app_check/src/common/debug_provider_common.cc
@@ -38,7 +38,7 @@ DebugAppCheckProviderFactory* DebugAppCheckProviderFactory::GetInstance() {
 }
 
 DebugAppCheckProviderFactory::DebugAppCheckProviderFactory()
-  : internal_(new internal::DebugAppCheckProviderFactoryInternal()) {}
+    : internal_(new internal::DebugAppCheckProviderFactoryInternal()) {}
 
 DebugAppCheckProviderFactory::~DebugAppCheckProviderFactory() {
   if (internal_) {

--- a/app_check/src/common/debug_provider_common.cc
+++ b/app_check/src/common/debug_provider_common.cc
@@ -1,0 +1,58 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "firebase/app_check/debug_provider.h"
+
+// Include the header that matches the platform being used.
+#if FIREBASE_PLATFORM_ANDROID
+#include "app_check/src/android/debug_provider_android.h"
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+#include "app_check/src/ios/debug_provider_ios.h"
+#else
+#include "app_check/src/desktop/debug_provider_desktop.h"
+#endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
+        // FIREBASE_PLATFORM_TVOS
+
+namespace firebase {
+namespace app_check {
+
+static DebugAppCheckProviderFactory* g_debug_app_check_provider_factory =
+    nullptr;
+
+DebugAppCheckProviderFactory* DebugAppCheckProviderFactory::GetInstance() {
+  if (!g_debug_app_check_provider_factory) {
+    g_debug_app_check_provider_factory = new DebugAppCheckProviderFactory();
+  }
+  return g_debug_app_check_provider_factory;
+}
+
+DebugAppCheckProviderFactory::DebugAppCheckProviderFactory()
+  : internal_(new internal::DebugAppCheckProviderFactoryInternal()) {}
+
+DebugAppCheckProviderFactory::~DebugAppCheckProviderFactory() {
+  if (internal_) {
+    delete internal_;
+    internal_ = nullptr;
+  }
+}
+
+AppCheckProvider* DebugAppCheckProviderFactory::CreateProvider(App* app) {
+  if (internal_) {
+    return internal_->CreateProvider(app);
+  }
+  return nullptr;
+}
+
+}  // namespace app_check
+}  // namespace firebase

--- a/app_check/src/desktop/debug_provider_desktop.cc
+++ b/app_check/src/desktop/debug_provider_desktop.cc
@@ -12,28 +12,22 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "app_check/src/desktop/debug_provider_desktop.h"
+
 #include "firebase/app_check/debug_provider.h"
 
 namespace firebase {
 namespace app_check {
+namespace internal {
 
-static DebugAppCheckProviderFactory* g_debug_app_check_provider_factory =
-    nullptr;
+DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
 
-DebugAppCheckProviderFactory* DebugAppCheckProviderFactory::GetInstance() {
-  if (!g_debug_app_check_provider_factory) {
-    g_debug_app_check_provider_factory = new DebugAppCheckProviderFactory();
-  }
-  return g_debug_app_check_provider_factory;
-}
+DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
 
-DebugAppCheckProviderFactory::DebugAppCheckProviderFactory() {}
-
-DebugAppCheckProviderFactory::~DebugAppCheckProviderFactory() {}
-
-AppCheckProvider* DebugAppCheckProviderFactory::CreateProvider(App* app) {
+AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) {
   return nullptr;
 }
 
+}  // namespace internal
 }  // namespace app_check
 }  // namespace firebase

--- a/app_check/src/desktop/debug_provider_desktop.cc
+++ b/app_check/src/desktop/debug_provider_desktop.cc
@@ -24,7 +24,8 @@ DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
 
 DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
 
-AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) {
+AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(
+    App* app) {
   return nullptr;
 }
 

--- a/app_check/src/desktop/debug_provider_desktop.h
+++ b/app_check/src/desktop/debug_provider_desktop.h
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "app_check/src/ios/debug_provider_ios.h"
+#ifndef FIREBASE_APP_CHECK_SRC_DESKTOP_DEBUG_PROVIDER_DESKTOP_H_
+#define FIREBASE_APP_CHECK_SRC_DESKTOP_DEBUG_PROVIDER_DESKTOP_H_
 
-#include "firebase/app_check/debug_provider.h"
+#include "firebase/app_check.h"
 
 namespace firebase {
 namespace app_check {
 namespace internal {
 
-DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
+class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
+ public:
+  DebugAppCheckProviderFactoryInternal();
 
-DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
+  virtual ~DebugAppCheckProviderFactoryInternal();
 
-AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) { return nullptr; }
+  AppCheckProvider* CreateProvider(App* app) override;
+};
 
 }  // namespace internal
 }  // namespace app_check
 }  // namespace firebase
+
+#endif  // FIREBASE_APP_CHECK_SRC_DESKTOP_DEBUG_PROVIDER_DESKTOP_H_

--- a/app_check/src/include/firebase/app_check/debug_provider.h
+++ b/app_check/src/include/firebase/app_check/debug_provider.h
@@ -20,11 +20,9 @@
 namespace firebase {
 namespace app_check {
 
-/// @cond FIREBASE_APP_INTERNAL
 namespace internal {
 class DebugAppCheckProviderFactoryInternal;
 }
-/// @endcond
 
 /// Implementation of an {@link AppCheckProviderFactory} that builds
 /// DebugAppCheckProviders.
@@ -50,9 +48,7 @@ class DebugAppCheckProviderFactory : public AppCheckProviderFactory {
  private:
   DebugAppCheckProviderFactory();
 
-  /// @cond FIREBASE_APP_INTERNAL
   internal::DebugAppCheckProviderFactoryInternal* internal_;
-  /// @endcond
 };
 
 }  // namespace app_check

--- a/app_check/src/include/firebase/app_check/debug_provider.h
+++ b/app_check/src/include/firebase/app_check/debug_provider.h
@@ -49,7 +49,7 @@ class DebugAppCheckProviderFactory : public AppCheckProviderFactory {
 
  private:
   DebugAppCheckProviderFactory();
-  
+
   /// @cond FIREBASE_APP_INTERNAL
   internal::DebugAppCheckProviderFactoryInternal* internal_;
   /// @endcond

--- a/app_check/src/include/firebase/app_check/debug_provider.h
+++ b/app_check/src/include/firebase/app_check/debug_provider.h
@@ -20,6 +20,12 @@
 namespace firebase {
 namespace app_check {
 
+/// @cond FIREBASE_APP_INTERNAL
+namespace internal {
+class DebugAppCheckProviderFactoryInternal;
+}
+/// @endcond
+
 /// Implementation of an {@link AppCheckProviderFactory} that builds
 /// DebugAppCheckProviders.
 ///
@@ -43,6 +49,10 @@ class DebugAppCheckProviderFactory : public AppCheckProviderFactory {
 
  private:
   DebugAppCheckProviderFactory();
+  
+  /// @cond FIREBASE_APP_INTERNAL
+  internal::DebugAppCheckProviderFactoryInternal* internal_;
+  /// @endcond
 };
 
 }  // namespace app_check

--- a/app_check/src/ios/debug_provider_ios.h
+++ b/app_check/src/ios/debug_provider_ios.h
@@ -12,20 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "app_check/src/ios/debug_provider_ios.h"
+#ifndef FIREBASE_APP_CHECK_SRC_IOS_DEBUG_PROVIDER_IOS_H_
+#define FIREBASE_APP_CHECK_SRC_IOS_DEBUG_PROVIDER_IOS_H_
 
-#include "firebase/app_check/debug_provider.h"
+#include "firebase/app_check.h"
 
 namespace firebase {
 namespace app_check {
 namespace internal {
 
-DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal() {}
+class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
+ public:
+  DebugAppCheckProviderFactoryInternal();
 
-DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {}
+  virtual ~DebugAppCheckProviderFactoryInternal();
 
-AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app) { return nullptr; }
+  AppCheckProvider* CreateProvider(App* app) override;
+};
 
 }  // namespace internal
 }  // namespace app_check
 }  // namespace firebase
+
+#endif  // FIREBASE_APP_CHECK_SRC_IOS_DEBUG_PROVIDER_IOS_H_


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Make the App Check debug provider use an internal class, so that each platform can add privates without affecting the others.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Locally building and
https://github.com/firebase/firebase-cpp-sdk/actions/runs/3317166856/jobs/5479887578
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
