### PR TITLE
Update gma to use mavenCentral

### DIFF
--- a/gma/build.gradle
+++ b/gma/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -24,16 +24,11 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 
 apply plugin: 'com.android.library'
-
-ext {
-  firebaseAndroidStl = System.getenv('FIREBASE_ANDROID_STL')
-  firebaseAndroidStl = firebaseAndroidStl != null ? firebaseAndroidStl : ''
-}
 
 android {
   compileSdkVersion 28
@@ -71,8 +66,7 @@ android {
         //           Only include needed project.
         arguments '-DFIREBASE_CPP_USE_PRIOR_GRADLE_BUILD=ON',
                 '-DFIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF',
-                '-DFIREBASE_INCLUDE_GMA=ON',
-		            "-DFIREBASE_ANDROID_STL=${firebaseAndroidStl}"
+                '-DFIREBASE_INCLUDE_GMA=ON'
 	    }
     }
   }

--- a/gma/gma_resources/build.gradle
+++ b/gma/gma_resources/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -25,7 +25,7 @@ buildscript {
 allprojects {
   repositories {
     google()
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/gma/integration_test/build.gradle
+++ b/gma/integration_test/build.gradle
@@ -17,7 +17,7 @@ buildscript {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:3.3.3'
@@ -29,7 +29,7 @@ allprojects {
   repositories {
     mavenLocal()
     maven { url 'https://maven.google.com'  }
-    jcenter()
+    mavenCentral()
   }
 }
 

--- a/scripts/gha/ui_testing/uitest_android/build.gradle
+++ b/scripts/gha/ui_testing/uitest_android/build.gradle
@@ -15,7 +15,7 @@
 buildscript {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
@@ -28,7 +28,7 @@ buildscript {
 allprojects {
     repositories {
         google()
-        jcenter()
+        mavenCentral()
     }
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

jcenter has been deprecated, and mavenCentral should be used instead. The other products were already updated, but gma missed the update, which might be causing some of the flakes on building the Android testapp.  Also remove the unnecessary android stl flag.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
