### PR TITLE
Fix error with request ToString

### DIFF
--- a/app/rest/request.cc
+++ b/app/rest/request.cc
@@ -45,12 +45,13 @@ void Request::set_post_fields(const char* data) {
 
 std::string Request::ToString() {
   std::string output = options_.url + '\n';
+  size_t cached_offset = read_buffer_offset_;
   if (!ReadBodyIntoString(&output)) {
     output += "*** aborted ***\n";
   }
   output += "\n";
-  // Reset the buffer offset, since this moved it.
-  read_buffer_offset_ = 0;
+  // Reset the buffer offset, since the read moves it.
+  read_buffer_offset_ = cached_offset;
   return output;
 }
 

--- a/app/rest/request.cc
+++ b/app/rest/request.cc
@@ -49,6 +49,8 @@ std::string Request::ToString() {
     output += "*** aborted ***\n";
   }
   output += "\n";
+  // Reset the buffer offset, since this moved it.
+  read_buffer_offset_ = 0;
   return output;
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The desktop rest request has a ToString method used for debugging, but it reads to the end of the body, causing the request to fail when trying to send it.  Fix by resetting the buffer offset afterwards.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
