### PR TITLE
Implement ObjectArena and ArenaRef to solve JNI Global Reference Issue

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -285,6 +285,7 @@ target_link_libraries(firebase_firestore
   PUBLIC
     firebase_app
     firebase_auth
+    absl_variant
 )
 
 if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -138,6 +138,7 @@ set(android_SRCS
     src/android/wrapper.h
     src/android/write_batch_android.cc
     src/android/write_batch_android.h
+    src/jni/arena_ref.h
     src/jni/array.h
     src/jni/array_list.cc
     src/jni/array_list.h
@@ -173,8 +174,8 @@ set(android_SRCS
     src/jni/map.h
     src/jni/object.cc
     src/jni/object.h
-    src/jni/object_arena.h
     src/jni/object_arena.cc
+    src/jni/object_arena.h
     src/jni/ownership.h
     src/jni/set.h
     src/jni/string.cc

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -173,6 +173,8 @@ set(android_SRCS
     src/jni/map.h
     src/jni/object.cc
     src/jni/object.h
+    src/jni/object_arena.h
+    src/jni/object_arena.cc
     src/jni/ownership.h
     src/jni/set.h
     src/jni/string.cc

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -285,7 +285,6 @@ target_link_libraries(firebase_firestore
   PUBLIC
     firebase_app
     firebase_auth
-    absl_variant
 )
 
 if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -118,6 +118,7 @@ set(FIREBASE_INTEGRATION_TEST_ANDROID_TEST_SRCS
     src/android/snapshot_metadata_android_test.cc
     src/android/timestamp_android_test.cc
     src/android/transaction_options_android_test.cc
+    src/jni/arena_ref_test.cc
     src/jni/declaration_test.cc
     src/jni/env_test.cc
     src/jni/object_test.cc

--- a/firestore/integration_test_internal/src/field_value_test.cc
+++ b/firestore/integration_test_internal/src/field_value_test.cc
@@ -34,6 +34,11 @@ namespace firestore {
 using Type = FieldValue::Type;
 using FieldValueTest = FirestoreIntegrationTest;
 
+TEST(DenverTest, zzyzx) {
+  auto field_value = FieldValue::String("hello");
+  ASSERT_EQ(field_value.ToString(), "zzyzx");
+}
+
 // Sanity test for stubs
 TEST_F(FieldValueTest, TestFieldValueTypes) {
   FieldValue::Null();

--- a/firestore/integration_test_internal/src/jni/arena_ref_test.cc
+++ b/firestore/integration_test_internal/src/jni/arena_ref_test.cc
@@ -15,6 +15,8 @@
  */
 
 #include "firestore/src/jni/arena_ref.h"
+#include "firestore/src/jni/boolean.h"
+
 #include "firestore_integration_test.h"
 
 namespace firebase {
@@ -26,8 +28,32 @@ using ArenaRefTest = FirestoreIntegrationTest;
 
 TEST_F(ArenaRefTest, ConstructorTest) {
   Env env(GetEnv());
-  ArenaRef ref(ObjectArena::Create(env));
-  EXPECT_TRUE(ref.is_valid());
+  auto boxed_ptr = Boolean::Create(env, true);
+  ArenaRef ref1(boxed_ptr);
+  EXPECT_TRUE(ref1.is_valid());
+
+  ArenaRef ref2(ref1);
+  EXPECT_TRUE(ref1.is_valid());
+  EXPECT_TRUE(ref2.is_valid());
+
+  ArenaRef ref3(std::move(ref2));
+  EXPECT_TRUE(ref3.is_valid());
+}
+
+TEST_F(ArenaRefTest, AssignmentOperatorTest) {
+  Env env(GetEnv());
+  auto boxed_ptr = Boolean::Create(env, true);
+  ArenaRef ref1(boxed_ptr);
+  EXPECT_TRUE(ref1.is_valid());
+
+  ArenaRef ref2, ref3;
+
+  ref2 = ref1;
+  EXPECT_TRUE(ref1.is_valid());
+  EXPECT_TRUE(ref2.is_valid());
+
+  ref3 = std::move(ref2);
+  EXPECT_TRUE(ref3.is_valid());
 }
 
 }  // namespace

--- a/firestore/integration_test_internal/src/jni/arena_ref_test.cc
+++ b/firestore/integration_test_internal/src/jni/arena_ref_test.cc
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "firestore/src/jni/arena_ref.h"
+#include "firestore_integration_test.h"
+
+namespace firebase {
+namespace firestore {
+namespace jni {
+namespace {
+
+using ArenaRefTest = FirestoreIntegrationTest;
+
+TEST_F(ArenaRefTest, ConstructorTest) {
+  Env env(GetEnv());
+  ArenaRef ref(ObjectArena::Create(env));
+  EXPECT_TRUE(ref.is_valid());
+}
+
+}  // namespace
+}  // namespace jni
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/src/android/field_value_android.cc
+++ b/firestore/src/android/field_value_android.cc
@@ -106,31 +106,36 @@ FieldValueInternal::FieldValueInternal(Type type, const Object& object)
 FieldValueInternal::FieldValueInternal(bool value)
     : cached_type_(Type::kBoolean) {
   Env env = GetEnv();
-  object_ = Boolean::Create(env, value);
+  auto boxed_ptr = Boolean::Create(env, value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(int64_t value)
     : cached_type_(Type::kInteger) {
   Env env = GetEnv();
-  object_ = Long::Create(env, value);
+  auto boxed_ptr = Long::Create(env, value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(double value)
     : cached_type_(Type::kDouble) {
   Env env = GetEnv();
-  object_ = Double::Create(env, value);
+  auto boxed_ptr = Double::Create(env, value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(Timestamp value)
     : cached_type_(Type::kTimestamp) {
   Env env = GetEnv();
-  object_ = TimestampInternal::Create(env, value);
+  auto boxed_ptr = TimestampInternal::Create(env, value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(std::string value)
     : cached_type_(Type::kString) {
   Env env = GetEnv();
-  object_ = env.NewStringUtf(value);
+  auto boxed_ptr = env.NewStringUtf(value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 // We do not initialize cached_blob_ with value here as the instance constructed
@@ -140,20 +145,22 @@ FieldValueInternal::FieldValueInternal(std::string value)
 FieldValueInternal::FieldValueInternal(const uint8_t* value, size_t size)
     : cached_type_(Type::kBlob) {
   Env env = GetEnv();
-  object_ = BlobInternal::Create(env, value, size);
+  auto boxed_ptr = BlobInternal::Create(env, value, size);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(DocumentReference value)
     : cached_type_{Type::kReference} {
   if (value.internal_ != nullptr) {
-    object_ = value.internal_->ToJava();
+    object_ = jni::ArenaRef(value.internal_->ToJava());
   }
 }
 
 FieldValueInternal::FieldValueInternal(GeoPoint value)
     : cached_type_(Type::kGeoPoint) {
   Env env = GetEnv();
-  object_ = GeoPointInternal::Create(env, value);
+  auto boxed_ptr = GeoPointInternal::Create(env, value);
+  object_ = jni::ArenaRef(boxed_ptr);
 }
 
 FieldValueInternal::FieldValueInternal(const std::vector<FieldValue>& value)
@@ -164,7 +171,7 @@ FieldValueInternal::FieldValueInternal(const std::vector<FieldValue>& value)
     // TODO(b/150016438): don't conflate invalid `FieldValue`s and null.
     list.Add(env, ToJava(element));
   }
-  object_ = list;
+  object_ = jni::ArenaRef(list);
 }
 
 FieldValueInternal::FieldValueInternal(const MapFieldValue& value)
@@ -176,63 +183,63 @@ FieldValueInternal::FieldValueInternal(const MapFieldValue& value)
     Local<String> key = env.NewStringUtf(kv.first);
     map.Put(env, key, ToJava(kv.second));
   }
-  object_ = map;
+  object_ = jni::ArenaRef(map);
 }
 
 Type FieldValueInternal::type() const {
   if (cached_type_ != Type::kNull) {
     return cached_type_;
   }
-  if (!object_) {
+  if (!object_.has_value()) {
     return Type::kNull;
   }
 
   // We do not have any knowledge on the type yet. Check the runtime type with
   // each known type.
   Env env = GetEnv();
-  if (env.IsInstanceOf(object_, Boolean::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), Boolean::GetClass())) {
     cached_type_ = Type::kBoolean;
     return Type::kBoolean;
   }
-  if (env.IsInstanceOf(object_, Long::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), Long::GetClass())) {
     cached_type_ = Type::kInteger;
     return Type::kInteger;
   }
-  if (env.IsInstanceOf(object_, Double::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), Double::GetClass())) {
     cached_type_ = Type::kDouble;
     return Type::kDouble;
   }
-  if (env.IsInstanceOf(object_, TimestampInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), TimestampInternal::GetClass())) {
     cached_type_ = Type::kTimestamp;
     return Type::kTimestamp;
   }
-  if (env.IsInstanceOf(object_, String::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), String::GetClass())) {
     cached_type_ = Type::kString;
     return Type::kString;
   }
-  if (env.IsInstanceOf(object_, BlobInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), BlobInternal::GetClass())) {
     cached_type_ = Type::kBlob;
     return Type::kBlob;
   }
-  if (env.IsInstanceOf(object_, DocumentReferenceInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), DocumentReferenceInternal::GetClass())) {
     cached_type_ = Type::kReference;
     return Type::kReference;
   }
-  if (env.IsInstanceOf(object_, GeoPointInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), GeoPointInternal::GetClass())) {
     cached_type_ = Type::kGeoPoint;
     return Type::kGeoPoint;
   }
-  if (env.IsInstanceOf(object_, List::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), List::GetClass())) {
     cached_type_ = Type::kArray;
     return Type::kArray;
   }
-  if (env.IsInstanceOf(object_, Map::GetClass())) {
+  if (env.IsInstanceOf(object_.get(), Map::GetClass())) {
     cached_type_ = Type::kMap;
     return Type::kMap;
   }
 
   FIREBASE_ASSERT_MESSAGE(false, "Unsupported FieldValue type: %s",
-                          Class::GetClassName(env, object_).c_str());
+                          Class::GetClassName(env, object_.get()).c_str());
   return Type::kNull;
 }
 
@@ -391,12 +398,12 @@ bool operator==(const FieldValueInternal& lhs, const FieldValueInternal& rhs) {
 template <typename T>
 T FieldValueInternal::Cast(jni::Env& env, Type type) const {
   if (cached_type_ == Type::kNull) {
-    FIREBASE_ASSERT(env.IsInstanceOf(object_, T::GetClass()));
+    FIREBASE_ASSERT(env.IsInstanceOf(object_.get(), T::GetClass()));
     cached_type_ = type;
   } else {
     FIREBASE_ASSERT(cached_type_ == type);
   }
-  auto typed_value = static_cast<jni::JniType<T>>(object_.get());
+  auto typed_value = static_cast<jni::JniType<T>>(object_.get().get());
   return T(typed_value);
 }
 
@@ -412,7 +419,7 @@ Local<Array<Object>> FieldValueInternal::MakeArray(
 Env FieldValueInternal::GetEnv() { return FirestoreInternal::GetEnv(); }
 
 Object FieldValueInternal::ToJava(const FieldValue& value) {
-  return value.internal_ ? value.internal_->object_ : Object();
+  return value.internal_ ? value.internal_->object_.get() : Object();
 }
 
 }  // namespace firestore

--- a/firestore/src/android/field_value_android.cc
+++ b/firestore/src/android/field_value_android.cc
@@ -197,49 +197,50 @@ Type FieldValueInternal::type() const {
   // We do not have any knowledge on the type yet. Check the runtime type with
   // each known type.
   Env env = GetEnv();
-  if (env.IsInstanceOf(object_.get(), Boolean::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), Boolean::GetClass())) {
     cached_type_ = Type::kBoolean;
     return Type::kBoolean;
   }
-  if (env.IsInstanceOf(object_.get(), Long::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), Long::GetClass())) {
     cached_type_ = Type::kInteger;
     return Type::kInteger;
   }
-  if (env.IsInstanceOf(object_.get(), Double::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), Double::GetClass())) {
     cached_type_ = Type::kDouble;
     return Type::kDouble;
   }
-  if (env.IsInstanceOf(object_.get(), TimestampInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), TimestampInternal::GetClass())) {
     cached_type_ = Type::kTimestamp;
     return Type::kTimestamp;
   }
-  if (env.IsInstanceOf(object_.get(), String::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), String::GetClass())) {
     cached_type_ = Type::kString;
     return Type::kString;
   }
-  if (env.IsInstanceOf(object_.get(), BlobInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), BlobInternal::GetClass())) {
     cached_type_ = Type::kBlob;
     return Type::kBlob;
   }
-  if (env.IsInstanceOf(object_.get(), DocumentReferenceInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env),
+                       DocumentReferenceInternal::GetClass())) {
     cached_type_ = Type::kReference;
     return Type::kReference;
   }
-  if (env.IsInstanceOf(object_.get(), GeoPointInternal::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), GeoPointInternal::GetClass())) {
     cached_type_ = Type::kGeoPoint;
     return Type::kGeoPoint;
   }
-  if (env.IsInstanceOf(object_.get(), List::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), List::GetClass())) {
     cached_type_ = Type::kArray;
     return Type::kArray;
   }
