### PR TITLE
Reduce number of RewardedAd loads on iOS in CI

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -845,8 +845,7 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
   FLAKY_TEST_SECTION_BEGIN();
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
@@ -1010,6 +1009,9 @@ TEST_F(FirebaseGmaUITest, TestInterstitialAdLoadAndShow) {
 TEST_F(FirebaseGmaUITest, TestRewardedAdLoadAndShow) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
+
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
+  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
 
@@ -1851,9 +1853,8 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadEmptyRequest) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
+  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
 
   // Note: while showing an ad requires user interaction in another test,
   // this test is mean as a baseline loadAd functionality test.
@@ -1878,8 +1879,6 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadEmptyRequest) {
   EXPECT_FALSE(result_ptr->response_info().ToString().empty());
 
   delete rewarded;
-
-  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseGmaTest, TestRewardedAdErrorNotInitialized) {
@@ -1937,6 +1936,9 @@ TEST_F(FirebaseGmaTest, TesRewardedAdErrorAlreadyInitialized) {
 
 TEST_F(FirebaseGmaTest, TestRewardedAdErrorLoadInProgress) {
   SKIP_TEST_ON_DESKTOP;
+
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
+  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
   WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),
@@ -2065,7 +2067,7 @@ TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_EMULATOR;
 
-  // TODO(@drsanta): remove when GMA whitelists CI devices
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
   TEST_REQUIRES_USER_INTERACTION_ON_IOS;
 
   for (int i = 0; i < 10; ++i) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -2020,9 +2020,6 @@ TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_EMULATOR;
 
-  // TODO(@drsanta): remove when GMA whitelists CI devices.
-  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
-
   for (int i = 0; i < 10; ++i) {
     firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
 

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -2031,10 +2031,16 @@ TEST_F(FirebaseGmaTest, TestAdViewStress) {
 
     // Load the AdView ad.
     firebase::gma::AdRequest request = GetAdRequest();
-    WaitForCompletion(ad_view->LoadAd(request), "TestAdViewStress LoadAd");
-    EXPECT_EQ(ad_view->ad_size().width(), kBannerWidth);
-    EXPECT_EQ(ad_view->ad_size().height(), kBannerHeight);
-
+    firebase::Future<firebase::gma::AdResult> future = ad_view->LoadAd(request);
+    WaitForCompletionAnyResult(future, "TestAdViewStress LoadAd");
+    // Stress tests may exhaust the ad pool. If so, loadAd will return
+    // kAdErrorCodeNoFill.
+    EXPECT_TRUE(future.error() == firebase::gma::kAdErrorCodeNone ||
+                future.error() == firebase::gma::kAdErrorCodeNoFill);
+    if (future.error() == firebase::gma::kAdErrorCodeNone) {
+      EXPECT_EQ(ad_view->ad_size().width(), kBannerWidth);
+      EXPECT_EQ(ad_view->ad_size().height(), kBannerHeight);
+    }
     WaitForCompletion(ad_view->Destroy(), "Destroy the AdView");
     delete ad_view;
   }
@@ -2057,8 +2063,13 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdStress) {
 
     // When the InterstitialAd is initialized, load an ad.
     firebase::gma::AdRequest request = GetAdRequest();
-    WaitForCompletion(interstitial->LoadAd(kInterstitialAdUnit, request),
-                      "TestInterstitialAdStress LoadAd");
+    firebase::Future<firebase::gma::AdResult> future =
+        interstitial->LoadAd(kInterstitialAdUnit, request);
+    WaitForCompletionAnyResult(future, "TestInterstitialAdStress LoadAd");
+    // Stress tests may exhaust the ad pool. If so, loadAd will return
+    // kAdErrorCodeNoFill.
+    EXPECT_TRUE(future.error() == firebase::gma::kAdErrorCodeNone ||
+                future.error() == firebase::gma::kAdErrorCodeNoFill);
     delete interstitial;
   }
 }
@@ -2078,8 +2089,13 @@ TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
 
     // When the RewardedAd is initialized, load an ad.
     firebase::gma::AdRequest request = GetAdRequest();
-    WaitForCompletion(rewarded->LoadAd(kRewardedAdUnit, request),
-                      "TestRewardedAdStress LoadAd");
+    firebase::Future<firebase::gma::AdResult> future =
+        rewarded->LoadAd(kRewardedAdUnit, request);
+    WaitForCompletionAnyResult(future, "TestRewardedAdStress LoadAd");
+    // Stress tests may exhaust the ad pool. If so, loadAd will return
+    // kAdErrorCodeNoFill.
+    EXPECT_TRUE(future.error() == firebase::gma::kAdErrorCodeNone ||
+                future.error() == firebase::gma::kAdErrorCodeNoFill);
     delete rewarded;
   }
 }

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -778,18 +778,12 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAd) {
   firebase::Future<firebase::gma::AdResult> load_ad_future;
   const firebase::gma::AdResult* result_ptr = nullptr;
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   load_ad_future = ad_view->LoadAd(GetAdRequest());
   WaitForCompletion(load_ad_future, "LoadAd");
 
   result_ptr = load_ad_future.result();
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_TRUE(result_ptr->is_successful());
-
-  FLAKY_TEST_SECTION_END();
 
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
@@ -810,10 +804,6 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAd) {
 TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
-
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
 
   firebase::gma::InterstitialAd* interstitial =
       new firebase::gma::InterstitialAd();
@@ -837,16 +827,11 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
 
   load_ad_future.Release();
   delete interstitial;
-
-  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
-
-  // TODO(@drsanta): remove when GMA whitelists CI devices.
-  FLAKY_TEST_SECTION_BEGIN();
 
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
 
@@ -869,8 +854,6 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
 
   load_ad_future.Release();
   delete rewarded;
-
-  FLAKY_TEST_SECTION_END();
 }
 
 // Interactive test section.  These have been placed up front so that the
