### PR TITLE
Fix for unresolved symbol IsRunningOnEmulator 

### DIFF
--- a/gma/integration_test/CMakeLists.txt
+++ b/gma/integration_test/CMakeLists.txt
@@ -188,6 +188,7 @@ else()
   # Platform abstraction layer for the desktop integration test.
   set(FIREBASE_APP_FRAMEWORK_DESKTOP_SRCS
     src/desktop/desktop_app_framework.cc
+    src/desktop/desktop_firebase_test_framework.cc
   )
 
   set(integration_test_target_name "integration_test")


### PR DESCRIPTION
### Description
This should resolve the following failure when building testapps on windows:
unresolved external symbol .. IsRunningOnEmulator ... referenced in function FirebaseGmaTest_TestAdViewLoadAd
Example: https://github.com/firebase/firebase-cpp-sdk/actions/runs/3628003197/jobs/6118528835

IsRunningOnEmulator is implemented in desktop_firebase_test_framework, so this adds that as a source file for the gma integration test (which is how the same source file is used in messaging and dynamic links integration tests)

### Testing
Triggered integration test workflow to build gma integration test on windows
https://github.com/firebase/firebase-cpp-sdk/actions/runs/3651337419/jobs/6168441033
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
