### PR TITLE
Firestore: Add absl header-only support for Android builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,14 @@ set(FIREBASE_PYTHON_EXECUTABLE "python" CACHE FILEPATH
 set(FIREBASE_XCODE_TARGET_FORMAT "frameworks" CACHE STRING
                                  "Format to output, 'frameworks' or 'libraries'")
 
+# The cmake executable to use when compiling subprojects that are intended to be
+# run on the host, rather than on the target, such as flatc. Normally, the
+# default value (finding `cmake` in the PATH) is fine; however, in cases where
+# `cmake` is *not* in the PATH (e.g. when building from CLion using the Android
+# toolchain) it must be specified via this cache variable.
+set(FIREBASE_HOST_CMAKE_COMMAND "cmake" CACHE FILEPATH
+  "The cmake command to use when compiling subprojects for the host.")
+
 # Define this directory to be the root of the C++ SDK, which the libraries can
 # then refer to.
 set(FIREBASE_CPP_SDK_ROOT_DIR ${CMAKE_CURRENT_LIST_DIR})
@@ -524,20 +532,13 @@ else()
     set(ENV_COMMAND env -i PATH=${firebase_command_line_path})
   endif()
 
-  # The cmake executable to use when compiling flatc. Normally, the default
-  # value (finding cmake in the PATH) is fine; however, in cases where cmake is
-  # *not* in the PATH (e.g. when building from CLion using the Android
-  # toolchain) it must be specified via via this cache variable.
-  set(FIREBASE_FLATC_CMAKE_COMMAND "cmake" CACHE FILEPATH
-    "The cmake command to use when compiling flatc.")
-
   # Build flatc by invoking the cmake build, with only the flatc target.
   file(MAKE_DIRECTORY ${firebase_external_flatc_build_dir})
   add_custom_command(
     OUTPUT ${firebase_external_flatc}
     COMMAND cd ${firebase_external_flatc_build_dir} ${COMMAND_CONCAT}
-            ${ENV_COMMAND} ${FIREBASE_FLATC_CMAKE_COMMAND} ${FLATBUFFERS_SOURCE_DIR} ${COMMAND_CONCAT}
-            ${ENV_COMMAND} ${FIREBASE_FLATC_CMAKE_COMMAND} --build . --target flatc
+            ${ENV_COMMAND} ${FIREBASE_HOST_CMAKE_COMMAND} ${FLATBUFFERS_SOURCE_DIR} ${COMMAND_CONCAT}
+            ${ENV_COMMAND} ${FIREBASE_HOST_CMAKE_COMMAND} --build . --target flatc
     COMMENT "Building flatc (the FlatBuffer schema compiler)")
 
   # Add a target so that we can run the custom commands before the code build.

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -22,12 +22,14 @@
 #     (optional) A description to include in log messages about the command.
 #     Example: "run the foo output through the bar filter"
 function(execute_process_ex)
+  # TODO: Upgrade the call of cmake_parse_arguments() to the PARSE_ARGV form
+  # once the Android build upgrades its cmake version from 3.6 to 3.7+.
   cmake_parse_arguments(
-    PARSE_ARGV 0
     ARG
     "" # zero-value arguments
     "DESCRIPTION" # single-value arguments
     "COMMAND" # multi-value arguments
+    ${ARGN}
   )
 
   # Validate the arguments
@@ -35,7 +37,7 @@ function(execute_process_ex)
   if(ARG_COMMAND_LENGTH EQUAL 0)
     message(
       FATAL_ERROR
-      "COMMAND must be specified to ${CMAKE_CURRENT_FUNCTION} "
+      "COMMAND must be specified to execute_process_ex() "
       "and must have at least one value (DESCRIPTION=${ARG_DESCRIPTION})"
     )
   endif()

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -41,6 +41,12 @@ function(execute_process_ex)
       "and must have at least one value (DESCRIPTION=${ARG_DESCRIPTION})"
     )
   endif()
