### PR TITLE
Disable SessionID test on Android

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -107,6 +107,14 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
 }
 
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
+#if defined(__ANDROID__)
+  // Android continues to have random failures on this test despite the
+  // workarounds below, so just skip it for now.
+  LogInfo("Skipping TestGetSessionID on Android");
+  GTEST_SKIP();
+  return;
+#endif
+
   // Android emulator tests are currently not working due to getSessionId being
   // disabled on virtual FTL devices, due to an older version of Google Play
   // services.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The SessionID test is failing on Android due to problems with the test runner, not the product itself. Disable the tests for now, until we can fix the problem.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
