### PR TITLE
Add compile time warning for C++14 upgrade

### DIFF
--- a/admob/src/include/firebase/admob.h
+++ b/admob/src/include/firebase/admob.h
@@ -28,6 +28,7 @@
 #include "firebase/admob/rewarded_video.h"
 #include "firebase/admob/types.h"
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)

--- a/admob/src/include/firebase/admob.h
+++ b/admob/src/include/firebase/admob.h
@@ -28,7 +28,7 @@
 #include "firebase/admob/rewarded_video.h"
 #include "firebase/admob/types.h"
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)

--- a/analytics/src/include/firebase/analytics.h
+++ b/analytics/src/include/firebase/analytics.h
@@ -23,7 +23,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 #include "firebase/variant.h"

--- a/analytics/src/include/firebase/analytics.h
+++ b/analytics/src/include/firebase/analytics.h
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 #include "firebase/variant.h"

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -251,7 +251,7 @@ endif()
 
 set(internal_HDRS
     src/include/firebase/app.h
-    src/include/firebase/cpp_warning.h
+        src/include/firebase/cpp_version_warning.h
     src/include/firebase/future.h
     src/include/firebase/internal/common.h
     src/include/firebase/internal/future_impl.h

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -251,6 +251,7 @@ endif()
 
 set(internal_HDRS
     src/include/firebase/app.h
+    src/include/firebase/cpp_warning.h
     src/include/firebase/future.h
     src/include/firebase/internal/common.h
     src/include/firebase/internal/future_impl.h

--- a/app/src/include/firebase/app.h
+++ b/app/src/include/firebase/app.h
@@ -17,6 +17,7 @@
 #ifndef FIREBASE_APP_SRC_INCLUDE_FIREBASE_APP_H_
 #define FIREBASE_APP_SRC_INCLUDE_FIREBASE_APP_H_
 
+#include "cpp_warning.h"
 #include "firebase/internal/platform.h"
 
 #if FIREBASE_PLATFORM_ANDROID

--- a/app/src/include/firebase/app.h
+++ b/app/src/include/firebase/app.h
@@ -17,7 +17,7 @@
 #ifndef FIREBASE_APP_SRC_INCLUDE_FIREBASE_APP_H_
 #define FIREBASE_APP_SRC_INCLUDE_FIREBASE_APP_H_
 
-#include "cpp_warning.h"
+#include "cpp_version_warning.h"
 #include "firebase/internal/platform.h"
 
 #if FIREBASE_PLATFORM_ANDROID

--- a/app/src/include/firebase/cpp_version_warning.h
+++ b/app/src/include/firebase/cpp_version_warning.h
@@ -15,7 +15,7 @@
  */
 
 #if __cplusplus < 201400
-#warning \
-    "The next major release of the Firebase C++ SDK will drop support for \
-C++11, setting the new minimum C++ version to C++14."
+#pragma message                                            \
+    "The next major release of the Firebase C++ SDK will " \
+    "drop support for C++11, setting the new minimum C++ version to C++14."
 #endif

--- a/app/src/include/firebase/cpp_warning.h
+++ b/app/src/include/firebase/cpp_warning.h
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if __cplusplus < 201400
+#warning \
+    "The next major release of the Firebase C++ SDK will drop support for \
+C++11, setting the new minimum C++ version to C++14."
+#endif

--- a/app_check/src/include/firebase/app_check.h
+++ b/app_check/src/include/firebase/app_check.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 
 namespace firebase {

--- a/app_check/src/include/firebase/app_check.h
+++ b/app_check/src/include/firebase/app_check.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 
 namespace firebase {

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -21,6 +21,7 @@
 
 #include "firebase/app.h"
 #include "firebase/auth/user.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -21,7 +21,7 @@
 
 #include "firebase/app.h"
 #include "firebase/auth/user.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/database/src/include/firebase/database.h
+++ b/database/src/include/firebase/database.h
@@ -16,7 +16,7 @@
 #define FIREBASE_DATABASE_SRC_INCLUDE_FIREBASE_DATABASE_H_
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/database/common.h"
 #include "firebase/database/data_snapshot.h"
 #include "firebase/database/database_reference.h"

--- a/database/src/include/firebase/database.h
+++ b/database/src/include/firebase/database.h
@@ -16,6 +16,7 @@
 #define FIREBASE_DATABASE_SRC_INCLUDE_FIREBASE_DATABASE_H_
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/database/common.h"
 #include "firebase/database/data_snapshot.h"
 #include "firebase/database/database_reference.h"

--- a/dynamic_links/src/include/firebase/dynamic_links.h
+++ b/dynamic_links/src/include/firebase/dynamic_links.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)

--- a/dynamic_links/src/include/firebase/dynamic_links.h
+++ b/dynamic_links/src/include/firebase/dynamic_links.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -23,6 +23,7 @@
 #include "firebase/internal/common.h"
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/log.h"
 // Include *all* the public headers to make sure including just "firestore.h" is

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -23,7 +23,7 @@
 #include "firebase/internal/common.h"
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/log.h"
 // Include *all* the public headers to make sure including just "firestore.h" is

--- a/functions/src/include/firebase/functions.h
+++ b/functions/src/include/firebase/functions.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/functions/callable_reference.h"
 #include "firebase/functions/callable_result.h"
 #include "firebase/functions/common.h"

--- a/functions/src/include/firebase/functions.h
+++ b/functions/src/include/firebase/functions.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/functions/callable_reference.h"
 #include "firebase/functions/callable_result.h"
 #include "firebase/functions/common.h"

--- a/gma/src/include/firebase/gma.h
+++ b/gma/src/include/firebase/gma.h
@@ -26,6 +26,7 @@
 #include <vector>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/gma/ad_view.h"
 #include "firebase/gma/interstitial_ad.h"
 #include "firebase/gma/rewarded_ad.h"

--- a/gma/src/include/firebase/gma.h
+++ b/gma/src/include/firebase/gma.h
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/gma/ad_view.h"
 #include "firebase/gma/interstitial_ad.h"
 #include "firebase/gma/rewarded_ad.h"

--- a/installations/src/include/firebase/installations.h
+++ b/installations/src/include/firebase/installations.h
@@ -19,7 +19,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/installations/src/include/firebase/installations.h
+++ b/installations/src/include/firebase/installations.h
@@ -19,6 +19,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/messaging/src/include/firebase/messaging.h
+++ b/messaging/src/include/firebase/messaging.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/messaging/src/include/firebase/messaging.h
+++ b/messaging/src/include/firebase/messaging.h
@@ -22,7 +22,7 @@
 #include <vector>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 

--- a/performance/src/include/firebase/performance.h
+++ b/performance/src/include/firebase/performance.h
@@ -4,6 +4,7 @@
 #define FIREBASE_PERFORMANCE_SRC_INCLUDE_FIREBASE_PERFORMANCE_H_
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/performance/http_metric.h"
 #include "firebase/performance/trace.h"
 

--- a/performance/src/include/firebase/performance.h
+++ b/performance/src/include/firebase/performance.h
@@ -4,7 +4,7 @@
 #define FIREBASE_PERFORMANCE_SRC_INCLUDE_FIREBASE_PERFORMANCE_H_
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/performance/http_metric.h"
 #include "firebase/performance/trace.h"
 

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -642,6 +642,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    - General: Add build time warning for C++11, since the next major release of
+      the Firebase C++ SDK will set the new minimum C++ version to C++14.
+
 ### 10.6.0
 -   Changes
     - General (Android): Update to Firebase Android BoM version 31.2.3.

--- a/remote_config/src/include/firebase/remote_config.h
+++ b/remote_config/src/include/firebase/remote_config.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 #include "firebase/internal/platform.h"

--- a/remote_config/src/include/firebase/remote_config.h
+++ b/remote_config/src/include/firebase/remote_config.h
@@ -20,7 +20,7 @@
 #include <vector>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/future.h"
 #include "firebase/internal/common.h"
 #include "firebase/internal/platform.h"

--- a/storage/src/include/firebase/storage.h
+++ b/storage/src/include/firebase/storage.h
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/internal/common.h"
 #include "firebase/storage/common.h"
 #include "firebase/storage/controller.h"

--- a/storage/src/include/firebase/storage.h
+++ b/storage/src/include/firebase/storage.h
@@ -18,7 +18,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/internal/common.h"
 #include "firebase/storage/common.h"
 #include "firebase/storage/controller.h"

--- a/testlab/src/include/firebase/testlab.h
+++ b/testlab/src/include/firebase/testlab.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "firebase/app.h"
+#include "firebase/cpp_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)

--- a/testlab/src/include/firebase/testlab.h
+++ b/testlab/src/include/firebase/testlab.h
@@ -20,7 +20,7 @@
 #include <string>
 
 #include "firebase/app.h"
-#include "firebase/cpp_warning.h"
+#include "firebase/cpp_version_warning.h"
 #include "firebase/internal/common.h"
 
 #if !defined(DOXYGEN) && !defined(SWIG)


### PR DESCRIPTION
### Description
> Add compile time warning for C++14 upgrade.

***
### Testing
> Compile with C++11 and make sure the warning present.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
