### PR TITLE
Update SHA256 hash for leveldb 1.23.

### DIFF
--- a/cmake/external/firestore.patch.txt
+++ b/cmake/external/firestore.patch.txt
@@ -19,7 +19,7 @@ index 920bf2928..c5c9cc7ee 100644
    DOWNLOAD_NAME leveldb-${version}.tar.gz
    URL https://github.com/google/leveldb/archive/${version}.tar.gz
 -  URL_HASH SHA256=55423cac9e3306f4a9502c738a001e4a339d1a38ffbee7572d4a07d5d63949b2
-+  URL_HASH SHA256=9a37f8a6174f09bd622bc723b55881dc541cd50747cbd08831c2a82d620f6d76
++  URL_HASH SHA256=668eb4a1264a56f053974452dbdf5856541b6d4b747d9a4a2fa48a0a0e30225f
  
    PREFIX ${PROJECT_BINARY_DIR}
  

--- a/cmake/external/leveldb.cmake
+++ b/cmake/external/leveldb.cmake
@@ -29,7 +29,7 @@ ExternalProject_Add(
   DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
   DOWNLOAD_NAME leveldb-${version}.tar.gz
   URL https://github.com/google/leveldb/archive/${version}.tar.gz
-  URL_HASH SHA256=9a37f8a6174f09bd622bc723b55881dc541cd50747cbd08831c2a82d620f6d76
+  URL_HASH SHA256=668eb4a1264a56f053974452dbdf5856541b6d4b747d9a4a2fa48a0a0e30225f
 
   PREFIX ${PROJECT_BINARY_DIR}
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

GitHub tarball hashes are not guaranteed to be stable - and the leveldb one has changed.

We still have a build failure after this as the Firestore core (from firebase-ios-sdk) also has hashes to fix.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