+  if(NOT ("${ARG_UNPARSED_ARGUMENTS}" STREQUAL ""))
+    message(
+      FATAL_ERROR
+      "Unexpected arguments to execute_process_ex(): ${ARG_UNPARSED_ARGUMENTS}"
+    )
+  endif()
 
   # Log that the process is about to be executed.
   set(ARG_COMMAND_STR "")

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -72,7 +72,24 @@ function(execute_process_ex)
     RESULT_VARIABLE
       EXECUTE_PROCESS_RESULT
   )
+
+  # If WORKING_DIRECTORY is specified, then validate it (for maximally-
+  # informative error messages) and add it to the arguments for execute_process.
   if(NOT ("${ARG_WORKING_DIRECTORY}" STREQUAL ""))
+    if(NOT (EXISTS "${ARG_WORKING_DIRECTORY}"))
+      message(
+        FATAL_ERROR
+        "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+        "WORKING_DIRECTORY does not exist: ${ARG_WORKING_DIRECTORY}"
+      )
+    endif()
+    if(NOT (IS_DIRECTORY "${ARG_WORKING_DIRECTORY}"))
+      message(
+        FATAL_ERROR
+        "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+        "WORKING_DIRECTORY is not a directory: ${ARG_WORKING_DIRECTORY}"
+      )
+    endif()
     list(
       APPEND
       EXECUTE_PROCESS_ARGS
@@ -81,7 +98,8 @@ function(execute_process_ex)
     )
   endif()
 
-  # Execute the process
+  # Execute the process by calling cmake's built-in execute_process() function
+  # with the arguments specified to this function.
   execute_process(${EXECUTE_PROCESS_ARGS})
 
   # Verify that the command completed successfully.

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -1,0 +1,82 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Invokes cmake's built-in execute_process() function, but also performs some
+# logging and fails cmake if the process completes with a non-zero exit code.
+#
+# Arguments:
+#   COMMAND
+#     The command to run; it is forwarded verbatim to execute_process().
+#   DESCRIPTION
+#     (optional) A description to include in log messages about the command.
+#     Example: "run the foo output through the bar filter"
+function(execute_process_ex)
+  cmake_parse_arguments(
+    PARSE_ARGV 0
+    ARG
+    "" # zero-value arguments
+    "DESCRIPTION" # single-value arguments
+    "COMMAND" # multi-value arguments
+  )
+
+  # Validate the arguments
+  list(LENGTH ARG_COMMAND ARG_COMMAND_LENGTH)
+  if(ARG_COMMAND_LENGTH EQUAL 0)
+    message(
+      FATAL_ERROR
+      "COMMAND must be specified to ${CMAKE_CURRENT_FUNCTION} "
+      "and must have at least one value (DESCRIPTION=${ARG_DESCRIPTION})"
+    )
+  endif()
+
+  # Log that the process is about to be executed.
+  set(ARG_COMMAND_STR "")
+  foreach(ARG_COMMAND_STR_COMPONENT ${ARG_COMMAND})
+    string(APPEND ARG_COMMAND_STR " ${ARG_COMMAND_STR_COMPONENT}")
+  endforeach()
+  string(SUBSTRING "${ARG_COMMAND_STR}" 1, -1 ARG_COMMAND_STR)
+  if("${ARG_DESCRIPTION}" STREQUAL "")
+    message(STATUS "Command starting: ${ARG_COMMAND_STR}")
+  else()
+    message(STATUS "Command starting (${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}")
+  endif()
+
+  # Execute the process
+  execute_process(
+    COMMAND
+      ${ARG_COMMAND}
+    RESULT_VARIABLE
+      EXECUTE_PROCESS_RESULT
+  )
+
+  # Verify that the command completed successfully.
+  if(NOT (EXECUTE_PROCESS_RESULT EQUAL 0))
+    message(
+      FATAL_ERROR
+      "Command completed with non-zero exit code ${EXECUTE_PROCESS_RESULT} "
+      "(DESCRIPTION=${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}"
+    )
+  endif()
+
+  # Log the success of the command.
+  if("${ARG_DESCRIPTION}" STREQUAL "")
+    message(STATUS "Command completed successfully: ${ARG_COMMAND_STR}")
+  else()
+    message(
+      STATUS
+      "Command completed successfully (${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}"
+    )
+  endif()
+
+endfunction(execute_process_ex)

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -18,6 +18,8 @@
 # Arguments:
 #   COMMAND
 #     The command to run; it is forwarded verbatim to execute_process().
