### PR TITLE
Implement AppCheck Android token-changed listeners

### DIFF
--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -460,8 +460,6 @@ TEST_F(FirebaseAppCheckTest, TestGetTokenLastResult) {
             future2.result()->expire_time_millis);
 }
 
-// Android does not yet implement token changed listeners
-#if !FIREBASE_PLATFORM_ANDROID
 TEST_F(FirebaseAppCheckTest, TestAddTokenChangedListener) {
   InitializeAppCheckWithDebug();
   InitializeApp();
@@ -481,10 +479,7 @@ TEST_F(FirebaseAppCheckTest, TestAddTokenChangedListener) {
   ASSERT_EQ(token_changed_listener.num_token_changes_, 1);
   EXPECT_EQ(token_changed_listener.last_token_.token, token.token);
 }
-#endif  // !FIREBASE_PLATFORM_ANDROID
 
-// Android does not yet implement token changed listeners
-#if !FIREBASE_PLATFORM_ANDROID
 TEST_F(FirebaseAppCheckTest, TestRemoveTokenChangedListener) {
   InitializeAppCheckWithDebug();
   InitializeApp();
@@ -503,7 +498,6 @@ TEST_F(FirebaseAppCheckTest, TestRemoveTokenChangedListener) {
 
   ASSERT_EQ(token_changed_listener.num_token_changes_, 0);
 }
-#endif  // !FIREBASE_PLATFORM_ANDROID
 
 TEST_F(FirebaseAppCheckTest, TestSignIn) {
   InitializeAppCheckWithDebug();

--- a/app_check/src/android/app_check_android.cc
+++ b/app_check/src/android/app_check_android.cc
@@ -348,6 +348,7 @@ AppCheckInternal::~AppCheckInternal() {
   future_manager().ReleaseFutureApi(this);
   JNIEnv* env = app_->GetJNIEnv();
   app_ = nullptr;
+  listeners_.clear();
 
   if (j_app_check_listener_ != nullptr) {
     env->CallVoidMethod(

--- a/app_check/src/android/app_check_android.h
+++ b/app_check/src/android/app_check_android.h
@@ -15,11 +15,14 @@
 #ifndef FIREBASE_APP_CHECK_SRC_ANDROID_APP_CHECK_ANDROID_H_
 #define FIREBASE_APP_CHECK_SRC_ANDROID_APP_CHECK_ANDROID_H_
 
+#include <vector>
+
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"
 #include "app/src/include/firebase/future.h"
 #include "app/src/util_android.h"
 #include "app_check/src/include/firebase/app_check.h"
+#include "app/src/include/firebase/internal/mutex.h"
 
 namespace firebase {
 namespace app_check {
@@ -45,15 +48,26 @@ class AppCheckInternal {
 
   void RemoveAppCheckListener(AppCheckListener* listener);
 
+  void NotifyTokenChanged(AppCheckToken token);
+
   FutureManager& future_manager() { return future_manager_; }
 
   ReferenceCountedFutureImpl* future();
 
  private:
   ::firebase::App* app_;
+
+  // A Java FirebaseAppCheck instance
   jobject app_check_impl_;
+
+  // A Java AppCheckListener instance
   jobject j_app_check_listener_;
-  std::vector<AppCheckListener*> app_check_listeners_;
+
+  // A collection of C++ AppCheckListeners
+  std::vector<AppCheckListener*> listeners_;
+
+  // Lock object for accessing listeners_.
+  Mutex listeners_mutex_;
 
   FutureManager future_manager_;
 };

--- a/app_check/src/android/app_check_android.h
+++ b/app_check/src/android/app_check_android.h
@@ -20,9 +20,9 @@
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"
 #include "app/src/include/firebase/future.h"
+#include "app/src/include/firebase/internal/mutex.h"
 #include "app/src/util_android.h"
 #include "app_check/src/include/firebase/app_check.h"
-#include "app/src/include/firebase/internal/mutex.h"
 
 namespace firebase {
 namespace app_check {

--- a/app_check/src/android/app_check_android.h
+++ b/app_check/src/android/app_check_android.h
@@ -52,6 +52,8 @@ class AppCheckInternal {
  private:
   ::firebase::App* app_;
   jobject app_check_impl_;
+  jobject j_app_check_listener_;
+  std::vector<AppCheckListener*> app_check_listeners_;
 
   FutureManager future_manager_;
 };

--- a/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
+++ b/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.google.firebase.appcheck.internal.cpp;
+
+import androidx.annotation.NonNull;
+import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
+import com.google.firebase.appcheck.AppCheckToken;
+/**
+ * An AppCheckListener that notifies C++ of token changes.
+ */
+public class JniAppCheckListener implements AppCheckListener {
+  // A C++ pointer to a vector of AppCheckListeners
+  private long cListeners;
+
+  JniAppCheckListener(long cListeners) {
+    this.cListeners = cListeners;
+  }
+
+  // TODO see if I need safeRunNativeMethod or disconnect like AuthStateListener
+  public void onAppCheckTokenChanged(@NonNull AppCheckToken token) {
+    nativeOnAppCheckTokenChanged(cListeners, token);
+  }
+
+  /**
+   * This function is implemented in the AppCheck C++ library (app_check_android.cc).
+   */
+  private native void nativeOnAppCheckTokenChanged(long cListeners, AppCheckToken token);
+}

--- a/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
+++ b/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
@@ -17,8 +17,8 @@
 package com.google.firebase.appcheck.internal.cpp;
 
 import androidx.annotation.NonNull;
-import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.appcheck.AppCheckToken;
+import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 
 /**
  * An AppCheckListener that notifies C++ of token changes.

--- a/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
+++ b/app_check/src_java/com/google/firebase/appcheck/internal/cpp/JniAppCheckListener.java
@@ -19,24 +19,24 @@ package com.google.firebase.appcheck.internal.cpp;
 import androidx.annotation.NonNull;
 import com.google.firebase.appcheck.FirebaseAppCheck.AppCheckListener;
 import com.google.firebase.appcheck.AppCheckToken;
+
 /**
  * An AppCheckListener that notifies C++ of token changes.
  */
 public class JniAppCheckListener implements AppCheckListener {
-  // A C++ pointer to a vector of AppCheckListeners
-  private long cListeners;
+  // A C++ pointer to AppCheckInternal
+  private long cAppCheck;
 
-  JniAppCheckListener(long cListeners) {
-    this.cListeners = cListeners;
+  JniAppCheckListener(long cAppCheck) {
+    this.cAppCheck = cAppCheck;
   }
 
-  // TODO see if I need safeRunNativeMethod or disconnect like AuthStateListener
   public void onAppCheckTokenChanged(@NonNull AppCheckToken token) {
-    nativeOnAppCheckTokenChanged(cListeners, token);
+    nativeOnAppCheckTokenChanged(cAppCheck, token);
   }
 
   /**
    * This function is implemented in the AppCheck C++ library (app_check_android.cc).
    */
-  private native void nativeOnAppCheckTokenChanged(long cListeners, AppCheckToken token);
+  private native void nativeOnAppCheckTokenChanged(long cAppCheck, AppCheckToken token);
 }


### PR DESCRIPTION
### Description
Defines a Java AppCheckListener to pass to the Android SDK.
Maintains a vector of C++ AppCheckListeners that are called when android reports a token change.

### Testing
Enabled token-change listener integration test cases on Android. Ran integration tests locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
