### PR TITLE
Change GetGooglePlayServices to use reflection to avoid build errors

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -108,7 +108,7 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
 
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   // Don't run this test if Google Play services is < 23.0.0.
-  SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(230000);
+  SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(230000);
 
   // iOS simulator tests are currently extra flaky, occasionally failing with an
   // "Analytics uninitialized" error even after multiple attempts.

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -108,7 +108,7 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
 
 TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   // Don't run this test if Google Play services is < 23.0.0.
-  SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(230000);
+  SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_IS_OLDER_THAN(230000);
 
   // iOS simulator tests are currently extra flaky, occasionally failing with an
   // "Analytics uninitialized" error even after multiple attempts.

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -32,27 +32,28 @@ public final class TestHelper {
         || Build.DEVICE.contains("vbox86p") || Build.HARDWARE.contains("vbox86");
   }
   public static int getGooglePlayServicesVersion(Context context) {
-      // Use reflection to invoke GoogleApiAvailability.getInstance().getApkVersion(context).
-      // This avoids needing Google Play services to be present (and returns 0 if it's not)..
+    // Use reflection to invoke GoogleApiAvailability.getInstance().getApkVersion(context).
+    // This avoids needing Google Play services to be present (and returns 0 if it's not)..
 
-      // GoogleApiAvailability
-      Class<?> googleApiAvailabilityClass = Class.forName("com.google.android.gms.common.GoogleApiAvailability");
-      if (googleApiAvailabilityClass == null) {
-	  return 0;
-      }
-      // .getInstance()
-      Method getInstanceMethod = googleApiAvailabilityClass.getDeclaredMethod("getInstance");
-      Object instance = getInstanceMethod.invoke(null);
+    // GoogleApiAvailability
+    Class<?> googleApiAvailabilityClass =
+        Class.forName("com.google.android.gms.common.GoogleApiAvailability");
+    if (googleApiAvailabilityClass == null) {
+      return 0;
+    }
+    // .getInstance()
+    Method getInstanceMethod = googleApiAvailabilityClass.getDeclaredMethod("getInstance");
+    Object instance = getInstanceMethod.invoke(null);
 
-      // .getApkVersion(context)
-      Class[] getApkVersionParams = new Class[]{Class.forName("android.build.Context")};
-      Method getApkVersionMethod = googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
-      Object apkVersionObject = getInstanceMethod.invoke(instance, context);
-      if (apkVersionObject is Integer) {
-	  return (apkVersionObject as Integer).intValue;
-      }
-      else {
-	  return 0;
-      }
+    // .getApkVersion(context)
+    Class[] getApkVersionParams = new Class[] {Class.forName("android.build.Context")};
+    Method getApkVersionMethod =
+        googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
+    Object apkVersionObject = getInstanceMethod.invoke(instance, context);
+    if (apkVersionObject is Integer) {
+      return (apkVersionObject as Integer).intValue;
+    } else {
+      return 0;
+    }
   }
 }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -53,18 +53,8 @@ public final class TestHelper {
       if (apkVersionObject != null && apkVersionObject instanceof Integer) {
         return ((Integer) apkVersionObject).intValue();
       }
-    } catch (ClassNotFoundException e) {
-	Log.e(TAG, e.toString());
-	return -1;
-    } catch (IllegalAccessException e) {
-	Log.e(TAG, e.toString());
-	return -2;
-    } catch (InvocationTargetException e) {
-	Log.e(TAG, e.toString());
-	return -3;
-    } catch (NoSuchMethodException e) {
-	Log.e(TAG, e.toString());
-	return -4;
+    } catch (Exception e) {
+      Log.e(TAG, e.toString());
     }
     return 0;
   }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -16,7 +16,8 @@ package com.google.firebase.example;
 
 import android.content.Context;
 import android.os.Build;
