### PR TITLE
Update release notes to mention x86 linux issue

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -641,6 +641,9 @@ code.
     - Firestore (Android): Reduce the number of JNI global references consumed
       when creating or updating documents
       ([#1111](https://github.com/firebase/firebase-cpp-sdk/pull/1111)).
+-   Known Issues
+    - Linux x86 builds are broken since C++ SDK version 9.6.0. A fix is in
+      progress.
 
 ### 10.0.0
 -   Changes


### PR DESCRIPTION
### Description
Adding a line to v 10.1.0 release notes to mention the known issue of linux x86 builds being broken
***
### Testing
N/A
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
