### PR TITLE
Disable failing iOS storage integration test cases 

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -573,7 +573,12 @@ const char kPutFileTestFile[] = "PutFileTest.txt";
 const char kGetFileTestFile[] = "GetFileTest.txt";
 const char kFileUriScheme[] = "file://";
 
+// TODO(b/255839066): Re-enable this test after the iOS 10.1.0 release
+#if FIREBASE_PLATFORM_IOS
+TEST_F(FirebaseStorageTest, DISABLED_TestPutFileAndGetFile) {
+#else
 TEST_F(FirebaseStorageTest, TestPutFileAndGetFile) {
+#endif  // FIREBASE_PLATFORM_IOS
   SignIn();
 
   firebase::storage::StorageReference ref =
@@ -1461,7 +1466,13 @@ TEST_F(FirebaseStorageTest, TestLargeFileCancelUpload) {
   // Cancel the operation and verify it was successfully canceled.
   EXPECT_TRUE(controller.Cancel());
 
+#if FIREBASE_PLATFORM_IOS
+  // TODO(b/255839066): Change this to expect kErrorCancelled once iOS SDK
+  // returns the correct error code.
+  WaitForCompletion(future, "PutBytes", firebase::storage::kErrorUnknown);
+#else
   WaitForCompletion(future, "PutBytes", firebase::storage::kErrorCancelled);
+#endif  // FIREBASE_PLATFORM_IOS
 
   FLAKY_TEST_SECTION_END();
 }


### PR DESCRIPTION
### Description
Disables FirebaseStorageTest.TestPutFileAndGetFile on iOS
Changes FirebaseStorageTest.TestLargeFileCancelUpload on iOS to expect error code unknown instead of cancelled

These are temporary changes since the underlying cause of failures are unintended changes in iOS SDK 10.0.0
These will be reverted once iOS SDK functionality is restored to normal.

The cause of the TestPutFileAndGetFile error is here: [https://github.com/firebase/firebase-ios-sdk/issues/10353](https://www.google.com/url?q=https://github.com/firebase/firebase-ios-sdk/issues/10353&sa=D&source=buganizer&usg=AOvVaw26Q1fQKcmRdHVgGwF1gRCB), which is set to be fixed by the iOS 10.1.0 release.

The cause of TestLargeFileCancelUpload is less clear, but iOS SDK appears to be returning error code unknown.
***
### Testing
Built and ran storage integration test locally with and without the change to verify the fix
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
