### PR TITLE
Ignore C5264 ('const' variable is not used) warning in boringssl.

### DIFF
--- a/scripts/git/patches/boringssl/0001-disable-warnings.patch
+++ b/scripts/git/patches/boringssl/0001-disable-warnings.patch
@@ -1,6 +1,6 @@
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -193,6 +193,10 @@ elseif(MSVC)
+@@ -193,6 +193,11 @@ elseif(MSVC)
                # possible loss of data
        "C4244" # 'function' : conversion from 'int' to 'uint8_t',
                # possible loss of data
@@ -8,6 +8,7 @@
 +              # '(void)'
 +      "C4191" # 'operator/operation' : unsafe conversion from 'type of
 +              # expression' to 'type required'
++      "C5264" # 'const' variable is not used
        "C4267" # conversion from 'size_t' to 'int', possible loss of data
        "C4371" # layout of class may have changed from a previous version of the
                # compiler due to better packing of member '...'


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Due to some Windows compiler setting changing, the warning C5264 is coming up in boringssl builds on some Windows runners, which breaks due to the treat-warnings-as-errors flag. This PR adds that warning to the "ignore warnings" list.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

C++ Packaging run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/3586408287
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
