### PR TITLE
Remove Strawberry Perl as part of GHA setup

### DIFF
--- a/scripts/gha/install_prereqs_desktop.py
+++ b/scripts/gha/install_prereqs_desktop.py
@@ -109,6 +109,11 @@ def main():
        ['python3' if utils.is_command_installed('python3') else 'python', '-m',
             'pip', 'install', '-r', 'external/pip_requirements.txt', '--user'] )
 
+    # If running on GHA Windows, remove the Strawberry Perl directory, since it can cause
+    # architecture conflicts when searching for the zlib library.
+    if utils.is_windows_os() and args.gha_build:
+      utils.run_command(['rm', '-r', 'C:/Strawberry'])
+
   if args.arch == 'x86':
     utils.install_x86_support_libraries(args.gha_build)
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Strawberry Perl can cause conflicts when searching for and resolving libraries, specifically zlib. By removing the directory, this will also prevent other possible libraries from having the same issue, which is a common Strawberry problem.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