-  if (env.IsInstanceOf(object_.get(), Map::GetClass())) {
+  if (env.IsInstanceOf(object_.get(env), Map::GetClass())) {
     cached_type_ = Type::kMap;
     return Type::kMap;
   }
 
   FIREBASE_ASSERT_MESSAGE(false, "Unsupported FieldValue type: %s",
-                          Class::GetClassName(env, object_.get()).c_str());
+                          Class::GetClassName(env, object_.get(env)).c_str());
   return Type::kNull;
 }
 
@@ -398,12 +399,12 @@ bool operator==(const FieldValueInternal& lhs, const FieldValueInternal& rhs) {
 template <typename T>
 T FieldValueInternal::Cast(jni::Env& env, Type type) const {
   if (cached_type_ == Type::kNull) {
-    FIREBASE_ASSERT(env.IsInstanceOf(object_.get(), T::GetClass()));
+    FIREBASE_ASSERT(env.IsInstanceOf(object_.get(env), T::GetClass()));
     cached_type_ = type;
   } else {
     FIREBASE_ASSERT(cached_type_ == type);
   }
-  auto typed_value = static_cast<jni::JniType<T>>(object_.get().get());
+  auto typed_value = static_cast<jni::JniType<T>>(object_.get(env).get());
   return T(typed_value);
 }
 
@@ -418,8 +419,14 @@ Local<Array<Object>> FieldValueInternal::MakeArray(
 
 Env FieldValueInternal::GetEnv() { return FirestoreInternal::GetEnv(); }
 
+jni::Local<jni::Object> FieldValueInternal::ToJava() const {
+  Env env = GetEnv();
+  return object_.get(env);
+}
+
 Object FieldValueInternal::ToJava(const FieldValue& value) {
-  return value.internal_ ? value.internal_->object_.get() : Object();
+  Env env = GetEnv();
+  return value.internal_ ? value.internal_->object_.get(env) : Object();
 }
 
 }  // namespace firestore

--- a/firestore/src/android/field_value_android.h
+++ b/firestore/src/android/field_value_android.h
@@ -25,6 +25,7 @@
 #include "firebase/firestore/timestamp.h"
 #include "firestore/src/include/firebase/firestore/document_reference.h"
 #include "firestore/src/include/firebase/firestore/field_value.h"
+#include "firestore/src/jni/arena_ref.h"
 #include "firestore/src/jni/jni_fwd.h"
 #include "firestore/src/jni/object.h"
 #include "firestore/src/jni/ownership.h"
@@ -87,7 +88,7 @@ class FieldValueInternal {
   std::vector<FieldValue> array_value() const;
   MapFieldValue map_value() const;
 
-  const jni::Global<jni::Object>& ToJava() const { return object_; }
+  jni::Local<jni::Object> ToJava() const { return object_.get(); }
 
   static FieldValue Delete();
   static FieldValue ServerTimestamp();
@@ -116,7 +117,7 @@ class FieldValueInternal {
 
   static jni::Env GetEnv();
 
-  jni::Global<jni::Object> object_;
+  jni::ArenaRef object_;
 
   // Below are cached type information. It is costly to get type info from
   // jobject of Object type. So we cache it if we have already known.

--- a/firestore/src/android/field_value_android.h
+++ b/firestore/src/android/field_value_android.h
@@ -88,7 +88,7 @@ class FieldValueInternal {
   std::vector<FieldValue> array_value() const;
   MapFieldValue map_value() const;
 
-  jni::Local<jni::Object> ToJava() const { return object_.get(); }
+  jni::Local<jni::Object> ToJava() const;
 
   static FieldValue Delete();
   static FieldValue ServerTimestamp();

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -314,7 +314,6 @@ bool FirestoreInternal::Initialize(App* app) {
     jni::List::Initialize(loader);
     jni::Long::Initialize(loader);
     jni::Map::Initialize(loader);
-    jni::ObjectArena::Initialize(env, loader);
 
     InitializeFirestore(loader);
     InitializeFirestoreTasks(loader);

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -303,7 +303,6 @@ bool FirestoreInternal::Initialize(App* app) {
     loader.CacheEmbeddedFiles();
 
     jni::Object::Initialize(loader);
-    jni::ObjectArena::Initialize(env, loader);
     jni::String::Initialize(env, loader);
     jni::ArrayList::Initialize(loader);
     jni::Boolean::Initialize(loader);
@@ -315,6 +314,7 @@ bool FirestoreInternal::Initialize(App* app) {
     jni::List::Initialize(loader);
     jni::Long::Initialize(loader);
     jni::Map::Initialize(loader);
+    jni::ObjectArena::Initialize(env, loader);
 
     InitializeFirestore(loader);
     InitializeFirestoreTasks(loader);

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -73,6 +73,7 @@
 #include "firestore/src/jni/loader.h"
 #include "firestore/src/jni/long.h"
 #include "firestore/src/jni/map.h"
+#include "firestore/src/jni/object_arena.h"
 #include "firestore/src/jni/set.h"
 #include "firestore/src/jni/task.h"
 

--- a/firestore/src/android/firestore_android.cc
+++ b/firestore/src/android/firestore_android.cc
@@ -302,6 +302,7 @@ bool FirestoreInternal::Initialize(App* app) {
     loader.CacheEmbeddedFiles();
 
     jni::Object::Initialize(loader);
+    jni::ObjectArena::Initialize(env, loader);
     jni::String::Initialize(env, loader);
     jni::ArrayList::Initialize(loader);
     jni::Boolean::Initialize(loader);

--- a/firestore/src/jni/arena_ref.h
+++ b/firestore/src/jni/arena_ref.h
@@ -39,13 +39,13 @@ class ArenaRef {
 
   explicit ArenaRef(const Object& ob) {
     Env env(GetEnv());
-    id_ = assignState(ObjectArena::GetInstance().Put(env, ob));
+    assignState(ObjectArena::GetInstance().Put(env, ob));
   }
 
   ArenaRef(const ArenaRef& other) {
     if (other.id_.first) {
       Env env(GetEnv());
-      id_ = assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
+      assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
     }
   }
 
@@ -57,8 +57,7 @@ class ArenaRef {
       }
       reset();
       if (other.id_.first) {
-        id_ =
-            assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
+        assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
       }
     }
     return *this;
@@ -72,7 +71,7 @@ class ArenaRef {
       if (id_.first) {
         ObjectArena::GetInstance().Remove(env, id_.second);
       }
-      id_ = assignState(other.release());
+      assignState(other.release());
     }
     return *this;
   }
@@ -84,7 +83,10 @@ class ArenaRef {
     }
   }
 
+  bool has_value() const { return id_.first; }
+
   Local<Object> get() const {
+    FIREBASE_DEV_ASSERT(id_.first);
     Env env(GetEnv());
     return ObjectArena::GetInstance().Get(env, id_.second);
   }
@@ -107,7 +109,7 @@ class ArenaRef {
     return id;
   }
 
-  std::pair<bool, int64_t> assignState(int64_t id) { id_ = {true, id}; }
+  void assignState(int64_t id) { id_ = {true, id}; }
 
   void reset() { id_ = {false, -1}; }
 

--- a/firestore/src/jni/arena_ref.h
+++ b/firestore/src/jni/arena_ref.h
@@ -1,0 +1,123 @@
+/*
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_FIRESTORE_SRC_JNI_ARENA_REF_H_
+#define FIREBASE_FIRESTORE_SRC_JNI_ARENA_REF_H_
+
+#include <utility>
+
+#include "app/src/assert.h"
+#include "firestore/src/jni/env.h"
+#include "firestore/src/jni/object.h"
+#include "firestore/src/jni/object_arena.h"
+
+namespace firebase {
+namespace firestore {
+namespace jni {
+
+/**
+ * An RAII wrapper that uses ObjectArena to manage the reference. It
+ * automatically deletes the JNI local reference when it goes out of scope.
+ * Copies and moves are handled by creating additional references as required.
+ */
+class ArenaRef {
+ public:
+  ArenaRef() = default;
+
+  explicit ArenaRef(const Object& ob) {
+    Env env(GetEnv());
+    id_ = assignState(ObjectArena::GetInstance().Put(env, ob));
+  }
+
+  ArenaRef(const ArenaRef& other) {
+    if (other.id_.first) {
+      Env env(GetEnv());
+      id_ = assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
+    }
+  }
+
+  ArenaRef& operator=(const ArenaRef& other) {
+    if (id_ != other.id_) {
+      Env env(GetEnv());
+      if (id_.first) {
+        ObjectArena::GetInstance().Remove(env, id_.second);
+      }
+      reset();
+      if (other.id_.first) {
+        id_ =
+            assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
+      }
+    }
+    return *this;
+  }
+
+  ArenaRef(ArenaRef&& other) noexcept : ArenaRef(other.release()) {}
+
+  ArenaRef& operator=(ArenaRef&& other) noexcept {
+    if (id_.second != other.id_.second) {
+      Env env(GetEnv());
+      if (id_.first) {
+        ObjectArena::GetInstance().Remove(env, id_.second);
+      }
+      id_ = assignState(other.release());
+    }
+    return *this;
+  }
+
+  ~ArenaRef() {
+    if (id_.first) {
+      Env env(GetEnv());
+      ObjectArena::GetInstance().Remove(env, id_.second);
+    }
+  }
+
+  Local<Object> get() const {
+    Env env(GetEnv());
+    return ObjectArena::GetInstance().Get(env, id_.second);
+  }
+
+  void clear() {
+    if (id_.first) {
+      Env env(GetEnv());
+      ObjectArena::GetInstance().Remove(env, id_.second);
+      reset();
+    }
+  }
+
+ private:
+  explicit ArenaRef(int64_t id) { assignState(id); }
+
+  int64_t release() {
+    FIREBASE_DEV_ASSERT(id_.first);
+    int64_t id = id_.second;
+    reset();
+    return id;
+  }
+
+  std::pair<bool, int64_t> assignState(int64_t id) { id_ = {true, id}; }
+
+  void reset() { id_ = {false, -1}; }
+
+  // A pair of variables which indicate the state of ArenaRef. If id_.first set
+  // to
+  std::pair<bool, int64_t> id_{false, -1};
+};
+
+}  // namespace jni
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIREBASE_FIRESTORE_SRC_JNI_ARENA_REF_H_

--- a/firestore/src/jni/arena_ref.h
+++ b/firestore/src/jni/arena_ref.h
@@ -38,8 +38,8 @@ class ArenaRef {
   ArenaRef() = default;
 
   explicit ArenaRef(const Object& ob) {
-    Env env(GetEnv());
-    int64_t id = ObjectArena::GetInstance().Put(env, ob);
+    Env env;
+    int64_t id = ObjectArena::GetInstance(env).Put(env, ob.get());
     if (env.ok()) {
       assignState(id);
     }
@@ -47,8 +47,8 @@ class ArenaRef {
 
   explicit ArenaRef(const ArenaRef& other) {
     if (other.valid_) {
-      Env env(GetEnv());
-      int64_t id = ObjectArena::GetInstance().Dup(env, other.id_);
+      Env env;
+      int64_t id = ObjectArena::GetInstance(env).Dup(env, other.id_);
       if (env.ok()) {
         assignState(id);
       }
@@ -56,11 +56,11 @@ class ArenaRef {
   }
 
   ArenaRef& operator=(const ArenaRef& other) {
-    Env env(GetEnv());
+    Env env;
     clear(env);
     if (other.valid_ && id_ != other.id_) {
       if (other.valid_) {
-        int64_t id = ObjectArena::GetInstance().Dup(env, other.id_);
+        int64_t id = ObjectArena::GetInstance(env).Dup(env, other.id_);
         if (env.ok()) {
           assignState(id);
         }
@@ -88,8 +88,8 @@ class ArenaRef {
 
   ~ArenaRef() {
     if (valid_) {
-      Env env(GetEnv());
-      ObjectArena::GetInstance().Remove(env, id_);
+      Env env;
+      ObjectArena::GetInstance(env).Remove(env, id_);
     }
   }
 
@@ -97,12 +97,12 @@ class ArenaRef {
 
   Local<Object> get(Env& env) const {
     FIREBASE_DEV_ASSERT(valid_);
-    return ObjectArena::GetInstance().Get(env, id_);
+    return env.MakeResult<Object>(ObjectArena::GetInstance(env).Get(env, id_));
   }
 
   void clear(Env& env) {
     if (valid_) {
-      ObjectArena::GetInstance().Remove(env, id_);
+      ObjectArena::GetInstance(env).Remove(env, id_);
       reset();
     }
   }

--- a/firestore/src/jni/declaration.h
+++ b/firestore/src/jni/declaration.h
@@ -24,7 +24,6 @@ namespace firestore {
 namespace jni {
 
 class Class;
-class Env;
 
 /**
  * A base class containing the details of a Java constructor. See

--- a/firestore/src/jni/env.h
+++ b/firestore/src/jni/env.h
@@ -474,6 +474,17 @@ class Env {
     RecordException();
   }
 
+  template <typename T>
+  EnableForReference<T, Local<T>> MakeResult(jobject object) {
+    // JNI object method results are always jobject, even when the actual type
+    // is jstring or jclass. Cast to the correct type here so that Local<T>
+    // doesn't have to account for this.
+    auto typed_object = static_cast<JniType<T>>(object);
+    return Local<T>(env_, typed_object);
+  }
+
+  void RecordException();
+
  private:
   /**
    * Invokes the JNI instance method using the given method reference on JNIEnv.
@@ -513,22 +524,12 @@ class Env {
     RecordException();
   }
 
-  void RecordException();
   std::string ErrorDescription(const Object& object);
   const char* ErrorName(jint error);
 
   template <typename T>
   EnableForPrimitive<T, T> MakeResult(JniType<T> value) {
     return static_cast<T>(value);
-  }
-
-  template <typename T>
-  EnableForReference<T, Local<T>> MakeResult(jobject object) {
-    // JNI object method results are always jobject, even when the actual type
-    // is jstring or jclass. Cast to the correct type here so that Local<T>
-    // doesn't have to account for this.
-    auto typed_object = static_cast<JniType<T>>(object);
-    return Local<T>(env_, typed_object);
   }
 
   JNIEnv* env_ = nullptr;

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -31,33 +31,29 @@ Global<ObjectArena> kInstance;
 }  // namespace
 
 void ObjectArena::Initialize(Env& env, Loader& loader) {
-  kInstance = ObjectArena::Create(env);
+  kInstance = ObjectArena(env);
 }
 
-Global<ObjectArena> ObjectArena::Create(Env& env) {
-  ObjectArena ob;
-  ob.kHashMap = HashMap::Create(env);
-  return ob;
-}
+ObjectArena::ObjectArena(Env& env) : hash_map_(HashMap::Create(env)) {}
 
 ObjectArena& ObjectArena::GetInstance() { return kInstance; }
 
 Local<Object> ObjectArena::Get(Env& env, int64_t key) {
-  return kHashMap.Get(env, Long::Create(env, key));
+  return hash_map_.Get(env, Long::Create(env, key));
 }
 
 int64_t ObjectArena::Put(Env& env, const Object& value) {
-  kHashMap.Put(env, Long::Create(env, next_key_), value);
+  hash_map_.Put(env, Long::Create(env, next_key_), value);
   return next_key_++;
 }
 
 void ObjectArena::Remove(Env& env, int64_t key) {
-  kHashMap.Remove(env, Long::Create(env, key));
+  hash_map_.Remove(env, Long::Create(env, key));
 }
 
 int64_t ObjectArena::Dup(Env& env, int64_t key) {
-  kHashMap.Put(env, Long::Create(env, next_key_),
-               kHashMap.Get(env, Long::Create(env, key)));
+  hash_map_.Put(env, Long::Create(env, next_key_),
+                hash_map_.Get(env, Long::Create(env, key)));
   return next_key_++;
 }
 

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -1,0 +1,61 @@
+/*
+* Copyright 2022 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+ */
+
+#include "firestore/src/jni/object_arena.h"
+
+#include "firestore/src/jni/env.h"
+#include "firestore/src/jni/loader.h"
+#include "firestore/src/jni/hash_map.h"
+#include "firestore/src/jni/long.h"
+
+namespace firebase {
+namespace firestore {
+namespace jni {
+namespace {
+
+Global<ObjectArena> kInstance;
+Global<HashMap> kHashMap;
+
+}  // namespace
+
+void ObjectArena::Initialize(Env& env, Loader& loader) {
+
+}
+
+ObjectArena& ObjectArena::GetInstance() { return kInstance; }
+
+Local<Object> ObjectArena::Get(Env& env, int64_t key) {
+    return kHashMap.Get(env, Long::Create(env, key));
+}
+
+int64_t ObjectArena::Put(Env& env, const Object& value) {
+  kHashMap.Put(env, Long::Create(env, next_key_), value);
+  return next_key_++;
+}
+
+void ObjectArena::Remove(Env& env, int64_t key) {
+  kHashMap.Remove(env, Long::Create(env, key));
+}
+
+int64_t ObjectArena::Dup(Env& env, int64_t key) {
+  kHashMap.Put(env, Long::Create(env, next_key_),
+               kHashMap.Get(env, Long::Create(env, key)));
+  return next_key_++;
+}
+
+}  // namespace jni
+}  // namespace firestore
+}  // namespace firebase

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -16,6 +16,7 @@
 
 #include "firestore/src/jni/object_arena.h"
 
+#include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/jni/env.h"
 #include "firestore/src/jni/hash_map.h"
 #include "firestore/src/jni/loader.h"
@@ -34,7 +35,12 @@ void ObjectArena::Initialize(Env& env, Loader& loader) {
   kInstance = ObjectArena(env);
 }
 
-ObjectArena::ObjectArena(Env& env) : hash_map_(HashMap::Create(env)) {}
+ObjectArena::ObjectArena(Env& env) : hash_map_(HashMap::Create(env)) {
+    if (! env.ok()) {
+      env.get()->ExceptionDescribe();
+    }
+    SIMPLE_HARD_ASSERT(hash_map_, "zzyzx hash_map_ is null");
+}
 
 ObjectArena& ObjectArena::GetInstance() { return kInstance; }
 

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -27,24 +27,19 @@ namespace firestore {
 namespace jni {
 namespace {
 
-Global<ObjectArena> kInstance;
-
 }  // namespace
 
-void ObjectArena::Initialize(Env& env, Loader& loader) {
-  kInstance = ObjectArena(env);
+ObjectArena::ObjectArena(Env& env) {
+  hash_map_class_ = env.get()->FindClass("java/lang/HashMap");
+  hash_map_put_ = env.get()->GetMethodID(hash_map_class_, "put", "(Ljava/lang/object");
 }
 
-ObjectArena::ObjectArena(Env& env) : hash_map_(HashMap::Create(env)) {
-    if (! env.ok()) {
-      env.get()->ExceptionDescribe();
-    }
-    SIMPLE_HARD_ASSERT(hash_map_, "zzyzx hash_map_ is null");
+ObjectArena& ObjectArena::GetInstance(Env& env) {
+  static auto* instance = new ObjectArena(env);
+  return *instance;
 }
 
-ObjectArena& ObjectArena::GetInstance() { return kInstance; }
-
-Local<Object> ObjectArena::Get(Env& env, int64_t key) {
+jobject ObjectArena::Get(Env& env, int64_t key) {
   return hash_map_.Get(env, Long::Create(env, key));
 }
 

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -1,24 +1,24 @@
 /*
-* Copyright 2022 Google LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #include "firestore/src/jni/object_arena.h"
 
 #include "firestore/src/jni/env.h"
-#include "firestore/src/jni/loader.h"
 #include "firestore/src/jni/hash_map.h"
+#include "firestore/src/jni/loader.h"
 #include "firestore/src/jni/long.h"
 
 namespace firebase {
@@ -31,14 +31,12 @@ Global<HashMap> kHashMap;
 
 }  // namespace
 
-void ObjectArena::Initialize(Env& env, Loader& loader) {
-
-}
+void ObjectArena::Initialize(Env& env, Loader& loader) {}
 
 ObjectArena& ObjectArena::GetInstance() { return kInstance; }
 
 Local<Object> ObjectArena::Get(Env& env, int64_t key) {
-    return kHashMap.Get(env, Long::Create(env, key));
+  return kHashMap.Get(env, Long::Create(env, key));
 }
 
 int64_t ObjectArena::Put(Env& env, const Object& value) {

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -27,11 +27,18 @@ namespace jni {
 namespace {
 
 Global<ObjectArena> kInstance;
-Global<HashMap> kHashMap;
 
 }  // namespace
 
-void ObjectArena::Initialize(Env& env, Loader& loader) {}
+void ObjectArena::Initialize(Env& env, Loader& loader) {
+  kInstance = ObjectArena::Create(env);
+}
+
+Global<ObjectArena> ObjectArena::Create(Env& env) {
+  ObjectArena ob;
+  ob.kHashMap = HashMap::Create(env);
+  return ob;
+}
 
 ObjectArena& ObjectArena::GetInstance() { return kInstance; }
 

--- a/firestore/src/jni/object_arena.cc
+++ b/firestore/src/jni/object_arena.cc
@@ -18,9 +18,7 @@
 
 #include "firestore/src/common/hard_assert_common.h"
 #include "firestore/src/jni/env.h"
-#include "firestore/src/jni/hash_map.h"
 #include "firestore/src/jni/loader.h"
-#include "firestore/src/jni/long.h"
 
 namespace firebase {
 namespace firestore {
@@ -30,8 +28,20 @@ namespace {
 }  // namespace
 
 ObjectArena::ObjectArena(Env& env) {
-  hash_map_class_ = env.get()->FindClass("java/lang/HashMap");
-  hash_map_put_ = env.get()->GetMethodID(hash_map_class_, "put", "(Ljava/lang/object");
+  hash_map_class_ = env.get()->FindClass("java/util/HashMap");
+  hash_map_ctor_ = env.get()->GetMethodID(hash_map_class_, "<init>", "()V");
+  hash_map_ = env.get()->NewGlobalRef(
+          env.get()->NewObject(hash_map_class_, hash_map_ctor_));
+
+  hash_map_get_ = env.get()->GetMethodID(hash_map_class_, "get",
+                                         "(Ljava/lang/Object;)Ljava/lang/Object;");
+  hash_map_put_ = env.get()->GetMethodID(hash_map_class_, "put",
+                                         "(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;");
+  hash_map_remove_ = env.get()->GetMethodID(hash_map_class_, "remove",
+                                         "(Ljava/lang/Object;)Ljava/lang/Object;");
+
+  long_class_ = env.get()->FindClass("java/lang/Long");
+  long_ctor_ = env.get()->GetMethodID(long_class_, "<init>", "(J)V");
 }
 
 ObjectArena& ObjectArena::GetInstance(Env& env) {
@@ -40,22 +50,41 @@ ObjectArena& ObjectArena::GetInstance(Env& env) {
 }
 
 jobject ObjectArena::Get(Env& env, int64_t key) {
-  return hash_map_.Get(env, Long::Create(env, key));
+  jobject long_key = MakeKey(env, key);
+  jobject result = env.get()->CallObjectMethod(hash_map_, hash_map_get_, long_key);
+  SIMPLE_HARD_ASSERT(env.ok(), "Get() fails");
+  return result;
 }
 
-int64_t ObjectArena::Put(Env& env, const Object& value) {
-  hash_map_.Put(env, Long::Create(env, next_key_), value);
+int64_t ObjectArena::Put(Env& env, jobject value) {
+  SIMPLE_HARD_ASSERT(reinterpret_cast<jobject>(0x1) != value, "value is null");
+  SIMPLE_HARD_ASSERT(reinterpret_cast<jobject>(0x1) != hash_map_, "hash_map_ is null");
+  env.RecordException();
+  env.get()->CallObjectMethod(hash_map_, hash_map_put_, next_key_, value);
+  env.RecordException();
+  SIMPLE_HARD_ASSERT(env.ok(), "Put() fails");
   return next_key_++;
 }
 
 void ObjectArena::Remove(Env& env, int64_t key) {
-  hash_map_.Remove(env, Long::Create(env, key));
+  jobject long_key = MakeKey(env, key);
+  env.get()->CallObjectMethod(hash_map_, hash_map_remove_, long_key);
+  SIMPLE_HARD_ASSERT(env.ok(), "Remove() fails");
 }
 
 int64_t ObjectArena::Dup(Env& env, int64_t key) {
-  hash_map_.Put(env, Long::Create(env, next_key_),
-                hash_map_.Get(env, Long::Create(env, key)));
+  jobject long_key = MakeKey(env, key);
+  jobject old_key = env.get()->CallObjectMethod(hash_map_, hash_map_get_, long_key);
+  env.get()->CallObjectMethod(hash_map_, hash_map_put_,
+                              MakeKey(env, next_key_),
+                              old_key);
+  SIMPLE_HARD_ASSERT(env.ok(), "Dup() fails");
   return next_key_++;
+}
+jobject ObjectArena::MakeKey(Env& env, int64_t key) {
+  jobject result = env.get()->NewObject(long_class_, long_ctor_, key);
+  SIMPLE_HARD_ASSERT(env.ok(), "MakeKey() fails");
+  return result;
 }
 
 }  // namespace jni

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -17,7 +17,9 @@
 #ifndef FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
 #define FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
 
+#include "firestore/src/jni/hash_map.h"
 #include "firestore/src/jni/object.h"
+#include "firestore/src/jni/ownership.h"
 
 namespace firebase {
 namespace firestore {
@@ -32,6 +34,8 @@ class ObjectArena : public Object {
 
   static ObjectArena& GetInstance();
 
+  static Global<ObjectArena> Create(Env& env);
+
   Local<Object> Get(Env& env, int64_t key);
   int64_t Put(Env& env, const Object& value);
   void Remove(Env& env, int64_t key);
@@ -39,6 +43,7 @@ class ObjectArena : public Object {
 
  private:
   int64_t next_key_ = 0;
+  Global<HashMap> kHashMap;
 };
 
 }  // namespace jni

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -34,7 +34,7 @@ class ObjectArena : public Object {
 
   static ObjectArena& GetInstance();
 
-  static Global<ObjectArena> Create(Env& env);
+  explicit ObjectArena(Env& env);
 
   Local<Object> Get(Env& env, int64_t key);
   int64_t Put(Env& env, const Object& value);
@@ -43,7 +43,7 @@ class ObjectArena : public Object {
 
  private:
   int64_t next_key_ = 0;
-  Global<HashMap> kHashMap;
+  Global<HashMap> hash_map_;
 };
 
 }  // namespace jni

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -1,18 +1,18 @@
 /*
-* Copyright 2022 Google LLC
-*
-* Licensed under the Apache License, Version 2.0 (the "License");
-* you may not use this file except in compliance with the License.
-* You may obtain a copy of the License at
-*
-*      http://www.apache.org/licenses/LICENSE-2.0
-*
-* Unless required by applicable law or agreed to in writing, software
-* distributed under the License is distributed on an "AS IS" BASIS,
-* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-* See the License for the specific language governing permissions and
-* limitations under the License.
-*/
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 
 #ifndef FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
 #define FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
@@ -25,20 +25,20 @@ namespace jni {
 
 /** `ObjectArena` serves as a local HashMap. */
 class ObjectArena : public Object {
-public:
- using Object::Object;
+ public:
+  using Object::Object;
 
- static void Initialize(Env& env, Loader& loader);
+  static void Initialize(Env& env, Loader& loader);
 
- static ObjectArena& GetInstance();
+  static ObjectArena& GetInstance();
 
- Local<Object> Get(Env& env, int64_t key);
- int64_t Put(Env& env, const Object& value);
- void Remove(Env& env, int64_t key);
- int64_t Dup(Env& env, int64_t key);
+  Local<Object> Get(Env& env, int64_t key);
+  int64_t Put(Env& env, const Object& value);
+  void Remove(Env& env, int64_t key);
+  int64_t Dup(Env& env, int64_t key);
 
-private:
- int64_t next_key_ = 0;
+ private:
+  int64_t next_key_ = 0;
 };
 
 }  // namespace jni

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -32,17 +32,25 @@ class ObjectArena {
 
   static ObjectArena& GetInstance(Env& env);
 
-  Local<Object> Get(Env& env, int64_t key);
-  int64_t Put(Env& env, const Object& value);
+  jobject Get(Env& env, int64_t key);
+  int64_t Put(Env& env, jobject value);
   void Remove(Env& env, int64_t key);
   int64_t Dup(Env& env, int64_t key);
 
  private:
   explicit ObjectArena(Env& env);
+  jobject MakeKey(Env& env, int64_t key);
 
   int64_t next_key_ = 0;
   jclass hash_map_class_ = nullptr;
+  jmethodID hash_map_ctor_ = nullptr;
+  jobject hash_map_ = nullptr;
+  jmethodID hash_map_get_ = nullptr;
   jmethodID hash_map_put_ = nullptr;
+  jmethodID hash_map_remove_ = nullptr;
+
+  jclass long_class_ = nullptr;
+  jmethodID long_ctor_ = nullptr;
 };
 
 }  // namespace jni

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -1,0 +1,48 @@
+/*
+* Copyright 2022 Google LLC
+*
+* Licensed under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License.
+* You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+
+#ifndef FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
+#define FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_
+
+#include "firestore/src/jni/object.h"
+
+namespace firebase {
+namespace firestore {
+namespace jni {
+
+/** `ObjectArena` serves as a local HashMap. */
+class ObjectArena : public Object {
+public:
+ using Object::Object;
+
+ static void Initialize(Env& env, Loader& loader);
+
+ static ObjectArena& GetInstance();
+
+ Local<Object> Get(Env& env, int64_t key);
+ int64_t Put(Env& env, const Object& value);
+ void Remove(Env& env, int64_t key);
+ int64_t Dup(Env& env, int64_t key);
+
+private:
+ int64_t next_key_ = 0;
+};
+
+}  // namespace jni
+}  // namespace firestore
+}  // namespace firebase
+
+#endif  // FIREBASE_FIRESTORE_SRC_JNI_OBJECT_ARENA_H_

--- a/firestore/src/jni/object_arena.h
+++ b/firestore/src/jni/object_arena.h
@@ -26,15 +26,11 @@ namespace firestore {
 namespace jni {
 
 /** `ObjectArena` serves as a local HashMap. */
-class ObjectArena : public Object {
+class ObjectArena {
  public:
-  using Object::Object;
+  ~ObjectArena() = delete;
 
-  static void Initialize(Env& env, Loader& loader);
-
-  static ObjectArena& GetInstance();
-
-  explicit ObjectArena(Env& env);
+  static ObjectArena& GetInstance(Env& env);
 
   Local<Object> Get(Env& env, int64_t key);
   int64_t Put(Env& env, const Object& value);
@@ -42,8 +38,11 @@ class ObjectArena : public Object {
   int64_t Dup(Env& env, int64_t key);
 
  private:
+  explicit ObjectArena(Env& env);
+
   int64_t next_key_ = 0;
-  Global<HashMap> hash_map_;
+  jclass hash_map_class_ = nullptr;
+  jmethodID hash_map_put_ = nullptr;
 };
 
 }  // namespace jni

--- a/firestore/src/jni/ownership.h
+++ b/firestore/src/jni/ownership.h
@@ -20,10 +20,7 @@
 #include <jni.h>
 
 #include <string>
-#include <utility>
 
-#include "firestore/src/jni/env.h"
-#include "firestore/src/jni/object_arena.h"
 #include "firestore/src/jni/traits.h"
 
 namespace firebase {
@@ -283,94 +280,6 @@ class Global : public T {
       return GetEnv();
     }
   }
-};
-
-/**
- * An RAII wrapper that uses ObjectArena to manage the reference. It
- * automatically deletes the JNI local reference when it goes out of scope.
- * Copies and moves are handled by creating additional references as required.
- */
-class ArenaRef {
- public:
-  ArenaRef() = default;
-
-  explicit ArenaRef(const Object& ob) {
-    Env env(GetEnv());
-    id_ = assignState(ObjectArena::GetInstance().Put(env, ob));
-  }
-
-  ArenaRef(const ArenaRef& other) {
-    if (other.id_.first) {
-      Env env(GetEnv());
-      id_ = assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
-    }
-  }
-
-  ArenaRef& operator=(const ArenaRef& other) {
-    if (id_ != other.id_) {
-      Env env(GetEnv());
-      if (id_.first) {
-        ObjectArena::GetInstance().Remove(env, id_.second);
-      }
-      reset();
-      if (other.id_.first) {
-        id_ =
-            assignState(ObjectArena::GetInstance().Dup(env, other.id_.second));
-      }
-    }
-    return *this;
-  }
-
-  ArenaRef(ArenaRef&& other) noexcept : ArenaRef(other.release()) {}
-
-  ArenaRef& operator=(ArenaRef&& other) noexcept {
-    if (id_.second != other.id_.second) {
-      Env env(GetEnv());
-      if (id_.first) {
-        ObjectArena::GetInstance().Remove(env, id_.second);
-      }
-      id_ = assignState(other.release());
-    }
-    return *this;
-  }
-
-  ~ArenaRef() {
-    if (id_.first) {
-      Env env(GetEnv());
-      ObjectArena::GetInstance().Remove(env, id_.second);
-    }
-  }
-
-  Local<Object> get() const {
-    Env env(GetEnv());
-    return ObjectArena::GetInstance().Get(env, id_.second);
-  }
-
-  void clear() {
-    if (id_.first) {
-      Env env(GetEnv());
-      ObjectArena::GetInstance().Remove(env, id_.second);
-      reset();
-    }
-  }
-
- private:
-  explicit ArenaRef(int64_t id) { assignState(id); }
-
-  int64_t release() {
-    FIREBASE_DEV_ASSERT(id_.first);
-    int64_t id = id_.second;
-    reset();
-    return id;
-  }
-
-  std::pair<bool, int64_t> assignState(int64_t id) { id_ = {true, id}; }
-
-  void reset() { id_ = {false, -1}; }
-
-  // A pair of variables which indicate the state of ArenaRef. If id_.first set
-  // to
-  std::pair<bool, int64_t> id_{false, -1};
 };
 
 }  // namespace jni

--- a/firestore/src/jni/ownership.h
+++ b/firestore/src/jni/ownership.h
@@ -286,15 +286,15 @@ class Global : public T {
 };
 
 /**
- * An RAII wrapper that uses ObjectArena to manage the reference. It automatically
- * deletes the JNI local reference when it goes out of scope. Copies and moves
- * are handled by creating additional references as required.
+ * An RAII wrapper that uses ObjectArena to manage the reference. It
+ * automatically deletes the JNI local reference when it goes out of scope.
+ * Copies and moves are handled by creating additional references as required.
  */
 class ArenaRef {
  public:
   ArenaRef() = default;
 
-  ArenaRef(const Object& ob) {
+  explicit ArenaRef(const Object& ob) {
     Env env(GetEnv());
     id_ = ObjectArena::GetInstance().Put(env, ob);
   }
@@ -354,7 +354,7 @@ class ArenaRef {
   }
 
  private:
-  ArenaRef(int64_t id): id_(id) {}
+  explicit ArenaRef(int64_t id) : id_(id) {}
 
   int64_t release() {
     FIREBASE_DEV_ASSERT(id_);


### PR DESCRIPTION
### Description
> Implemented `ArenaRef` which uses as a replacement of Global Reference in order to solve problems caused by JNI Global Reference limitation.
***
### Testing
> Integration tests
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. ([#569](https://github.com/firebase/firebase-unity-sdk/issues/569))([#1193](https://github.com/firebase/quickstart-unity/issues/1193#issuecomment-1242203289))
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