+#   WORKING_DIRECTORY
+#     The directory to set as the current working directory of the child process.
 #   DESCRIPTION
 #     (optional) A description to include in log messages about the command.
 #     Example: "run the foo output through the bar filter"
@@ -27,7 +29,7 @@ function(execute_process_ex)
   cmake_parse_arguments(
     ARG
     "" # zero-value arguments
-    "DESCRIPTION" # single-value arguments
+    "DESCRIPTION;WORKING_DIRECTORY" # single-value arguments
     "COMMAND" # multi-value arguments
     ${ARGN}
   )
@@ -60,13 +62,25 @@ function(execute_process_ex)
     message(STATUS "Command starting (${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}")
   endif()
 
-  # Execute the process
-  execute_process(
+  # Build up the arguments to specify to execute_process().
+  set(
+    EXECUTE_PROCESS_ARGS
     COMMAND
       ${ARG_COMMAND}
     RESULT_VARIABLE
       EXECUTE_PROCESS_RESULT
   )
+  if(NOT ("${ARG_WORKING_DIRECTORY}" STREQUAL ""))
+    list(
+      APPEND
+      EXECUTE_PROCESS_ARGS
+      WORKING_DIRECTORY
+      "${ARG_WORKING_DIRECTORY}"
+    )
+  endif()
+
+  # Execute the process
+  execute_process(${EXECUTE_PROCESS_ARGS})
 
   # Verify that the command completed successfully.
   if(NOT (EXECUTE_PROCESS_RESULT EQUAL 0))

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -40,14 +40,15 @@ function(execute_process_ex)
   if(ARG_COMMAND_LENGTH EQUAL 0)
     message(
       FATAL_ERROR
-      "COMMAND must be specified to execute_process_ex() "
-      "and must have at least one value (COMMENT=${ARG_COMMENT})"
+      "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+      "COMMAND must be specified and must have at least one value."
     )
   endif()
   if(NOT ("${ARG_UNPARSED_ARGUMENTS}" STREQUAL ""))
     message(
       FATAL_ERROR
-      "Unexpected arguments to execute_process_ex(): ${ARG_UNPARSED_ARGUMENTS}"
+      "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+      "unexpected arguments: ${ARG_UNPARSED_ARGUMENTS}"
     )
   endif()
 
@@ -57,11 +58,11 @@ function(execute_process_ex)
     string(APPEND ARG_COMMAND_STR " ${ARG_COMMAND_STR_COMPONENT}")
   endforeach()
   string(SUBSTRING "${ARG_COMMAND_STR}" 1, -1 ARG_COMMAND_STR)
-  if("${ARG_COMMENT}" STREQUAL "")
-    message(STATUS "Command starting: ${ARG_COMMAND_STR}")
-  else()
-    message(STATUS "Command starting (${ARG_COMMENT}): ${ARG_COMMAND_STR}")
-  endif()
+  message(
+    STATUS
+    "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+    "Command starting: ${ARG_COMMAND_STR}"
+  )
 
   # Build up the arguments to specify to execute_process().
   set(
@@ -87,19 +88,17 @@ function(execute_process_ex)
   if(NOT (EXECUTE_PROCESS_RESULT EQUAL 0))
     message(
       FATAL_ERROR
-      "Command completed with non-zero exit code ${EXECUTE_PROCESS_RESULT} "
-      "(COMMENT=${ARG_COMMENT}): ${ARG_COMMAND_STR}"
+      "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+      "Command completed with non-zero exit code ${EXECUTE_PROCESS_RESULT}: "
+      "${ARG_COMMAND_STR}"
     )
   endif()
 
   # Log the success of the command.
-  if("${ARG_COMMENT}" STREQUAL "")
-    message(STATUS "Command completed successfully: ${ARG_COMMAND_STR}")
-  else()
-    message(
-      STATUS
-      "Command completed successfully (${ARG_COMMENT}): ${ARG_COMMAND_STR}"
-    )
-  endif()
+  message(
+    STATUS
+    "execute_process_ex(COMMENT=${ARG_COMMENT}): "
+    "Command completed successfully: ${ARG_COMMAND_STR}"
+  )
 
 endfunction(execute_process_ex)

--- a/cmake/execute_process_ex.cmake
+++ b/cmake/execute_process_ex.cmake
@@ -19,9 +19,10 @@
 #   COMMAND
 #     The command to run; it is forwarded verbatim to execute_process().
 #   WORKING_DIRECTORY
-#     The directory to set as the current working directory of the child process.
-#   DESCRIPTION
-#     (optional) A description to include in log messages about the command.
+#     (optional) The directory to set as the current working directory of the
+#     child process. If not specified, then the current directory is used.
+#   COMMENT
+#     (optional) A comment to include in log messages about the command.
 #     Example: "run the foo output through the bar filter"
 function(execute_process_ex)
   # TODO: Upgrade the call of cmake_parse_arguments() to the PARSE_ARGV form
@@ -29,7 +30,7 @@ function(execute_process_ex)
   cmake_parse_arguments(
     ARG
     "" # zero-value arguments
-    "DESCRIPTION;WORKING_DIRECTORY" # single-value arguments
+    "COMMENT;WORKING_DIRECTORY" # single-value arguments
     "COMMAND" # multi-value arguments
     ${ARGN}
   )
@@ -40,7 +41,7 @@ function(execute_process_ex)
     message(
       FATAL_ERROR
       "COMMAND must be specified to execute_process_ex() "
-      "and must have at least one value (DESCRIPTION=${ARG_DESCRIPTION})"
+      "and must have at least one value (COMMENT=${ARG_COMMENT})"
     )
   endif()
   if(NOT ("${ARG_UNPARSED_ARGUMENTS}" STREQUAL ""))
@@ -56,10 +57,10 @@ function(execute_process_ex)
     string(APPEND ARG_COMMAND_STR " ${ARG_COMMAND_STR_COMPONENT}")
   endforeach()
   string(SUBSTRING "${ARG_COMMAND_STR}" 1, -1 ARG_COMMAND_STR)
-  if("${ARG_DESCRIPTION}" STREQUAL "")
+  if("${ARG_COMMENT}" STREQUAL "")
     message(STATUS "Command starting: ${ARG_COMMAND_STR}")
   else()
-    message(STATUS "Command starting (${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}")
+    message(STATUS "Command starting (${ARG_COMMENT}): ${ARG_COMMAND_STR}")
   endif()
 
   # Build up the arguments to specify to execute_process().
@@ -87,17 +88,17 @@ function(execute_process_ex)
     message(
       FATAL_ERROR
       "Command completed with non-zero exit code ${EXECUTE_PROCESS_RESULT} "
-      "(DESCRIPTION=${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}"
+      "(COMMENT=${ARG_COMMENT}): ${ARG_COMMAND_STR}"
     )
   endif()
 
   # Log the success of the command.
-  if("${ARG_DESCRIPTION}" STREQUAL "")
+  if("${ARG_COMMENT}" STREQUAL "")
     message(STATUS "Command completed successfully: ${ARG_COMMAND_STR}")
   else()
     message(
       STATUS
-      "Command completed successfully (${ARG_DESCRIPTION}): ${ARG_COMMAND_STR}"
+      "Command completed successfully (${ARG_COMMENT}): ${ARG_COMMAND_STR}"
     )
   endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -429,7 +429,7 @@ if (ANDROID)
     DESCRIPTION
       "configure firebase-ios-sdk with cmake"
     COMMAND
-      "${CMAKE_COMMAND}"
+      "${FIREBASE_HOST_CMAKE_COMMAND}"
       "${PROJECT_BINARY_DIR}/external/src/firestore"
     WORKING_DIRECTORY
       "${PROJECT_BINARY_DIR}/external/src/firestore-build"

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -427,8 +427,9 @@ if (ANDROID)
   if(NOT (IS_DIRECTORY "${FIRESTORE_SOURCE_DIR}"))
     message(
       FATAL_ERROR
-      "The directory into which the firebase-ios-sdk repository was expected "
-      "to have been cloned does not exist: ${FIRESTORE_SOURCE_DIR}"
+      "FIRESTORE_SOURCE_DIR, the directory into which the firebase-ios-sdk "
+      "repository was expected to have been cloned, does not exist: "
+      "${FIRESTORE_SOURCE_DIR}"
     )
   endif()
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -450,7 +450,7 @@ if (ANDROID)
   # Provide access to the absl headers in the Android Firestore C++ SDK build.
   # This enables the build to use header-only components of absl, like
   # absl::optional. In the future, to add support for non-header-only parts of
-  # abs, use add_subdirectory() instead; however, this must be done with great
+  # absl, use add_subdirectory() instead; however, this must be done with great
   # care as it may cause ABI issues and/or ODR violations with customers who
   # also use absl.
   target_include_directories(

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -424,14 +424,14 @@ endif()
 # depend on the firebase-ios-sdk and, therefore, automatically have acces to the
 # absl headers that it downloads.
 if (ANDROID)
+  file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")
   execute_process_ex(
     DESCRIPTION
       "configure firebase-ios-sdk with cmake"
     COMMAND
       "${CMAKE_COMMAND}"
-      -S
       "${PROJECT_BINARY_DIR}/external/src/firestore"
-      -B
+    WORKING_DIRECTORY
       "${PROJECT_BINARY_DIR}/external/src/firestore-build"
   )
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -421,8 +421,8 @@ endif()
 # use the headers from absl to enjoy the header-only components of absl.
 #
 # This only needs to be done for Android because all other targets directly
-# depend on the firebase-ios-sdk and, therefore, automatically have acces to the
-# absl headers that it downloads.
+# depend on the firebase-ios-sdk and, therefore, automatically have access to
+# the absl headers via a transitive dependency.
 if (ANDROID)
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")
   execute_process_ex(

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+include(execute_process_ex)
+
 if(APPLE AND NOT ANDROID)
   set(settings_apple_SRCS
       src/common/settings_apple.mm)
@@ -414,24 +416,50 @@ elseif(IOS)
   endif()
 endif()
 
+# Configure the cmake project in the firebase-ios-sdk solely to trigger
+# downloading its dependencies. Once those dependencies are downloaded, then
+# use the headers from absl to enjoy the header-only components of absl.
+#
+# This only needs to be done for Android because all other targets directly
+# depend on the firebase-ios-sdk and, therefore, automatically have acces to the
+# absl headers that it downloads.
 if (ANDROID)
-  execute_process(
+  execute_process_ex(
+    DESCRIPTION
+      "configure firebase-ios-sdk with cmake"
     COMMAND
       "${CMAKE_COMMAND}"
       -S
       "${PROJECT_BINARY_DIR}/external/src/firestore"
       -B
       "${PROJECT_BINARY_DIR}/external/src/firestore-build"
-    RESULT_VARIABLE
-      FIRESTORE_CMAKE_RESULT
   )
-  if(NOT FIRESTORE_CMAKE_RESULT EQUAL 0)
-    message(FATAL_ERROR "Running cmake to configure the firebase-ios-sdk failed")
+
+  set(
+    FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR
+    "${PROJECT_BINARY_DIR}/external/src/firestore-build/external/src/abseil-cpp"
+  )
+  if(NOT (IS_DIRECTORY "${FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR}"))
+    message(
+      FATAL_ERROR
+      "Directory does not exist or is not a directory: "
+      "${FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR}"
+    )
   endif()
+
+  # Add a header-only library for the absl headers used in Android builds.
+  add_library(firebase_firestore_android_absl_headers INTERFACE)
   target_include_directories(
+    firebase_firestore_android_absl_headers
+    INTERFACE
+    "${FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR}"
+  )
+
+  # Provide access to the absl headers in the Android Firestore SDK build.
+  target_link_libraries(
     firebase_firestore
     PRIVATE
-    "${PROJECT_BINARY_DIR}/external/src/firestore-build/external/src/abseil-cpp"
+    firebase_firestore_android_absl_headers
   )
 endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -424,6 +424,14 @@ endif()
 # depend on the firebase-ios-sdk and, therefore, automatically have access to
 # the absl headers via a transitive dependency.
 if (ANDROID)
+  if(NOT (IS_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore"))
+    message(
+      FATAL_ERROR
+      "The directory into which the firebase-ios-sdk repository was expected "
+      "to have been cloned does not exist: "
+      "${PROJECT_BINARY_DIR}/external/src/firestore"
+    )
+  endif()
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")
   execute_process_ex(
     COMMENT

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -414,5 +414,26 @@ elseif(IOS)
   endif()
 endif()
 
+if (ANDROID)
+  execute_process(
+    COMMAND
+      "${CMAKE_COMMAND}"
+      -S
+      "${PROJECT_BINARY_DIR}/external/src/firestore"
+      -B
+      "${PROJECT_BINARY_DIR}/external/src/firestore-build"
+    RESULT_VARIABLE
+      FIRESTORE_CMAKE_RESULT
+  )
+  if(NOT FIRESTORE_CMAKE_RESULT EQUAL 0)
+    message(FATAL_ERROR "Running cmake to configure the firebase-ios-sdk failed")
+  endif()
+  target_include_directories(
+    firebase_firestore
+    PRIVATE
+    "${PROJECT_BINARY_DIR}/external/src/firestore-build/external/src/abseil-cpp"
+  )
+endif()
+
 cpp_pack_library(firebase_firestore "")
 cpp_pack_public_headers()

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -426,7 +426,7 @@ endif()
 if (ANDROID)
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")
   execute_process_ex(
-    DESCRIPTION
+    COMMENT
       "configure firebase-ios-sdk with cmake"
     COMMAND
       "${FIREBASE_HOST_CMAKE_COMMAND}"

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -447,19 +447,16 @@ if (ANDROID)
     )
   endif()
 
-  # Add a header-only library for the absl headers used in Android builds.
-  add_library(firebase_firestore_android_absl_headers INTERFACE)
+  # Provide access to the absl headers in the Android Firestore C++ SDK build.
+  # This enables the build to use header-only components of absl, like
+  # absl::optional. In the future, to add support for non-header-only parts of
+  # abs, use add_subdirectory() instead; however, this must be done with great
+  # care as it may cause ABI issues and/or ODR violations with customers who
+  # also use absl.
   target_include_directories(
-    firebase_firestore_android_absl_headers
-    INTERFACE
-    "${FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR}"
-  )
-
-  # Provide access to the absl headers in the Android Firestore SDK build.
-  target_link_libraries(
     firebase_firestore
     PRIVATE
-    firebase_firestore_android_absl_headers
+    "${FIREBASE_FIRESTORE_ANDROID_ABSL_HEADERS_DIR}"
   )
 endif()
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -424,12 +424,11 @@ endif()
 # depend on the firebase-ios-sdk and, therefore, automatically have access to
 # the absl headers via a transitive dependency.
 if (ANDROID)
-  if(NOT (IS_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore"))
+  if(NOT (IS_DIRECTORY "${FIRESTORE_SOURCE_DIR}"))
     message(
       FATAL_ERROR
       "The directory into which the firebase-ios-sdk repository was expected "
-      "to have been cloned does not exist: "
-      "${PROJECT_BINARY_DIR}/external/src/firestore"
+      "to have been cloned does not exist: ${FIRESTORE_SOURCE_DIR}"
     )
   endif()
   file(MAKE_DIRECTORY "${PROJECT_BINARY_DIR}/external/src/firestore-build")
@@ -438,7 +437,7 @@ if (ANDROID)
       "configure firebase-ios-sdk with cmake"
     COMMAND
       "${FIREBASE_HOST_CMAKE_COMMAND}"
-      "${PROJECT_BINARY_DIR}/external/src/firestore"
+      "${FIRESTORE_SOURCE_DIR}"
     WORKING_DIRECTORY
       "${PROJECT_BINARY_DIR}/external/src/firestore-build"
   )

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -184,34 +184,10 @@ else()
   )
 endif()
 
-if(ANDROID)
-  # Firestore's internal integration test requires absl on Android,
-  # so download it now.
-  set(ABSEIL_CPP_ROOT ${CMAKE_CURRENT_LIST_DIR}/external/abseil-cpp/src/abseil-cpp)
-  if (NOT EXISTS ${ABSEIL_CPP_ROOT}/absl)
-    configure_file(abseil-cpp.cmake
-      ${CMAKE_CURRENT_LIST_DIR}/external/abseil-cpp/CMakeLists.txt COPYONLY)
-    execute_process(COMMAND ${CMAKE_COMMAND} .
-      -G ${CMAKE_GENERATOR}
-      -DCMAKE_MAKE_PROGRAM=${CMAKE_MAKE_PROGRAM}
-      -DCMAKE_TOOLCHAIN_FILE=${CMAKE_TOOLCHAIN_FILE}
-      RESULT_VARIABLE result
-      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/external/abseil-cpp )
-    if(result)
-      message(FATAL_ERROR "CMake step for abseil-cpp failed: ${result}")
-    endif()
-    execute_process(COMMAND ${CMAKE_COMMAND} --build .
-      RESULT_VARIABLE result
-      WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}/external/abseil-cpp )
-    if(result)
-      message(FATAL_ERROR "Build step for abseil-cpp failed: ${result}")
-    endif()
-  endif()
-  add_subdirectory(external/abseil-cpp)
-else()
-  set(ABSEIL_CPP_ROOT
-      ${PROJECT_BINARY_DIR}/bin/external/src/firestore-build/external/src/abseil-cpp)
-endif()
+set(
+  ABSEIL_CPP_ROOT
+  "${PROJECT_BINARY_DIR}/bin/external/src/firestore-build/external/src/abseil-cpp"
+)
 
 # The include directory for the testapp.
 include_directories(src)
@@ -304,8 +280,6 @@ if(ANDROID)
 
   set(ADDITIONAL_LIBS log android atomic native_app_glue)
 else()
-  set(ABSEIL_CPP_ROOT ${CMAKE_CURRENT_LIST_DIR}/external/abseil-cpp/src/abseil-cpp)
-
   # Build a desktop application.
   add_definitions(-D_GLIBCXX_USE_CXX11_ABI=0)
 
@@ -389,6 +363,15 @@ endif()
 
 # Add the Firebase libraries to the target using the function from the SDK.
 add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
+
+# Verify that absl was downloaded into the expected location.
+if(NOT (IS_DIRECTORY "${ABSEIL_CPP_ROOT}"))
+  message(
+    FATAL_ERROR
+    "Directory does not exist or is not a directory: "
+    "${ABSEIL_CPP_ROOT}"
+  )
+endif()
 
 # Note that firebase_app needs to be last in the list.
 set(firebase_libs firebase_firestore firebase_auth firebase_app)

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -368,7 +368,7 @@ add_subdirectory(${FIREBASE_CPP_SDK_DIR} bin/ EXCLUDE_FROM_ALL)
 if(NOT (IS_DIRECTORY "${ABSEIL_CPP_ROOT}"))
   message(
     FATAL_ERROR
-    "Directory does not exist or is not a directory: "
+    "ABSEIL_CPP_ROOT does not exist or is not a directory: "
     "${ABSEIL_CPP_ROOT}"
   )
 endif()


### PR DESCRIPTION
This PR enables the Firestore component to use header-only components of absl when targeting Android. This was achieved by downloading the firebase-ios-sdk and calling cmake on it to trigger the download of absl.

This PR also includes some broader-reaching changes:
1. The `FIREBASE_FLATC_CMAKE_COMMAND` cmake cache variables is renamed to `FIREBASE_HOST_CMAKE_COMMAND`, since it's no longer exclusively used when building flatc, but also when running cmake on the firebase-ios-sdk during Android builds.
2. A cmake function `execute_process_ex()` is added in the new file `cmake/execute_process_ex.cmake`, which simply calls the built-in `execute_process()` function but (a) adds some logging around it and (b) checks the exit code of the process and fails the build if it is non-zero.
3. Firestore's `integration_test_internal` no longer downloads its own copy of absl, but rather uses the one downloaded by the main build.