### PR TITLE
Remove Firestore Emulator initilaization in CI

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -998,19 +998,6 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: 16.x
-      - name: Setup java 17 for Firestore emulator
-        uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '17'
-      - name: Setup Firestore Emulator
-        if: steps.device-info.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-        uses: nick-invision/retry@v2
-        with:
-          shell: bash
-          timeout_minutes: 5
-          max_attempts: 3
-          command: npm install -g firebase-tools     
       - name: Setup java 8 for test_simulator.py
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1011,10 +1011,10 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: npm install -g firebase-tools     
-      - name: Start Firestore Emulator
-        if: steps.device-info.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-        run: |
-          firebase emulators:start --only firestore --project demo-example &
+      #- name: Start Firestore Emulator
+      #  if: steps.device-info.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
+      #  run: |
+      #    firebase emulators:start --only firestore --project demo-example &
       - name: Setup java 8 for test_simulator.py
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1011,10 +1011,6 @@ jobs:
           timeout_minutes: 5
           max_attempts: 3
           command: npm install -g firebase-tools     
-      #- name: Start Firestore Emulator
-      #  if: steps.device-info.outputs.device_type == 'virtual' && contains(needs.check_and_prepare.outputs.apis, 'firestore')
-      #  run: |
-      #    firebase emulators:start --only firestore --project demo-example &
       - name: Setup java 8 for test_simulator.py
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Removes the installation and initialization of the Firestone Emulator CI step which interfered with the testing. The test had assumed it was talking to production and would timeout when it was actually pointing at the emulator.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3431579830) - failures are due to messaging only, which will be fixed in a different PR.

[Updated Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3439596673) - after removing Java 17 installation and Firebase Emulator download/installation steps.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
