### PR TITLE
Re-enable storage test in ios now that ios 10.1 is being used

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -573,12 +573,7 @@ const char kPutFileTestFile[] = "PutFileTest.txt";
 const char kGetFileTestFile[] = "GetFileTest.txt";
 const char kFileUriScheme[] = "file://";
 
-// TODO(b/255839066): Re-enable this test after the iOS 10.1.0 release
-#if FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
-TEST_F(FirebaseStorageTest, DISABLED_TestPutFileAndGetFile) {
-#else
 TEST_F(FirebaseStorageTest, TestPutFileAndGetFile) {
-#endif  // FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
   SignIn();
 
   firebase::storage::StorageReference ref =


### PR DESCRIPTION
### Description
This is a partial revert of #1123
TestPutFileAndGetFile was broken by iOS 10.0 release and fixed by 10.1 release
***

### Testing
ran iOS storage integration tests locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
