### PR TITLE
Clang-tidy and common typo fixes for gma/

### DIFF
--- a/app/src/util_ios.h
+++ b/app/src/util_ios.h
@@ -313,7 +313,7 @@ class ClassMethodImplementationCache {
   // indexed by selector name with each element that referencing a dictionary
   // of potential names for the selector that contains the original method
   // implementation on the class.
-  // i.e
+  // i.e.
   // selector_implementation_names_dict = dict[original_selector_name];
   NSMutableDictionary *selector_implementation_names_per_selector_;
 

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -1050,7 +1050,7 @@ TEST_F(FirebaseGmaUITest, TestRewardedAdLoadAndShow) {
     LogDebug("Waiting for a moment to ensure all callbacks are recorded.");
     app_framework::ProcessEvents(2000);
 
-    // If not running the UI test in CI (running mannually), keep this check.
+    // If not running the UI test in CI (running manually), keep this check.
     // Else running the UI test in CI, skip this check.
     if (!ShouldRunUITests()) {
       EXPECT_EQ(content_listener.num_ad_clicked(), 1);

--- a/gma/src/android/ad_request_converter.cc
+++ b/gma/src/android/ad_request_converter.cc
@@ -28,7 +28,6 @@
 
 #include "app/src/log.h"
 #include "app/src/util_android.h"
-#include "gma/gma_resources.h"
 #include "gma/src/android/gma_android.h"
 #include "gma/src/common/gma_common.h"
 #include "gma/src/include/firebase/gma.h"

--- a/gma/src/android/ad_request_converter.h
+++ b/gma/src/android/ad_request_converter.h
@@ -32,7 +32,7 @@ namespace gma {
 /// AdRequest.
 /// @param[out] error kAdErrorCodeNone on success, or another error if
 /// problems occurred.
-/// @return On succes, a local reference to an Android object representing the
+/// @return On success, a local reference to an Android object representing the
 /// AdRequest, or nullptr on error.
 jobject GetJavaAdRequestFromCPPAdRequest(const AdRequest& request,
                                          gma::AdErrorCode* error);

--- a/gma/src/android/ad_view_internal_android.cc
+++ b/gma/src/android/ad_view_internal_android.cc
@@ -25,7 +25,6 @@
 
 #include "app/src/assert.h"
 #include "app/src/util_android.h"
-#include "gma/gma_resources.h"
 #include "gma/src/android/ad_request_converter.h"
 #include "gma/src/android/gma_android.h"
 #include "gma/src/common/gma_common.h"
@@ -108,9 +107,9 @@ struct NulleryInvocationOnMainThreadData {
 
 AdViewInternalAndroid::AdViewInternalAndroid(AdView* base)
     : AdViewInternal(base),
+      destroyed_(false),
       helper_(nullptr),
-      initialized_(false),
-      destroyed_(false) {
+      initialized_(false) {
   firebase::MutexLock lock(mutex_);
 
   JNIEnv* env = ::firebase::gma::GetJNI();

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -246,7 +246,7 @@ static AdapterInitializationStatus PopulateAdapterInitializationStatus(
 }
 
 // Initializes the Google Mobile Ads SDK using the MobileAds.initialize()
-// method. The GMA app ID is retreived from the App's android manifest.
+// method. The GMA app ID is retrieved from the App's android manifest.
 Future<AdapterInitializationStatus> InitializeGoogleMobileAds(JNIEnv* env) {
   Future<AdapterInitializationStatus> future_to_return;
   {
@@ -622,7 +622,6 @@ void CallOpenAdInspector(void* data) {
   OpenAdInspectorCallData* call_data =
       reinterpret_cast<OpenAdInspectorCallData*>(data);
   JNIEnv* env = firebase::util::GetThreadsafeJNIEnv(call_data->vm);
-  bool jni_env_exists = (env != nullptr);
   jlong jlistener = (jlong)call_data->listener;
 
   jobject ad_inspector_helper_ref = env->NewObject(
@@ -653,7 +652,7 @@ void OpenAdInspector(AdParent parent, AdInspectorClosedListener* listener) {
   call_data->ad_parent = env->NewGlobalRef(parent);
   call_data->listener = listener;
   jobject activity = ::firebase::gma::GetActivity();
-  util::RunOnMainThread(env, g_activity, CallOpenAdInspector, call_data);
+  util::RunOnMainThread(env, activity, CallOpenAdInspector, call_data);
 }
 
 void SetIsSameAppKeyEnabled(bool is_enabled) {}
@@ -816,8 +815,9 @@ AdValue::PrecisionType ConvertAndroidPrecisionTypeToCPPPrecisionType(
     default:
       LogWarning("Could not convert AdValue precisionType: %l",
                  j_precision_type);
+      return AdValue::kAdValuePrecisionUnknown;
     case 0:
-      return AdValue::kdValuePrecisionUnknown;
+      return AdValue::kAdValuePrecisionUnknown;
     case 1:  // ESTIMATED
       return AdValue::kAdValuePrecisionEstimated;
     case 2:  // PUBLISHER_PROVIDED
@@ -1216,10 +1216,10 @@ jobject CreateJavaAdSize(JNIEnv* env, jobject j_activity,
               ad_size::GetMethodId(
                   ad_size::kGetCurrentOrientationAnchoredAdaptiveBannerAdSize),
               j_activity, adsize.width());
-
+          break;
         default:
           FIREBASE_ASSERT_MESSAGE(true,
-                                  "Uknown Anchor Adaptive AdSize Orientation");
+                                  "Unknown Anchor Adaptive AdSize Orientation");
       }
       break;
     case AdSize::kTypeInlineAdaptive:
@@ -1253,7 +1253,7 @@ jobject CreateJavaAdSize(JNIEnv* env, jobject j_activity,
             break;
           default:
             FIREBASE_ASSERT_MESSAGE(
-                true, "Uknown Inline Adaptive AdSize Orientation");
+                true, "Unknown Inline Adaptive AdSize Orientation");
         }
       }
       break;
@@ -1263,7 +1263,7 @@ jobject CreateJavaAdSize(JNIEnv* env, jobject j_activity,
                                  adsize.width(), adsize.height());
       break;
     default:
-      FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Type");
+      FIREBASE_ASSERT_MESSAGE(true, "Unknown AdSize Type");
   }
   bool jni_exception = util::CheckAndClearJniExceptions(env);
   FIREBASE_ASSERT(!jni_exception);

--- a/gma/src/android/gma_android.h
+++ b/gma/src/android/gma_android.h
@@ -175,7 +175,7 @@ METHOD_LOOKUP_DECLARATION(gma_initialization_helper,
 // Needed when GMA is initialized without Firebase.
 JNIEnv* GetJNI();
 
-// Retrieves the activity used to initalize GMA.
+// Retrieves the activity used to initialize GMA.
 jobject GetActivity();
 
 // Register the native callbacks needed by the Futures.

--- a/gma/src/android/interstitial_ad_internal_android.cc
+++ b/gma/src/android/interstitial_ad_internal_android.cc
@@ -24,7 +24,6 @@
 
 #include "app/src/assert.h"
 #include "app/src/util_android.h"
-#include "gma/gma_resources.h"
 #include "gma/src/android/ad_request_converter.h"
 #include "gma/src/android/gma_android.h"
 #include "gma/src/common/gma_common.h"

--- a/gma/src/android/response_info_android.cc
+++ b/gma/src/android/response_info_android.cc
@@ -51,7 +51,7 @@ ResponseInfo::ResponseInfo(const ResponseInfoInternal& response_info_internal) {
   const int list_size = (int)env->CallIntMethod(
       j_adapter_response_info_list, util::list::GetMethodId(util::list::kSize));
   for (int i = 0; i < list_size; ++i) {
-    // AdatperResponseInfo for this adapter.
+    // AdapterResponseInfo for this adapter.
     jobject j_adapter_response_info =
         env->CallObjectMethod(j_adapter_response_info_list,
                               util::list::GetMethodId(util::list::kGet), i);

--- a/gma/src/android/rewarded_ad_internal_android.cc
+++ b/gma/src/android/rewarded_ad_internal_android.cc
@@ -24,7 +24,6 @@
 
 #include "app/src/assert.h"
 #include "app/src/util_android.h"
-#include "gma/gma_resources.h"
 #include "gma/src/android/ad_request_converter.h"
 #include "gma/src/android/gma_android.h"
 #include "gma/src/common/gma_common.h"

--- a/gma/src/common/ad_view.cc
+++ b/gma/src/common/ad_view.cc
@@ -24,9 +24,6 @@
 namespace firebase {
 namespace gma {
 
-const char kUninitializedError[] =
-    "Initialize() must be called before this method.";
-
 AdView::AdView() {
   FIREBASE_ASSERT(gma::IsInitialized());
   internal_ = internal::AdViewInternal::CreateInstance(this);

--- a/gma/src/common/ad_view_internal.h
+++ b/gma/src/common/ad_view_internal.h
@@ -139,7 +139,7 @@ class AdViewInternal {
   // Future data used to synchronize asynchronous calls.
   FutureData future_data_;
 
-  // Listener for AdView Lifecyle event callbacks.
+  // Listener for AdView Lifecycle event callbacks.
   AdListener* ad_listener_;
 
   // Tracks the size of the AdView.

--- a/gma/src/common/gma_common.cc
+++ b/gma/src/common/gma_common.cc
@@ -122,10 +122,10 @@ const AdSize AdSize::kLeaderboard(728, 90);
 const AdSize AdSize::kMediumRectangle(300, 250);
 
 AdSize::AdSize(uint32_t width, uint32_t height)
-    : width_(width),
+    : orientation_(AdSize::kOrientationCurrent),
+      width_(width),
       height_(height),
-      type_(AdSize::kTypeStandard),
-      orientation_(AdSize::kOrientationCurrent) {}
+      type_(AdSize::kTypeStandard) {}
 
 AdSize AdSize::GetAnchoredAdaptiveBannerAdSize(uint32_t width,
                                                Orientation orientation) {

--- a/gma/src/common/gma_common.h
+++ b/gma/src/common/gma_common.h
@@ -165,7 +165,7 @@ class GmaInternal {
 
   // Update the AdViewInternal's AdSize width and height after it has been
   // loaded as AdViews with adaptive AdSizes may have varying dimensions.
-  // This is done through the GmaInternal since its a friend of AdViewInternal.
+  // This is done through the GmaInternal since it's a friend of AdViewInternal.
   static void UpdateAdViewInternalAdSizeDimensions(
       internal::AdViewInternal* ad_view_internal, int width, int height);
 };

--- a/gma/src/common/interstitial_ad.cc
+++ b/gma/src/common/interstitial_ad.cc
@@ -24,9 +24,6 @@
 namespace firebase {
 namespace gma {
 
-const char kUninitializedError[] =
-    "Initialize() must be called before this method.";
-
 InterstitialAd::InterstitialAd() {
   FIREBASE_ASSERT(gma::IsInitialized());
   internal_ = internal::InterstitialAdInternal::CreateInstance(this);

--- a/gma/src/common/rewarded_ad.cc
+++ b/gma/src/common/rewarded_ad.cc
@@ -24,9 +24,6 @@
 namespace firebase {
 namespace gma {
 
-const char kUninitializedError[] =
-    "Initialize() must be called before this method.";
-
 RewardedAd::RewardedAd() {
   FIREBASE_ASSERT(gma::IsInitialized());
   internal_ = internal::RewardedAdInternal::CreateInstance(this);

--- a/gma/src/include/firebase/gma/ad_view.h
+++ b/gma/src/include/firebase/gma/ad_view.h
@@ -141,7 +141,7 @@ class AdView {
   /// (x, y). Coordinates are in pixels from the top-left corner of the screen.
   ///
   /// When built for Android, the library will not display an ad on top of or
-  /// beneath an <code>Activity</code>'s status bar. If a call to SetPostion
+  /// beneath an <code>Activity</code>'s status bar. If a call to SetPosition
   /// would result in an overlap, the @ref AdView is placed just below the
   /// status bar, so no overlap occurs.
   /// @param[in] x The desired horizontal coordinate.

--- a/gma/src/include/firebase/gma/types.h
+++ b/gma/src/include/firebase/gma/types.h
@@ -576,7 +576,7 @@ class AdSize {
 
   /// Comparison operator.
   ///
-  /// @returns true if `rhs` refers to a different AdSize as `this`.
+  /// @return true if `rhs` refers to a different AdSize as `this`.
   bool operator!=(const AdSize& rhs) const;
 
   /// The width of the region represented by this AdSize.  Value is in
@@ -596,7 +596,7 @@ class AdSize {
  private:
   friend class firebase::gma::internal::AdViewInternal;
 
-  /// Returns an Anchor Adpative AdSize Object given a width and orientation.
+  /// Returns an Anchor Adaptive AdSize Object given a width and orientation.
   static AdSize GetAnchoredAdaptiveBannerAdSize(uint32_t width,
                                                 Orientation orientation);
 
@@ -709,7 +709,7 @@ class AdReward {
  public:
   /// Creates an @ref AdReward.
   AdReward(const std::string& type, int64_t amount)
-      : type_(type), amount_(amount) {}
+      : amount_(amount), type_(type) {}
 
   /// Returns the reward amount.
   int64_t amount() const { return amount_; }
@@ -728,7 +728,7 @@ class AdValue {
   /// Allowed constants for @ref precision_type().
   enum PrecisionType {
     /// An ad value with unknown precision.
-    kdValuePrecisionUnknown = 0,
+    kAdValuePrecisionUnknown = 0,
     /// An ad value estimated from aggregated data.
     kAdValuePrecisionEstimated,
     /// A publisher-provided ad value, such as manual CPMs in a mediation group.

--- a/gma/src/ios/FADAdSize.h
+++ b/gma/src/ios/FADAdSize.h
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 namespace firebase {
 namespace gma {
 
-/// Returns a GADAdSize from an gma::AdSize.
+/// Returns a GADAdSize from a gma::AdSize.
 GADAdSize GADSizeFromCppAdSize(const AdSize& ad_size);
 
 }  // namespace gma

--- a/gma/src/ios/FADAdSize.mm
+++ b/gma/src/ios/FADAdSize.mm
@@ -32,12 +32,13 @@ GADAdSize GADSizeFromCppAdSize(const AdSize& ad_size) {
         case AdSize::kOrientationCurrent:
           return GADCurrentOrientationAnchoredAdaptiveBannerAdSizeWithWidth(ad_size.width());
         default:
-          FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Orientation");
+          FIREBASE_ASSERT_MESSAGE(true, "Unknown AdSize Orientation");
       }
       break;
     case AdSize::kTypeInlineAdaptive:
-      if(ad_size.height() != 0) {
-        return GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight(ad_size.width(), ad_size.height());
+      if (ad_size.height() != 0) {
+        return GADInlineAdaptiveBannerAdSizeWithWidthAndMaxHeight(ad_size.width(),
+                                                                  ad_size.height());
       }
       switch (ad_size.orientation()) {
         case AdSize::kOrientationLandscape:
@@ -47,14 +48,14 @@ GADAdSize GADSizeFromCppAdSize(const AdSize& ad_size) {
         case AdSize::kOrientationCurrent:
           return GADCurrentOrientationInlineAdaptiveBannerAdSizeWithWidth(ad_size.width());
         default:
-          FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Orientation");
+          FIREBASE_ASSERT_MESSAGE(true, "Unknown AdSize Orientation");
       }
-    break;
+      break;
     case AdSize::kTypeStandard:
       return GADAdSizeFromCGSize(CGSizeMake(ad_size.width(), ad_size.height()));
       break;
     default:
-      FIREBASE_ASSERT_MESSAGE(true, "Uknown AdSize Type");
+      FIREBASE_ASSERT_MESSAGE(true, "Unknown AdSize Type");
   }
 }
 

--- a/gma/src/ios/FADAdView.h
+++ b/gma/src/ios/FADAdView.h
@@ -40,7 +40,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithView:(UIView *)view
                     adUnitID:(NSString *)adUnitID
                       adSize:(firebase::gma::AdSize)adSize
-          internalAdView:(firebase::gma::internal::AdViewInternalIOS *)cppAdView  // NOLINT
+              internalAdView:(firebase::gma::internal::AdViewInternalIOS *)cppAdView  // NOLINT
     NS_DESIGNATED_INITIALIZER;
 
 /// Requests a banner ad.
@@ -59,8 +59,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)moveAdViewToXCoordinate:(int)x yCoordinate:(int)y;
 
 /// Moves the banner view to a AdView::Position.
-- (void)moveAdViewToPosition:(firebase::gma::AdView::Position)position; // NOLINT
-
+- (void)moveAdViewToPosition:(firebase::gma::AdView::Position)position;  // NOLINT
 
 @end
 

--- a/gma/src/ios/FADAdView.mm
+++ b/gma/src/ios/FADAdView.mm
@@ -16,8 +16,8 @@
 
 #include "gma/src/ios/FADAdView.h"
 
-#import "gma/src/ios/gma_ios.h"
 #import "gma/src/ios/FADAdSize.h"
+#import "gma/src/ios/gma_ios.h"
 
 namespace gma = firebase::gma;
 
@@ -58,7 +58,7 @@ firebase::gma::AdView::Position _position;
 - (instancetype)initWithView:(UIView *)view
                     adUnitID:(NSString *)adUnitID
                       adSize:(firebase::gma::AdSize)adSize
-          internalAdView:(firebase::gma::internal::AdViewInternalIOS *)cppAdView {
+              internalAdView:(firebase::gma::internal::AdViewInternalIOS *)cppAdView {
   GADAdSize gadsize = GADSizeFromCppAdSize(adSize);
   CGRect frame = CGRectMake(0, 0, gadsize.size.width, gadsize.size.height);
   self = [super initWithFrame:frame];
@@ -95,17 +95,15 @@ firebase::gma::AdView::Position _position;
 
   // Add layout constraints to center the banner view vertically and horizontally.
   NSDictionary *viewDictionary = NSDictionaryOfVariableBindings(_adView);
-  NSArray *verticalConstraints =
-      [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_adView]|"
-                                              options:0
-                                              metrics:nil
-                                                views:viewDictionary];
+  NSArray *verticalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"V:|[_adView]|"
+                                                                         options:0
+                                                                         metrics:nil
+                                                                           views:viewDictionary];
   [self addConstraints:verticalConstraints];
-  NSArray *horizontalConstraints =
-      [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_adView]|"
-                                              options:0
-                                              metrics:nil
-                                                views:viewDictionary];
+  NSArray *horizontalConstraints = [NSLayoutConstraint constraintsWithVisualFormat:@"H:|[_adView]|"
+                                                                           options:0
+                                                                           metrics:nil
+                                                                             views:viewDictionary];
   [self addConstraints:horizontalConstraints];
 
   UIView *strongView = _parentView;
@@ -113,8 +111,8 @@ firebase::gma::AdView::Position _position;
   [strongView addSubview:self];
   self.translatesAutoresizingMaskIntoConstraints = NO;
   [self updateAdViewLayoutConstraintsWithPosition:(gma::AdView::kPositionTopLeft)
-                                          xCoordinate:0
-                                          yCoordinate:0];
+                                      xCoordinate:0
+                                      yCoordinate:0];
 }
 
 #pragma mark - Property Accessor Methods
@@ -169,22 +167,20 @@ firebase::gma::AdView::Position _position;
   CGFloat xPoints = x / scale;
   CGFloat yPoints = y / scale;
   [self updateAdViewLayoutConstraintsWithPosition:(_position)
-                                          xCoordinate:xPoints
-                                          yCoordinate:yPoints];
+                                      xCoordinate:xPoints
+                                      yCoordinate:yPoints];
 }
 
 - (void)moveAdViewToPosition:(gma::AdView::Position)position {
-  [self updateAdViewLayoutConstraintsWithPosition:position
-                                          xCoordinate:0
-                                          yCoordinate:0];
+  [self updateAdViewLayoutConstraintsWithPosition:position xCoordinate:0 yCoordinate:0];
 }
 
 #pragma mark - Private Methods
 
 /// Updates the layout constraints for the view.
 - (void)updateAdViewLayoutConstraintsWithPosition:(gma::AdView::Position)position
-                                          xCoordinate:(CGFloat)x
-                                          yCoordinate:(CGFloat)y {
+                                      xCoordinate:(CGFloat)x
+                                      yCoordinate:(CGFloat)y {
   NSLayoutAttribute verticalLayoutAttribute = NSLayoutAttributeNotAnAttribute;
   NSLayoutAttribute horizontalLayoutAttribute = NSLayoutAttributeNotAnAttribute;
 
@@ -223,20 +219,19 @@ firebase::gma::AdView::Position _position;
   // exist.
   UIView *strongView = _parentView;
   if (_adViewVerticalLayoutConstraint && _adViewHorizontalLayoutConstraint) {
-    NSArray *AdViewLayoutConstraints = @[ _adViewVerticalLayoutConstraint,
-                                              _adViewHorizontalLayoutConstraint ];
+    NSArray *AdViewLayoutConstraints =
+        @[ _adViewVerticalLayoutConstraint, _adViewHorizontalLayoutConstraint ];
     [strongView removeConstraints:AdViewLayoutConstraints];
   }
 
   // Set the vertical and horizontal layout constraints for the banner view.
-  _adViewVerticalLayoutConstraint =
-      [NSLayoutConstraint constraintWithItem:self
-                                   attribute:verticalLayoutAttribute
-                                   relatedBy:NSLayoutRelationEqual
-                                      toItem:strongView
-                                   attribute:verticalLayoutAttribute
-                                  multiplier:1
-                                    constant:y];
+  _adViewVerticalLayoutConstraint = [NSLayoutConstraint constraintWithItem:self
+                                                                 attribute:verticalLayoutAttribute
+                                                                 relatedBy:NSLayoutRelationEqual
+                                                                    toItem:strongView
+                                                                 attribute:verticalLayoutAttribute
+                                                                multiplier:1
+                                                                  constant:y];
   [strongView addConstraint:_adViewVerticalLayoutConstraint];
   _adViewHorizontalLayoutConstraint =
       [NSLayoutConstraint constraintWithItem:self
@@ -272,25 +267,26 @@ firebase::gma::AdView::Position _position;
 #pragma mark - GADBannerViewDelegate
 
 - (void)bannerViewDidReceiveAd:(nonnull GADBannerView *)bannerView {
-  NSInteger width = (NSInteger) (floor(bannerView.intrinsicContentSize.width));
-  NSInteger height = (NSInteger) (floor(bannerView.intrinsicContentSize.height));
+  NSInteger width = (NSInteger)(floor(bannerView.intrinsicContentSize.width));
+  NSInteger height = (NSInteger)(floor(bannerView.intrinsicContentSize.height));
   _adLoaded = YES;
   _cppAdView->AdViewDidReceiveAd(width, height, bannerView.responseInfo);
-  gma::BoundingBox bounding_box = self.boundingBox;
 }
-- (void)bannerView:(nonnull GADBannerView *)bannerView didFailToReceiveAdWithError:(nonnull NSError *)error {
+
+- (void)bannerView:(nonnull GADBannerView *)bannerView
+    didFailToReceiveAdWithError:(nonnull NSError *)error {
   _cppAdView->AdViewDidFailToReceiveAdWithError(error);
 }
 
 - (void)bannerViewDidRecordClick:(nonnull GADBannerView *)bannerView {
-   _cppAdView->NotifyListenerAdClicked();
+  _cppAdView->NotifyListenerAdClicked();
 }
 
 - (void)bannerViewDidRecordImpression:(nonnull GADBannerView *)bannerView {
   _cppAdView->NotifyListenerAdImpression();
 }
 
-// Note that the following callbacks are only called on in-app overlay events. 
+// Note that the following callbacks are only called on in-app overlay events.
 // See https://www.googblogs.com/google-mobile-ads-sdk-a-note-on-ad-click-events/
 // and https://groups.google.com/g/google-admob-ads-sdk/c/lzdt5szxSVU
 - (void)bannerViewWillPresentScreen:(nonnull GADBannerView *)bannerView {

--- a/gma/src/ios/FADInterstitialDelegate.h
+++ b/gma/src/ios/FADInterstitialDelegate.h
@@ -32,7 +32,7 @@ class InterstitialAdInternalIOS;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FADInterstitialDelegate : NSObject<GADFullScreenContentDelegate>
+@interface FADInterstitialDelegate : NSObject <GADFullScreenContentDelegate>
 
 /// Returns a FADInterstitialDelegate object with InterstitialAdInternalIOS.
 - (FADInterstitialDelegate *)initWithInternalInterstitialAd:

--- a/gma/src/ios/FADInterstitialDelegate.mm
+++ b/gma/src/ios/FADInterstitialDelegate.mm
@@ -52,16 +52,16 @@
 }
 
 - (void)ad:(nonnull id<GADFullScreenPresentingAd>)ad
-didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
+    didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
   firebase::gma::AdErrorInternal ad_error_internal;
   ad_error_internal.ad_error_type =
-    firebase::gma::AdErrorInternal::kAdErrorInternalFullScreenContentError;
+      firebase::gma::AdErrorInternal::kAdErrorInternalFullScreenContentError;
   ad_error_internal.is_successful = false;
   ad_error_internal.native_ad_error = error;
   // Invoke GmaInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.
-  const firebase::gma::AdError& ad_error =
-    firebase::gma::GmaInternal::CreateAdError(ad_error_internal);
+  const firebase::gma::AdError &ad_error =
+      firebase::gma::GmaInternal::CreateAdError(ad_error_internal);
   _interstitialAd->NotifyListenerOfAdFailedToShowFullScreenContent(ad_error);
 }
 

--- a/gma/src/ios/FADRequest.h
+++ b/gma/src/ios/FADRequest.h
@@ -26,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 namespace firebase {
 namespace gma {
 
-/// Returns a GADRequest from an gma::AdRequest.
+/// Returns a GADRequest from a gma::AdRequest.
 /// Converts instances of the AdRequest struct used by the C++ wrapper to
 /// to Mobile Ads SDK GADRequest objects.
 ///
@@ -36,9 +36,9 @@ namespace gma {
 /// problems occurred.
 /// @param[out] error_message a string representation of any error that
 /// occurs.
-/// @return On succes, a pointer to a GADRequest object representing the
+/// @return On success, a pointer to a GADRequest object representing the
 /// AdRequest, or nullptr on error.
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
+GADRequest* GADRequestFromCppAdRequest(const AdRequest& adRequest,
                                        gma::AdErrorCode* error,
                                        std::string* error_message);
 
@@ -48,7 +48,8 @@ AdErrorCode MapAdRequestErrorCodeToCPPErrorCode(GADErrorCode error_code);
 
 // Converts the iOS error codes from attempting to show a full screen
 // ad into the platform independent error codes defined in AdError.
-AdErrorCode MapFullScreenContentErrorCodeToCPPErrorCode(GADPresentationErrorCode error_code);
+AdErrorCode MapFullScreenContentErrorCodeToCPPErrorCode(
+    GADPresentationErrorCode error_code);
 
 }  // namespace gma
 }  // namespace firebase

--- a/gma/src/ios/FADRequest.mm
+++ b/gma/src/ios/FADRequest.mm
@@ -16,43 +16,40 @@
 
 #import "gma/src/ios/FADRequest.h"
 
-#include "gma/src/common/gma_common.h"
 #include "app/src/util_ios.h"
+#include "gma/src/common/gma_common.h"
 
 #include "app/src/log.h"
 
 namespace firebase {
 namespace gma {
 
-GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest, 
-                                      gma::AdErrorCode* error, 
-                                      std::string* error_message) {
+GADRequest* GADRequestFromCppAdRequest(const AdRequest& adRequest, gma::AdErrorCode* error,
+                                       std::string* error_message) {
   FIREBASE_ASSERT(error);
   FIREBASE_ASSERT(error_message);
   *error = kAdErrorCodeNone;
 
   // Create the GADRequest.
-  GADRequest *gadRequest = [GADRequest request];
+  GADRequest* gadRequest = [GADRequest request];
 
   // Keywords.
   const std::unordered_set<std::string>& keywords = adRequest.keywords();
-  if( keywords.size() > 0 ) {
-    NSMutableArray *gadKeywords = [[NSMutableArray alloc] init];
+  if (keywords.size() > 0) {
+    NSMutableArray* gadKeywords = [[NSMutableArray alloc] init];
     for (auto keyword = keywords.begin(); keyword != keywords.end(); ++keyword) {
-      [gadKeywords addObject: util::StringToNSString(*keyword)];
+      [gadKeywords addObject:util::StringToNSString(*keyword)];
     }
     gadRequest.keywords = gadKeywords;
   }
-  
+
   // Extras.
-  const std::map<std::string, std::map<std::string, std::string>>& extras =
-      adRequest.extras();
-  for (auto adapter_iter = extras.begin(); adapter_iter != extras.end(); 
-       ++adapter_iter) {
+  const std::map<std::string, std::map<std::string, std::string>>& extras = adRequest.extras();
+  for (auto adapter_iter = extras.begin(); adapter_iter != extras.end(); ++adapter_iter) {
     const std::string adapterClassName = adapter_iter->first;
     // Attempt to resolve the custom class.
     Class extrasClass = NSClassFromString(util::StringToNSString(adapterClassName));
-    if (extrasClass == nil ) {
+    if (extrasClass == nil) {
       *error_message = "Failed to resolve extras class: ";
       error_message->append(adapterClassName);
       LogError(error_message->c_str());
@@ -74,14 +71,14 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
     // Add the key/value dictionary to the object.
     // adpter_iter->second is a std::map of the key/value pairs.
     if (!adapter_iter->second.empty()) {
-      NSMutableDictionary *additionalParameters = [[NSMutableDictionary alloc] init];
-      for (auto extra_iter = adapter_iter->second.begin();
-           extra_iter != adapter_iter->second.end(); ++extra_iter) {
-        NSString *key = util::StringToNSString(extra_iter->first);
-        NSString *value = util::StringToNSString(extra_iter->second);
+      NSMutableDictionary* additionalParameters = [[NSMutableDictionary alloc] init];
+      for (auto extra_iter = adapter_iter->second.begin(); extra_iter != adapter_iter->second.end();
+           ++extra_iter) {
+        NSString* key = util::StringToNSString(extra_iter->first);
+        NSString* value = util::StringToNSString(extra_iter->second);
         additionalParameters[key] = value;
       }
-      
+
       GADExtras* gadExtras = (GADExtras*)gadExtrasId;
       gadExtras.additionalParameters = additionalParameters;
       [gadRequest registerAdNetworkExtras:gadExtras];
@@ -96,7 +93,7 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
   // Neighboring Content URLs
   if (!adRequest.neighboring_content_urls().empty()) {
     gadRequest.neighboringContentURLStrings =
-      util::StringUnorderedSetToNSMutableArray(adRequest.neighboring_content_urls());
+        util::StringUnorderedSetToNSMutableArray(adRequest.neighboring_content_urls());
   }
 
   // Set the request agent string so requests originating from this library can
@@ -109,38 +106,37 @@ GADRequest *GADRequestFromCppAdRequest(const AdRequest& adRequest,
 AdErrorCode MapAdRequestErrorCodeToCPPErrorCode(GADErrorCode error_code) {
   // iOS error code sourced from
   // https://developers.google.com/admob/ios/api/reference/Enums/GADErrorCode
-  switch(error_code)
-  {
-    case GADErrorInvalidRequest:               // 0
+  switch (error_code) {
+    case GADErrorInvalidRequest:  // 0
       return kAdErrorCodeInvalidRequest;
-    case GADErrorNoFill:                       // 1
+    case GADErrorNoFill:  // 1
       return kAdErrorCodeNoFill;
-    case GADErrorNetworkError:                 // 2
+    case GADErrorNetworkError:  // 2
       return kAdErrorCodeNetworkError;
-    case GADErrorServerError:                  // 3
+    case GADErrorServerError:  // 3
       return kAdErrorCodeServerError;
-    case GADErrorOSVersionTooLow:              // 4
+    case GADErrorOSVersionTooLow:  // 4
       return kAdErrorCodeOSVersionTooLow;
-    case GADErrorTimeout:                      // 5
+    case GADErrorTimeout:  // 5
       return kAdErrorCodeTimeout;
     // no error 6.
-    case GADErrorMediationDataError:           // 7
+    case GADErrorMediationDataError:  // 7
       return kAdErrorCodeMediationDataError;
-    case GADErrorMediationAdapterError:        // 8
+    case GADErrorMediationAdapterError:  // 8
       return kAdErrorCodeMediationAdapterError;
-    case GADErrorMediationNoFill:              // 9
+    case GADErrorMediationNoFill:  // 9
       return kAdErrorCodeMediationNoFill;
-    case GADErrorMediationInvalidAdSize:       // 10
+    case GADErrorMediationInvalidAdSize:  // 10
       return kAdErrorCodeMediationInvalidAdSize;
-    case GADErrorInternalError:                // 11
+    case GADErrorInternalError:  // 11
       return kAdErrorCodeInternalError;
-    case GADErrorInvalidArgument:              // 12
+    case GADErrorInvalidArgument:  // 12
       return kAdErrorCodeInvalidArgument;
-    case GADErrorReceivedInvalidResponse:      // 13
+    case GADErrorReceivedInvalidResponse:  // 13
       return kAdErrorCodeReceivedInvalidResponse;
-    case GADErrorAdAlreadyUsed:                // 19 (no error #s 14-18)
+    case GADErrorAdAlreadyUsed:  // 19 (no error #s 14-18)
       return kAdErrorCodeAdAlreadyUsed;
-    case GADErrorApplicationIdentifierMissing: // 20
+    case GADErrorApplicationIdentifierMissing:  // 20
       return kAdErrorCodeApplicationIdentifierMissing;
     default:
       return kAdErrorCodeUnknown;
@@ -150,19 +146,18 @@ AdErrorCode MapAdRequestErrorCodeToCPPErrorCode(GADErrorCode error_code) {
 AdErrorCode MapFullScreenContentErrorCodeToCPPErrorCode(GADPresentationErrorCode error_code) {
   // iOS error code sourced from
   // https://developers.google.com/admob/ios/api/reference/Enums/GADPresentationErrorCode
-  switch(error_code)
-  {
-    case GADPresentationErrorCodeAdNotReady:     // 15
+  switch (error_code) {
+    case GADPresentationErrorCodeAdNotReady:  // 15
       return kAdErrorCodeAdNotReady;
-    case GADPresentationErrorCodeAdTooLarge:     // 16
+    case GADPresentationErrorCodeAdTooLarge:  // 16
       return kAdErrorCodeAdTooLarge;
-    case GADPresentationErrorCodeInternal:       // 17
+    case GADPresentationErrorCodeInternal:  // 17
       return kAdErrorCodeInternalError;
     case GADPresentationErrorCodeAdAlreadyUsed:  // 18
       return kAdErrorCodeAdAlreadyUsed;
-    case GADPresentationErrorNotMainThread:      // 21
+    case GADPresentationErrorNotMainThread:  // 21
       return kAdErrorCodeNotMainThread;
-    case GADPresentationErrorMediation:          // 22
+    case GADPresentationErrorMediation:  // 22
       return kAdErrorCodeMediationShowError;
     default:
       return kAdErrorCodeUnknown;

--- a/gma/src/ios/FADRewardedAdDelegate.h
+++ b/gma/src/ios/FADRewardedAdDelegate.h
@@ -33,7 +33,7 @@ class RewardedAdInternalIOS;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FADRewardedAdDelegate : NSObject<GADFullScreenContentDelegate>
+@interface FADRewardedAdDelegate : NSObject <GADFullScreenContentDelegate>
 
 /// Returns a FADInterstitialDelegate object with InterstitialAdInternalIOS.
 - (FADRewardedAdDelegate *)initWithInternalRewardedAd:

--- a/gma/src/ios/FADRewardedAdDelegate.mm
+++ b/gma/src/ios/FADRewardedAdDelegate.mm
@@ -52,16 +52,16 @@
 }
 
 - (void)ad:(nonnull id<GADFullScreenPresentingAd>)ad
-didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
+    didFailToPresentFullScreenContentWithError:(nonnull NSError *)error {
   firebase::gma::AdErrorInternal ad_error_internal;
   ad_error_internal.ad_error_type =
-    firebase::gma::AdErrorInternal::kAdErrorInternalFullScreenContentError;
+      firebase::gma::AdErrorInternal::kAdErrorInternalFullScreenContentError;
   ad_error_internal.is_successful = false;
   ad_error_internal.native_ad_error = error;
   // Invoke GmaInternal, a friend of AdResult, to have it access its
   // protected constructor with the AdError data.
-  const firebase::gma::AdError& ad_error =
-    firebase::gma::GmaInternal::CreateAdError(ad_error_internal);
+  const firebase::gma::AdError &ad_error =
+      firebase::gma::GmaInternal::CreateAdError(ad_error_internal);
   _rewardedAd->NotifyListenerOfAdFailedToShowFullScreenContent(ad_error);
 }
 

--- a/gma/src/ios/ad_error_ios.mm
+++ b/gma/src/ios/ad_error_ios.mm
@@ -22,12 +22,13 @@ extern "C" {
 
 #include <string>
 
+#include "app/src/assert.h"
+#include "app/src/util_ios.h"
 #include "gma/src/common/ad_error_internal.h"
 #include "gma/src/include/firebase/gma.h"
 #include "gma/src/ios/ad_error_ios.h"
 #include "gma/src/ios/response_info_ios.h"
 
-#include "app/src/util_ios.h"
 
 namespace firebase {
 namespace gma {
@@ -62,15 +63,14 @@ AdError::AdError(const AdErrorInternal& ad_error_internal) {
   response_info_ = new ResponseInfo();
 
   // AdErrors can be returned on success, or for errors encountered in the C++
-  // SDK wrapper, or in the iOS GMA SDK.  The stucture is populated
+  // SDK wrapper, or in the iOS GMA SDK.  The structure is populated
   // differently across these three scenarios.
   if (internal_->is_successful) {
     internal_->code = kAdErrorCodeNone;
     internal_->message = "";
     internal_->domain = "";
     internal_->to_string = "";
-  } else if (internal_->ad_error_type ==
-             AdErrorInternal::kAdErrorInternalWrapperError) {
+  } else if (internal_->ad_error_type == AdErrorInternal::kAdErrorInternalWrapperError) {
     // Wrapper errors come with prepopulated code, domain, etc, fields.
     internal_->code = ad_error_internal.code;
     internal_->domain = ad_error_internal.domain;
@@ -88,8 +88,8 @@ AdError::AdError(const AdErrorInternal& ad_error_internal) {
     switch (internal_->ad_error_type) {
       case AdErrorInternal::kAdErrorInternalFullScreenContentError:
         // Full screen content errors have their own error codes.
-        internal_->code =
-            MapFullScreenContentErrorCodeToCPPErrorCode((GADPresentationErrorCode)internal_->native_ad_error.code);
+        internal_->code = MapFullScreenContentErrorCodeToCPPErrorCode(
+            (GADPresentationErrorCode)internal_->native_ad_error.code);
         break;
       case AdErrorInternal::kAdErrorInternalOpenAdInspectorError:
         // OpenAdInspector errors are all internal errors on iOS.
@@ -101,22 +101,21 @@ AdError::AdError(const AdErrorInternal& ad_error_internal) {
     }
 
     internal_->domain = util::NSStringToString(internal_->native_ad_error.domain);
-    internal_->message =
-      util::NSStringToString(internal_->native_ad_error.localizedDescription);
+    internal_->message = util::NSStringToString(internal_->native_ad_error.localizedDescription);
 
     // Errors from LoadAd attempts have extra data pertaining to adapter
     // responses.
     if (internal_->ad_error_type == AdErrorInternal::kAdErrorInternalLoadAdError) {
-      ResponseInfoInternal response_info_internal = ResponseInfoInternal( {
-        ad_error_internal.native_ad_error.userInfo[GADErrorUserInfoKeyResponseInfo]
-      });
+      ResponseInfoInternal response_info_internal = ResponseInfoInternal(
+          {ad_error_internal.native_ad_error.userInfo[GADErrorUserInfoKeyResponseInfo]});
       *response_info_ = ResponseInfo(response_info_internal);
     }
 
-    NSString* ns_to_string = [[NSString alloc]initWithFormat:@"Received error with "
-        "domain: %@, code: %ld, message: %@", internal_->native_ad_error.domain,
-        (long)internal_->native_ad_error.code,
-        internal_->native_ad_error.localizedDescription];
+    NSString* ns_to_string = [[NSString alloc]
+        initWithFormat:@"Received error with "
+                        "domain: %@, code: %ld, message: %@",
+                       internal_->native_ad_error.domain, (long)internal_->native_ad_error.code,
+                       internal_->native_ad_error.localizedDescription];
     internal_->to_string = util::NSStringToString(ns_to_string);
   }
 }

--- a/gma/src/ios/ad_response_info_ios.h
+++ b/gma/src/ios/ad_response_info_ios.h
@@ -21,7 +21,7 @@ extern "C" {
 #include <objc/objc.h>
 }  // extern "C"
 
-#import <GoogleMobileAds/GoogleMobileAds.h>>
+#import <GoogleMobileAds/GoogleMobileAds.h>
 
 namespace firebase {
 namespace gma {

--- a/gma/src/ios/ad_view_internal_ios.h
+++ b/gma/src/ios/ad_view_internal_ios.h
@@ -54,8 +54,9 @@ class AdViewInternalIOS : public AdViewInternal {
   }
 
 #ifdef __OBJC__
-  void AdViewDidReceiveAd(int width, int height, GADResponseInfo *gad_response_info);
-  void AdViewDidFailToReceiveAdWithError(NSError *gad_error);
+  void AdViewDidReceiveAd(int width, int height,
+                          GADResponseInfo* gad_response_info);
+  void AdViewDidFailToReceiveAdWithError(NSError* gad_error);
 #endif  // __OBJC__
 
  private:
@@ -74,7 +75,7 @@ class AdViewInternalIOS : public AdViewInternal {
   /// and needs to be waited on in the destructor.
   Mutex destroy_mutex_;
 
-  /// Prevents duplicate invocations of initailize on the AdView.
+  /// Prevents duplicate invocations of initialize on the AdView.
   bool initialized_;
 
   // Mutex to guard against concurrent operations;

--- a/gma/src/ios/ad_view_internal_ios.mm
+++ b/gma/src/ios/ad_view_internal_ios.mm
@@ -16,9 +16,9 @@
 
 #include "gma/src/ios/ad_view_internal_ios.h"
 
-#import "gma/src/ios/gma_ios.h"
 #import "gma/src/ios/FADAdView.h"
 #import "gma/src/ios/FADRequest.h"
+#import "gma/src/ios/gma_ios.h"
 
 #include "app/src/util_ios.h"
 #include "gma/src/ios/response_info_ios.h"
@@ -35,7 +35,7 @@ AdViewInternalIOS::AdViewInternalIOS(AdView* base)
       initialized_(false) {}
 
 AdViewInternalIOS::~AdViewInternalIOS() {
-  if(ad_load_callback_data_ != nil) {
+  if (ad_load_callback_data_ != nil) {
     delete ad_load_callback_data_;
     ad_load_callback_data_ = nil;
   }
@@ -55,23 +55,23 @@ AdViewInternalIOS::~AdViewInternalIOS() {
   util::DispatchAsyncSafeMainQueue(destroyBlock);
 }
 
-Future<void> AdViewInternalIOS::Initialize(AdParent parent,
-      const char* ad_unit_id, const AdSize& size) {
+Future<void> AdViewInternalIOS::Initialize(AdParent parent, const char* ad_unit_id,
+                                           const AdSize& size) {
   firebase::MutexLock lock(mutex_);
   const SafeFutureHandle<void> future_handle =
-    future_data_.future_impl.SafeAlloc<void>(kAdViewFnInitialize);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnInitialize);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
-  if(initialized_) {
-    CompleteFuture(kAdErrorCodeAlreadyInitialized,
-      kAdAlreadyInitializedErrorMessage, future_handle, &future_data_);
+  if (initialized_) {
+    CompleteFuture(kAdErrorCodeAlreadyInitialized, kAdAlreadyInitializedErrorMessage, future_handle,
+                   &future_data_);
   } else {
     initialized_ = true;
 
     // Guard against parameter object destruction before the async operation
     // executes (below).
     AdParent local_ad_parent = parent;
-    NSString *local_ad_unit_id = @(ad_unit_id);
+    NSString* local_ad_unit_id = @(ad_unit_id);
     ad_size_ = size;
 
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -79,7 +79,7 @@ Future<void> AdViewInternalIOS::Initialize(AdParent parent,
                                         adUnitID:local_ad_unit_id
                                           adSize:ad_size_
                                   internalAdView:this];
-    CompleteFuture(kAdErrorCodeNone, nullptr, future_handle, &future_data_);
+      CompleteFuture(kAdErrorCodeNone, nullptr, future_handle, &future_data_);
     });
   }
   return future;
@@ -88,14 +88,12 @@ Future<void> AdViewInternalIOS::Initialize(AdParent parent,
 Future<AdResult> AdViewInternalIOS::LoadAd(const AdRequest& request) {
   firebase::MutexLock lock(mutex_);
   FutureCallbackData<AdResult>* callback_data =
-    CreateAdResultFutureCallbackData(kAdViewFnLoadAd,
-                                     &future_data_);
-  Future<AdResult> future = MakeFuture(&future_data_.future_impl,
-    callback_data->future_handle);
+      CreateAdResultFutureCallbackData(kAdViewFnLoadAd, &future_data_);
+  Future<AdResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
   if (ad_load_callback_data_ != nil) {
     CompleteLoadAdInternalError(callback_data, kAdErrorCodeLoadInProgress,
-      kAdLoadInProgressErrorMessage);
+                                kAdLoadInProgressErrorMessage);
     return future;
   }
   // Persist a pointer to the callback data so that we may use it after the iOS
@@ -110,20 +108,19 @@ Future<AdResult> AdViewInternalIOS::LoadAd(const AdRequest& request) {
     AdErrorCode error_code = kAdErrorCodeNone;
     std::string error_message;
 
-    // Create a GADRequest from an gma::AdRequest.
-    GADRequest *ad_request =
-     GADRequestFromCppAdRequest(local_ad_request, &error_code, &error_message);
+    // Create a GADRequest from a gma::AdRequest.
+    GADRequest* ad_request =
+        GADRequestFromCppAdRequest(local_ad_request, &error_code, &error_message);
     if (ad_request == nullptr) {
       if (error_code == kAdErrorCodeNone) {
         error_code = kAdErrorCodeInternalError;
         error_message = kAdCouldNotParseAdRequestErrorMessage;
       }
-      CompleteLoadAdInternalError(ad_load_callback_data_, error_code,
-                                  error_message.c_str());
+      CompleteLoadAdInternalError(ad_load_callback_data_, error_code, error_message.c_str());
       ad_load_callback_data_ = nil;
     } else {
       // Make the AdView ad request.
-      [(GADBannerView*)ad_view_ loadRequest: ad_request];
+      [(GADBannerView*)ad_view_ loadRequest:ad_request];
     }
   });
   return future;
@@ -132,7 +129,7 @@ Future<AdResult> AdViewInternalIOS::LoadAd(const AdRequest& request) {
 Future<void> AdViewInternalIOS::SetPosition(int x, int y) {
   firebase::MutexLock lock(mutex_);
   const firebase::SafeFutureHandle<void> future_handle =
-    future_data_.future_impl.SafeAlloc<void>(kAdViewFnSetPosition);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnSetPosition);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -151,7 +148,7 @@ Future<void> AdViewInternalIOS::SetPosition(int x, int y) {
 Future<void> AdViewInternalIOS::SetPosition(AdView::Position position) {
   firebase::MutexLock lock(mutex_);
   const firebase::SafeFutureHandle<void> future_handle =
-    future_data_.future_impl.SafeAlloc<void>(kAdViewFnSetPosition);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnSetPosition);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
   // Guard against parameter object destruction before the async operation
@@ -174,7 +171,7 @@ Future<void> AdViewInternalIOS::SetPosition(AdView::Position position) {
 Future<void> AdViewInternalIOS::Hide() {
   firebase::MutexLock lock(mutex_);
   const SafeFutureHandle<void> future_handle =
-    future_data_.future_impl.SafeAlloc<void>(kAdViewFnHide);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnHide);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -187,7 +184,7 @@ Future<void> AdViewInternalIOS::Hide() {
 Future<void> AdViewInternalIOS::Show() {
   firebase::MutexLock lock(mutex_);
   const firebase::SafeFutureHandle<void> future_handle =
-    future_data_.future_impl.SafeAlloc<void>(kAdViewFnShow);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnShow);
   Future<void> future = MakeFuture(&future_data_.future_impl, future_handle);
 
   dispatch_async(dispatch_get_main_queue(), ^{
@@ -201,16 +198,14 @@ Future<void> AdViewInternalIOS::Show() {
 Future<void> AdViewInternalIOS::Pause() {
   firebase::MutexLock lock(mutex_);
   // Required method. No-op.
-  return CreateAndCompleteFuture(kAdViewFnPause, kAdErrorCodeNone, nullptr,
-    &future_data_);
+  return CreateAndCompleteFuture(kAdViewFnPause, kAdErrorCodeNone, nullptr, &future_data_);
 }
 
 /// This method is part of the C++ interface and is used only on Android.
 Future<void> AdViewInternalIOS::Resume() {
   firebase::MutexLock lock(mutex_);
   // Required method. No-op.
-  return CreateAndCompleteFuture(kAdViewFnResume, kAdErrorCodeNone, nullptr,
-    &future_data_);
+  return CreateAndCompleteFuture(kAdViewFnResume, kAdErrorCodeNone, nullptr, &future_data_);
 }
 
 /// Cleans up any resources created in AdViewInternalIOS.
@@ -219,17 +214,16 @@ Future<void> AdViewInternalIOS::Destroy() {
   destroy_mutex_.Acquire();
 
   const firebase::SafeFutureHandle<void> future_handle =
-     future_data_.future_impl.SafeAlloc<void>(kAdViewFnDestroy);
+      future_data_.future_impl.SafeAlloc<void>(kAdViewFnDestroy);
 
-  if(ad_load_callback_data_ != nil) {
+  if (ad_load_callback_data_ != nil) {
     delete ad_load_callback_data_;
     ad_load_callback_data_ = nil;
   }
 
   // Consistent with Android SDK which returns a final bounding box of
   // -1 values upon deletion.
-  bounding_box_.width = bounding_box_.height =
-    bounding_box_.x = bounding_box_.y = -1;
+  bounding_box_.width = bounding_box_.height = bounding_box_.x = bounding_box_.y = -1;
   bounding_box_.position = AdView::kPositionUndefined;
   NotifyListenerOfBoundingBoxChange(bounding_box_);
 
@@ -252,26 +246,24 @@ Future<void> AdViewInternalIOS::Destroy() {
   return MakeFuture(&future_data_.future_impl, future_handle);
 }
 
-BoundingBox AdViewInternalIOS::bounding_box() const {
-  return bounding_box_;
-}
+BoundingBox AdViewInternalIOS::bounding_box() const { return bounding_box_; }
 
 void AdViewInternalIOS::AdViewDidReceiveAd(int width, int height,
-    GADResponseInfo *gad_response_info) {
+                                           GADResponseInfo* gad_response_info) {
   firebase::MutexLock lock(mutex_);
   update_ad_size_dimensions(width, height);
 
-  if(ad_load_callback_data_ != nil) {
+  if (ad_load_callback_data_ != nil) {
     CompleteLoadAdInternalSuccess(ad_load_callback_data_,
-      ResponseInfoInternal({ gad_response_info }));
+                                  ResponseInfoInternal({gad_response_info}));
     ad_load_callback_data_ = nil;
   }
 }
 
-void AdViewInternalIOS::AdViewDidFailToReceiveAdWithError(NSError *error) {
+void AdViewInternalIOS::AdViewDidFailToReceiveAdWithError(NSError* error) {
   firebase::MutexLock lock(mutex_);
   FIREBASE_ASSERT(error);
-  if(ad_load_callback_data_ != nil) {
+  if (ad_load_callback_data_ != nil) {
     CompleteAdResultError(ad_load_callback_data_, error,
                           /*is_load_ad_error=*/true);
     ad_load_callback_data_ = nil;

--- a/gma/src/ios/adapter_response_info_ios.mm
+++ b/gma/src/ios/adapter_response_info_ios.mm
@@ -20,35 +20,35 @@ extern "C" {
 
 #include <string>
 
-#include "gma/src/include/firebase/gma.h"
-#include "gma/src/include/firebase/gma/types.h"
-#include "gma/src/ios/adapter_response_info_ios.h"
-#include "gma/src/ios/ad_error_ios.h"
 #include "app/src/include/firebase/internal/mutex.h"
 #include "app/src/util_ios.h"
+#include "app/src/assert.h"
+#include "gma/src/include/firebase/gma.h"
+#include "gma/src/include/firebase/gma/types.h"
+#include "gma/src/ios/ad_error_ios.h"
+#include "gma/src/ios/adapter_response_info_ios.h"
 
 namespace firebase {
 namespace gma {
 
-AdapterResponseInfo::AdapterResponseInfo(
-  const AdapterResponseInfoInternal& internal) : ad_result_() {
+AdapterResponseInfo::AdapterResponseInfo(const AdapterResponseInfoInternal& internal)
+    : ad_result_() {
   FIREBASE_ASSERT(internal.ad_network_response_info);
 
-  if(internal.ad_network_response_info.error != nil) {
+  if (internal.ad_network_response_info.error != nil) {
     AdErrorInternal ad_error_internal;
     ad_error_internal.native_ad_error = internal.ad_network_response_info.error;
     AdError ad_error = AdError(ad_error_internal);
-    if(ad_error.code() != kAdErrorCodeNone) {
+    if (ad_error.code() != kAdErrorCodeNone) {
       ad_result_ = AdResult(AdError(ad_error_internal));
     }
   }
 
-  adapter_class_name_ = util::NSStringToString(
-    internal.ad_network_response_info.adNetworkClassName);
-  
+  adapter_class_name_ =
+      util::NSStringToString(internal.ad_network_response_info.adNetworkClassName);
+
   // ObjC latency is an NSInterval, which is in seconds.  Convert to millis.
-  latency_ = (int64_t)(internal.ad_network_response_info.latency) *
-    (int64_t)1000;
+  latency_ = (int64_t)(internal.ad_network_response_info.latency) * (int64_t)1000;
 
   to_string_ = util::NSStringToString(internal.ad_network_response_info.description);
 }

--- a/gma/src/ios/gma_ios.h
+++ b/gma/src/ios/gma_ios.h
@@ -32,19 +32,19 @@ namespace gma {
 
 // Completes AdResult futures for successful ad loads.
 void CompleteLoadAdInternalSuccess(
-  FutureCallbackData<AdResult>* callback_data,
-  const ResponseInfoInternal& response_info_internal);
+    FutureCallbackData<AdResult>* callback_data,
+    const ResponseInfoInternal& response_info_internal);
 
 // Resolves LoadAd errors that exist in the C++ SDK before they reach the iOS
 // SDK.
-void CompleteLoadAdInternalError(
-  FutureCallbackData<AdResult>* callback_data, AdErrorCode error_code,
-  const char* error_message);
+void CompleteLoadAdInternalError(FutureCallbackData<AdResult>* callback_data,
+                                 AdErrorCode error_code,
+                                 const char* error_message);
 
 // Parses information from the NSError to populate an AdResult
 // and completes the AdResult Future on iOS.
 void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
-                         NSError *error, bool is_load_ad_error);
+                           NSError* error, bool is_load_ad_error);
 
 // Converts the iOS GMA GADAdValue structure into a CPP
 // firebase::gma::Advalue structure.

--- a/gma/src/ios/gma_ios.mm
+++ b/gma/src/ios/gma_ios.mm
@@ -24,16 +24,16 @@
 
 #import "gma/src/ios/FADRequest.h"
 
+#include "app/src/include/firebase/app.h"
+#include "app/src/include/firebase/future.h"
+#include "app/src/include/firebase/internal/mutex.h"
+#include "app/src/log.h"
+#include "app/src/util_ios.h"
 #include "gma/src/common/gma_common.h"
 #include "gma/src/include/firebase/gma/types.h"
 #include "gma/src/ios/ad_error_ios.h"
 #include "gma/src/ios/adapter_response_info_ios.h"
 #include "gma/src/ios/response_info_ios.h"
-#include "app/src/include/firebase/app.h"
-#include "app/src/include/firebase/future.h"
-#include "app/src/log.h"
-#include "app/src/include/firebase/internal/mutex.h"
-#include "app/src/util_ios.h"
 
 namespace firebase {
 namespace gma {
@@ -55,45 +55,45 @@ static Mutex g_future_impl_mutex;  // NOLINT
 // Take an iOS GADInitializationStatus object and populate our own
 // AdapterInitializationStatus class.
 static AdapterInitializationStatus PopulateAdapterInitializationStatus(
-  GADInitializationStatus *init_status) {
+    GADInitializationStatus* init_status) {
   if (!init_status) return GmaInternal::CreateAdapterInitializationStatus({});
 
   std::map<std::string, AdapterStatus> adapter_status_map;
 
-  NSDictionary<NSString *, GADAdapterStatus*> *status_dict = init_status.adapterStatusesByClassName;
+  NSDictionary<NSString*, GADAdapterStatus*>* status_dict = init_status.adapterStatusesByClassName;
   for (NSString* key in status_dict) {
     GADAdapterStatus* status = [status_dict objectForKey:key];
-    AdapterStatus adapter_status =
-      GmaInternal::CreateAdapterStatus(util::NSStringToString(status.description),
-                                         status.state == GADAdapterInitializationStateReady,
-                                         status.latency);
+    AdapterStatus adapter_status = GmaInternal::CreateAdapterStatus(
+        util::NSStringToString(status.description),
+        status.state == GADAdapterInitializationStateReady, status.latency);
     adapter_status_map[util::NSStringToString(key)] = adapter_status;
   }
   return GmaInternal::CreateAdapterInitializationStatus(adapter_status_map);
 }
-  
+
 static Future<AdapterInitializationStatus> InitializeGma() {
   MutexLock lock(g_future_impl_mutex);
   FIREBASE_ASSERT(g_future_impl);
 
   SafeFutureHandle<AdapterInitializationStatus> handle =
-    g_future_impl->SafeAlloc<AdapterInitializationStatus>(kGmaFnInitialize);
-  [GADMobileAds.sharedInstance startWithCompletionHandler:^(GADInitializationStatus *_Nonnull status){
-      // GAD initialization has completed, with adapter initialization status.
-      AdapterInitializationStatus adapter_status = PopulateAdapterInitializationStatus(status);
-      {
-        MutexLock lock(g_future_impl_mutex);
-        // Check if g_future_impl still exists; if not, Terminate() was called, ignore the
-        // result of this callback.
-        if (g_future_impl) {
-          g_future_impl->CompleteWithResult(handle, 0, "", adapter_status);
+      g_future_impl->SafeAlloc<AdapterInitializationStatus>(kGmaFnInitialize);
+  [GADMobileAds.sharedInstance
+      startWithCompletionHandler:^(GADInitializationStatus* _Nonnull status) {
+        // GAD initialization has completed, with adapter initialization status.
+        AdapterInitializationStatus adapter_status = PopulateAdapterInitializationStatus(status);
+        {
+          MutexLock lock(g_future_impl_mutex);
+          // Check if g_future_impl still exists; if not, Terminate() was called, ignore the
+          // result of this callback.
+          if (g_future_impl) {
+            g_future_impl->CompleteWithResult(handle, 0, "", adapter_status);
+          }
         }
-      }
-    }];
+      }];
   return MakeFuture(g_future_impl, handle);
 }
- 
-Future<AdapterInitializationStatus> Initialize(InitResult *init_result_out) {
+
+Future<AdapterInitializationStatus> Initialize(InitResult* init_result_out) {
   FIREBASE_ASSERT(!g_initialized);
   g_initialized = true;
 
@@ -109,7 +109,8 @@ Future<AdapterInitializationStatus> Initialize(InitResult *init_result_out) {
   return InitializeGma();
 }
 
-Future<AdapterInitializationStatus> Initialize(const ::firebase::App& app, InitResult *init_result_out) { 
+Future<AdapterInitializationStatus> Initialize(const ::firebase::App& app,
+                                               InitResult* init_result_out) {
   FIREBASE_ASSERT(!g_initialized);
   g_initialized = true;
   {
@@ -126,50 +127,45 @@ Future<AdapterInitializationStatus> Initialize(const ::firebase::App& app, InitR
 
 bool IsInitialized() { return g_initialized; }
 
-void DisableSDKCrashReporting() {
-  [GADMobileAds.sharedInstance disableSDKCrashReporting];
-}
+void DisableSDKCrashReporting() { [GADMobileAds.sharedInstance disableSDKCrashReporting]; }
 
 void DisableMediationInitialization() {
   [GADMobileAds.sharedInstance disableMediationInitialization];
 }
 
-void SetRequestConfiguration(const RequestConfiguration& request_configuration)
-{
+void SetRequestConfiguration(const RequestConfiguration& request_configuration) {
   GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers =
-    util::StringVectorToNSMutableArray(request_configuration.test_device_ids);
+      util::StringVectorToNSMutableArray(request_configuration.test_device_ids);
 
-  switch(request_configuration.max_ad_content_rating) {
+  switch (request_configuration.max_ad_content_rating) {
     case RequestConfiguration::kMaxAdContentRatingG:
       GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating =
-        GADMaxAdContentRatingGeneral;
+          GADMaxAdContentRatingGeneral;
       break;
     case RequestConfiguration::kMaxAdContentRatingPG:
       GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating =
-        GADMaxAdContentRatingParentalGuidance;
+          GADMaxAdContentRatingParentalGuidance;
       break;
     case RequestConfiguration::kMaxAdContentRatingT:
       GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating =
-        GADMaxAdContentRatingTeen;
+          GADMaxAdContentRatingTeen;
       break;
     case RequestConfiguration::kMaxAdContentRatingMA:
       GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating =
-        GADMaxAdContentRatingMatureAudience;
+          GADMaxAdContentRatingMatureAudience;
       break;
     case RequestConfiguration::kMaxAdContentRatingUnspecified:
     default:
       // Do not set this value, which has significance in the iOS SDK.
       break;
   }
-  
-  switch(request_configuration.tag_for_child_directed_treatment) {
+
+  switch (request_configuration.tag_for_child_directed_treatment) {
     case RequestConfiguration::kChildDirectedTreatmentFalse:
-      [GADMobileAds.sharedInstance.requestConfiguration 
-        tagForChildDirectedTreatment:NO];
+      [GADMobileAds.sharedInstance.requestConfiguration tagForChildDirectedTreatment:NO];
       break;
     case RequestConfiguration::kChildDirectedTreatmentTrue:
-      [GADMobileAds.sharedInstance.requestConfiguration
-        tagForChildDirectedTreatment:YES];
+      [GADMobileAds.sharedInstance.requestConfiguration tagForChildDirectedTreatment:YES];
       break;
     default:
     case RequestConfiguration::kChildDirectedTreatmentUnspecified:
@@ -177,14 +173,12 @@ void SetRequestConfiguration(const RequestConfiguration& request_configuration)
       break;
   }
 
-  switch(request_configuration.tag_for_under_age_of_consent) {
+  switch (request_configuration.tag_for_under_age_of_consent) {
     case RequestConfiguration::kUnderAgeOfConsentFalse:
-      [GADMobileAds.sharedInstance.requestConfiguration
-        tagForUnderAgeOfConsent:NO];
+      [GADMobileAds.sharedInstance.requestConfiguration tagForUnderAgeOfConsent:NO];
       break;
     case RequestConfiguration::kUnderAgeOfConsentTrue:
-      [GADMobileAds.sharedInstance.requestConfiguration
-        tagForUnderAgeOfConsent:YES];
+      [GADMobileAds.sharedInstance.requestConfiguration tagForUnderAgeOfConsent:YES];
       break;
     default:
     case RequestConfiguration::kUnderAgeOfConsentUnspecified:
@@ -197,62 +191,57 @@ RequestConfiguration GetRequestConfiguration() {
   RequestConfiguration request_configuration;
 
   GADMaxAdContentRating content_rating =
-    GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating;
-  if(content_rating == GADMaxAdContentRatingGeneral) {
-    request_configuration.max_ad_content_rating =
-      RequestConfiguration::kMaxAdContentRatingG;
-  }
-  else if(content_rating == GADMaxAdContentRatingParentalGuidance) {
-    request_configuration.max_ad_content_rating =
-      RequestConfiguration::kMaxAdContentRatingPG;
-  }
-  else if(content_rating == GADMaxAdContentRatingTeen) {
-    request_configuration.max_ad_content_rating =
-      RequestConfiguration::kMaxAdContentRatingT;
-  }
-  else if(content_rating == GADMaxAdContentRatingMatureAudience) {
-    request_configuration.max_ad_content_rating =
-      RequestConfiguration::kMaxAdContentRatingMA;
+      GADMobileAds.sharedInstance.requestConfiguration.maxAdContentRating;
+  if (content_rating == GADMaxAdContentRatingGeneral) {
+    request_configuration.max_ad_content_rating = RequestConfiguration::kMaxAdContentRatingG;
+  } else if (content_rating == GADMaxAdContentRatingParentalGuidance) {
+    request_configuration.max_ad_content_rating = RequestConfiguration::kMaxAdContentRatingPG;
+  } else if (content_rating == GADMaxAdContentRatingTeen) {
+    request_configuration.max_ad_content_rating = RequestConfiguration::kMaxAdContentRatingT;
+  } else if (content_rating == GADMaxAdContentRatingMatureAudience) {
+    request_configuration.max_ad_content_rating = RequestConfiguration::kMaxAdContentRatingMA;
   } else {
     request_configuration.max_ad_content_rating =
-      RequestConfiguration::kMaxAdContentRatingUnspecified;
+        RequestConfiguration::kMaxAdContentRatingUnspecified;
   }
 
   request_configuration.tag_for_under_age_of_consent =
-    RequestConfiguration::kUnderAgeOfConsentUnspecified;
+      RequestConfiguration::kUnderAgeOfConsentUnspecified;
   request_configuration.tag_for_child_directed_treatment =
-    RequestConfiguration::kChildDirectedTreatmentUnspecified;
+      RequestConfiguration::kChildDirectedTreatmentUnspecified;
 
   util::NSArrayOfNSStringToVectorOfString(
-    GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers,
-    &request_configuration.test_device_ids);
+      GADMobileAds.sharedInstance.requestConfiguration.testDeviceIdentifiers,
+      &request_configuration.test_device_ids);
 
   return request_configuration;
 }
 
 void OpenAdInspector(AdParent ad_parent, AdInspectorClosedListener* listener) {
   dispatch_async(dispatch_get_main_queue(), ^{
-    [GADMobileAds.sharedInstance presentAdInspectorFromViewController:(UIViewController*)ad_parent
-      completionHandler:^(NSError *error) {
-        // Error will be non-nil if there was an issue and the inspector was not displayed.  
-        AdResult ad_result;
-        if(error != nil) {
-          AdErrorInternal ad_error_internal;
-          ad_error_internal.ad_error_type =
-            AdErrorInternal::kAdErrorInternalOpenAdInspectorError;
-          ad_error_internal.native_ad_error = error;
-          ad_error_internal.is_successful = false;
-          ad_result = AdResult(GmaInternal::CreateAdError(ad_error_internal));
-        }
+    [GADMobileAds.sharedInstance
+        presentAdInspectorFromViewController:(UIViewController*)ad_parent
+                           completionHandler:^(NSError* error) {
+                             // Error will be non-nil if there was an issue and the inspector was
+                             // not displayed.
+                             AdResult ad_result;
+                             if (error != nil) {
+                               AdErrorInternal ad_error_internal;
+                               ad_error_internal.ad_error_type =
+                                   AdErrorInternal::kAdErrorInternalOpenAdInspectorError;
+                               ad_error_internal.native_ad_error = error;
+                               ad_error_internal.is_successful = false;
+                               ad_result = AdResult(GmaInternal::CreateAdError(ad_error_internal));
+                             }
 
-        listener->OnAdInspectorClosed(ad_result);
-      }];
-  });  
+                             listener->OnAdInspectorClosed(ad_result);
+                           }];
+  });
 }
 
 void SetIsSameAppKeyEnabled(bool is_enabled) {
   dispatch_async(dispatch_get_main_queue(), ^{
-    if(is_enabled) {
+    if (is_enabled) {
       [GADMobileAds.sharedInstance.requestConfiguration setSameAppKeyEnabled:YES];
     } else {
       [GADMobileAds.sharedInstance.requestConfiguration setSameAppKeyEnabled:NO];
@@ -263,16 +252,15 @@ void SetIsSameAppKeyEnabled(bool is_enabled) {
 Future<AdapterInitializationStatus> InitializeLastResult() {
   MutexLock lock(g_future_impl_mutex);
   return g_future_impl ? static_cast<const Future<AdapterInitializationStatus>&>(
-                            g_future_impl->LastResult(kGmaFnInitialize))
-                      : Future<AdapterInitializationStatus>();
+                             g_future_impl->LastResult(kGmaFnInitialize))
+                       : Future<AdapterInitializationStatus>();
 }
 
 AdapterInitializationStatus GetInitializationStatus() {
   if (g_initialized) {
     GADInitializationStatus* status = GADMobileAds.sharedInstance.initializationStatus;
     return PopulateAdapterInitializationStatus(status);
-  }
-  else {
+  } else {
     // Returns an empty map.
     return PopulateAdapterInitializationStatus(nil);
   }
@@ -297,9 +285,8 @@ const ::firebase::App* GetApp() { return g_app; }
 
 // Constructs AdResult objects based on the encountered error, beit one that
 // originated from C++ SDK Wrapper or an error returned from the iOS GMA SDK.
-void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
-                           NSError *error, bool is_load_ad_error,
-                           AdErrorCode error_code,
+void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data, NSError* error,
+                           bool is_load_ad_error, AdErrorCode error_code,
                            const char* error_message) {
   FIREBASE_ASSERT(callback_data);
   FIREBASE_ASSERT(error_message);
@@ -311,74 +298,65 @@ void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
   ad_error_internal.is_successful = false;
   ad_error_internal.code = error_code;
 
-  // Futher result configuration is based on success/failure.
+  // Further result configuration is based on success/failure.
   if (error != nullptr) {
     // The iOS SDK returned an error.  The NSError object will be used by the
     // AdError implementation to populate its fields.
     ad_error_internal.is_successful = false;
     if (is_load_ad_error) {
-      ad_error_internal.ad_error_type =
-        AdErrorInternal::kAdErrorInternalLoadAdError;
+      ad_error_internal.ad_error_type = AdErrorInternal::kAdErrorInternalLoadAdError;
     } else {
-      ad_error_internal.ad_error_type =
-        AdErrorInternal::kAdErrorInternalAdError;
+      ad_error_internal.ad_error_type = AdErrorInternal::kAdErrorInternalAdError;
     }
   } else {
     FIREBASE_ASSERT_MESSAGE(ad_error_internal.code != kAdErrorCodeNone,
-      "GMA CompleteAdResultError couldn't determine the type of error");
+                            "GMA CompleteAdResultError couldn't determine the type of error");
 
     // C++ SDK iOS GMA Wrapper encountered an error.
-    ad_error_internal.ad_error_type =
-      AdErrorInternal::kAdErrorInternalWrapperError;
+    ad_error_internal.ad_error_type = AdErrorInternal::kAdErrorInternalWrapperError;
     ad_error_internal.message = std::string(error_message);
     ad_error_internal.domain = "SDK";
-    ad_error_internal.to_string = std::string("Internal error: ") +
-      ad_error_internal.message;
+    ad_error_internal.to_string = std::string("Internal error: ") + ad_error_internal.message;
     future_error_message = ad_error_internal.message;
   }
 
-  GmaInternal::CompleteLoadAdFutureFailure(
-      callback_data, ad_error_internal.code, future_error_message,
-      ad_error_internal);
+  GmaInternal::CompleteLoadAdFutureFailure(callback_data, ad_error_internal.code,
+                                           future_error_message, ad_error_internal);
 }
 
-void CompleteLoadAdInternalSuccess(
-    FutureCallbackData<AdResult>* callback_data,
-    const ResponseInfoInternal& response_info_internal) {
+void CompleteLoadAdInternalSuccess(FutureCallbackData<AdResult>* callback_data,
+                                   const ResponseInfoInternal& response_info_internal) {
   FIREBASE_ASSERT(callback_data);
 
-  GmaInternal::CompleteLoadAdFutureSuccess(
-      callback_data, response_info_internal);
+  GmaInternal::CompleteLoadAdFutureSuccess(callback_data, response_info_internal);
 }
 
-void CompleteLoadAdInternalError(
-     FutureCallbackData<AdResult>* callback_data,
-     AdErrorCode error_code, const char* error_message) {
+void CompleteLoadAdInternalError(FutureCallbackData<AdResult>* callback_data,
+                                 AdErrorCode error_code, const char* error_message) {
   FIREBASE_ASSERT(callback_data);
   FIREBASE_ASSERT(error_message);
 
   CompleteAdResultError(callback_data, /*error=*/nullptr,
-     /*is_load_ad_error=*/false, error_code, error_message);
+                        /*is_load_ad_error=*/false, error_code, error_message);
 }
 
-void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data,
-                           NSError *gad_error, bool is_load_ad_error) {
+void CompleteAdResultError(FutureCallbackData<AdResult>* callback_data, NSError* gad_error,
+                           bool is_load_ad_error) {
   FIREBASE_ASSERT(callback_data);
 
-  AdErrorCode error_code =
-    MapAdRequestErrorCodeToCPPErrorCode((GADErrorCode)gad_error.code);
-  CompleteAdResultError(callback_data, gad_error, is_load_ad_error,
-    error_code, util::NSStringToString(gad_error.localizedDescription).c_str());
+  AdErrorCode error_code = MapAdRequestErrorCodeToCPPErrorCode((GADErrorCode)gad_error.code);
+  CompleteAdResultError(callback_data, gad_error, is_load_ad_error, error_code,
+                        util::NSStringToString(gad_error.localizedDescription).c_str());
 }
 
 AdValue ConvertGADAdValueToCppAdValue(GADAdValue* gad_value) {
   FIREBASE_ASSERT(gad_value);
 
   AdValue::PrecisionType precision_type;
-  switch(gad_value.precision) {
+  switch (gad_value.precision) {
     default:
     case GADAdValuePrecisionUnknown:
-      precision_type = AdValue::kdValuePrecisionUnknown;
+      precision_type = AdValue::kAdValuePrecisionUnknown;
       break;
     case GADAdValuePrecisionEstimated:
       precision_type = AdValue::kAdValuePrecisionEstimated;
@@ -391,9 +369,8 @@ AdValue ConvertGADAdValueToCppAdValue(GADAdValue* gad_value) {
       break;
   }
 
-  return AdValue(util::NSStringToString(gad_value.currencyCode).c_str(),
-    precision_type, (int64_t)gad_value.value.longLongValue);
-
+  return AdValue(util::NSStringToString(gad_value.currencyCode).c_str(), precision_type,
+                 (int64_t)gad_value.value.longLongValue);
 }
 
 }  // namespace gma

--- a/gma/src/ios/interstitial_ad_internal_ios.h
+++ b/gma/src/ios/interstitial_ad_internal_ios.h
@@ -25,8 +25,8 @@ extern "C" {
 #include <objc/objc.h>
 }  // extern "C"
 
-#include "gma/src/common/interstitial_ad_internal.h"
 #include "app/src/include/firebase/internal/mutex.h"
+#include "gma/src/common/interstitial_ad_internal.h"
 
 namespace firebase {
 namespace gma {
@@ -44,7 +44,7 @@ class InterstitialAdInternalIOS : public InterstitialAdInternal {
 
 #ifdef __OBJC__
   void InterstitialDidReceiveAd(GADInterstitialAd* ad);
-  void InterstitialDidFailToReceiveAdWithError(NSError *gad_error);
+  void InterstitialDidFailToReceiveAdWithError(NSError* gad_error);
   void InterstitialWillPresentScreen();
   void InterstitialDidDismissScreen();
 #endif  // __OBJC__
@@ -52,7 +52,7 @@ class InterstitialAdInternalIOS : public InterstitialAdInternal {
   bool is_initialized() const override { return initialized_; }
 
  private:
-  /// Prevents duplicate invocations of initailize on the Interstitial Ad.
+  /// Prevents duplicate invocations of initialize on the Interstitial Ad.
   bool initialized_;
 
   /// Contains information to asynchronously complete the LoadAd Future.

--- a/gma/src/ios/response_info_ios.mm
+++ b/gma/src/ios/response_info_ios.mm
@@ -23,47 +23,43 @@
 #include "gma/src/include/firebase/gma/types.h"
 #include "gma/src/ios/adapter_response_info_ios.h"
 
-#include "gma/src/ios/ad_error_ios.h"
 #include "app/src/include/firebase/internal/mutex.h"
 #include "app/src/util_ios.h"
+#include "gma/src/ios/ad_error_ios.h"
 
 namespace firebase {
 namespace gma {
 
-ResponseInfo::ResponseInfo() {
-  to_string_ = "This ResponseInfo has not been initialized.";
-}
+ResponseInfo::ResponseInfo() { to_string_ = "This ResponseInfo has not been initialized."; }
 
 ResponseInfo::ResponseInfo(const ResponseInfoInternal& response_info_internal) {
   if (response_info_internal.gad_response_info == nil) {
-      return;
+    return;
   }
 
-  response_id_ = util::NSStringToString(
-    response_info_internal.gad_response_info.responseIdentifier);
+  response_id_ =
+      util::NSStringToString(response_info_internal.gad_response_info.responseIdentifier);
 
-  mediation_adapter_class_name_ = util::NSStringToString(
-    response_info_internal.gad_response_info.adNetworkClassName );
+  mediation_adapter_class_name_ =
+      util::NSStringToString(response_info_internal.gad_response_info.adNetworkClassName);
 
-  NSEnumerator* enumerator = 
-    [response_info_internal.gad_response_info.adNetworkInfoArray
-      objectEnumerator];
+  NSEnumerator* enumerator =
+      [response_info_internal.gad_response_info.adNetworkInfoArray objectEnumerator];
 
   GADAdNetworkResponseInfo* gad_response_info;
   while (gad_response_info = [enumerator nextObject]) {
     AdapterResponseInfoInternal adapter_response_info_internal;
-    adapter_response_info_internal.ad_network_response_info =
-      gad_response_info;
-    adapter_responses_.push_back(
-      AdapterResponseInfo(adapter_response_info_internal));
+    adapter_response_info_internal.ad_network_response_info = gad_response_info;
+    adapter_responses_.push_back(AdapterResponseInfo(adapter_response_info_internal));
   }
 
-  NSString *to_string = [[NSString alloc]initWithFormat:@"ResponseInfo "
-    "response_id: %@, mediation_adapter_classname : %@, "
-    "adapter_response_info: %@", 
-    response_info_internal.gad_response_info.responseIdentifier,
-    response_info_internal.gad_response_info.adNetworkClassName,
-    response_info_internal.gad_response_info.adNetworkInfoArray];
+  NSString* to_string =
+      [[NSString alloc] initWithFormat:@"ResponseInfo "
+                                        "response_id: %@, mediation_adapter_classname : %@, "
+                                        "adapter_response_info: %@",
+                                       response_info_internal.gad_response_info.responseIdentifier,
+                                       response_info_internal.gad_response_info.adNetworkClassName,
+                                       response_info_internal.gad_response_info.adNetworkInfoArray];
   to_string_ = util::NSStringToString(to_string);
 }
 

--- a/gma/src/ios/rewarded_ad_internal_ios.h
+++ b/gma/src/ios/rewarded_ad_internal_ios.h
@@ -25,8 +25,8 @@ extern "C" {
 #include <objc/objc.h>
 }  // extern "C"
 
-#include "gma/src/common/rewarded_ad_internal.h"
 #include "app/src/include/firebase/internal/mutex.h"
+#include "gma/src/common/rewarded_ad_internal.h"
 
 namespace firebase {
 namespace gma {
@@ -45,13 +45,13 @@ class RewardedAdInternalIOS : public RewardedAdInternal {
 
 #ifdef __OBJC__
   void RewardedAdDidReceiveAd(GADRewardedAd* ad);
-  void RewardedAdDidFailToReceiveAdWithError(NSError *gad_error);
+  void RewardedAdDidFailToReceiveAdWithError(NSError* gad_error);
   void RewardedAdWillPresentScreen();
   void RewardedAdDidDismissScreen();
 #endif  // __OBJC__
 
  private:
-  /// Prevents duplicate invocations of initailize on the Rewarded Ad.
+  /// Prevents duplicate invocations of initialize on the Rewarded Ad.
   bool initialized_;
 
   /// Contains information to asynchronously complete the LoadAd Future.

--- a/gma/src/stub/ad_error_stub.cc
+++ b/gma/src/stub/ad_error_stub.cc
@@ -29,11 +29,11 @@ AdError::AdError() {}
 
 AdError::AdError(const AdErrorInternal& ad_error_internal) {}
 
-AdError::AdError(const AdError& ad_result) : AdError() {}
+AdError::AdError(const AdError& ad_error) : AdError() {}
 
 AdError::~AdError() {}
 
-AdError& AdError::operator=(const AdError& ad_result) { return *this; }
+AdError& AdError::operator=(const AdError& obj) { return *this; }
 
 std::unique_ptr<AdError> AdError::GetCause() const {
   return std::unique_ptr<AdError>(nullptr);

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/AdInspectorHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/AdInspectorHelper.java
@@ -22,34 +22,28 @@ import com.google.android.gms.ads.AdInspectorError;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.OnAdInspectorClosedListener;
 
-/**
- * Helper class for listening to AdInspector closed events.
- */
+/** Helper class for listening to AdInspector closed events. */
 public final class AdInspectorHelper implements OnAdInspectorClosedListener {
   /**
-   * Pointer to the C++ AdInspectorClosedListener object to invoke
-   * when the AdInsepctor has been closed.
+   * Pointer to the C++ AdInspectorClosedListener object to invoke when the AdInspector has been
+   * closed.
    */
   private long mNativeCallbackPtr;
 
-  /**
-   * Constructor.
-   */
+  /** Constructor. */
   AdInspectorHelper(long nativeCallbackPtr) {
     mNativeCallbackPtr = nativeCallbackPtr;
   }
 
-  /**
-   * Method that the Android GMA SDK invokes when the AdInsepctor
-   * has been closed.
-   */
+  /** Method that the Android GMA SDK invokes when the AdInspector has been closed. */
+  @Override
   public void onAdInspectorClosed(AdInspectorError error) {
     adInspectorClosedCallback(mNativeCallbackPtr, error);
   }
 
   /**
-   * Native callback to which will signal the customer's application
-   * that the AdInsepctor has been closed.  A null AdError signifies success.
+   * Native callback to which will signal the customer's application that the AdInspector has been
+   * closed. A null AdError signifies success.
    */
   public static native void adInspectorClosedCallback(long nativeCallbackPtr, AdError error);
 }

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/AdRequestHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/AdRequestHelper.java
@@ -20,15 +20,16 @@ import java.util.Calendar;
 import java.util.Date;
 
 /**
- * Helper class to make interactions between the GMA C++ wrapper and Java
- * AdRequest objects cleaner. This involves translating calls coming from C++
- * into their (typically more complicated) Java equivalents.
+ * Helper class to make interactions between the GMA C++ wrapper and Java AdRequest objects cleaner.
+ * This involves translating calls coming from C++ into their (typically more complicated) Java
+ * equivalents.
  */
 public class AdRequestHelper {
   public AdRequestHelper() {}
 
   /**
    * Creates a {@link java.lang.Date} from the provided date information.
+   *
    * @param year The year to use in creating the Date object
    * @param month The month to use in creating the Date object
    * @param day The day to use in creating the Date object

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/ConstantsHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/ConstantsHelper.java
@@ -16,13 +16,9 @@
 
 package com.google.firebase.gma.internal.cpp;
 
-/**
- * Helper class containing constants that are shared across the various GMA ad formats.
- */
+/** Helper class containing constants that are shared across the various GMA ad formats. */
 public final class ConstantsHelper {
-  /**
-   * Error codes used in completing futures. These match the AdError enumeration in the C++ API.
-   */
+  /** Error codes used in completing futures. These match the AdError enumeration in the C++ API. */
   public static final int CALLBACK_ERROR_NONE = 0;
 
   public static final int CALLBACK_ERROR_UNINITIALIZED = 1;
@@ -72,8 +68,8 @@ public final class ConstantsHelper {
   public static final String CALLBACK_ERROR_MESSAGE_UNKNOWN = "Unknown error occurred.";
 
   /**
-   * Ad view positions (matches the AdView::Position and NativeExpressAdView::Position
-   * enumerations in the public C++ API).
+   * Ad view positions (matches the AdView::Position and NativeExpressAdView::Position enumerations
+   * in the public C++ API).
    */
   public static final int AD_VIEW_POSITION_UNDEFINED = -1;
 

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/GmaInitializationHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/GmaInitializationHelper.java
@@ -21,9 +21,7 @@ import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.initialization.InitializationStatus;
 import com.google.android.gms.ads.initialization.OnInitializationCompleteListener;
 
-/**
- * Helper class for initializing the Google Mobile Ads SDK.
- */
+/** Helper class for initializing the Google Mobile Ads SDK. */
 public final class GmaInitializationHelper {
   public static void initializeGma(Context context) {
     MobileAds.initialize(context, new OnInitializationCompleteListener() {

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/InterstitialAdHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/InterstitialAdHelper.java
@@ -104,9 +104,7 @@ public class InterstitialAdHelper {
     });
   }
 
-  /**
-   * Disconnect the helper from the interstital ad.
-   */
+  /** Disconnect the helper from the interstital ad. */
   public void disconnect() {
     synchronized (mInterstitialLock) {
       mInterstitialAdInternalPtr = CPP_NULLPTR;
@@ -131,9 +129,7 @@ public class InterstitialAdHelper {
     });
   }
 
-  /**
-   * Loads an ad for the underlying {@link InterstitialAd} object.
-   */
+  /** Loads an ad for the underlying {@link InterstitialAd} object. */
   public void loadAd(long callbackDataPtr, String adUnitId, final AdRequest request) {
     if (mActivity == null) {
       return;
@@ -176,9 +172,7 @@ public class InterstitialAdHelper {
     });
   }
 
-  /**
-   * Shows a previously loaded ad.
-   */
+  /** Shows a previously loaded ad. */
   public void show(final long callbackDataPtr) {
     mActivity.runOnUiThread(new Runnable() {
       @Override
@@ -286,36 +280,29 @@ public class InterstitialAdHelper {
     }
   }
 
-  /**
-   * Native callback to instruct the C++ wrapper to complete the corresponding future.
-   */
+  /** Native callback to instruct the C++ wrapper to complete the corresponding future. */
   public static native void completeInterstitialAdFutureCallback(
       long nativeInternalPtr, int errorCode, String errorMessage);
 
-  /**
-   * Native callback invoked upon successfully loading an ad.
-   */
+  /** Native callback invoked upon successfully loading an ad. */
   public static native void completeInterstitialLoadedAd(
       long nativeInternalPtr, ResponseInfo responseInfo);
 
   /**
-   * Native callback upon encountering an error loading an Ad Request. Returns
-   * Android Google Mobile Ads SDK error codes.
-   **/
+   * Native callback upon encountering an error loading an Ad Request. Returns Android Google Mobile
+   * Ads SDK error codes.
+   */
   public static native void completeInterstitialLoadAdError(
       long nativeInternalPtr, LoadAdError error, int errorCode, String errorMessage);
 
   /**
-   * Native callback upon encountering a wrapper/internal error when
-   * processing an Ad Request. Returns integers representing
-   * firebase::gma::AdError codes.
+   * Native callback upon encountering a wrapper/internal error when processing an Ad Request.
+   * Returns integers representing firebase::gma::AdError codes.
    */
   public static native void completeInterstitialLoadAdInternalError(
       long nativeInternalPtr, int gmaErrorCode, String errorMessage);
 
-  /**
-   * Native callbacks to notify the C++ wrapper of ad events
-   */
+  /** Native callbacks to notify the C++ wrapper of ad events */
   public static native void notifyAdClickedFullScreenContentEvent(long nativeInternalPtr);
 
   public static native void notifyAdDismissedFullScreenContentEvent(long nativeInternalPtr);

--- a/gma/src_java/com/google/firebase/gma/internal/cpp/RewardedAdHelper.java
+++ b/gma/src_java/com/google/firebase/gma/internal/cpp/RewardedAdHelper.java
@@ -32,9 +32,9 @@ import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
 import com.google.android.gms.ads.rewarded.ServerSideVerificationOptions;
 
 /**
- * Helper class to make interactions between the GMA C++ wrapper and Java {@link RewardedAd}
- * objects cleaner. It's designed to wrap and adapt a single instance of {@link RewardedAd},
- * translate calls coming from C++ into their (typically more complicated) Java equivalents.
+ * Helper class to make interactions between the GMA C++ wrapper and Java {@link RewardedAd} objects
+ * cleaner. It's designed to wrap and adapt a single instance of {@link RewardedAd}, translate calls
+ * coming from C++ into their (typically more complicated) Java equivalents.
  */
 public class RewardedAdHelper {
   // C++ nullptr for use with the callbacks.
@@ -64,9 +64,7 @@ public class RewardedAdHelper {
   // complete the Future associated with the latest call to LoadAd.
   private long mLoadAdCallbackDataPtr;
 
-  /**
-   * Constructor.
-   */
+  /** Constructor. */
   public RewardedAdHelper(long rewardedAdInternalPtr) {
     mRewardedAdInternalPtr = rewardedAdInternalPtr;
     mRewardedLock = new Object();
@@ -76,8 +74,8 @@ public class RewardedAdHelper {
   }
 
   /**
-   * Initializes the {@link RewardedAd}. This creates the corresponding GMA SDK {@link
-   * RewardedAd} object and sets it up.
+   * Initializes the {@link RewardedAd}. This creates the corresponding GMA SDK {@link RewardedAd}
+   * object and sets it up.
    */
   public void initialize(final long callbackDataPtr, Activity activity) {
     mActivity = activity;
@@ -108,9 +106,7 @@ public class RewardedAdHelper {
     });
   }
 
-  /**
-   * Disconnect the helper from the interstital ad.
-   */
+  /** Disconnect the helper from the interstital ad. */
   public void disconnect() {
     synchronized (mRewardedLock) {
       mRewardedAdInternalPtr = CPP_NULLPTR;
@@ -135,9 +131,7 @@ public class RewardedAdHelper {
     });
   }
 
-  /**
-   * Loads an ad for the underlying {@link RewardedAd} object.
-   */
+  /** Loads an ad for the underlying {@link RewardedAd} object. */
   public void loadAd(long callbackDataPtr, String adUnitId, final AdRequest request) {
     if (mActivity == null) {
       return;
@@ -309,36 +303,29 @@ public class RewardedAdHelper {
     }
   }
 
-  /**
-   * Native callback to instruct the C++ wrapper to complete the corresponding future.
-   */
+  /** Native callback to instruct the C++ wrapper to complete the corresponding future. */
   public static native void completeRewardedAdFutureCallback(
       long nativeInternalPtr, int errorCode, String errorMessage);
 
-  /**
-   * Native callback invoked upon successfully loading an ad.
-   */
+  /** Native callback invoked upon successfully loading an ad. */
   public static native void completeRewardedLoadedAd(
       long nativeInternalPtr, ResponseInfo responseInfo);
 
   /**
-   * Native callback upon encountering an error loading an Ad Request. Returns
-   * Android Google Mobile Ads SDK error codes.
-   **/
+   * Native callback upon encountering an error loading an Ad Request. Returns Android Google Mobile
+   * Ads SDK error codes.
+   */
   public static native void completeRewardedLoadAdError(
       long nativeInternalPtr, LoadAdError error, int errorCode, String errorMessage);
 
   /**
-   * Native callback upon encountering a wrapper/internal error when
-   * processing an Ad Request. Returns integers representing
-   * firebase::gma::AdError codes.
+   * Native callback upon encountering a wrapper/internal error when processing an Ad Request.
+   * Returns integers representing firebase::gma::AdError codes.
    */
   public static native void completeRewardedLoadAdInternalError(
       long nativeInternalPtr, int gmaErrorCode, String errorMessage);
 
-  /**
-   * Native callbacks to notify the C++ wrapper of ad events
-   */
+  /** Native callbacks to notify the C++ wrapper of ad events */
   public static native void notifyUserEarnedRewardEvent(
       long mRewardedAdInternalPtr, String type, int amount);
 


### PR DESCRIPTION
### Description
This PR addresses some of the clang-tidy and common-typo fixes. Specifically,
* Fixes common typos (e.g. s/Uknown/Unknown)
* Reorders includes alphabetically
* Removes unused variables
* Renames AdValue::kdValuePrecisionUnknown to return AdValue::kAdValuePrecisionUnknown 
* Makes some alignment changes and removes extra whitespaces.

### Testing
Confirmed builds. No other testing has been done. 

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***