### PR TITLE
Remove obsolete Firestore validation tests

### DIFF
--- a/firestore/integration_test_internal/src/validation_test.cc
+++ b/firestore/integration_test_internal/src/validation_test.cc
@@ -856,13 +856,6 @@ TEST_F(ValidationTest, QueriesWithInequalityDifferentThanFirstOrderByFail) {
                reason);
 }
 
-TEST_F(ValidationTest, QueriesWithMultipleArrayContainsFiltersFail) {
-  EXPECT_ERROR(Collection()
-                   .WhereArrayContains("foo", FieldValue::Integer(1))
-                   .WhereArrayContains("foo", FieldValue::Integer(2)),
-               ErrorMessage(ErrorCase::kQueryMultipleArrayContains));
-}
-
 TEST_F(ValidationTest, QueriesMustNotSpecifyStartingOrEndingPointAfterOrderBy) {
   CollectionReference collection = Collection();
   Query query = collection.OrderBy("foo");


### PR DESCRIPTION
### Description
Firestore implementation has been updated such that the validation no longer rejects use of multiple array-contains filters.
https://github.com/firebase/firebase-ios-sdk/pull/10449/files#diff-e11c1c8fc02726cb87283757008e935497911ea74a41f0efa93c4d2d6517d050

So this PR removes a test that expected this to throw an exception.
Example of a failure of the test before this change:
https://github.com/firebase/firebase-cpp-sdk/actions/runs/4242014548/jobs/7373657438
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
