### PR TITLE
Change storage download size on Android, to prevent FTL flake.

### DIFF
--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -61,10 +61,14 @@ using app_framework::LogError;
 const char* kStorageUrl = nullptr;
 
 #if FIREBASE_PLATFORM_DESKTOP
-// Use a larger file on desktop...
+// Use a larger file on desktop.
 const int kLargeFileMegabytes = 64;
-#else
-// ...and a smaller file on mobile.
+#elif FIREBASE_PLATFORM_ANDROID
+// Android FTL devices can sometimes be really slow.
+// Use a much smaller file.
+const int kLargeFileMegabytes = 8;
+#else // iOS or tvOS
+// iOS FTL devices can handle a medium-sized file.
 const int kLargeFileMegabytes = 32;
 #endif
 

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -67,7 +67,7 @@ const int kLargeFileMegabytes = 64;
 // Android FTL devices can sometimes be really slow.
 // Use a much smaller file.
 const int kLargeFileMegabytes = 8;
-#else // iOS or tvOS
+#else  // iOS or tvOS
 // iOS FTL devices can handle a medium-sized file.
 const int kLargeFileMegabytes = 32;
 #endif


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Occasionally, an Android FTL device will run the Storage tests really slowly. See if reducing the size down to 25% on Android fixes this.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Running integration tests.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