-import com.google.android.gms.common.GoogleApiAvailability;
+import java.lang.Class;
+import java.lang.reflect.Method;
 
 /**
  * A simple class with test helper methods.
@@ -31,6 +32,22 @@ public final class TestHelper {
         || Build.DEVICE.contains("vbox86p") || Build.HARDWARE.contains("vbox86");
   }
   public static int getGooglePlayServicesVersion(Context context) {
-    return GoogleApiAvailability.getInstance().getApkVersion(context);
+      // Use reflection to invoke GoogleApiAvailability.getInstance().getApkVersion(context).
+      // This avoids needing Google Play services to be present (and returns 0 if it's not)..
+
+      // GoogleApiAvailability
+      Class<?> googleApiAvailabilityClass = Class.forName("com.google.android.gms.common.GoogleApiAvailability");
+      if (googleApiAvailabilityClass == null) {
+	  return 0;
+      }
+      // .getInstance()
+      Method getInstanceMethod = googleApiAvailabilityClass.getDeclaredMethod("getInstance");
+      Object instance = getInstanceMethod.invoke(null);
+
+      // .getApkVersion(context)
+      Method getApkVersionMethod = googleApiAvailabilityClass.getMethod("getApkVersion", new Class[]{context.class});
+      Object apkVersionObject = getInstanceMethod.invoke(instance, context);
+
+      int apkVersion = apkVersionObject.intValue;
   }
 }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -16,6 +16,7 @@ package com.google.firebase.example;
 
 import android.content.Context;
 import android.os.Build;
+import android.util.Log;
 import java.lang.Class;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -53,9 +54,17 @@ public final class TestHelper {
         return ((Integer) apkVersionObject).intValue();
       }
     } catch (ClassNotFoundException e) {
+	Log.e(TAG, e.toString());
+	return 1;
     } catch (IllegalAccessException e) {
+	Log.e(TAG, e.toString());
+	return 2;
     } catch (InvocationTargetException e) {
+	Log.e(TAG, e.toString());
+	return 3;
     } catch (NoSuchMethodException e) {
+	Log.e(TAG, e.toString());
+	return 4;
     }
     return 0;
   }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -34,26 +34,27 @@ public final class TestHelper {
   public static int getGooglePlayServicesVersion(Context context) {
     // Use reflection to invoke GoogleApiAvailability.getInstance().getApkVersion(context).
     // This avoids needing Google Play services to be present (and returns 0 if it's not)..
+    try {
+      // GoogleApiAvailability
+      Class<?> googleApiAvailabilityClass =
+          Class.forName("com.google.android.gms.common.GoogleApiAvailability");
 
-    // GoogleApiAvailability
-    Class<?> googleApiAvailabilityClass =
-        Class.forName("com.google.android.gms.common.GoogleApiAvailability");
-    if (googleApiAvailabilityClass == null) {
-      return 0;
-    }
-    // .getInstance()
-    Method getInstanceMethod = googleApiAvailabilityClass.getDeclaredMethod("getInstance");
-    Object instance = getInstanceMethod.invoke(null);
+      // .getInstance()
+      Method getInstanceMethod = googleApiAvailabilityClass.getDeclaredMethod("getInstance");
+      Object instance = getInstanceMethod.invoke(null);
 
-    // .getApkVersion(context)
-    Class[] getApkVersionParams = new Class[] {Class.forName("android.build.Context")};
-    Method getApkVersionMethod =
-        googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
-    Object apkVersionObject = getInstanceMethod.invoke(instance, context);
-    if (apkVersionObject instanceof Integer) {
-      return ((Integer) apkVersionObject).intValue();
-    } else {
-      return 0;
+      // .getApkVersion(context)
+      Class[] getApkVersionParams = new Class[] {Class.forName("android.build.Context")};
+      Method getApkVersionMethod =
+          googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
+      Object apkVersionObject = getInstanceMethod.invoke(instance, context);
+      if (apkVersionObject != null && apkVersionObject instanceof Integer) {
+        return ((Integer) apkVersionObject).intValue();
+      }
+    } catch (ClassNotFoundException e) {
+    } catch (IllegalAccessException e) {
+    } catch (NoSuchMethodException e) {
     }
+    return 0;
   }
 }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -46,7 +46,7 @@ public final class TestHelper {
       Object instance = getInstanceMethod.invoke(null);
 
       // .getApkVersion(context)
-      Class[] getApkVersionParams = new Class[] {Class.forName("android.build.Context")};
+      Class[] getApkVersionParams = new Class[] {Class.forName("android.content.Context")};
       Method getApkVersionMethod =
           googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
       Object apkVersionObject = getApkVersionMethod.invoke(instance, context);

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -32,8 +32,8 @@ public final class TestHelper {
         || Build.DEVICE.contains("vbox86p") || Build.HARDWARE.contains("vbox86");
   }
   public static int getGooglePlayServicesVersion(Context context) {
-    // Use reflection to invoke GoogleApiAvailability.getInstance().getApkVersion(context).
-    // This avoids needing Google Play services to be present (and returns 0 if it's not)..
+    // Use reflection to return GoogleApiAvailability.getInstance().getApkVersion(context);
+    // This avoids needing Google Play services to be present (and returns 0 if it's not).
     try {
       // GoogleApiAvailability
       Class<?> googleApiAvailabilityClass =
@@ -53,6 +53,7 @@ public final class TestHelper {
       }
     } catch (ClassNotFoundException e) {
     } catch (IllegalAccessException e) {
+    } catch (InvocationTargetException e) {
     } catch (NoSuchMethodException e) {
     }
     return 0;

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -51,7 +51,7 @@ public final class TestHelper {
         googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
     Object apkVersionObject = getInstanceMethod.invoke(instance, context);
     if (apkVersionObject is Integer) {
-      return (apkVersionObject as Integer).intValue;
+      return (apkVersionObject as Integer).intValue();
     } else {
       return 0;
     }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -45,9 +45,14 @@ public final class TestHelper {
       Object instance = getInstanceMethod.invoke(null);
 
       // .getApkVersion(context)
-      Method getApkVersionMethod = googleApiAvailabilityClass.getMethod("getApkVersion", new Class[]{context.class});
+      Class[] getApkVersionParams = new Class[]{Class.forName("android.build.Context")};
+      Method getApkVersionMethod = googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
       Object apkVersionObject = getInstanceMethod.invoke(instance, context);
-
-      int apkVersion = apkVersionObject.intValue;
+      if (apkVersionObject is Integer) {
+	  return (apkVersionObject as Integer).intValue;
+      }
+      else {
+	  return 0;
+      }
   }
 }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -17,6 +17,7 @@ package com.google.firebase.example;
 import android.content.Context;
 import android.os.Build;
 import java.lang.Class;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 /**

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -49,22 +49,22 @@ public final class TestHelper {
       Class[] getApkVersionParams = new Class[] {Class.forName("android.build.Context")};
       Method getApkVersionMethod =
           googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
-      Object apkVersionObject = getInstanceMethod.invoke(instance, context);
+      Object apkVersionObject = getApkVersionMethod.invoke(instance, context);
       if (apkVersionObject != null && apkVersionObject instanceof Integer) {
         return ((Integer) apkVersionObject).intValue();
       }
     } catch (ClassNotFoundException e) {
 	Log.e(TAG, e.toString());
-	return 1;
+	return -1;
     } catch (IllegalAccessException e) {
 	Log.e(TAG, e.toString());
-	return 2;
+	return -2;
     } catch (InvocationTargetException e) {
 	Log.e(TAG, e.toString());
-	return 3;
+	return -3;
     } catch (NoSuchMethodException e) {
 	Log.e(TAG, e.toString());
-	return 4;
+	return -4;
     }
     return 0;
   }

--- a/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
+++ b/testing/test_framework/src/android/java/com/google/firebase/example/TestHelper.java
@@ -50,8 +50,8 @@ public final class TestHelper {
     Method getApkVersionMethod =
         googleApiAvailabilityClass.getMethod("getApkVersion", getApkVersionParams);
     Object apkVersionObject = getInstanceMethod.invoke(instance, context);
-    if (apkVersionObject is Integer) {
-      return (apkVersionObject as Integer).intValue();
+    if (apkVersionObject instanceof Integer) {
+      return ((Integer) apkVersionObject).intValue();
     } else {
       return 0;
     }

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -215,7 +215,7 @@ namespace firebase_test_framework {
       _required_ver_ *= 1000;                                             \
     }                                                                     \
     int _actual_ver_ = GetGooglePlayServicesVersion();                    \
-    if (_actual_ver_ < _required_ver_) {                                  \
+    if (_actual_ver_ > 0 && _actual_ver_ < _required_ver_) {              \
       app_framework::LogInfo(                                             \
           "Skipping %s, as Google Play services %d is below required %d", \
           test_info_->name(), _actual_ver_, _required_ver_);              \

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -206,7 +206,7 @@ namespace firebase_test_framework {
 #endif
 
 #if defined(ANDROID)
-#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x)                \
+#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(x)                \
   {                                                                       \
     int _required_ver_ = (x);                                             \
     /* Example: 23.1.2 has version code 230102???. */                     \
