### PR TITLE
Fix build script when `NDK_ROOT` is set

### DIFF
--- a/build_scripts/android/build.sh
+++ b/build_scripts/android/build.sh
@@ -27,7 +27,7 @@ absbuildpath=$( pwd -P )
 cd "${origpath}"
 
 # If NDK_ROOT is not set or is the wrong version, use to the version in /tmp.
-if [[ -z "${NDK_ROOT}" || ! $(grep -q "Pkg\.Revision = 21\." "${NDK_ROOT}/source.properties") ]]; then
+if [[ -z "${NDK_ROOT}" || -z $(grep "Pkg\.Revision = 21\." "${NDK_ROOT}/source.properties") ]]; then
     if [[ ! -d /tmp/android-ndk-r21e ]]; then
         echo "Recommended NDK version r21e not present in /tmp."
         echo "Please run install_prereqs.sh if you wish to use the recommended NDK version."


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When `NDK_ROOT` is set, this script would still set it to `/tmp/android-ndk-r21e`, which does not normally contains NDK unless `NDK_ROOT` is NOT set and `install_prereqs.sh` is called before.

Fix that line so that the if statement would properly exit when `NDK_ROOT` is set.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Ran locally. 

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
