### PR TITLE
Refactor the App Check internal call logic used by other products

### DIFF
--- a/app_check/src/common/app_check.cc
+++ b/app_check/src/common/app_check.cc
@@ -149,16 +149,6 @@ Future<AppCheckToken> AppCheck::GetAppCheckTokenLastResult() {
                    : Future<AppCheckToken>();
 }
 
-Future<std::string> AppCheck::GetAppCheckTokenStringInternal() {
-  // This is a call meant only to be used by the Desktop implementation
-#if FIREBASE_PLATFORM_DESKTOP
-  return internal_ ? internal_->GetAppCheckTokenStringInternal()
-                   : Future<std::string>();
-#else
-  return Future<std::string>();
-#endif  // FIREBASE_PLATFORM_DESKTOP
-}
-
 void AppCheck::AddAppCheckListener(AppCheckListener* listener) {
   if (!internal_) return;
   internal_->AddAppCheckListener(listener);

--- a/app_check/src/common/app_check.cc
+++ b/app_check/src/common/app_check.cc
@@ -149,6 +149,16 @@ Future<AppCheckToken> AppCheck::GetAppCheckTokenLastResult() {
                    : Future<AppCheckToken>();
 }
 
+Future<std::string> AppCheck::GetAppCheckTokenStringInternal() {
+  // This is a call meant only to be used by the Desktop implementation
+#if FIREBASE_PLATFORM_DESKTOP
+  return internal_ ? internal_->GetAppCheckTokenStringInternal()
+                   : Future<std::string>();
+#else
+  return Future<std::string>();
+#endif  // FIREBASE_PLATFORM_DESKTOP
+}
+
 void AppCheck::AddAppCheckListener(AppCheckListener* listener) {
   if (!internal_) return;
   internal_->AddAppCheckListener(listener);

--- a/app_check/src/common/common.h
+++ b/app_check/src/common/common.h
@@ -22,6 +22,7 @@ namespace internal {
 // Used by App Check functions that return a future
 enum AppCheckFn {
   kAppCheckFnGetAppCheckToken = 0,
+  kAppCheckFnGetAppCheckStringInternal,
   kAppCheckFnCount,
 };
 

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -79,7 +79,9 @@ void AppCheckInternal::SetAppCheckProviderFactory(
 }
 
 void AppCheckInternal::SetTokenAutoRefreshEnabled(
-    bool is_token_auto_refresh_enabled) {}
+    bool is_token_auto_refresh_enabled) {
+  is_token_auto_refresh_enabled_ = is_token_auto_refresh_enabled;
+}
 
 Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
   auto handle = future()->SafeAlloc<AppCheckToken>(kAppCheckFnGetAppCheckToken);
@@ -116,7 +118,7 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckTokenLastResult() {
 }
 
 Future<std::string> AppCheckInternal::GetAppCheckTokenStringInternal() {
-  auto handle = future()->SafeAlloc<std::string>(kAppCheckFnGetAppCheckToken);
+  auto handle = future()->SafeAlloc<std::string>(kAppCheckFnGetAppCheckStringInternal);
   if (HasValidCacheToken()) {
     future()->CompleteWithResult(handle, 0, cached_token_.token);
   } else if (is_token_auto_refresh_enabled_) {

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -28,7 +28,10 @@ namespace internal {
 static AppCheckProviderFactory* g_provider_factory = nullptr;
 
 AppCheckInternal::AppCheckInternal(App* app)
-    : app_(app), cached_token_(), cached_provider_(), is_token_auto_refresh_enabled_(true) {
+    : app_(app),
+      cached_token_(),
+      cached_provider_(),
+      is_token_auto_refresh_enabled_(true) {
   future_manager().AllocFutureApi(this, kAppCheckFnCount);
   InitRegistryCalls();
 }
@@ -140,8 +143,9 @@ Future<std::string> AppCheckInternal::GetAppCheckTokenStringInternal() {
           "No AppCheckProvider installed.");
     }
   } else {
-    future()->Complete(handle, kAppCheckErrorUnknown,
-                       "No AppCheck token available, and auto refresh is disabled");
+    future()->Complete(
+        handle, kAppCheckErrorUnknown,
+        "No AppCheck token available, and auto refresh is disabled");
   }
   return MakeFuture(future(), handle);
 }

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -118,7 +118,8 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckTokenLastResult() {
 }
 
 Future<std::string> AppCheckInternal::GetAppCheckTokenStringInternal() {
-  auto handle = future()->SafeAlloc<std::string>(kAppCheckFnGetAppCheckStringInternal);
+  auto handle =
+      future()->SafeAlloc<std::string>(kAppCheckFnGetAppCheckStringInternal);
   if (HasValidCacheToken()) {
     future()->CompleteWithResult(handle, 0, cached_token_.token);
   } else if (is_token_auto_refresh_enabled_) {

--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -197,8 +197,8 @@ bool AppCheckInternal::GetAppCheckTokenAsyncForRegistry(App* app,
   }
 
   AppCheck* app_check = AppCheck::GetInstance(app);
-  if (app_check) {
-    *out_future = app_check->GetAppCheckTokenStringInternal();
+  if (app_check && app_check->internal_) {
+    *out_future = app_check->internal_->GetAppCheckTokenStringInternal();
     return true;
   }
   return false;

--- a/app_check/src/desktop/app_check_desktop.h
+++ b/app_check/src/desktop/app_check_desktop.h
@@ -16,6 +16,7 @@
 #define FIREBASE_APP_CHECK_SRC_DESKTOP_APP_CHECK_DESKTOP_H_
 
 #include <list>
+#include <string>
 
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"

--- a/app_check/src/desktop/app_check_desktop.h
+++ b/app_check/src/desktop/app_check_desktop.h
@@ -86,7 +86,8 @@ class AppCheckInternal {
   AppCheckToken cached_token_;
   // List of registered listeners for Token changes.
   std::list<AppCheckListener*> token_listeners_;
-  // Should it automatically get an App Check token if there is not a valid cached token.
+  // Should it automatically get an App Check token if there is not a valid
+  // cached token.
   bool is_token_auto_refresh_enabled_;
 };
 

--- a/app_check/src/desktop/app_check_desktop.h
+++ b/app_check/src/desktop/app_check_desktop.h
@@ -42,6 +42,10 @@ class AppCheckInternal {
 
   Future<AppCheckToken> GetAppCheckTokenLastResult();
 
+  // Gets the App Check token as just the string, to be used by
+  // internal methods to not conflict with the publicly returned future.
+  Future<std::string> GetAppCheckTokenStringInternal();
+
   void AddAppCheckListener(AppCheckListener* listener);
 
   void RemoveAppCheckListener(AppCheckListener* listener);
@@ -82,6 +86,8 @@ class AppCheckInternal {
   AppCheckToken cached_token_;
   // List of registered listeners for Token changes.
   std::list<AppCheckListener*> token_listeners_;
+  // Should it automatically get an App Check token if there is not a valid cached token.
+  bool is_token_auto_refresh_enabled_;
 };
 
 }  // namespace internal

--- a/app_check/src/include/firebase/app_check.h
+++ b/app_check/src/include/firebase/app_check.h
@@ -156,7 +156,7 @@ class AppCheck {
   explicit AppCheck(::firebase::App* app);
 
   void DeleteInternal();
-  
+
   // Make the Internal version a friend class, so that it can access itself.
   friend class internal::AppCheckInternal;
   internal::AppCheckInternal* internal_;

--- a/app_check/src/include/firebase/app_check.h
+++ b/app_check/src/include/firebase/app_check.h
@@ -156,14 +156,10 @@ class AppCheck {
   explicit AppCheck(::firebase::App* app);
 
   void DeleteInternal();
-
-  internal::AppCheckInternal* internal_;
-
+  
+  // Make the Internal version a friend class, so that it can access itself.
   friend class internal::AppCheckInternal;
-  // Internal method that can be called by the function registry to handle
-  // other products retrieving an App Check token. Returned as a string, to
-  // not require those products depend on App Check for the struct definition.
-  Future<std::string> GetAppCheckTokenStringInternal();
+  internal::AppCheckInternal* internal_;
 };
 
 }  // namespace app_check

--- a/app_check/src/include/firebase/app_check.h
+++ b/app_check/src/include/firebase/app_check.h
@@ -158,6 +158,12 @@ class AppCheck {
   void DeleteInternal();
 
   internal::AppCheckInternal* internal_;
+
+  friend class internal::AppCheckInternal;
+  // Internal method that can be called by the function registry to handle
+  // other products retrieving an App Check token. Returned as a string, to
+  // not require those products depend on App Check for the struct definition.
+  Future<std::string> GetAppCheckTokenStringInternal();
 };
 
 }  // namespace app_check

--- a/storage/src/desktop/storage_reference_desktop.cc
+++ b/storage/src/desktop/storage_reference_desktop.cc
@@ -29,7 +29,6 @@
 #include "app/src/function_registry.h"
 #include "app/src/include/firebase/app.h"
 #include "app/src/thread.h"
-#include "app_check/src/include/firebase/app_check.h"
 #include "storage/src/common/common_internal.h"
 #include "storage/src/desktop/controller_desktop.h"
 #include "storage/src/desktop/metadata_desktop.h"
@@ -259,15 +258,15 @@ void StorageReferenceInternal::PrepareRequestBlocking(
                       storage_->user_agent().c_str());
 
   // Use the function registry to get the App Check token.
-  Future<::firebase::app_check::AppCheckToken> app_check_future;
+  Future<std::string> app_check_future;
   bool succeeded = storage_->app()->function_registry()->CallFunction(
       ::firebase::internal::FnAppCheckGetTokenAsync, storage_->app(), nullptr,
       &app_check_future);
   if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
-    const ::firebase::app_check::AppCheckToken* token =
+    const std::string* token =
         app_check_future.Await(kAppCheckTokenTimeoutMs);
     if (token) {
-      request->add_header("X-Firebase-AppCheck", token->token.c_str());
+      request->add_header("X-Firebase-AppCheck", token->c_str());
     }
   }
 }

--- a/storage/src/desktop/storage_reference_desktop.cc
+++ b/storage/src/desktop/storage_reference_desktop.cc
@@ -263,8 +263,7 @@ void StorageReferenceInternal::PrepareRequestBlocking(
       ::firebase::internal::FnAppCheckGetTokenAsync, storage_->app(), nullptr,
       &app_check_future);
   if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
-    const std::string* token =
-        app_check_future.Await(kAppCheckTokenTimeoutMs);
+    const std::string* token = app_check_future.Await(kAppCheckTokenTimeoutMs);
     if (token) {
       request->add_header("X-Firebase-AppCheck", token->c_str());
     }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Change the internal call logic to return the token as just a string, instead of the struct. This prevents the need for the products using the function registry to include the App Check header for the struct definition. Also, use a new future, instead of reusing the public one, which might have lead to confusion with the LastResult functionality. 
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Local testing of the desktop implementation.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
