### PR TITLE
Auto update GMA deps on iOS.

### DIFF
--- a/scripts/update_android_ios_dependencies.py
+++ b/scripts/update_android_ios_dependencies.py
@@ -324,6 +324,8 @@ def modify_pod_file(pod_file, pod_version_map, dryrun=True):
       pod_version_map (dict): Map of podnames to their respective version.
       dryrun (bool, optional): Just print the substitutions.
                                Do not write to file. Defaults to True.
+      ignore_ios_versions (set): If the old version number for a pod
+                                 matches one of these, don't update it.
   """
   global logfile_lines
   to_update = False
@@ -341,9 +343,13 @@ def modify_pod_file(pod_file, pod_version_map, dryrun=True):
     match = re.match(RE_PODFILE_VERSION, line)
     if match:
       pod_name = match['pod_name']
+      skip_line = False
+      for ignore_version in ignore_ios_versions:
+        if ignore_version in match['version']:
+          skip_line = True
       # Firebase/Auth -> Firestore (due to being a subspec)
       pod_name_key = re.sub(r'/.*$', '', pod_name)
-      if pod_name_key in pod_version_map:
+      if pod_name_key in pod_version_map and not skip_line:
         latest_version = pod_version_map[pod_name_key]
         substituted_line = line.replace(match['version'], latest_version)
         if substituted_line != line:
@@ -693,6 +699,9 @@ def parse_cmdline_args():
   parser.add_argument('--ignore_ios_pods', nargs='+', default=(),
             help='Ignore iOS pods which have any of the items specified in '
                  'this list as substrings.')
+  parser.add_argument('--ignore_ios_versions', nargs='+', default=('cppsdk',),
+            help='Do not update any iOS pods whose versions contain any of '
+                 'the items specified in this list as substrings.')
   parser.add_argument('--podfiles', nargs='+', default=(os.getcwd(),),
             help= 'List of pod files or directories containing podfiles')
   parser.add_argument('--specs_repo',
@@ -701,7 +710,8 @@ def parse_cmdline_args():
   parser.add_argument('--skip_android', action='store_true',
             help='Skip Android libraries version update completely.')
   # TODO: remove default values when Ads SDK does not need to be pinned.
-  parser.add_argument('--ignore_android_packages', nargs='+', default=(),
+  parser.add_argument('--ignore_android_packages', nargs='+',
+            default=('firebase-ads',),
             help='Ignore Android packages which have any of the items '
                  'specified in this list as substrings.')
   parser.add_argument('--depfiles', nargs='+',
@@ -753,7 +763,8 @@ def main():
     pod_files = get_files(args.podfiles, file_extension='', file_name='Podfile',
                           ignore_directories=set(args.ignore_directories))
     for pod_file in pod_files:
-      modify_pod_file(pod_file, latest_pod_versions_map, args.dryrun)
+      modify_pod_file(pod_file, latest_pod_versions_map, args.dryrun,
+                      args.ignore_ios_versions)
     for readme_file in readme_files:
       modify_readme_file_pods(readme_file, latest_pod_versions_map, args.dryrun)
 

--- a/scripts/update_android_ios_dependencies.py
+++ b/scripts/update_android_ios_dependencies.py
@@ -690,8 +690,7 @@ def parse_cmdline_args():
   parser.add_argument('--skip_ios', action='store_true',
             help='Skip iOS pod version update completely.')
   # TODO: remove default values when Ads SDK does not need to be pinned.
-  parser.add_argument('--ignore_ios_pods', nargs='+',
-            default=('Google-Mobile-Ads-SDK',),
+  parser.add_argument('--ignore_ios_pods', nargs='+', default=(),
             help='Ignore iOS pods which have any of the items specified in '
                  'this list as substrings.')
   parser.add_argument('--podfiles', nargs='+', default=(os.getcwd(),),
@@ -702,8 +701,7 @@ def parse_cmdline_args():
   parser.add_argument('--skip_android', action='store_true',
             help='Skip Android libraries version update completely.')
   # TODO: remove default values when Ads SDK does not need to be pinned.
-  parser.add_argument('--ignore_android_packages', nargs='+',
-            default=('firebase-ads',),
+  parser.add_argument('--ignore_android_packages', nargs='+', default=(),
             help='Ignore Android packages which have any of the items '
                  'specified in this list as substrings.')
   parser.add_argument('--depfiles', nargs='+',

--- a/scripts/update_android_ios_dependencies.py
+++ b/scripts/update_android_ios_dependencies.py
@@ -316,7 +316,7 @@ def get_pod_files(dirs_and_files):
 RE_PODFILE_VERSION = re.compile(
   r"\s+pod '(?P<pod_name>.+)', '(?P<version>.+)'\n")
 
-def modify_pod_file(pod_file, pod_version_map, dryrun=True):
+def modify_pod_file(pod_file, pod_version_map, dryrun=True, ignore_ios_versions=[]):
   """Update pod versions in specified podfile.
 
   Args:

--- a/scripts/update_android_ios_dependencies.py
+++ b/scripts/update_android_ios_dependencies.py
@@ -344,6 +344,7 @@ def modify_pod_file(pod_file, pod_version_map, dryrun=True):
     if match:
       pod_name = match['pod_name']
       skip_line = False
+      # Check if the old version matches anything in ignore_ios_versions
       for ignore_version in ignore_ios_versions:
         if ignore_version in match['version']:
           skip_line = True
@@ -700,8 +701,8 @@ def parse_cmdline_args():
             help='Ignore iOS pods which have any of the items specified in '
                  'this list as substrings.')
   parser.add_argument('--ignore_ios_versions', nargs='+', default=('cppsdk',),
-            help='Do not update any iOS pods whose versions contain any of '
-                 'the items specified in this list as substrings.')
+            help='Do not update any iOS pods when the old version contains '
+                 'any of the items specified in this list as substrings.')
   parser.add_argument('--podfiles', nargs='+', default=(os.getcwd(),),
             help= 'List of pod files or directories containing podfiles')
   parser.add_argument('--specs_repo',


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Requires some custom code to handle the old 'admob' iOS SDK.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Ran manually, it updated everything correctly and skipped the old admob SDK.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
