### PR TITLE
Temporarily disable broken ios tests on tvos as well

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -574,11 +574,11 @@ const char kGetFileTestFile[] = "GetFileTest.txt";
 const char kFileUriScheme[] = "file://";
 
 // TODO(b/255839066): Re-enable this test after the iOS 10.1.0 release
-#if FIREBASE_PLATFORM_IOS
+#if FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
 TEST_F(FirebaseStorageTest, DISABLED_TestPutFileAndGetFile) {
 #else
 TEST_F(FirebaseStorageTest, TestPutFileAndGetFile) {
-#endif  // FIREBASE_PLATFORM_IOS
+#endif  // FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
   SignIn();
 
   firebase::storage::StorageReference ref =
@@ -1466,13 +1466,13 @@ TEST_F(FirebaseStorageTest, TestLargeFileCancelUpload) {
   // Cancel the operation and verify it was successfully canceled.
   EXPECT_TRUE(controller.Cancel());
 
-#if FIREBASE_PLATFORM_IOS
+#if FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
   // TODO(b/255839066): Change this to expect kErrorCancelled once iOS SDK
   // returns the correct error code.
   WaitForCompletion(future, "PutBytes", firebase::storage::kErrorUnknown);
 #else
   WaitForCompletion(future, "PutBytes", firebase::storage::kErrorCancelled);
-#endif  // FIREBASE_PLATFORM_IOS
+#endif  // FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
 
   FLAKY_TEST_SECTION_END();
 }


### PR DESCRIPTION
### Description
Temporarily disable a couple tests that are broken due for tvos as a side effect of the ios 10.0 sdk
This is the same as #1123 but for tvos as well, since tvos is failing in the same way due to using the same iOS SDK.
***

### Testing
Not manually tested on tvos, but this fix worked for iOS and the cause of the issue is the same
Example failure: FirebaseStorageTest.TestPutFileAndGetFile
https://github.com/firebase/firebase-cpp-sdk/actions/runs/3340116284/jobs/5530848566
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
