### PR TITLE
Check Google Play services version in Analytics test

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -106,23 +106,6 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
   EXPECT_FALSE(future.result()->empty());
 }
 
-TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
-  // Log an event with no parameters.
-  firebase::analytics::LogEvent(firebase::analytics::kEventLogin);
-
-  // Log an event with a floating point parameter.
-  firebase::analytics::LogEvent("progress", "percent", 0.4f);
-
-  // Log an event with an integer parameter.
-  firebase::analytics::LogEvent(firebase::analytics::kEventPostScore,
-                                firebase::analytics::kParameterScore, 42);
-
-  // Log an event with a string parameter.
-  firebase::analytics::LogEvent(firebase::analytics::kEventJoinGroup,
-                                firebase::analytics::kParameterGroupID,
-                                "spoon_welders");
-}
-
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   // Don't run this test if Google Play services is < 23.0.0.
   SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(230000);
@@ -146,6 +129,10 @@ TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
     return;
   }
 #endif
+  // Log an event once, to ensure that there is currently an active Analytics
+  // session.
+  firebase::analytics::LogEvent(firebase::analytics::kEventSignUp);
+
   firebase::Future<int64_t> future;
 
   // Give Analytics a moment to initialize and create a session.
@@ -203,6 +190,23 @@ TEST_F(FirebaseAnalyticsTest, TestSetProperties) {
   // Initiate on-device conversion measurement.
   firebase::analytics::InitiateOnDeviceConversionMeasurementWithEmailAddress(
       "my_email@site.com");
+}
+
+TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
+  // Log an event with no parameters.
+  firebase::analytics::LogEvent(firebase::analytics::kEventLogin);
+
+  // Log an event with a floating point parameter.
+  firebase::analytics::LogEvent("progress", "percent", 0.4f);
+
+  // Log an event with an integer parameter.
+  firebase::analytics::LogEvent(firebase::analytics::kEventPostScore,
+                                firebase::analytics::kParameterScore, 42);
+
+  // Log an event with a string parameter.
+  firebase::analytics::LogEvent(firebase::analytics::kEventJoinGroup,
+                                firebase::analytics::kParameterGroupID,
+                                "spoon_welders");
 }
 
 TEST_F(FirebaseAnalyticsTest, TestLogEventWithMultipleParameters) {

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -125,7 +125,7 @@ TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
 
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   // Don't run this test if Google Play services is < 23.0.0.
-  SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(23_00_00);
+  SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(230000);
 
   // iOS simulator tests are currently extra flaky, occasionally failing with an
   // "Analytics uninitialized" error even after multiple attempts.

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -124,17 +124,8 @@ TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
 }
 
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
-  int version = GetGooglePlayServicesVersion();
-  LogInfo("Google Play services version: %d", version);
-  
-  // Android continues to have random failures on this test despite the
-  // workarounds below, so just skip it for now.
-  // SKIP_TEST_ON_ANDROID;
-
-  // Android emulator tests are currently not working due to getSessionId being
-  // disabled on virtual FTL devices, due to an older version of Google Play
-  // services.
-  // SKIP_TEST_ON_ANDROID_EMULATOR;
+  // Don't run this test if Google Play services is < 23.0.0.
+  SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(23_00_00);
 
   // iOS simulator tests are currently extra flaky, occasionally failing with an
   // "Analytics uninitialized" error even after multiple attempts.
@@ -144,6 +135,9 @@ TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   // needs to be restarted after consent is denied or it won't generate a new
   // sessionID. To not break the tests, skip this test in that case.
 #if defined(__ANDROID__)
