### PR TITLE
App Check Desktop - GetToken and Listeners support

### DIFF
--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -370,12 +370,17 @@ TEST_F(FirebaseAppCheckTest, TestGetTokenForcingRefresh) {
   EXPECT_NE(token.token, "");
   EXPECT_NE(token.expire_time_millis, 0);
 
+  // Wait a bit to make sure the expire time would be different
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
+
   // GetToken with force_refresh=false will return the same token.
   firebase::Future<::firebase::app_check::AppCheckToken> future2 =
       app_check->GetAppCheckToken(false);
   EXPECT_TRUE(WaitForCompletion(future2, "GetToken #2"));
   EXPECT_EQ(future.result()->expire_time_millis,
             future2.result()->expire_time_millis);
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(500));
 
   // GetToken with force_refresh=true will return a new token.
   firebase::Future<::firebase::app_check::AppCheckToken> future3 =
@@ -452,7 +457,7 @@ TEST_F(FirebaseAppCheckTest, TestSignIn) {
 TEST_F(FirebaseAppCheckTest, TestDebugProviderValidToken) {
   firebase::app_check::DebugAppCheckProviderFactory* factory =
       firebase::app_check::DebugAppCheckProviderFactory::GetInstance();
-#if FIREBASE_PLATFORM_IOS
+#if FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_DESKTOP
   ASSERT_NE(factory, nullptr);
   InitializeApp();
   firebase::app_check::AppCheckProvider* provider =

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -75,18 +75,20 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
     }
     if (provider != nullptr) {
       auto token_callback{
-        [this, handle](firebase::app_check::AppCheckToken token,
-                  int error_code, const std::string& error_message) {
-        if (error_code == firebase::app_check::kAppCheckErrorNone) {
-          UpdateCachedToken(token);
-          future()->CompleteWithResult(handle, 0, token);
-        } else {
-          future()->Complete(handle, error_code, error_message.c_str());
-        }
-      }};
+          [this, handle](firebase::app_check::AppCheckToken token,
+                         int error_code, const std::string& error_message) {
+            if (error_code == firebase::app_check::kAppCheckErrorNone) {
+              UpdateCachedToken(token);
+              future()->CompleteWithResult(handle, 0, token);
+            } else {
+              future()->Complete(handle, error_code, error_message.c_str());
+            }
+          }};
       provider->GetToken(token_callback);
     } else {
-      future()->Complete(handle, firebase::app_check::kAppCheckErrorInvalidConfiguration, "No AppCheckProvider installed.");
+      future()->Complete(
+          handle, firebase::app_check::kAppCheckErrorInvalidConfiguration,
+          "No AppCheckProvider installed.");
     }
   }
   return MakeFuture(future(), handle);

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -22,19 +22,36 @@ namespace internal {
 
 static AppCheckProviderFactory* g_provider_factory = nullptr;
 
-AppCheckInternal::AppCheckInternal(App* app) : app_(app) {
+AppCheckInternal::AppCheckInternal(App* app) : app_(app), cached_token_() {
   future_manager().AllocFutureApi(this, kAppCheckFnCount);
 }
 
 AppCheckInternal::~AppCheckInternal() {
   future_manager().ReleaseFutureApi(this);
   app_ = nullptr;
+  // Clear the cached token by setting the expiration
+  cached_token_.expire_time_millis = 0;
 }
 
 ::firebase::App* AppCheckInternal::app() const { return app_; }
 
 ReferenceCountedFutureImpl* AppCheckInternal::future() {
   return future_manager().GetFutureApi(this);
+}
+
+bool AppCheckInternal::HasValidCacheToken() const {
+  // Get the current time, in milliseconds
+  int64_t current_time = std::time(nullptr) * 1000;
+  // TODO(amaurice): Add some additional time to the check
+  return cached_token_.expire_time_millis > current_time;
+}
+
+void AppCheckInternal::UpdateCachedToken(AppCheckToken token) {
+  cached_token_ = token;
+  // Call the token listeners
+  for (AppCheckListener* listener : token_listeners_) {
+    listener->OnAppCheckTokenChanged(token);
+  }
 }
 
 void AppCheckInternal::SetAppCheckProviderFactory(
@@ -47,8 +64,31 @@ void AppCheckInternal::SetTokenAutoRefreshEnabled(
 
 Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
   auto handle = future()->SafeAlloc<AppCheckToken>(kAppCheckFnGetAppCheckToken);
-  AppCheckToken token;
-  future()->CompleteWithResult(handle, 0, token);
+  if (!force_refresh && HasValidCacheToken()) {
+    // If the cached token is valid, and not told to refresh, return the cache
+    future()->CompleteWithResult(handle, 0, cached_token_);
+  } else {
+    // Get a new token, and pass the result into the future.
+    AppCheckProvider* provider = nullptr;
+    if (g_provider_factory && app_) {
+      provider = g_provider_factory->CreateProvider(app_);
+    }
+    if (provider != nullptr) {
+      auto token_callback{
+        [this, handle](firebase::app_check::AppCheckToken token,
+                  int error_code, const std::string& error_message) {
+        if (error_code == firebase::app_check::kAppCheckErrorNone) {
+          UpdateCachedToken(token);
+          future()->CompleteWithResult(handle, 0, token);
+        } else {
+          future()->Complete(handle, error_code, error_message.c_str());
+        }
+      }};
+      provider->GetToken(token_callback);
+    } else {
+      future()->Complete(handle, firebase::app_check::kAppCheckErrorInvalidConfiguration, "No AppCheckProvider installed.");
+    }
+  }
   return MakeFuture(future(), handle);
 }
 
@@ -57,9 +97,21 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckTokenLastResult() {
       future()->LastResult(kAppCheckFnGetAppCheckToken));
 }
 
-void AppCheckInternal::AddAppCheckListener(AppCheckListener* listener) {}
+void AppCheckInternal::AddAppCheckListener(AppCheckListener* listener) {
+  if (listener) {
+    token_listeners_.push_back(listener);
 
-void AppCheckInternal::RemoveAppCheckListener(AppCheckListener* listener) {}
+    if (HasValidCacheToken()) {
+      listener->OnAppCheckTokenChanged(cached_token_);
+    }
+  }
+}
+
+void AppCheckInternal::RemoveAppCheckListener(AppCheckListener* listener) {
+  if (listener) {
+    token_listeners_.remove(listener);
+  }
+}
 
 }  // namespace internal
 }  // namespace app_check

--- a/app_check/src/desktop/app_check_desktop.h
+++ b/app_check/src/desktop/app_check_desktop.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_APP_CHECK_SRC_DESKTOP_APP_CHECK_DESKTOP_H_
 #define FIREBASE_APP_CHECK_SRC_DESKTOP_APP_CHECK_DESKTOP_H_
 
+#include <list>
+
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"
 #include "app/src/include/firebase/future.h"
@@ -49,9 +51,19 @@ class AppCheckInternal {
   ReferenceCountedFutureImpl* future();
 
  private:
+  // Is the cached token valid
+  bool HasValidCacheToken() const;
+
+  // Update the cached Token, and call the listeners
+  void UpdateCachedToken(AppCheckToken token);
+
   ::firebase::App* app_;
 
   FutureManager future_manager_;
+
+  AppCheckToken cached_token_;
+
+  std::list<AppCheckListener*> token_listeners_;
 };
 
 }  // namespace internal


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Adds support for the GetAppCheckToken functionality, and registering / calling listeners for token changes.  With this, the enabled tests in the integration testapp all pass locally.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running the testapp locally, since passing the debug token hasn't been added to the GHA logic yet.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
