### PR TITLE
Patch sprintf in uWebsockets to use snprintf

### DIFF
--- a/cmake/external/uWebSockets.cmake
+++ b/cmake/external/uWebSockets.cmake
@@ -20,7 +20,7 @@ endif()
 
 set(uwebsockets_commit_tag 4d94401b9c98346f9afd838556fdc7dce30561eb)
 set(patch_file 
-  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/uWebSockets/0001-fix-want-write-crash.patch)
+  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/uWebSockets/0001-fix-want-write-and-sprintf-deprecation.patch)
 
 ExternalProject_Add(
   uWebSockets

--- a/scripts/git/patches/uWebSockets/0001-fix-want-write-and-sprintf-deprecation.patch
+++ b/scripts/git/patches/uWebSockets/0001-fix-want-write-and-sprintf-deprecation.patch
@@ -1,12 +1,26 @@
-From d868ac6f2ce8c6ba8359e33616caeb889e0c57e7 Mon Sep 17 00:00:00 2001
-From: "google.com" <google.com>
-Date: Wed, 7 Jul 2021 19:00:49 -0400
-Subject: [PATCH] fix want_write crash
+From 300161c1e2e1414fdd8df7ae6f036a6213c3672f Mon Sep 17 00:00:00 2001
+From: "drsanta@google.com" <drsanta@google.com>
+Date: Thu, 8 Dec 2022 18:52:28 -0500
+Subject: [PATCH] fix want write and sprintf deprecation
 
 ---
- src/Socket.h | 34 ++++++++++++++++++----------------
- 1 file changed, 18 insertions(+), 16 deletions(-)
+ src/HTTPSocket.h |  2 +-
+ src/Socket.h     | 34 ++++++++++++++++++----------------
+ 2 files changed, 19 insertions(+), 17 deletions(-)
 
+diff --git a/src/HTTPSocket.h b/src/HTTPSocket.h
+index 5cc7a7f..8b1ab20 100644
+--- a/src/HTTPSocket.h
++++ b/src/HTTPSocket.h
+@@ -204,7 +204,7 @@ struct HttpResponse {
+ 
+             static size_t transform(const char *src, char *dst, size_t length, TransformData transformData) {
+                 // todo: sprintf is extremely slow
+-                int offset = transformData.hasHead ? 0 : std::sprintf(dst, "HTTP/1.1 200 OK\r\nContent-Length: %u\r\n\r\n", (unsigned int) length);
++                int offset = transformData.hasHead ? 0 : std::snprintf(dst, length, "HTTP/1.1 200 OK\r\nContent-Length: %u\r\n\r\n", (unsigned int) length);
+                 memcpy(dst + offset, src, length);
+                 return length + offset;
+             }
 diff --git a/src/Socket.h b/src/Socket.h
 index 2179ff8..521e798 100644
 --- a/src/Socket.h
@@ -55,5 +69,5 @@ index 2179ff8..521e798 100644
                  sent = ::send(getFd(), message->data, message->length, MSG_NOSIGNAL);
                  if (sent == (ssize_t) message->length) {
 -- 
-2.32.0.93.g670b81a890-goog
+2.39.0.rc1.256.g54fd8350bd-goog
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The latest Xcode tools have deprecated the use of `sprintf`. Use of that functions now produces warnings, and our builds treat such warnings as errors.

uWebSockets uses `sprintf` in one location.

This change updates the git patch that we already apply to uWebSockets sources to also update its use of `sprintf` to use `snprintf` instead. Thankfully, the size of the buffer that sprintf was writing into was readily available.

Note: we can't push this change back to uWebSockets as they've since rewritten the library.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3653515052)
[Packaged Build](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3653527149) -> [Integration CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3654361002)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
