### PR TITLE
Use the new linux32 logic when building the testapps from source

### DIFF
--- a/scripts/gha/build_testapps.py
+++ b/scripts/gha/build_testapps.py
@@ -267,8 +267,7 @@ def main(argv):
         "-DFIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=%s" % sys.executable,
     ))
 
-  if (_DESKTOP in platforms and FLAGS.packaged_sdk and
-      utils.is_linux_os() and FLAGS.arch == "x86"):
+  if (_DESKTOP in platforms and utils.is_linux_os() and FLAGS.arch == "x86"):
       # Write out a temporary toolchain file to force 32-bit Linux builds, as
       # the SDK-included toolchain file may not be present when building against
       # the packaged SDK.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Building the testapps from source also needs to use the new toolchain logic to correctly specify 32 bit linux.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