+  // Log the Google Play services version for debugging in case this test fails.
+  LogInfo("Google Play services version: %d", GetGooglePlayServicesVersion());
+  
   if (did_test_setconsent_) {
     LogInfo(
         "Skipping TestGetSessionID after TestSetConsent, as GetSessionId() "

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -137,7 +137,7 @@ TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
 #if defined(__ANDROID__)
   // Log the Google Play services version for debugging in case this test fails.
   LogInfo("Google Play services version: %d", GetGooglePlayServicesVersion());
-  
+
   if (did_test_setconsent_) {
     LogInfo(
         "Skipping TestGetSessionID after TestSetConsent, as GetSessionId() "

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -106,19 +106,35 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
   EXPECT_FALSE(future.result()->empty());
 }
 
+TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
+  // Log an event with no parameters.
+  firebase::analytics::LogEvent(firebase::analytics::kEventLogin);
+
+  // Log an event with a floating point parameter.
+  firebase::analytics::LogEvent("progress", "percent", 0.4f);
+
+  // Log an event with an integer parameter.
+  firebase::analytics::LogEvent(firebase::analytics::kEventPostScore,
+                                firebase::analytics::kParameterScore, 42);
+
+  // Log an event with a string parameter.
+  firebase::analytics::LogEvent(firebase::analytics::kEventJoinGroup,
+                                firebase::analytics::kParameterGroupID,
+                                "spoon_welders");
+}
+
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
-#if defined(__ANDROID__)
+  int version = GetGooglePlayServicesVersion();
+  LogInfo("Google Play services version: %d", version);
+  
   // Android continues to have random failures on this test despite the
   // workarounds below, so just skip it for now.
-  LogInfo("Skipping TestGetSessionID on Android");
-  GTEST_SKIP();
-  return;
-#endif
+  // SKIP_TEST_ON_ANDROID;
 
   // Android emulator tests are currently not working due to getSessionId being
   // disabled on virtual FTL devices, due to an older version of Google Play
   // services.
-  SKIP_TEST_ON_ANDROID_EMULATOR;
+  // SKIP_TEST_ON_ANDROID_EMULATOR;
 
   // iOS simulator tests are currently extra flaky, occasionally failing with an
   // "Analytics uninitialized" error even after multiple attempts.
@@ -193,23 +209,6 @@ TEST_F(FirebaseAnalyticsTest, TestSetProperties) {
   // Initiate on-device conversion measurement.
   firebase::analytics::InitiateOnDeviceConversionMeasurementWithEmailAddress(
       "my_email@site.com");
-}
-
-TEST_F(FirebaseAnalyticsTest, TestLogEvents) {
-  // Log an event with no parameters.
-  firebase::analytics::LogEvent(firebase::analytics::kEventLogin);
-
-  // Log an event with a floating point parameter.
-  firebase::analytics::LogEvent("progress", "percent", 0.4f);
-
-  // Log an event with an integer parameter.
-  firebase::analytics::LogEvent(firebase::analytics::kEventPostScore,
-                                firebase::analytics::kParameterScore, 42);
-
-  // Log an event with a string parameter.
-  firebase::analytics::LogEvent(firebase::analytics::kEventJoinGroup,
-                                firebase::analytics::kParameterGroupID,
-                                "spoon_welders");
 }
 
 TEST_F(FirebaseAnalyticsTest, TestLogEventWithMultipleParameters) {

--- a/testing/test_framework/src/android/android_firebase_test_framework.cc
+++ b/testing/test_framework/src/android/android_firebase_test_framework.cc
@@ -244,4 +244,26 @@ bool FirebaseTest::IsRunningOnEmulator() {
   return result ? true : false;
 }
 
+int FirebaseTest::GetGooglePlayServicesVersion() {
+  JNIEnv* env = app_framework::GetJniEnv();
+  jobject activity = app_framework::GetActivity();
+  jclass test_helper_class = app_framework::FindClass(
+      env, activity, "com/google/firebase/example/TestHelper");
+  if (env->ExceptionCheck()) {
+    env->ExceptionDescribe();
+    env->ExceptionClear();
+    return false;
+  }
+  jmethodID get_google_play_services_version =
+      env->GetStaticMethodID(test_helper_class, "getGooglePlayServicesVersion", "()I");
+  jint result =
+      env->CallStaticIntMethod(test_helper_class, get_google_play_services_version);
+  if (env->ExceptionCheck()) {
+    env->ExceptionDescribe();
+    env->ExceptionClear();
+    return false;
+  }
+  return static_cast<int>(result);
+}
+
 }  // namespace firebase_test_framework

--- a/testing/test_framework/src/android/android_firebase_test_framework.cc
+++ b/testing/test_framework/src/android/android_firebase_test_framework.cc
@@ -255,9 +255,9 @@ int FirebaseTest::GetGooglePlayServicesVersion() {
     return false;
   }
   jmethodID get_google_play_services_version =
-      env->GetStaticMethodID(test_helper_class, "getGooglePlayServicesVersion", "()I");
+      env->GetStaticMethodID(test_helper_class, "getGooglePlayServicesVersion", "(Landroid/content/Context;)I");
   jint result =
-      env->CallStaticIntMethod(test_helper_class, get_google_play_services_version);
+    env->CallStaticIntMethod(test_helper_class, get_google_play_services_version, activity);
   if (env->ExceptionCheck()) {
     env->ExceptionDescribe();
     env->ExceptionClear();

--- a/testing/test_framework/src/android/android_firebase_test_framework.cc
+++ b/testing/test_framework/src/android/android_firebase_test_framework.cc
@@ -255,9 +255,10 @@ int FirebaseTest::GetGooglePlayServicesVersion() {
     return false;
   }
   jmethodID get_google_play_services_version =
-      env->GetStaticMethodID(test_helper_class, "getGooglePlayServicesVersion", "(Landroid/content/Context;)I");
-  jint result =
-    env->CallStaticIntMethod(test_helper_class, get_google_play_services_version, activity);
+      env->GetStaticMethodID(test_helper_class, "getGooglePlayServicesVersion",
+                             "(Landroid/content/Context;)I");
+  jint result = env->CallStaticIntMethod(
+      test_helper_class, get_google_play_services_version, activity);
   if (env->ExceptionCheck()) {
     env->ExceptionDescribe();
     env->ExceptionClear();

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -15,6 +15,7 @@
 package com.google.firebase.example;
 
 import android.os.Build;
+import com.google.android.gms.common.GoogleApiAvailability;
 
 /**
  * A simple class with test helper methods.
@@ -27,5 +28,8 @@ public final class TestHelper {
         || Build.PRODUCT.contains("sdk") || Build.HARDWARE.contains("goldfish")
         || Build.MANUFACTURER.contains("Genymotion") || Build.PRODUCT.contains("vbox86p")
         || Build.DEVICE.contains("vbox86p") || Build.HARDWARE.contains("vbox86");
+  }
+  public static int getGooglePlayServicesVersion() {
+    return GoogleApiAvailability.getInstance().getApkVersion(getContext());
   }
 }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -14,6 +14,7 @@
 
 package com.google.firebase.example;
 
+import android.content.Context;
 import android.os.Build;
 import com.google.android.gms.common.GoogleApiAvailability;
 
@@ -29,7 +30,7 @@ public final class TestHelper {
         || Build.MANUFACTURER.contains("Genymotion") || Build.PRODUCT.contains("vbox86p")
         || Build.DEVICE.contains("vbox86p") || Build.HARDWARE.contains("vbox86");
   }
-  public static int getGooglePlayServicesVersion() {
-    return GoogleApiAvailability.getInstance().getApkVersion(getContext());
+  public static int getGooglePlayServicesVersion(Context context) {
+    return GoogleApiAvailability.getInstance().getApkVersion(context);
   }
 }

--- a/testing/test_framework/src/desktop/desktop_firebase_test_framework.cc
+++ b/testing/test_framework/src/desktop/desktop_firebase_test_framework.cc
@@ -54,4 +54,9 @@ bool FirebaseTest::IsRunningOnEmulator() {
   return false;
 }
 
+int FirebaseTest::GetGooglePlayServicesVersion() {
+  // No Google Play services on desktop.
+  return 0;
+}
+
 }  // namespace firebase_test_framework

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -224,7 +224,7 @@ namespace firebase_test_framework {
   }
 #else
 #define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)
-#endif
+#endif  // defined(ANDROID)
 
 #if defined(STLPORT)
 #define SKIP_TEST_IF_USING_STLPORT                                             \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -215,7 +215,7 @@ namespace firebase_test_framework {
       _required_ver_ *= 1000;                                             \
     }                                                                     \
     int _actual_ver_ = GetGooglePlayServicesVersion();                    \
-    if (_actual_ver < _required_ver_) {                                   \
+    if (_actual_ver_ < _required_ver_) {                                  \
       app_framework::LogInfo(                                             \
           "Skipping %s, as Google Play services %d is below required %d", \
           test_info_->name(), _actual_ver_, _required_ver_);              \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -206,19 +206,21 @@ namespace firebase_test_framework {
 #endif
 
 #if defined(ANDROID)
-#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x)                     \
-  {                                                                            \
-   int _reqver_ = (x);                                                         \
-   /* Example: 23.1.2 has version code 230102???. */                           \
-   /* Allow specifying version as 23_01_02 or as 230102000. */                 \
-   if (_reqver_ < 10000000) { _reqver_ *= 1000; }                              \
-   if ((int _actver_ = GetGooglePlayServicesVersion()) < _reqver_){            \
-      app_framework::LogInfo(                                                  \
-         "Skipping %s, as Google Play services %d is below required %d",       \
-         test_info_->name(), _actver_, _reqver_);                              \
-      GTEST_SKIP();                                                            \
-      return;                                                                  \
-    }                                                                          \
+#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x)                \
+  {                                                                       \
+    int _reqver_ = (x);                                                   \
+    /* Example: 23.1.2 has version code 230102???. */                     \
+    /* Allow specifying version as 23_01_02 or as 230102000. */           \
+    if (_reqver_ < 10000000) {                                            \
+      _reqver_ *= 1000;                                                   \
+    }                                                                     \
+    if ((int _actver_ = GetGooglePlayServicesVersion()) < _reqver_) {     \
+      app_framework::LogInfo(                                             \
+          "Skipping %s, as Google Play services %d is below required %d", \
+          test_info_->name(), _actver_, _reqver_);                        \
+      GTEST_SKIP();                                                       \
+      return;                                                             \
+    }                                                                     \
   }
 #else
 #define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -210,7 +210,7 @@ namespace firebase_test_framework {
   {                                                                       \
     int _required_ver_ = (x);                                             \
     /* Example: 23.1.2 has version code 230102???. */                     \
-    /* Allow specifying version as 23_01_02 or as 230102000. */           \
+    /* Allow specifying version as 230102 or as 230102000. */             \
     if (_required_ver_ < 10000000) {                                      \
       _required_ver_ *= 1000;                                             \
     }                                                                     \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -205,6 +205,25 @@ namespace firebase_test_framework {
 #define SKIP_TEST_ON_ANDROID_EMULATOR ((void)0)
 #endif
 
+#if defined(ANDROID)
+#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x)                     \
+  {                                                                            \
+   int _reqver_ = (x);                                                         \
+   /* Example: 23.1.2 has version code 230102???. */                           \
+   /* Allow specifying version as 23_01_02 or as 230102000. */                 \
+   if (_reqver_ < 10000000) { _reqver_ *= 1000; }                              \
+   if ((int _actver_ = GetGooglePlayServicesVersion()) < _reqver_){            \
+      app_framework::LogInfo(                                                  \
+         "Skipping %s, as Google Play services %d is below required %d",       \
+         test_info_->name(), _actver_, _reqver_);                              \
+      GTEST_SKIP();                                                            \
+      return;                                                                  \
+    }                                                                          \
+  }
+#else
+#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)
+#endif
+
 #if defined(STLPORT)
 #define SKIP_TEST_IF_USING_STLPORT                                             \
   {                                                                            \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -208,7 +208,7 @@ namespace firebase_test_framework {
 #if defined(ANDROID)
 #define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x)                \
   {                                                                       \
-    int _reqver_ = (x);                                                   \
+    int _required_ver_ = (x);                                             \
     /* Example: 23.1.2 has version code 230102???. */                     \
     /* Allow specifying version as 23_01_02 or as 230102000. */           \
     if (_required_ver_ < 10000000) {                                      \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -332,6 +332,9 @@ class FirebaseTest : public testing::Test {
   // on a real device (or on desktop).
   static bool IsRunningOnEmulator();
 
+  // Return Google Play services version on Android, 0 elsewhere.
+  static int GetGooglePlayServicesVersion();
+
   // Returns true if the future completed as expected, fails the test and
   // returns false otherwise.
   static bool WaitForCompletion(const firebase::FutureBase& future,

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -211,13 +211,14 @@ namespace firebase_test_framework {
     int _reqver_ = (x);                                                   \
     /* Example: 23.1.2 has version code 230102???. */                     \
     /* Allow specifying version as 23_01_02 or as 230102000. */           \
-    if (_reqver_ < 10000000) {                                            \
-      _reqver_ *= 1000;                                                   \
+    if (_required_ver_ < 10000000) {                                      \
+      _required_ver_ *= 1000;                                             \
     }                                                                     \
-    if ((int _actver_ = GetGooglePlayServicesVersion()) < _reqver_) {     \
+    int _actual_ver_ = GetGooglePlayServicesVersion();                    \
+    if (_actual_ver < _required_ver_) {                                   \
       app_framework::LogInfo(                                             \
           "Skipping %s, as Google Play services %d is below required %d", \
-          test_info_->name(), _actver_, _reqver_);                        \
+          test_info_->name(), _actual_ver_, _required_ver_);              \
       GTEST_SKIP();                                                       \
       return;                                                             \
     }                                                                     \

--- a/testing/test_framework/src/ios/ios_firebase_test_framework.mm
+++ b/testing/test_framework/src/ios/ios_firebase_test_framework.mm
@@ -200,4 +200,9 @@ bool FirebaseTest::IsRunningOnEmulator() {
 #endif
 }
 
+int FirebaseTest::GetGooglePlayServicesVersion() {
+  // No Google Play services on iOS.
+  return 0;
+}
+
 }  // namespace firebase_test_framework


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Check the GMSCore version in the Analytics test - this allows us to simply skip the GetSessionId test on devices that don't support it.

Also force an event to be logged before getting the session ID, so we are sure to have an Analytics session.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