@@ -224,7 +224,7 @@ namespace firebase_test_framework {
     }                                                                     \
   }
 #else
-#define SKIP_TEST_ON_ANDROID_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)
+#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)
 #endif  // defined(ANDROID)
 
 #if defined(STLPORT)

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -88,6 +88,7 @@ namespace firebase_test_framework {
 // SKIP_TEST_ON_MACOS
 // SKIP_TEST_ON_SIMULATOR / SKIP_TEST_ON_EMULATOR (identical)
 // SKIP_TEST_ON_IOS_SIMULATOR / SKIP_TEST_ON_ANDROID_EMULATOR
+// SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_IS_OLDER_THAN(version_code)
 //
 // Also includes a special macro SKIP_TEST_IF_USING_STLPORT if compiling for
 // Android STLPort, which does not fully support C++11.
@@ -206,7 +207,7 @@ namespace firebase_test_framework {
 #endif
 
 #if defined(ANDROID)
-#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(x)                \
+#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_IS_OLDER_THAN(x)     \
   {                                                                       \
     int _required_ver_ = (x);                                             \
     /* Example: 23.1.2 has version code 230102???. */                     \
@@ -224,7 +225,7 @@ namespace firebase_test_framework {
     }                                                                     \
   }
 #else
-#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_BELOW(x) ((void)0)
+#define SKIP_TEST_ON_ANDROID_IF_GOOGLE_PLAY_SERVICES_IS_OLDER_THAN(x) ((void)0)
 #endif  // defined(ANDROID)
 
 #if defined(STLPORT)

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -354,7 +354,8 @@ class FirebaseTest : public testing::Test {
   // on a real device (or on desktop).
   static bool IsRunningOnEmulator();
 
-  // Return Google Play services version on Android, 0 elsewhere.
+  // If on Android and Google Play services is available, returns the
+  // Google Play services version. Otherwise, returns 0.
   static int GetGooglePlayServicesVersion();
 
   // Returns true if the future completed as expected, fails the test and

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -355,8 +355,7 @@ class FirebaseTest : public testing::Test {
   static bool IsRunningOnEmulator();
 
   // If on Android and Google Play services is available, returns the
-  // Google Play services version. If an error occurred, returns < 0.
-  // Otherwise, returns 0.
+  // Google Play services version. Otherwise, returns 0.
   static int GetGooglePlayServicesVersion();
 
   // Returns true if the future completed as expected, fails the test and

--- a/testing/test_framework/src/firebase_test_framework.h
+++ b/testing/test_framework/src/firebase_test_framework.h
@@ -355,7 +355,8 @@ class FirebaseTest : public testing::Test {
   static bool IsRunningOnEmulator();
 
   // If on Android and Google Play services is available, returns the
-  // Google Play services version. Otherwise, returns 0.
+  // Google Play services version. If an error occurred, returns < 0.
+  // Otherwise, returns 0.
   static int GetGooglePlayServicesVersion();
 
   // Returns true if the future completed as expected, fails the test and


### PR DESCRIPTION
Some tests don't have play services enabled, which makes GoogleApiAvailbility not available. Use reflection to handle this case.

### Description
> Provide details of the change, and generalize the change in the PR title above.

The previous change #1235 broke a few tests, because they added a dependency to GoogleApiAvailability that some integration tests (e.g. admob) don't have.

This modifies the previous change so that it uses reflection to access GoogleApiAvailability, so it can handle the case where the play-services-base dependency is not included.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Integration tests in this PR.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