@@ -1095,17 +1078,11 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdEmptyAdRequest) {
   firebase::Future<firebase::gma::AdResult> load_ad_future;
   const firebase::gma::AdResult* result_ptr = nullptr;
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   load_ad_future = ad_view->LoadAd(request);
   WaitForCompletion(load_ad_future, "LoadAd");
   result_ptr = load_ad_future.result();
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_TRUE(result_ptr->is_successful());
-
-  FLAKY_TEST_SECTION_END();
 
   EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
   EXPECT_FALSE(
@@ -1135,13 +1112,7 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdAnchorAdaptiveAd) {
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
-
-  FLAKY_TEST_SECTION_END();
 
   const AdSize ad_size = ad_view->ad_size();
   EXPECT_EQ(ad_size.width(), kBannerWidth);
@@ -1165,13 +1136,7 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdInlineAdaptiveAd) {
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
-
-  FLAKY_TEST_SECTION_END();
 
   const AdSize ad_size = ad_view->ad_size();
   EXPECT_EQ(ad_size.width(), kBannerWidth);
@@ -1194,13 +1159,7 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdGetInlineAdaptiveBannerMaxHeight) {
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
-
-  FLAKY_TEST_SECTION_END();
 
   const AdSize ad_size = ad_view->ad_size();
   EXPECT_EQ(ad_size.width(), kBannerWidth);
@@ -1221,15 +1180,7 @@ TEST_F(FirebaseGmaTest, TestAdViewLoadAdDestroyNotCalled) {
   WaitForCompletion(ad_view->Initialize(app_framework::GetWindowContext(),
                                         kBannerAdUnit, banner_ad_size),
                     "Initialize");
-
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   WaitForCompletion(ad_view->LoadAd(GetAdRequest()), "LoadAd");
-
-  FLAKY_TEST_SECTION_END();
-
   delete ad_view;
 }
 
@@ -1306,10 +1257,6 @@ TEST_F(FirebaseGmaTest, TestAdViewAdSizeBeforeInitialization) {
 TEST_F(FirebaseGmaTest, TestAdView) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
-
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
 
   const firebase::gma::AdSize banner_ad_size(kBannerWidth, kBannerHeight);
   firebase::gma::AdView* ad_view = new firebase::gma::AdView();
@@ -1506,8 +1453,6 @@ TEST_F(FirebaseGmaTest, TestAdView) {
         bounding_box_listener.bounding_box_changes_.back().height == -1);
 #endif  // defined(ANDROID) || TARGET_OS_IPHONE
   }
-
-  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseGmaTest, TestAdViewErrorNotInitialized) {
@@ -1676,10 +1621,6 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
-  // Loading Ads has been deemed flaky as the AdMob Service has a chance to
-  // return NoFill for valid ad requests if there aren't any ads to serve.
-  FLAKY_TEST_SECTION_BEGIN();
-
   firebase::gma::InterstitialAd* interstitial =
       new firebase::gma::InterstitialAd();
 
@@ -1703,8 +1644,6 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
   EXPECT_FALSE(result_ptr->response_info().ToString().empty());
 
   delete interstitial;
-
-  FLAKY_TEST_SECTION_END();
 }
 
 TEST_F(FirebaseGmaTest, TestInterstitialAdErrorNotInitialized) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -833,6 +833,9 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_SIMULATOR;
 
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
+  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
+
   firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
 
   WaitForCompletion(rewarded->Initialize(app_framework::GetWindowContext()),

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -2020,6 +2020,9 @@ TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_EMULATOR;
 
+  // TODO(@drsanta): remove when GMA whitelists CI devices.
+  TEST_REQUIRES_USER_INTERACTION_ON_IOS;
+
   for (int i = 0; i < 10; ++i) {
     firebase::gma::RewardedAd* rewarded = new firebase::gma::RewardedAd();
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GMA backend doesn't whitelist iOS devices running in CI which means number of ads that can be served to iOS in CI is restricted. This is true even when using the prescribed [Demo Ad Unit Id](https://developers.google.com/admob/ios/test-ads). 

This PR reduces the number of ads we load on iOS in an attempt to minimize the chance of encountering NoFillErrors and push our CI to green.

Notes:
- Test a subset of RewardedAds behavior on iOS in GHA CI.
  - We no longer test successful RewardedAd loads.
  - Rewarded Ads stress tests are disabled on iOS.
- Added a NoFill error as an acceptable result on stress tests for other platforms. The tests were meant to stress the SDK though ad object creation and destruction. The result from the service is secondary, and NoFill would be a valid result.
   - These tests are not enabled for iOs, though, as the service often goes into backoff mode on iOS. Backoff mode is  represented by an obscure Internal Error code which could mean many different things.
- All of the tests can still be executed locally on a device simply by building the test app. We should manually run the iOS testapp whenever we update the GMA dependencies. 
- Remove Flaky block retries around tests. The "flaky" behavior stemmed from NoFill errors.
  - Retrying on a NoFill error will continue to return NoFill errors since the the pool of ads to serve has been exhausted.
  - Retrying will make the situation worse:
    - The test will still eventually fail, it will just take longer to do so.
    - Repeated NoFill errors can push the service into back-off mode which may take longer to recover from.
  - It's better to wait a few minutes and re-run the test.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/3833227384)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
