### PR TITLE
Add flaky retry to all network requests in Dynamic Links.

### DIFF
--- a/dynamic_links/integration_test/src/integration_test.cc
+++ b/dynamic_links/integration_test/src/integration_test.cc
@@ -657,8 +657,8 @@ TEST_F(FirebaseDynamicLinksTest,
     firebase::dynamic_links::DynamicLinkComponents components =
         GenerateComponentsForTest(kUrlToOpen);
 
-    FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
     firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
+    FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
     future = firebase::dynamic_links::GetShortLink(components);
     WaitForCompletion(future, "GetShortLinkFromLongLink");
     FLAKY_TEST_SECTION_END();  // Occasional connection errors.

--- a/dynamic_links/integration_test/src/integration_test.cc
+++ b/dynamic_links/integration_test/src/integration_test.cc
@@ -401,7 +401,8 @@ TEST_F(FirebaseDynamicLinksTest, TestGetShortLinkFromLongLink) {
   firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
 
   FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
-  future = firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
+  future =
+      firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
   WaitForCompletion(future, "GetShortLinkFromLongLink");
   FLAKY_TEST_SECTION_END();
 
@@ -581,7 +582,8 @@ TEST_F(FirebaseDynamicLinksTest, TestOpeningShortLinkFromLongLinkInRunningApp) {
     firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
 
     FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
-    future = firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
+    future =
+        firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
     WaitForCompletion(future, "GetShortLinkFromLongLink");
     FLAKY_TEST_SECTION_END();
 

--- a/dynamic_links/integration_test/src/integration_test.cc
+++ b/dynamic_links/integration_test/src/integration_test.cc
@@ -316,9 +316,12 @@ TEST_F(FirebaseDynamicLinksTest, TestGetShortLinkFromComponents) {
   components.android_parameters = &android_parameters;
   components.social_meta_tag_parameters = &social_parameters;
 
-  firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future =
-      firebase::dynamic_links::GetShortLink(components);
+  firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
+
+  FLAKY_TEST_SECTION_BEGIN();  // Occasionally there can be a connection error.
+  future = firebase::dynamic_links::GetShortLink(components);
   WaitForCompletion(future, "GetShortLinkFromComponents");
+  FLAKY_TEST_SECTION_END();
 
   if (is_desktop_stub_) {
     // On desktop, it's enough that we just don't crash.
@@ -395,9 +398,12 @@ TEST_F(FirebaseDynamicLinksTest, TestGetShortLinkFromLongLink) {
 
   firebase::dynamic_links::DynamicLinkOptions options;
   options.path_length = firebase::dynamic_links::kPathLengthShort;
-  firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future =
-      firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
+  firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
+
+  FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
+  future = firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
   WaitForCompletion(future, "GetShortLinkFromLongLink");
+  FLAKY_TEST_SECTION_END();
 
   const firebase::dynamic_links::GeneratedDynamicLink& generated_link =
       *future.result();
@@ -572,8 +578,12 @@ TEST_F(FirebaseDynamicLinksTest, TestOpeningShortLinkFromLongLinkInRunningApp) {
     // Shorten link.
     firebase::dynamic_links::DynamicLinkOptions options;
     options.path_length = firebase::dynamic_links::kPathLengthShort;
-    firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future =
-        firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
+    firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
+
+    FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
+    future = firebase::dynamic_links::GetShortLink(long_link.url.c_str(), options);
+    WaitForCompletion(future, "GetShortLinkFromLongLink");
+    FLAKY_TEST_SECTION_END();
 
     if (is_desktop_stub_) {
       // On desktop, it's enough that we just don't crash.
@@ -581,8 +591,6 @@ TEST_F(FirebaseDynamicLinksTest, TestOpeningShortLinkFromLongLinkInRunningApp) {
       SUCCEED();
       return;
     }
-
-    WaitForCompletion(future, "GetShortLinkFromLongLink");
     const firebase::dynamic_links::GeneratedDynamicLink& link =
         *future.result();
 
@@ -648,8 +656,12 @@ TEST_F(FirebaseDynamicLinksTest,
         "components...");
     firebase::dynamic_links::DynamicLinkComponents components =
         GenerateComponentsForTest(kUrlToOpen);
-    firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future =
-        firebase::dynamic_links::GetShortLink(components);
+
+    FLAKY_TEST_SECTION_BEGIN();  // Occasional connection errors.
+    firebase::Future<firebase::dynamic_links::GeneratedDynamicLink> future;
+    future = firebase::dynamic_links::GetShortLink(components);
+    WaitForCompletion(future, "GetShortLinkFromLongLink");
+    FLAKY_TEST_SECTION_END();  // Occasional connection errors.
 
     if (is_desktop_stub_) {
       // On desktop, it's enough that we just don't crash.
@@ -658,7 +670,6 @@ TEST_F(FirebaseDynamicLinksTest,
       return;
     }
 
-    WaitForCompletion(future, "GetShortLinkFromLongLink");
     const firebase::dynamic_links::GeneratedDynamicLink& link =
         *future.result();
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Sometimes the various GetShortLink* functions can fail with a network error, SSL error, etc. Add a retry to these operations in case they fail.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Run integration tests in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
