### PR TITLE
Replace OrderByList by std::vector<OrderBy> and Skip nested structure inside IN filter test case

### DIFF
--- a/firestore/integration_test_internal/src/query_test.cc
+++ b/firestore/integration_test_internal/src/query_test.cc
@@ -660,7 +660,7 @@ TEST_F(QueryTest, TestQueriesCanUseArrayContainsFilters) {
 }
 
 TEST_F(QueryTest, TestQueriesCanUseInFilters) {
-  GTEST_SKIP() << "Skipping this test until double free bug is fixed.";
+  GTEST_SKIP() << "Skip until double free bug (b/260406277) is fixed.";
   CollectionReference collection = Collection(
       {{"a", {{"zip", FieldValue::Integer(98101)}}},
        {"b", {{"zip", FieldValue::Integer(98102)}}},

--- a/firestore/integration_test_internal/src/query_test.cc
+++ b/firestore/integration_test_internal/src/query_test.cc
@@ -660,6 +660,7 @@ TEST_F(QueryTest, TestQueriesCanUseArrayContainsFilters) {
 }
 
 TEST_F(QueryTest, TestQueriesCanUseInFilters) {
+  GTEST_SKIP() << "Skipping this test until double free bug is fixed.";
   CollectionReference collection = Collection(
       {{"a", {{"zip", FieldValue::Integer(98101)}}},
        {"b", {{"zip", FieldValue::Integer(98102)}}},

--- a/firestore/src/main/query_main.cc
+++ b/firestore/src/main/query_main.cc
@@ -237,13 +237,8 @@ core::Bound QueryInternal::ToBound(
     const std::vector<FieldValue>& field_values) const {
   const core::Query& internal_query = query_.query();
   // Use explicit order bys  because it has to match the query the user made.
-#if TARGET_OS_IOS || TARGET_OS_TV
-  const core::OrderByList& explicit_order_bys =
-      internal_query.explicit_order_bys();
-#else
   const std::vector<core::OrderBy>& explicit_order_bys =
       internal_query.explicit_order_bys();
-#endif
 
   if (field_values.size() > explicit_order_bys.size()) {
     SimpleThrowInvalidArgument(


### PR DESCRIPTION
### Description
> Replace OrderByList by std::vector<OrderBy>
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
