### PR TITLE
iOS support for multiple User objects

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -162,7 +162,6 @@ void FirebaseAuthTest::Initialize() {
 
   ::firebase::ModuleInitializer initializer;
   initializer.Initialize(app_, &auth_, [](::firebase::App* app, void* target) {
-    LogDebug("Try to initialize Firebase Auth");
     firebase::InitResult result;
     firebase::auth::Auth** auth_ptr =
         reinterpret_cast<firebase::auth::Auth**>(target);
@@ -175,8 +174,6 @@ void FirebaseAuthTest::Initialize() {
 
   ASSERT_EQ(initializer.InitializeLastResult().error(), 0)
       << initializer.InitializeLastResult().error_message();
-
-  LogDebug("Successfully initialized Firebase Auth.");
 
   initialized_ = true;
 }
@@ -251,17 +248,18 @@ void FirebaseAuthTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (auth_->current_user_DEPRECATED() == nullptr) {
+  if (!auth_->current_user_DEPRECATED()->is_valid()) {
     // Already signed out.
     return;
   }
   auth_->SignOut();
   // Wait for the sign-out to finish.
-  while (auth_->current_user_DEPRECATED() != nullptr) {
+  while (auth_->current_user_DEPRECATED()->is_valid()) {
+    printf("process events...\n");
     if (ProcessEvents(100)) break;
   }
   ProcessEvents(100);
-  EXPECT_EQ(auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_EQ(auth_->current_user_DEPRECATED()->is_valid(), false);
 }
 
 void FirebaseAuthTest::DeleteUser() {
@@ -516,8 +514,8 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
   firebase::auth::Credential credential =
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
-  WaitForCompletion(user->LinkAndRetrieveDataWithCredential(credential),
-                    "LinkAndRetrieveDataWithCredential");
+  WaitForCompletion(user->LinkAndRetrieveDataWithCredential_DEPRECATED(credential),
+                    "LinkAndRetrieveDataWithCredential_DEPRECATED");
   WaitForCompletion(user->Unlink_DEPRECATED(credential.provider().c_str()),
                     "Unlink");
   SignOut();
@@ -768,10 +766,10 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Save the old provider ID list so we can make sure it's the same once
   // it's loaded again.
   std::vector<std::string> prev_provider_data_ids;
-  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data().size();
+  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
        i++) {
     prev_provider_data_ids.push_back(
-        auth_->current_user_DEPRECATED()->provider_data()[i]->provider_id());
+        auth_->current_user_DEPRECATED()->provider_data_DEPRECATED()[i]->provider_id());
   }
   Terminate();
   ProcessEvents(2000);
@@ -782,10 +780,10 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Make sure the provider IDs are the same as they were before.
   EXPECT_EQ(auth_->current_user_DEPRECATED()->provider_id(), prev_provider_id);
   std::vector<std::string> loaded_provider_data_ids;
-  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data().size();
+  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
        i++) {
     loaded_provider_data_ids.push_back(
-        auth_->current_user_DEPRECATED()->provider_data()[i]->provider_id());
+        auth_->current_user_DEPRECATED()->provider_data_DEPRECATED()[i]->provider_id());
   }
   EXPECT_TRUE(loaded_provider_data_ids == prev_provider_data_ids);
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -255,7 +255,6 @@ void FirebaseAuthTest::SignOut() {
   auth_->SignOut();
   // Wait for the sign-out to finish.
   while (auth_->current_user_DEPRECATED() != nullptr) {
-    printf("process events...\n");
     if (ProcessEvents(100)) break;
   }
   ProcessEvents(100);

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -248,18 +248,18 @@ void FirebaseAuthTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (!auth_->current_user_DEPRECATED()->is_valid()) {
+  if (auth_->current_user_DEPRECATED() == nullptr) {
     // Already signed out.
     return;
   }
   auth_->SignOut();
   // Wait for the sign-out to finish.
-  while (auth_->current_user_DEPRECATED()->is_valid()) {
+  while (auth_->current_user_DEPRECATED() != nullptr) {
     printf("process events...\n");
     if (ProcessEvents(100)) break;
   }
   ProcessEvents(100);
-  EXPECT_EQ(auth_->current_user_DEPRECATED()->is_valid(), false);
+  EXPECT_EQ(auth_->current_user_DEPRECATED(), nullptr);
 }
 
 void FirebaseAuthTest::DeleteUser() {
@@ -514,8 +514,9 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
   firebase::auth::Credential credential =
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
-  WaitForCompletion(user->LinkAndRetrieveDataWithCredential_DEPRECATED(credential),
-                    "LinkAndRetrieveDataWithCredential_DEPRECATED");
+  WaitForCompletion(
+      user->LinkAndRetrieveDataWithCredential_DEPRECATED(credential),
+      "LinkAndRetrieveDataWithCredential_DEPRECATED");
   WaitForCompletion(user->Unlink_DEPRECATED(credential.provider().c_str()),
                     "Unlink");
   SignOut();
@@ -766,10 +767,12 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Save the old provider ID list so we can make sure it's the same once
   // it's loaded again.
   std::vector<std::string> prev_provider_data_ids;
-  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
+  for (int i = 0;
+       i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
        i++) {
-    prev_provider_data_ids.push_back(
-        auth_->current_user_DEPRECATED()->provider_data_DEPRECATED()[i]->provider_id());
+    prev_provider_data_ids.push_back(auth_->current_user_DEPRECATED()
+                                         ->provider_data_DEPRECATED()[i]
+                                         ->provider_id());
   }
   Terminate();
   ProcessEvents(2000);
@@ -780,10 +783,12 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
   // Make sure the provider IDs are the same as they were before.
   EXPECT_EQ(auth_->current_user_DEPRECATED()->provider_id(), prev_provider_id);
   std::vector<std::string> loaded_provider_data_ids;
-  for (int i = 0; i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
+  for (int i = 0;
+       i < auth_->current_user_DEPRECATED()->provider_data_DEPRECATED().size();
        i++) {
-    loaded_provider_data_ids.push_back(
-        auth_->current_user_DEPRECATED()->provider_data_DEPRECATED()[i]->provider_id());
+    loaded_provider_data_ids.push_back(auth_->current_user_DEPRECATED()
+                                           ->provider_data_DEPRECATED()[i]
+                                           ->provider_id());
   }
   EXPECT_TRUE(loaded_provider_data_ids == prev_provider_data_ids);
 

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -81,13 +81,13 @@ Auth* Auth::GetAuth(App* app, InitResult* init_result_out) {
 
   // Create a new Auth and initialize.
   Auth* auth = new Auth(app, auth_impl);
-  LogDebug("Creating Auth %p for App %p", auth, app);
 
   // Stick it in the global map so we remember it, and can delete it on
   // shutdown.
   g_auths[app] = auth;
 
   if (init_result_out) *init_result_out = kInitResultSuccess;
+
   return auth;
 }
 

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -87,7 +87,6 @@ Auth* Auth::GetAuth(App* app, InitResult* init_result_out) {
   g_auths[app] = auth;
 
   if (init_result_out) *init_result_out = kInitResultSuccess;
-
   return auth;
 }
 

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_COMMON_H_
 #define FIREBASE_AUTH_SRC_COMMON_H_
 
+#include <string>
+
 #include "auth/src/data.h"
 
 namespace firebase {

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -120,7 +120,7 @@ void LogHeartbeat(Auth* auth);
 
 // Returns true if `auth_data` has a user that's currently active.
 inline bool ValidUser(const AuthData* auth_data) {
-  return auth_data->user_deprecated.is_valid();
+  return auth_data->deprecated_fields.user_deprecated->is_valid();
 }
 
 // Notify all the listeners of the state change.

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -22,6 +22,11 @@
 namespace firebase {
 namespace auth {
 
+// Error messages used for completing futures. These match the error codes in
+// the AdErrorCode enumeration in the C++ API.
+extern const char* kUserNotInitializedErrorMessage;
+extern const char* kPhoneAuthNotSupportedErrorMessage;
+
 // Enumeration for Credential API functions that return a Future.
 // This allows us to hold a Future for the most recent call to that API.
 enum CredentialApiFunction {
@@ -29,6 +34,59 @@ enum CredentialApiFunction {
 
   kNumCredentialFunctions
 };
+
+// Hold backing data for returned Futures.
+struct FutureData {
+  explicit FutureData(int num_functions_that_return_futures)
+      : future_impl(num_functions_that_return_futures) {}
+
+  // Handle calls from Futures that the API returns.
+  ReferenceCountedFutureImpl future_impl;
+};
+
+template <class T>
+struct FutureCallbackData {
+  FutureData* future_data;
+  SafeFutureHandle<T> future_handle;
+};
+
+// Create a future and update the corresponding last result.
+template <class T>
+SafeFutureHandle<T> CreateFuture(int fn_idx, FutureData* future_data) {
+  return future_data->future_impl.SafeAlloc<T>(fn_idx);
+}
+
+// Mark a Future<void> as complete.
+void CompleteFuture(int error, const char* error_msg,
+                    SafeFutureHandle<void> handle, FutureData* future_data);
+
+// Mark a Future<std::string> as complete
+void CompleteFuture(int error, const char* error_msg,
+                    SafeFutureHandle<std::string> handle,
+                    FutureData* future_data, const std::string& result);
+
+// Mark a Future<User *> as complete
+void CompleteFuture(int error, const char* error_msg,
+                    SafeFutureHandle<User*> handle, FutureData* future_data,
+                    User* user);
+
+// Mark a Future<SignInResult> as complete
+void CompleteFuture(int error, const char* error_msg,
+                    SafeFutureHandle<SignInResult> handle,
+                    FutureData* future_data, SignInResult result);
+
+// For calls that aren't asynchronous, create and complete a Future<void> at
+// the same time.
+Future<void> CreateAndCompleteFuture(int fn_idx, int error,
+                                     const char* error_msg,
+                                     FutureData* future_data);
+
+// For calls that aren't asynchronous, create and complete a
+// Future<std::string> at the same time.
+Future<std::string> CreateAndCompleteFuture(int fn_idx, int error,
+                                            const char* error_msg,
+                                            FutureData* future_data,
+                                            const std::string& result);
 
 // Platform-specific method to create the wrapped Auth class.
 void* CreatePlatformAuth(App* app);
@@ -62,7 +120,7 @@ void LogHeartbeat(Auth* auth);
 
 // Returns true if `auth_data` has a user that's currently active.
 inline bool ValidUser(const AuthData* auth_data) {
-  return auth_data->user_impl != nullptr;
+  return auth_data->user_deprecated.is_valid();
 }
 
 // Notify all the listeners of the state change.

--- a/auth/src/data.h
+++ b/auth/src/data.h
@@ -41,7 +41,15 @@ enum AuthApiFunction {
   kAuthFn_CreateUserWithEmailAndPassword_DEPRECATED,
   kAuthFn_SendPasswordResetEmail,
 
-  // External functions in the User API.
+  // Internal functions that are still handles, but are only used internally:
+  kInternalFn_GetTokenForRefresher,
+  kInternalFn_GetTokenForFunctionRegistry,
+
+  kAuthFnCount
+};
+
+// Constants representing each User function that returns a Future.
+enum UserFn {
   kUserFn_GetToken,
   kUserFn_UpdateEmail,
   kUserFn_UpdatePassword,
@@ -51,7 +59,7 @@ enum AuthApiFunction {
   kUserFn_ConfirmEmailVerification,
   kUserFn_UpdateUserProfile,
   kUserFn_LinkWithCredential_DEPRECATED,
-  kUserFn_LinkAndRetrieveDataWithCredential,
+  kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED,
   kUserFn_LinkWithProvider_DEPRECATED,
   kUserFn_ReauthenticateWithProvider_DEPRECATED,
   kUserFn_Unlink_DEPRECATED,
@@ -59,11 +67,7 @@ enum AuthApiFunction {
   kUserFn_Reload,
   kUserFn_Delete,
 
-  // Internal functions that are still handles, but are only used internally:
-  kInternalFn_GetTokenForRefresher,
-  kInternalFn_GetTokenForFunctionRegistry,
-
-  kNumAuthFunctions
+  kUserFnCount
 };
 
 /// Delete all the user_infos in auth_data and reset the length to zero.
@@ -76,10 +80,9 @@ struct AuthData {
   AuthData()
       : app(nullptr),
         auth(nullptr),
-        future_impl(kNumAuthFunctions),
-        current_user(this),
+        future_impl(kAuthFnCount),
         auth_impl(nullptr),
-        user_impl(nullptr),
+        user_deprecated(nullptr),
         listener_impl(nullptr),
         id_token_listener_impl(nullptr),
         expect_id_token_listener_callback(false),
@@ -96,7 +99,6 @@ struct AuthData {
     app = nullptr;
     auth = nullptr;
     auth_impl = nullptr;
-    user_impl = nullptr;
     listener_impl = nullptr;
     id_token_listener_impl = nullptr;
   }
@@ -122,16 +124,13 @@ struct AuthData {
   /// Identifier used to track futures associated with future_impl.
   std::string future_api_id;
 
-  /// Unique user for this Auth. Note: we only support one user per Auth.
-  User current_user;
-
   /// Platform-dependent implementation of Auth (that we're wrapping).
   /// For example, on Android `jobject`.
   void* auth_impl;
 
   /// Platform-dependent implementation of User (that we're wrapping).
-  /// For example, on iOS `FIRUser`.
-  void* user_impl;
+  /// TODO: remove when Auth deprecation APIs are removed.
+  User user_deprecated;
 
   /// Platform-dependent implementation of AuthStateListener (that we're
   /// wrapping). For example, on Android `jobject`.

--- a/auth/src/data.h
+++ b/auth/src/data.h
@@ -27,6 +27,20 @@
 namespace firebase {
 namespace auth {
 
+// @deprecated
+//
+// Fields that should be removed when the Auth Breaking Changes Deprecation
+// window ends.
+struct AuthDataDeprecatedFields {
+  // Used to return User* objects from deprecated methods.
+  User* user_deprecated;
+
+  // Internal implementation of user_deprecated. This object's contains a
+  // pointer the platform specific user object, which is updated on User
+  // operations.
+  UserInternal* user_internal_deprecated;
+};
+
 // Enumeration for API functions that return a Future.
 // This allows us to hold a Future for the most recent call to that API.
 enum AuthApiFunction {
@@ -82,7 +96,6 @@ struct AuthData {
         auth(nullptr),
         future_impl(kAuthFnCount),
         auth_impl(nullptr),
-        user_deprecated(nullptr),
         listener_impl(nullptr),
         id_token_listener_impl(nullptr),
         expect_id_token_listener_callback(false),
@@ -118,6 +131,14 @@ struct AuthData {
   /// Backpointer to the external Auth class that holds this internal data.
   Auth* auth;
 
+  /// @deprecated Remove when Auth deprecation APIs are removed.
+  ///
+  /// Contains a User object that's updated whenever the current user changes.
+  /// This is used to return User* values from deprecated Auth and User
+  /// methods. These methods have been replaced with methods that return
+  /// Users by value (now that we can copy users.)
+  AuthDataDeprecatedFields deprecated_fields;
+
   /// Handle calls from Futures that the API returns.
   ReferenceCountedFutureImpl future_impl;
 
@@ -127,10 +148,6 @@ struct AuthData {
   /// Platform-dependent implementation of Auth (that we're wrapping).
   /// For example, on Android `jobject`.
   void* auth_impl;
-
-  /// Platform-dependent implementation of User (that we're wrapping).
-  /// TODO: remove when Auth deprecation APIs are removed.
-  User user_deprecated;
 
   /// Platform-dependent implementation of AuthStateListener (that we're
   /// wrapping). For example, on Android `jobject`.

--- a/auth/src/desktop/user_desktop.h
+++ b/auth/src/desktop/user_desktop.h
@@ -26,7 +26,51 @@
 namespace firebase {
 namespace auth {
 
-// LINT.IfChange
+class UserInternal {
+ public:
+  // The user's ID, unique to the Firebase project.
+  std::string uid;
+
+  // The associated email, if any.
+  std::string email;
+
+  // The display name, if any.
+  std::string display_name;
+
+  // Associated photo url, if any.
+  std::string photo_url;
+
+  // A provider ID for the user e.g. "Facebook".
+  std::string provider_id;
+
+  // The user's phone number, if any.
+  std::string phone_number;
+
+  // Whether is anonymous.
+  bool is_anonymous;
+
+  // Whether email is verified.
+  bool is_email_verified;
+
+  // Tokens for authentication and authorization.
+  std::string id_token;  // an authorization code or access_token
+  std::string refresh_token;
+  std::string access_token;
+
+  // The approximate expiration date of the access token.
+  std::time_t access_token_expiration_date;
+
+  // Whether or not the user can be authenticated by provider 'password'.
+  bool has_email_password_credential;
+
+  /// The last sign in UTC timestamp in milliseconds.
+  /// See https://en.wikipedia.org/wiki/Unix_time for details of UTC.
+  uint64_t last_sign_in_timestamp;
+
+  /// The Firebase user creation UTC timestamp in milliseconds.
+  uint64_t creation_timestamp;
+};
+
 // The desktop-specific UserInfo implementation.
 struct UserInfoImpl {
   // Note: since Visual Studio 2013 and below don't autogenerate move

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -48,6 +48,7 @@ struct AuthCompletionHandle;
 class FederatedAuthProvider;
 class FederatedOAuthProvider;
 struct SignInResult;
+class UserInternal;
 
 /// @brief Firebase authentication object.
 ///
@@ -877,9 +878,13 @@ class FederatedAuthProvider {
  private:
   friend class ::firebase::auth::Auth;
   friend class ::firebase::auth::User;
+  friend class ::firebase::auth::UserInternal;
+
   virtual Future<SignInResult> SignIn(AuthData* auth_data) = 0;
-  virtual Future<SignInResult> Link(AuthData* auth_data) = 0;
-  virtual Future<SignInResult> Reauthenticate(AuthData* auth_data) = 0;
+  virtual Future<SignInResult> Link(AuthData* auth_data,
+                                    UserInternal* user_internal) = 0;
+  virtual Future<SignInResult> Reauthenticate(AuthData* auth_data,
+                                              UserInternal* user_internal) = 0;
 };
 
 /// @brief Authenticates with Federated OAuth Providers via the
@@ -961,10 +966,13 @@ class FederatedOAuthProvider : public FederatedAuthProvider {
 
  private:
   friend class ::firebase::auth::Auth;
+  friend class ::firebase::auth::UserInternal;
 
   Future<SignInResult> SignIn(AuthData* auth_data) override;
-  Future<SignInResult> Link(AuthData* auth_data) override;
-  Future<SignInResult> Reauthenticate(AuthData* auth_data) override;
+  Future<SignInResult> Link(AuthData* auth_data,
+                            UserInternal* user_internal) override;
+  Future<SignInResult> Reauthenticate(AuthData* auth_data,
+                                      UserInternal* user_internal) override;
 
   FederatedOAuthProviderData provider_data_;
 #ifdef INTERNAL_EXPERIMENTAL

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -28,6 +28,7 @@ namespace firebase {
 
 // Predeclarations.
 class App;
+class UserInternal;
 
 /// @cond FIREBASE_APP_INTERNAL
 template <typename T>
@@ -109,6 +110,7 @@ class Credential {
   /// @cond FIREBASE_APP_INTERNAL
   friend class Auth;
   friend class User;
+  friend class UserInternal;
 
   /// Platform-specific implementation.
   /// For example, FIRAuthCredential* on iOS.

--- a/auth/src/include/firebase/auth/types.h
+++ b/auth/src/include/firebase/auth/types.h
@@ -428,6 +428,9 @@ enum AuthError {
   kAuthErrorTokenRefreshUnavailable,
 
 #endif  // INTERNAL_EXEPERIMENTAL
+
+  /// An operation was attempted on an invalid User.
+  kAuthErrorInvalidUser,
 };
 
 /// @brief Contains information required to authenticate with a third party

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -179,12 +179,6 @@ class User : public UserInfoInterface {
     const char* photo_url;
   };
 
-  // Internal only.
-  //
-  // Constructor of an internal opaque type. Memory ownership of UserInternal
-  // passes to to this User object.
-  User(AuthData* auth_data, UserInternal* user_internal);
-
   // Copy Constructor.
   User(const User&);
 
@@ -529,6 +523,15 @@ class User : public UserInfoInterface {
   virtual std::string phone_number() const;
 
  private:
+  // @deprecated User references to auth_data should only be needed during
+  // the Google I/O 23 breaking changes deprecation window.
+  //
+  // Internal only.
+  //
+  // Constructor of an internal opaque type. Memory ownership of UserInternal
+  // passes to to this User object.
+  User(AuthData* auth_data, UserInternal* user_internal);
+
   /// @cond FIREBASE_APP_INTERNAL
   friend struct AuthData;
 

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -31,6 +31,7 @@ namespace auth {
 
 // Predeclarations.
 class Auth;
+class UserInternal;
 struct AuthData;
 
 class FederatedAuthProvider;
@@ -62,7 +63,7 @@ class UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string uid() const = 0;
+  virtual std::string uid() const;
 
   /// Gets email associated with the user, if any.
   /// <SWIG>
@@ -72,7 +73,7 @@ class UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string email() const = 0;
+  virtual std::string email() const;
 
   /// Gets the display name associated with the user, if any.
   /// <SWIG>
@@ -82,7 +83,7 @@ class UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string display_name() const = 0;
+  virtual std::string display_name() const;
 
   /// Gets the photo url associated with the user, if any.
   /// <SWIG>
@@ -92,7 +93,7 @@ class UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string photo_url() const = 0;
+  virtual std::string photo_url() const;
 
   /// Gets the provider ID for the user (For example, "Facebook").
   /// <SWIG>
@@ -102,10 +103,10 @@ class UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  virtual std::string provider_id() const = 0;
+  virtual std::string provider_id() const;
 
   /// Gets the phone number for the user, in E.164 format.
-  virtual std::string phone_number() const = 0;
+  virtual std::string phone_number() const;
 };
 
 /// @brief Additional user data returned from an identity provider.
@@ -178,7 +179,24 @@ class User : public UserInfoInterface {
     const char* photo_url;
   };
 
+  // Internal only.
+  //
+  // Constructor of an internal opaque type. Memory ownership of UserInternal
+  // passes to to this User object.
+  User(UserInternal* user_internal);
+
+  // Copy Constructor.
+  User(const User&);
+
+  // Assignment Operator.
+  User& operator=(const User& user);
+
   ~User();
+
+  /// Returns whether this User object represents a valid user. Could be false
+  /// on Users contained with @ref AuthResult structures from failed Auth
+  /// operations.
+  bool is_valid() const;
 
   /// The Java Web Token (JWT) that can be used to identify the user to
   /// the backend.
@@ -214,7 +232,11 @@ class User : public UserInfoInterface {
   /// </csproperty>
   /// @endxmlonly
   /// </SWIG>
-  const std::vector<UserInfoInterface*>& provider_data() const;
+  std::vector<UserInfoInterface> provider_data() const;
+
+  /// @deprecated This is a deprecated method. Please use @ref provider_data
+  /// instead.
+  const std::vector<UserInfoInterface*>& provider_data_DEPRECATED();
 
   /// Sets the email address for the user.
   ///
@@ -332,6 +354,9 @@ class User : public UserInfoInterface {
   FIREBASE_DEPRECATED Future<User*> LinkWithCredentialLastResult_DEPRECATED()
       const;
 
+  /// @deprecated This is a deprecated method. Please use
+  /// @ref LinkAndRetrieveDataWithCredential(const Credential&) instead.
+  ///
   /// Links the user with the given 3rd party credentials.
   ///
   /// For example, a Facebook login access token, a Twitter token/token-secret
@@ -343,12 +368,15 @@ class User : public UserInfoInterface {
   ///
   /// Data from the Identity Provider used to sign-in is returned in the
   /// @ref AdditionalUserInfo inside @ref SignInResult.
-  Future<SignInResult> LinkAndRetrieveDataWithCredential(
-      const Credential& credential);
+  FIREBASE_DEPRECATED Future<SignInResult>
+  LinkAndRetrieveDataWithCredential_DEPRECATED(const Credential& credential);
 
+  /// @deprecated
+  ///
   /// Get results of the most recent call to
-  /// @ref LinkAndRetrieveDataWithCredential.
-  Future<SignInResult> LinkAndRetrieveDataWithCredentialLastResult() const;
+  /// @ref LinkAndRetrieveDataWithCredential_DEPRECATED.
+  FIREBASE_DEPRECATED Future<SignInResult>
+  LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED() const;
 
   /// @deprecated This is a deprecated method. Please use
   /// @ref LinkWithProvider(FederatedAuthProvider*) instead.
@@ -363,7 +391,7 @@ class User : public UserInfoInterface {
   /// @note: This operation is supported only on iOS, tvOS and Android
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
-  Future<SignInResult> LinkWithProvider_DEPRECATED(
+  FIREBASE_DEPRECATED Future<SignInResult> LinkWithProvider_DEPRECATED(
       FederatedAuthProvider* provider) const;
 
   /// @deprecated This is a deprecated method. Please use @ref Unlink(const
@@ -371,12 +399,12 @@ class User : public UserInfoInterface {
   ///
   /// Unlinks the current user from the provider specified.
   /// Status will be an error if the user is not linked to the given provider.
-  Future<User*> Unlink_DEPRECATED(const char* provider);
+  FIREBASE_DEPRECATED Future<User*> Unlink_DEPRECATED(const char* provider);
 
   /// @deprecated
   ///
   /// Get results of the most recent call to @ref Unlink.
-  Future<User*> UnlinkLastResult_DEPRECATED() const;
+  FIREBASE_DEPRECATED Future<User*> UnlinkLastResult_DEPRECATED() const;
 
   /// @deprecated This is a deprecated method. Please use
   /// @ref UpdatePhoneNumberCredential(const PhoneAuthCredential&) instead.
@@ -386,7 +414,7 @@ class User : public UserInfoInterface {
   /// shortcut to calling Unlink_DEPRECATED(phone_credential.provider().c_str())
   /// and then LinkWithCredential_DEPRECATED(phone_credential). `credential`
   /// must have been created with @ref PhoneAuthProvider.
-  Future<User*> UpdatePhoneNumberCredential_DEPRECATED(
+  FIREBASE_DEPRECATED Future<User*> UpdatePhoneNumberCredential_DEPRECATED(
       const Credential& credential);
 
   /// @deprecated
@@ -503,14 +531,6 @@ class User : public UserInfoInterface {
  private:
   /// @cond FIREBASE_APP_INTERNAL
   friend struct AuthData;
-  // Only exists in AuthData. Access via @ref Auth::CurrentUser().
-  explicit User(AuthData* auth_data) : auth_data_(auth_data) {}
-
-  // Disable copy constructor.
-  User(const User&) = delete;
-  // Disable copy operator.
-  User& operator=(const User&) = delete;
-  /// @endcond
 
 #if defined(INTERNAL_EXPERIMENTAL)
   // Doxygen should not make docs for this function.
@@ -525,6 +545,7 @@ class User : public UserInfoInterface {
 
   // Use the pimpl mechanism to hide data details in the cpp files.
   AuthData* auth_data_;
+  UserInternal* user_internal_;
 };
 
 }  // namespace auth

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -183,7 +183,7 @@ class User : public UserInfoInterface {
   //
   // Constructor of an internal opaque type. Memory ownership of UserInternal
   // passes to to this User object.
-  User(UserInternal* user_internal);
+  User(AuthData* auth_data, UserInternal* user_internal);
 
   // Copy Constructor.
   User(const User&);

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -179,10 +179,10 @@ class User : public UserInfoInterface {
     const char* photo_url;
   };
 
-  // Copy Constructor.
+  /// Copy Constructor.
   User(const User&);
 
-  // Assignment Operator.
+  /// Assignment Operator.
   User& operator=(const User& user);
 
   ~User();

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -156,7 +156,6 @@ void UpdateCurrentUser(AuthData *auth_data) {
 
 // Platform-specific method to initialize AuthData.
 void Auth::InitPlatformAuth(AuthData *auth_data) {
-
   // Create persistent User data to continue to facilitate deprecated aysnc
   // methods which return a pointer to a User. Remove this structure when those
   // deprecated methods are removed.

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -151,12 +151,19 @@ void *CreatePlatformAuth(App *app) {
 void UpdateCurrentUser(AuthData *auth_data) {
   MutexLock lock(auth_data->future_impl.mutex());
   FIRUser *user = [AuthImpl(auth_data) currentUser];
-  printf("UpdateCurrentUser calling SetUserImpl\n");
   SetUserImpl(auth_data, user);
 }
 
 // Platform-specific method to initialize AuthData.
 void Auth::InitPlatformAuth(AuthData *auth_data) {
+
+  // Create persistent User data to continue to facilitate deprecated aysnc
+  // methods which return a pointer to a User. Remove this structure when those
+  // deprecated methods are removed.
+  auth_data->deprecated_fields.user_internal_deprecated = new UserInternal((FIRUser *)nil);
+  auth_data->deprecated_fields.user_deprecated =
+      new User(auth_data, auth_data->deprecated_fields.user_internal_deprecated);
+
   FIRCPPAuthListenerHandle *listener_cpp_handle = [[FIRCPPAuthListenerHandle alloc] init];
   listener_cpp_handle.authData = auth_data;
   reinterpret_cast<AuthDataIos *>(auth_data->auth_impl)->listener_handle = listener_cpp_handle;
@@ -164,7 +171,6 @@ void Auth::InitPlatformAuth(AuthData *auth_data) {
   // auth state change.
   FIRAuthStateDidChangeListenerHandle listener_handle = [AuthImpl(auth_data)
       addAuthStateDidChangeListener:^(FIRAuth *_Nonnull __strong, FIRUser *_Nullable __strong) {
-        printf("addAuthStateDidChangeListener\n");
         @synchronized(listener_cpp_handle) {
           AuthData *data = listener_cpp_handle.authData;
           if (data) {
@@ -176,7 +182,6 @@ void Auth::InitPlatformAuth(AuthData *auth_data) {
   FIRIDTokenDidChangeListenerHandle id_token_listener_handle = [AuthImpl(auth_data)
       addIDTokenDidChangeListener:^(FIRAuth *_Nonnull __strong, FIRUser *_Nullable __strong) {
         @synchronized(listener_cpp_handle) {
-          printf("addIDTokenDidChangeListener\n");
           AuthData *data = listener_cpp_handle.authData;
           if (data) {
             UpdateCurrentUser(data);
@@ -193,7 +198,6 @@ void Auth::InitPlatformAuth(AuthData *auth_data) {
   // Ensure initial user value is correct.
   // It's possible for the user to be signed-in at creation, if the user signed-in during a
   // previous run, for example.
-  printf("InitPlatformAuth calling UpdateCurrentUser\n");
   UpdateCurrentUser(auth_data);
 }
 
@@ -220,8 +224,14 @@ void Auth::DestroyPlatformAuth(AuthData *auth_data) {
   delete id_token_listener_handle_holder;
   auth_data->id_token_listener_impl = nullptr;
 
-  printf("DestroyPlatformAuth calling SetUserImp\n");
   SetUserImpl(auth_data, nullptr);
+
+  auth_data->deprecated_fields.user_internal_deprecated = nullptr;
+
+  // This also deletes auth_data->deprecated_fields.user_internal_deprecated
+  // since User has ownership of the UserInternal allocation.
+  delete auth_data->deprecated_fields.user_deprecated;
+  auth_data->deprecated_fields.user_deprecated = nullptr;
 
   // Release the FIRAuth* that we allocated in CreatePlatformAuth().
   delete auth_data_ios;
@@ -260,24 +270,29 @@ Future<Auth::FetchProvidersResult> Auth::FetchProvidersForEmail(const char *emai
   return MakeFuture(&futures, handle);
 }
 
-// It's safe to return a direct pointer to `current_user` because that class
-// holds nothing but a pointer to AuthData, which never changes.
-// All User functions that require synchronization go through AuthData's mutex.
+// Support the deprecated current_user method by returning a pointer to the
+// User contained within Auth. This maintains the older behavior of
+// current_user() via  current_user_DEPRECATED throughout the deprecation
+// window.
 User *Auth::current_user_DEPRECATED() {
   if (!auth_data_) return nullptr;
   MutexLock lock(auth_data_->future_impl.mutex());
-  return &auth_data_->user_deprecated;
+  if (auth_data_->deprecated_fields.user_deprecated == nullptr ||
+      !auth_data_->deprecated_fields.user_deprecated->is_valid()) {
+    return nullptr;
+  } else {
+    return auth_data_->deprecated_fields.user_deprecated;
+  }
 }
 
 static User *AssignUser(FIRUser *_Nullable user, AuthData *auth_data) {
   // Update our pointer to the iOS user that we're wrapping.
   MutexLock lock(auth_data->future_impl.mutex());
   if (user) {
-    printf("Assign User calling SetUserImpl\n");
     SetUserImpl(auth_data, user);
   }
 
-  return &auth_data->user_deprecated;
+  return auth_data->deprecated_fields.user_deprecated;
 }
 
 std::string Auth::language_code() const {
@@ -317,19 +332,14 @@ AuthError AuthErrorFromNSError(NSError *_Nullable error) {
 void SignInCallback(FIRUser *_Nullable user, NSError *_Nullable error,
                     SafeFutureHandle<User *> handle, ReferenceCountedFutureImpl &future_impl,
                     AuthData *auth_data) {
-  printf("SignInCallback start\n");
   User *result = AssignUser(user, auth_data);
 
-  printf("SignInCallback checking for valid future\n");
   if (future_impl.ValidFuture(handle)) {
-    printf("SignInCallback completing future");
     // Finish off the asynchronous call so that the caller can read it.
     future_impl.CompleteWithResult(handle, AuthErrorFromNSError(error),
                                    util::NSStringToString(error.localizedDescription).c_str(),
                                    result);
-    printf("SignInCallback future completed\n");
   }
-  printf("SignInCallback done\n");
 }
 
 void SignInResultWithProviderCallback(
@@ -474,7 +484,6 @@ void Auth::SignOut() {
   // TODO(jsanmiya): Verify with iOS team why this returns an error.
   NSError *_Nullable error;
   [AuthImpl(auth_data_) signOut:&error];
-  printf("Auth::SignOut calling SetUserImpl\n");
   SetUserImpl(auth_data_, NULL);
 }
 

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -29,6 +29,7 @@
 #include "app/src/log.h"
 #include "app/src/util_ios.h"
 #include "auth/src/common.h"
+#include "auth/src/include/firebase/auth.h"
 #include "auth/src/include/firebase/auth/user.h"
 
 @class FIRCPPAuthListenerHandle;
@@ -50,25 +51,108 @@ struct AuthDataIos {
   FIRCPPAuthListenerHandlePointer listener_handle;
 };
 
-/// Convert from the platform-independent void* to the Obj-C FIRUser pointer.
-static inline FIRUser *_Nullable UserImpl(AuthData *_Nonnull auth_data) {
-  return FIRUserPointer::SafeGet(static_cast<FIRUserPointer *>(auth_data->user_impl));
-}
+// Contains the interface between the public API and the underlying
+// Obj-C SDK FirebaseUser implemention.
+class UserInternal {
+ public:
+  // Constructor
+  UserInternal(FIRUser *user);
 
-/// Release the platform-dependent FIRUser object.
-static inline void SetUserImpl(AuthData *_Nonnull auth_data, FIRUser *_Nullable user) {
+  // Copy constructor.
+  UserInternal(const UserInternal &user_internal);
+
+  ~UserInternal();
+
+  bool is_valid() const;
+
+  Future<std::string> GetToken(bool force_refresh);
+  Future<std::string> GetTokenLastResult() const;
+
+  Future<void> UpdateEmail(const char *email);
+  Future<void> UpdateEmailLastResult() const;
+
+  std::vector<UserInfoInterface> provider_data() const;
+  const std::vector<UserInfoInterface *> &provider_data_DEPRECATED();
+
+  Future<void> UpdatePassword(const char *password);
+  Future<void> UpdatePasswordLastResult() const;
+
+  Future<void> UpdateUserProfile(const User::UserProfile &profile);
+  Future<void> UpdateUserProfileLastResult() const;
+
+  Future<void> SendEmailVerification();
+  Future<void> SendEmailVerificationLastResult() const;
+
+  Future<User *> LinkWithCredential_DEPRECATED(AuthData *auth_data, const Credential &credential);
+  Future<User *> LinkWithCredentialLastResult_DEPRECATED() const;
+
+  Future<SignInResult> LinkAndRetrieveDataWithCredential_DEPRECATED(AuthData *auth_data_,
+                                                                    const Credential &credential);
+  Future<SignInResult> LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED() const;
+
+  Future<SignInResult> LinkWithProvider_DEPRECATED(AuthData *auth_data,
+                                                   FederatedAuthProvider *provider);
+  Future<SignInResult> LinkWithProviderLastResult_DEPRECATED() const;
+
+  Future<User *> Unlink_DEPRECATED(AuthData *auth_data, const char *provider);
+  Future<User *> UnlinkLastResult_DEPRECATED() const;
+
+  Future<User *> UpdatePhoneNumberCredential_DEPRECATED(AuthData *auth_data,
+                                                        const Credential &credential);
+  Future<User *> UpdatePhoneNumberCredentialLastResult_DEPRECATED() const;
+
+  Future<void> Reload();
+  Future<void> ReloadLastResult() const;
+
+  Future<void> Reauthenticate(const Credential &credential);
+  Future<void> ReauthenticateLastResult() const;
+
+  Future<SignInResult> ReauthenticateAndRetrieveData_DEPRECATED(AuthData *auth_data,
+                                                                const Credential &credential);
+  Future<SignInResult> ReauthenticateAndRetrieveDataLastResult_DEPRECATED() const;
+
+  Future<SignInResult> ReauthenticateWithProvider_DEPRECATED(AuthData *auth_data,
+                                                             FederatedAuthProvider *provider);
+  Future<SignInResult> ReauthenticateWithProviderLastResult_DEPRECATED() const;
+
+  Future<void> Delete(AuthData *auth_data);
+  Future<void> DeleteLastResult() const;
+
+  UserMetadata metadata() const;
+  bool is_email_verified() const;
+  bool is_anonymous() const;
+  std::string uid() const;
+  std::string email() const;
+  std::string display_name() const;
+  std::string phone_number() const;
+  std::string photo_url() const;
+  std::string provider_id() const;
+
+ private:
+  friend class firebase::auth::FederatedOAuthProvider;
+  friend class firebase::auth::User;
+
+  void clear_user_infos();
+
+  // Obj-c Implementation of a User object.
+  FIRUser *user_;
+
+  // Future data used to synchronize asynchronous calls.
+  FutureData future_data_;
+
+  // Used to support older method invocation of provider_data_DEPRECATED().
+  std::vector<UserInfoInterface *> user_infos_;
+
+  Mutex user_info_mutex_;
+};
+
+/// Replace the platform-dependent FIRUser object.
+/// Note: this function is only used to support DEPRECATED methods which return User*. This
+/// functionality should be removed when those deprecated methods are removed.
+static inline void SetUserImpl(AuthData *_Nonnull auth_data, FIRUser *_Nullable ios_user) {
+  printf("SetUserImpl, ios_user: %p  user_deprecated->is_valid(): %d\n", ios_user, auth_data->user_deprecated.is_valid());
   MutexLock lock(auth_data->future_impl.mutex());
-
-  // Delete existing pointer to FIRUser.
-  if (auth_data->user_impl != nullptr) {
-    delete static_cast<FIRUserPointer *>(auth_data->user_impl);
-    auth_data->user_impl = nullptr;
-  }
-
-  // Create new pointer to FIRUser.
-  if (user != nullptr) {
-    auth_data->user_impl = new FIRUserPointer(user);
-  }
+  auth_data->user_deprecated = User(new UserInternal(ios_user));
 }
 
 /// Convert from the platform-independent void* to the Obj-C FIRAuth pointer.
@@ -87,12 +171,14 @@ AuthError AuthErrorFromNSError(NSError *_Nullable error);
 /// Common code for all API calls that return a User*.
 /// Initialize `auth_data->current_user` and complete the `future`.
 void SignInCallback(FIRUser *_Nullable user, NSError *_Nullable error,
-                    SafeFutureHandle<User *> handle, AuthData *_Nonnull auth_data);
+                    SafeFutureHandle<User *> handle, ReferenceCountedFutureImpl &future_impl,
+                    AuthData *_Nonnull auth_data);
 
 /// Common code for all API calls that return a SignInResult.
 /// Initialize `auth_data->current_user` and complete the `future`.
 void SignInResultCallback(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error,
-                          SafeFutureHandle<SignInResult> handle, AuthData *_Nonnull auth_data);
+                          SafeFutureHandle<SignInResult> handle,
+                          ReferenceCountedFutureImpl &future_impl, AuthData *_Nonnull auth_data);
 
 /// Common code for all FederatedOAuth API calls which return a SignInResult and
 /// must hold a reference to a FIROAuthProvider so that the provider is not
@@ -101,6 +187,7 @@ void SignInResultCallback(FIRAuthDataResult *_Nullable auth_result, NSError *_Nu
 void SignInResultWithProviderCallback(FIRAuthDataResult *_Nullable auth_result,
                                       NSError *_Nullable error,
                                       SafeFutureHandle<SignInResult> handle,
+                                      ReferenceCountedFutureImpl &future_impl,
                                       AuthData *_Nonnull auth_data,
                                       const FIROAuthProvider *_Nonnull ios_auth_provider);
 

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -26,6 +26,9 @@
 #import "FIRUserInfo.h"
 #import "FIRUserMetadata.h"
 
+#include <string>
+#include <vector>
+
 #include "app/src/log.h"
 #include "app/src/util_ios.h"
 #include "auth/src/common.h"
@@ -56,7 +59,7 @@ struct AuthDataIos {
 class UserInternal {
  public:
   // Constructor
-  UserInternal(FIRUser *user);
+  explicit UserInternal(FIRUser *user);
 
   // Copy constructor.
   UserInternal(const UserInternal &user_internal);

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -287,7 +287,7 @@ class IOSWrappedUserInfo : public UserInfoInterface {
 UserInternal::UserInternal(FIRUser *user) : user_(user), future_data_(kUserFnCount) {}
 
 UserInternal::UserInternal(const UserInternal &user_internal)
-    : user_(user_internal.user_), future_data_(kUserFnCount) { }
+    : user_(user_internal.user_), future_data_(kUserFnCount) {}
 
 UserInternal::~UserInternal() {
   user_ = nil;

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -19,6 +19,7 @@
 
 #if FIREBASE_PLATFORM_IOS
 #import "FIRPhoneAuthCredential.h"
+#import "FIRUser.h"
 #endif
 
 namespace firebase {
@@ -29,108 +30,405 @@ using util::StringFromNSUrl;
 
 const char kInvalidCredentialMessage[] = "Credential is not a phone credential.";
 
+///
+/// User Class
+/// Platform specific implementation
+///
+User::User(UserInternal *user_internal) {
+  printf("User constructed %p internal: %p\n", this, user_internal);
+  if (user_internal == nullptr) {
+    // Create an invalid user internal.
+    // This will return is_valid() false, and operations will fail.
+    user_internal_ = new UserInternal(nullptr);
+  } else {
+    user_internal_ = user_internal;
+  }
+}
+
+User::~User() {
+  printf("User::~User() %p deleting user_internal_: %p\n", this, user_internal_);
+  delete user_internal_;
+  user_internal_ = nullptr;
+  auth_data_ = nullptr;
+}
+
+User &User::operator=(const User &user) {
+  printf("User operator= %p from %p deleting user_internal: %p\n", this, &user, user_internal_);
+  assert(user_internal_);
+  delete user_internal_;
+  if (user.user_internal_ != nullptr) {
+    user_internal_ = new UserInternal(user.user_internal_->user_);
+  } else {
+    user_internal_ = new UserInternal(nullptr);
+  }
+  auth_data_ = user.auth_data_;
+  return *this;
+}
+
+bool User::is_valid() const {
+  assert(user_internal_);
+  return user_internal_->is_valid();
+}
+
+Future<std::string> User::GetToken(bool force_refresh) {
+  assert(user_internal_);
+  return user_internal_->GetToken(force_refresh);
+}
+
+std::vector<UserInfoInterface> User::provider_data() const {
+  assert(user_internal_);
+  return user_internal_->provider_data();
+}
+
+const std::vector<UserInfoInterface *> &User::provider_data_DEPRECATED() {
+  assert(user_internal_);
+  return user_internal_->provider_data_DEPRECATED();
+}
+
+Future<void> User::UpdateEmail(const char *email) {
+  assert(user_internal_);
+  return user_internal_->UpdateEmail(email);
+}
+
+Future<void> User::UpdateEmailLastResult() const {
+  assert(user_internal_);
+  return user_internal_->UpdateEmailLastResult();
+}
+
+Future<void> User::UpdatePassword(const char *password) {
+  assert(user_internal_);
+  return user_internal_->UpdatePassword(password);
+}
+
+Future<void> User::UpdatePasswordLastResult() const {
+  assert(user_internal_);
+  return user_internal_->UpdatePasswordLastResult();
+}
+
+Future<void> User::Reauthenticate(const Credential &credential) {
+  assert(user_internal_);
+  return user_internal_->Reauthenticate(credential);
+}
+
+Future<void> User::ReauthenticateLastResult() const {
+  assert(user_internal_);
+  return user_internal_->ReauthenticateLastResult();
+}
+
+Future<SignInResult> User::ReauthenticateAndRetrieveData_DEPRECATED(const Credential &credential) {
+  assert(user_internal_);
+  return user_internal_->ReauthenticateAndRetrieveData_DEPRECATED(auth_data_, credential);
+}
+
+Future<SignInResult> User::ReauthenticateAndRetrieveDataLastResult_DEPRECATED() const {
+  assert(user_internal_);
+  return user_internal_->ReauthenticateAndRetrieveDataLastResult_DEPRECATED();
+}
+
+Future<SignInResult> User::ReauthenticateWithProvider_DEPRECATED(
+    FederatedAuthProvider *provider) const {
+  assert(user_internal_);
+  return user_internal_->ReauthenticateWithProvider_DEPRECATED(auth_data_, provider);
+}
+
+Future<void> User::SendEmailVerification() {
+  assert(user_internal_);
+  return user_internal_->SendEmailVerification();
+}
+
+Future<void> User::SendEmailVerificationLastResult() const {
+  assert(user_internal_);
+  return user_internal_->SendEmailVerificationLastResult();
+}
+
+Future<void> User::UpdateUserProfile(const UserProfile &profile) {
+  assert(user_internal_);
+  return user_internal_->UpdateUserProfile(profile);
+}
+
+Future<void> User::UpdateUserProfileLastResult() const {
+  assert(user_internal_);
+  return user_internal_->UpdateUserProfileLastResult();
+}
+
+Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential) {
+  assert(user_internal_);
+  return user_internal_->LinkWithCredential_DEPRECATED(auth_data_, credential);
+}
+
+Future<User *> User::LinkWithCredentialLastResult_DEPRECATED() const {
+  assert(user_internal_);
+  return user_internal_->LinkWithCredentialLastResult_DEPRECATED();
+}
+
+Future<SignInResult> User::LinkAndRetrieveDataWithCredential_DEPRECATED(
+    const Credential &credential) {
+  assert(user_internal_);
+  return user_internal_->LinkAndRetrieveDataWithCredential_DEPRECATED(auth_data_, credential);
+}
+
+Future<SignInResult> User::LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED() const {
+  assert(user_internal_);
+  return user_internal_->LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED();
+}
+
+Future<SignInResult> User::LinkWithProvider_DEPRECATED(FederatedAuthProvider *provider) const {
+  assert(user_internal_);
+  return user_internal_->LinkWithProvider_DEPRECATED(auth_data_, provider);
+}
+
+Future<User *> User::Unlink_DEPRECATED(const char *provider) {
+  assert(user_internal_);
+  return user_internal_->Unlink_DEPRECATED(auth_data_, provider);
+}
+
+Future<User *> User::UnlinkLastResult_DEPRECATED() const {
+  assert(user_internal_);
+  return user_internal_->UnlinkLastResult_DEPRECATED();
+}
+
+Future<User *> User::UpdatePhoneNumberCredential_DEPRECATED(const Credential &credential) {
+  assert(user_internal_);
+  return user_internal_->UpdatePhoneNumberCredential_DEPRECATED(auth_data_, credential);
+}
+
+Future<void> User::Reload() {
+  assert(user_internal_);
+  return user_internal_->Reload();
+}
+
+Future<void> User::ReloadLastResult() const {
+  assert(user_internal_);
+  return user_internal_->ReloadLastResult();
+}
+
+Future<void> User::Delete() {
+  assert(user_internal_);
+  return user_internal_->Delete(auth_data_);
+}
+
+Future<void> User::DeleteLastResult() const {
+  assert(user_internal_);
+  return user_internal_->DeleteLastResult();
+}
+
+UserMetadata User::metadata() const {
+  assert(user_internal_);
+  return user_internal_->metadata();
+}
+
+bool User::is_email_verified() const {
+  assert(user_internal_);
+  return user_internal_->is_email_verified();
+}
+
+bool User::is_anonymous() const {
+  assert(user_internal_);
+  return user_internal_->is_anonymous();
+}
+
+std::string User::uid() const {
+  assert(user_internal_);
+  return user_internal_->uid();
+}
+
+std::string User::email() const {
+  assert(user_internal_);
+  return user_internal_->email();
+}
+
+std::string User::display_name() const {
+  assert(user_internal_);
+  return user_internal_->display_name();
+}
+
+std::string User::photo_url() const {
+  assert(user_internal_);
+  return user_internal_->photo_url();
+}
+
+std::string User::provider_id() const {
+  assert(user_internal_);
+  return user_internal_->provider_id();
+}
+
+std::string User::phone_number() const {
+  assert(user_internal_);
+  return user_internal_->phone_number();
+}
+
+///
+/// IOSWrapperUserInfo Class
+///
 class IOSWrappedUserInfo : public UserInfoInterface {
  public:
   explicit IOSWrappedUserInfo(id<FIRUserInfo> user_info) : user_info_(user_info) {}
 
   virtual ~IOSWrappedUserInfo() { user_info_ = nil; }
 
-  virtual std::string uid() const { return StringFromNSString(user_info_.uid); }
+  std::string uid() const override { return StringFromNSString(user_info_.uid); }
 
-  virtual std::string email() const { return StringFromNSString(user_info_.email); }
+  std::string email() const override { return StringFromNSString(user_info_.email); }
 
-  virtual std::string display_name() const { return StringFromNSString(user_info_.displayName); }
+  std::string display_name() const override { return StringFromNSString(user_info_.displayName); }
 
-  virtual std::string phone_number() const { return StringFromNSString(user_info_.phoneNumber); }
+  std::string phone_number() const override { return StringFromNSString(user_info_.phoneNumber); }
 
-  virtual std::string photo_url() const { return StringFromNSUrl(user_info_.photoURL); }
+  std::string photo_url() const override { return StringFromNSUrl(user_info_.photoURL); }
 
-  virtual std::string provider_id() const { return StringFromNSString(user_info_.providerID); }
+  std::string provider_id() const override { return StringFromNSString(user_info_.providerID); }
 
  private:
-  /// Pointer to the main class.
-  /// Needed for context in implementation of virtuals.
   id<FIRUserInfo> user_info_;
 };
 
-User::~User() {
+///
+/// UserInternal Class
+///
+UserInternal::UserInternal(FIRUser *user) : user_(user), future_data_(kUserFnCount) {
+  printf("UserInternal constructed %p FIRUser: %p\n", this, user);
+}
+
+UserInternal::UserInternal(const UserInternal &user_internal)
+    : user_(user_internal.user_), future_data_(kUserFnCount) {
+      printf("UserInternal copy constructed: %p\n", this);
+}
+
+UserInternal::~UserInternal() {
+  printf("~UserInternal delete %p\n", this);
+  user_ = nil;
+  {
+    MutexLock user_info_lock(user_info_mutex_);
+    clear_user_infos();
+  }
   // Make sure we don't have any pending futures in flight before we disappear.
-  while (!auth_data_->future_impl.IsSafeToDelete()) {
+  while(!future_data_.future_impl.IsSafeToDelete()) {
     internal::Sleep(100);
   }
+  printf("~UserInternal delete %p done.\n", this);
 }
 
-Future<std::string> User::GetToken(bool force_refresh) {
-  if (!ValidUser(auth_data_)) {
-    return Future<std::string>();
+bool UserInternal::is_valid() const { return user_ != nil; }
+
+void UserInternal::clear_user_infos() {
+  for (size_t i = 0; i < user_infos_.size(); ++i) {
+    delete user_infos_[i];
+    user_infos_[i] = nullptr;
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<std::string>(kUserFn_GetToken);
-  [UserImpl(auth_data_)
-      getIDTokenForcingRefresh:force_refresh
-                    completion:^(NSString *_Nullable token, NSError *_Nullable error) {
-                      futures.Complete(handle, AuthErrorFromNSError(error),
-                                       [error.localizedDescription UTF8String],
-                                       [token](std::string *data) {
-                                         data->assign(token == nullptr ? "" : [token UTF8String]);
-                                       });
-                    }];
-  return MakeFuture(&futures, handle);
+  user_infos_.clear();
 }
 
-const std::vector<UserInfoInterface *> &User::provider_data() const {
-  ClearUserInfos(auth_data_);
+Future<std::string> UserInternal::GetToken(bool force_refresh) {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_GetToken, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_, "");
+  }
 
-  if (ValidUser(auth_data_)) {
-    NSArray<id<FIRUserInfo>> *provider_data = UserImpl(auth_data_).providerData;
+  FutureCallbackData<std::string> *callback_data = new FutureCallbackData<std::string>{
+      &future_data_, future_data_.future_impl.SafeAlloc<std::string>(kUserFn_GetToken)};
+  Future<std::string> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
 
-    // Wrap the FIRUserInfos in our IOSWrappedUserInfo class.
-    auth_data_->user_infos.resize(provider_data.count);
+  [user_ getIDTokenForcingRefresh:force_refresh
+                       completion:^(NSString *_Nullable token, NSError *_Nullable error) {
+                         callback_data->future_data->future_impl.Complete(
+                             callback_data->future_handle, AuthErrorFromNSError(error),
+                             [error.localizedDescription UTF8String], [token](std::string *data) {
+                               data->assign(token == nullptr ? "" : [token UTF8String]);
+                             });
+                         delete callback_data;
+                       }];
+  return future;
+}
+
+std::vector<UserInfoInterface> UserInternal::provider_data() const {
+  std::vector<UserInfoInterface> local_user_infos;
+  if (is_valid()) {
+    NSArray<id<FIRUserInfo>> *provider_data = user_.providerData;
+    local_user_infos.resize(provider_data.count);
     for (size_t i = 0; i < provider_data.count; ++i) {
-      auth_data_->user_infos[i] = new IOSWrappedUserInfo(provider_data[i]);
+      local_user_infos[i] = IOSWrappedUserInfo(provider_data[i]);
+    }
+  }
+  return local_user_infos;
+}
+
+const std::vector<UserInfoInterface *> &UserInternal::provider_data_DEPRECATED() {
+  MutexLock user_info_lock(user_info_mutex_);
+  clear_user_infos();
+  if (is_valid()) {
+    NSArray<id<FIRUserInfo>> *provider_data = user_.providerData;
+    user_infos_.resize(provider_data.count);
+    for (size_t i = 0; i < provider_data.count; ++i) {
+      user_infos_[i] = new IOSWrappedUserInfo(provider_data[i]);
     }
   }
 
   // Return a reference to our internally-backed values.
-  return auth_data_->user_infos;
+  return user_infos_;
 }
 
-Future<void> User::UpdateEmail(const char *email) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
+Future<void> UserInternal::UpdateEmail(const char *email) {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_UpdateEmail, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdateEmail);
-  [UserImpl(auth_data_) updateEmail:@(email)
-                         completion:^(NSError *_Nullable error) {
-                           futures.Complete(handle, AuthErrorFromNSError(error),
-                                            [error.localizedDescription UTF8String]);
-                         }];
-  return MakeFuture(&futures, handle);
+
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_UpdateEmail)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ updateEmail:@(email)
+          completion:^(NSError *_Nullable error) {
+            callback_data->future_data->future_impl.Complete(
+                callback_data->future_handle, AuthErrorFromNSError(error),
+                [error.localizedDescription UTF8String]);
+            delete callback_data;
+          }];
+  return future;
 }
 
-Future<void> User::UpdatePassword(const char *password) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
-  }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdatePassword);
-  [UserImpl(auth_data_) updatePassword:@(password)
-                            completion:^(NSError *_Nullable error) {
-                              futures.Complete(handle, AuthErrorFromNSError(error),
-                                               [error.localizedDescription UTF8String]);
-                            }];
-  return MakeFuture(&futures, handle);
+Future<void> UserInternal::UpdateEmailLastResult() const {
+  return static_cast<const Future<void> &>(
+      future_data_.future_impl.LastResult(kUserFn_UpdateEmail));
 }
 
-Future<void> User::UpdateUserProfile(const UserProfile &profile) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
+Future<void> UserInternal::UpdatePassword(const char *password) {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_UpdatePassword, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdateUserProfile);
+
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_UpdatePassword)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ updatePassword:@(password)
+             completion:^(NSError *_Nullable error) {
+               callback_data->future_data->future_impl.Complete(
+                   callback_data->future_handle, AuthErrorFromNSError(error),
+                   [error.localizedDescription UTF8String]);
+               delete callback_data;
+             }];
+  return future;
+}
+
+Future<void> UserInternal::UpdatePasswordLastResult() const {
+  return static_cast<const Future<void> &>(
+      future_data_.future_impl.LastResult(kUserFn_UpdatePassword));
+}
+
+Future<void> UserInternal::UpdateUserProfile(const User::UserProfile &profile) {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_UpdateUserProfile, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
+  }
+
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_UpdateUserProfile)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
   // Create and populate the change request.
-  FIRUserProfileChangeRequest *request = [UserImpl(auth_data_) profileChangeRequest];
+  FIRUserProfileChangeRequest *request = [user_ profileChangeRequest];
   if (profile.display_name != nullptr) {
     request.displayName = @(profile.display_name);
   }
@@ -143,174 +441,307 @@ Future<void> User::UpdateUserProfile(const UserProfile &profile) {
 
   // Execute the change request.
   [request commitChangesWithCompletion:^(NSError *_Nullable error) {
-    futures.Complete(handle, AuthErrorFromNSError(error), [error.localizedDescription UTF8String]);
+    callback_data->future_data->future_impl.Complete(callback_data->future_handle,
+                                                     AuthErrorFromNSError(error),
+                                                     [error.localizedDescription UTF8String]);
+    delete callback_data;
   }];
-  return MakeFuture(&futures, handle);
+
+  return future;
 }
 
-Future<void> User::SendEmailVerification() {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
+Future<void> UserInternal::UpdateUserProfileLastResult() const {
+  return static_cast<const Future<void> &>(
+      future_data_.future_impl.LastResult(kUserFn_UpdateUserProfile));
+}
+
+Future<void> UserInternal::SendEmailVerification() {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_SendEmailVerification, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_SendEmailVerification);
-  [UserImpl(auth_data_) sendEmailVerificationWithCompletion:^(NSError *_Nullable error) {
-    futures.Complete(handle, AuthErrorFromNSError(error), [error.localizedDescription UTF8String]);
+
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_SendEmailVerification)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ sendEmailVerificationWithCompletion:^(NSError *_Nullable error) {
+    callback_data->future_data->future_impl.Complete(callback_data->future_handle,
+                                                     AuthErrorFromNSError(error),
+                                                     [error.localizedDescription UTF8String]);
+    delete callback_data;
   }];
-  return MakeFuture(&futures, handle);
+
+  return future;
 }
 
-Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential) {
-  if (!ValidUser(auth_data_)) {
-    return Future<User *>();
+Future<void> UserInternal::SendEmailVerificationLastResult() const {
+  return static_cast<const Future<void> &>(
+      future_data_.future_impl.LastResult(kUserFn_SendEmailVerification));
+}
+
+Future<User *> UserInternal::LinkWithCredential_DEPRECATED(AuthData *auth_data,
+                                                           const Credential &credential) {
+  if (!is_valid()) {
+    SafeFutureHandle<User *> future_handle =
+        future_data_.future_impl.SafeAlloc<User *>(kUserFn_LinkWithCredential_DEPRECATED);
+    Future<User *> future = MakeFuture(&future_data_.future_impl, future_handle);
+    CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                   &future_data_, (User *)nullptr);
+    return future;
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<User *>(kUserFn_LinkWithCredential_DEPRECATED);
-  [UserImpl(auth_data_)
-      linkWithCredential:CredentialFromImpl(credential.impl_)
-              completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
-                SignInCallback(auth_result.user, error, handle, auth_data_);
-              }];
-  return MakeFuture(&futures, handle);
+
+  FutureCallbackData<User *> *callback_data = new FutureCallbackData<User *>{
+      &future_data_,
+      future_data_.future_impl.SafeAlloc<User *>(kUserFn_LinkWithCredential_DEPRECATED)};
+  Future<User *> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ linkWithCredential:CredentialFromImpl(credential.impl_)
+                 completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
+                   SignInCallback(auth_result.user, error, callback_data->future_handle,
+                                  callback_data->future_data->future_impl, auth_data);
+                   delete callback_data;
+                 }];
+  return future;
 }
 
-Future<SignInResult> User::LinkAndRetrieveDataWithCredential(const Credential &credential) {
-  if (!ValidUser(auth_data_)) {
-    return Future<SignInResult>();
+Future<User *> UserInternal::LinkWithCredentialLastResult_DEPRECATED() const {
+  return static_cast<const Future<User *> &>(
+      future_data_.future_impl.LastResult(kUserFn_LinkWithCredential_DEPRECATED));
+}
+
+Future<SignInResult> UserInternal::LinkAndRetrieveDataWithCredential_DEPRECATED(
+    AuthData *auth_data, const Credential &credential) {
+  if (!is_valid()) {
+    SafeFutureHandle<SignInResult> future_handle = future_data_.future_impl.SafeAlloc<SignInResult>(
+        kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED);
+    Future<SignInResult> future = MakeFuture(&future_data_.future_impl, future_handle);
+    CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                   &future_data_, SignInResult());
+    return future;
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
-      kUserFn_LinkAndRetrieveDataWithCredential, SignInResult());
-  [UserImpl(auth_data_)
-      linkWithCredential:CredentialFromImpl(credential.impl_)
-              completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
-                SignInResultCallback(auth_result, error, handle, auth_data_);
-              }];
-  return MakeFuture(&futures, handle);
+
+  FutureCallbackData<SignInResult> *callback_data = new FutureCallbackData<SignInResult>{
+      &future_data_, future_data_.future_impl.SafeAlloc<SignInResult>(
+                         kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED)};
+  Future<SignInResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ linkWithCredential:CredentialFromImpl(credential.impl_)
+                 completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
+                   SignInResultCallback(auth_result, error, callback_data->future_handle,
+                                        callback_data->future_data->future_impl, auth_data);
+                   delete callback_data;
+                 }];
+  return future;
 }
 
-Future<SignInResult> User::LinkWithProvider_DEPRECATED(FederatedAuthProvider *provider) const {
+Future<SignInResult> UserInternal::LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED() const {
+  return static_cast<const Future<SignInResult> &>(
+      future_data_.future_impl.LastResult(kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED));
+}
+
+Future<SignInResult> UserInternal::LinkWithProvider_DEPRECATED(AuthData *auth_data,
+                                                               FederatedAuthProvider *provider) {
   FIREBASE_ASSERT_RETURN(Future<SignInResult>(), provider);
-  return provider->Link(auth_data_);
+  return provider->Link(auth_data, this);
 }
 
-Future<User *> User::Unlink_DEPRECATED(const char *provider) {
-  if (!ValidUser(auth_data_)) {
-    return Future<User *>();
+Future<User *> UserInternal::Unlink_DEPRECATED(AuthData *auth_data, const char *provider) {
+  if (!is_valid()) {
+    SafeFutureHandle<User *> future_handle =
+        future_data_.future_impl.SafeAlloc<User *>(kUserFn_Unlink_DEPRECATED);
+    Future<User *> future = MakeFuture(&future_data_.future_impl, future_handle);
+    CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                   &future_data_, (User *)nullptr);
+    return future;
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<User *>(kUserFn_Unlink_DEPRECATED);
-  [UserImpl(auth_data_) unlinkFromProvider:@(provider)
-                                completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
-                                  SignInCallback(user, error, handle, auth_data_);
-                                }];
-  return MakeFuture(&futures, handle);
+
+  FutureCallbackData<User *> *callback_data = new FutureCallbackData<User *>{
+      &future_data_, future_data_.future_impl.SafeAlloc<User *>(kUserFn_Unlink_DEPRECATED)};
+  Future<User *> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ unlinkFromProvider:@(provider)
+                 completion:^(FIRUser *_Nullable user, NSError *_Nullable error) {
+                   SignInCallback(user, error, callback_data->future_handle,
+                                  callback_data->future_data->future_impl, auth_data);
+                   delete callback_data;
+                 }];
+  return future;
 }
 
-Future<User *> User::UpdatePhoneNumberCredential_DEPRECATED(const Credential &credential) {
-  if (!ValidUser(auth_data_)) {
-    return Future<User *>();
-  }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<User *>(kUserFn_UpdatePhoneNumberCredential_DEPRECATED);
+Future<User *> UserInternal::UnlinkLastResult_DEPRECATED() const {
+  return static_cast<const Future<User *> &>(
+      future_data_.future_impl.LastResult(kUserFn_Unlink_DEPRECATED));
+}
 
+Future<User *> UserInternal::UpdatePhoneNumberCredential_DEPRECATED(AuthData *auth_data,
+                                                                    const Credential &credential) {
 #if FIREBASE_PLATFORM_IOS
+  if (!is_valid()) {
+    SafeFutureHandle<User *> future_handle =
+        future_data_.future_impl.SafeAlloc<User *>(kUserFn_UpdatePhoneNumberCredential_DEPRECATED);
+    Future<User *> future = MakeFuture(&future_data_.future_impl, future_handle);
+    CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                   &future_data_, (User *)nullptr);
+    return future;
+  }
+
+  FutureCallbackData<User *> *callback_data = new FutureCallbackData<User *>{
+      &future_data_,
+      future_data_.future_impl.SafeAlloc<User *>(kUserFn_UpdatePhoneNumberCredential_DEPRECATED)};
+  Future<User *> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
   FIRAuthCredential *objc_credential = CredentialFromImpl(credential.impl_);
   if ([objc_credential isKindOfClass:[FIRPhoneAuthCredential class]]) {
-    [UserImpl(auth_data_)
-        updatePhoneNumberCredential:(FIRPhoneAuthCredential *)objc_credential
-                         completion:^(NSError *_Nullable error) {
-                           futures.Complete(handle, AuthErrorFromNSError(error),
-                                            [error.localizedDescription UTF8String]);
-                         }];
+    [user_ updatePhoneNumberCredential:(FIRPhoneAuthCredential *)objc_credential
+                            completion:^(NSError *_Nullable error) {
+                              SignInCallback(user_, error, callback_data->future_handle,
+                                             callback_data->future_data->future_impl, auth_data);
+                              delete callback_data;
+                            }];
   } else {
-    futures.Complete(handle, kAuthErrorInvalidCredential, kInvalidCredentialMessage);
+    CompleteFuture(kAuthErrorInvalidCredential, kInvalidCredentialMessage,
+                   callback_data->future_handle, &future_data_, (User *)nullptr);
   }
+  return future;
 
 #else   // non iOS Apple platforms (eg: tvOS).
-  futures.Complete(handle, kAuthErrorApiNotAvailable,
-                   "Phone Auth is not supported on non-iOS apple platforms.");
+  SafeFutureHandle<User *> future_handle =
+      future_data_.future_impl.SafeAlloc<User *>(kUserFn_UpdatePhoneNumberCredential_DEPRECATED);
+  Future<User *> future = MakeFuture(&future_data_.future_impl, future_handle);
+  CompleteFuture(kAuthErrorApiNotAvailable, kPhoneAuthNotSupportedErrorMessage, future_handle,
+                 &future_data_, (User *)nullptr);
+  return future;
 #endif  // FIREBASE_PLATFORM_IOS
-
-  return MakeFuture(&futures, handle);
 }
 
-Future<void> User::Reload() {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
+Future<void> UserInternal::Reload() {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_Reload, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_Reload);
 
-  [UserImpl(auth_data_) reloadWithCompletion:^(NSError *_Nullable error) {
-    futures.Complete(handle, AuthErrorFromNSError(error), [error.localizedDescription UTF8String]);
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_Reload)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ reloadWithCompletion:^(NSError *_Nullable error) {
+    callback_data->future_data->future_impl.Complete(callback_data->future_handle,
+                                                     AuthErrorFromNSError(error),
+                                                     [error.localizedDescription UTF8String]);
+    delete callback_data;
   }];
-  return MakeFuture(&futures, handle);
+  return future;
 }
 
-Future<void> User::Reauthenticate(const Credential &credential) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
-  }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_Reauthenticate);
+Future<void> UserInternal::ReloadLastResult() const {
+  return static_cast<const Future<void> &>(future_data_.future_impl.LastResult(kUserFn_Reload));
+}
 
-  [UserImpl(auth_data_)
+Future<void> UserInternal::Reauthenticate(const Credential &credential) {
+  if (!is_valid()) {
+    return CreateAndCompleteFuture(kUserFn_Reauthenticate, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
+  }
+
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_Reauthenticate)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ reauthenticateWithCredential:CredentialFromImpl(credential.impl_)
+                           completion:^(FIRAuthDataResult *_Nullable auth_result,
+                                        NSError *_Nullable error) {
+                             callback_data->future_data->future_impl.Complete(
+                                 callback_data->future_handle, AuthErrorFromNSError(error),
+                                 [error.localizedDescription UTF8String]);
+                             delete callback_data;
+                           }];
+  return future;
+}
+
+Future<void> UserInternal::ReauthenticateLastResult() const {
+  return static_cast<const Future<void> &>(
+      future_data_.future_impl.LastResult(kUserFn_Reauthenticate));
+}
+
+Future<SignInResult> UserInternal::ReauthenticateAndRetrieveData_DEPRECATED(
+    AuthData *auth_data, const Credential &credential) {
+  if (!is_valid()) {
+    SafeFutureHandle<SignInResult> future_handle = future_data_.future_impl.SafeAlloc<SignInResult>(
+        kUserFn_ReauthenticateAndRetrieveData_DEPRECATED);
+    Future<SignInResult> future = MakeFuture(&future_data_.future_impl, future_handle);
+    CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                   &future_data_, SignInResult());
+    return future;
+  }
+
+  FutureCallbackData<SignInResult> *callback_data = new FutureCallbackData<SignInResult>{
+      &future_data_, future_data_.future_impl.SafeAlloc<SignInResult>(
+                         kUserFn_ReauthenticateAndRetrieveData_DEPRECATED)};
+  Future<SignInResult> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_
       reauthenticateWithCredential:CredentialFromImpl(credential.impl_)
                         completion:^(FIRAuthDataResult *_Nullable auth_result,
                                      NSError *_Nullable error) {
-                          futures.Complete(handle, AuthErrorFromNSError(error),
-                                           [error.localizedDescription UTF8String]);
+                          SignInResultCallback(auth_result, error, callback_data->future_handle,
+                                               callback_data->future_data->future_impl, auth_data);
+                          delete callback_data;
                         }];
-  return MakeFuture(&futures, handle);
+  return future;
 }
 
-Future<SignInResult> User::ReauthenticateAndRetrieveData_DEPRECATED(const Credential &credential) {
-  if (!ValidUser(auth_data_)) {
-    return Future<SignInResult>();
-  }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
-      kUserFn_ReauthenticateAndRetrieveData_DEPRECATED, SignInResult());
-
-  [UserImpl(auth_data_)
-      reauthenticateWithCredential:CredentialFromImpl(credential.impl_)
-                        completion:^(FIRAuthDataResult *_Nullable auth_result,
-                                     NSError *_Nullable error) {
-                          SignInResultCallback(auth_result, error, handle, auth_data_);
-                        }];
-  return MakeFuture(&futures, handle);
+Future<SignInResult> UserInternal::ReauthenticateAndRetrieveDataLastResult_DEPRECATED() const {
+  return static_cast<const Future<SignInResult> &>(
+      future_data_.future_impl.LastResult(kUserFn_ReauthenticateAndRetrieveData_DEPRECATED));
 }
 
-Future<SignInResult> User::ReauthenticateWithProvider_DEPRECATED(
-    FederatedAuthProvider *provider) const {
+Future<SignInResult> UserInternal::ReauthenticateWithProvider_DEPRECATED(
+    AuthData *auth_data, FederatedAuthProvider *provider) {
   FIREBASE_ASSERT_RETURN(Future<SignInResult>(), provider);
-  return provider->Reauthenticate(auth_data_);
+  return provider->Reauthenticate(auth_data, this);
 }
 
-Future<void> User::Delete() {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
+Future<void> UserInternal::Delete(AuthData *auth_data) {
+  printf("DEDB UserInternal::Delete() Start (UserInternal: %p) user_: %p\n", this, user_);
+  if (!is_valid()) {
+    printf("DEDB UserInternal::Delete() is not valid\n");
+    return CreateAndCompleteFuture(kUserFn_Delete, kAuthErrorInvalidUser,
+                                   kUserNotInitializedErrorMessage, &future_data_);
   }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_Delete);
 
-  [UserImpl(auth_data_) deleteWithCompletion:^(NSError *_Nullable error) {
+  FutureCallbackData<void> *callback_data = new FutureCallbackData<void>{
+      &future_data_, future_data_.future_impl.SafeAlloc<void>(kUserFn_Delete)};
+  Future<void> future = MakeFuture(&future_data_.future_impl, callback_data->future_handle);
+
+  [user_ deleteWithCompletion:^(NSError *_Nullable error) {
+    printf("UserInternal::Delete user completion\n");
     if (!error) {
-      UpdateCurrentUser(auth_data_);
-      futures.Complete(handle, kAuthErrorNone, "");
+      printf("UserInternal::Delete user no error\n");
+      callback_data->future_data->future_impl.Complete(callback_data->future_handle, kAuthErrorNone,
+                                                       "");
     } else {
-      futures.Complete(handle, AuthErrorFromNSError(error),
-                       [error.localizedDescription UTF8String]);
+      printf("UserInternal::Delete user error\n");
+      callback_data->future_data->future_impl.Complete(callback_data->future_handle,
+                                                       AuthErrorFromNSError(error),
+                                                       [error.localizedDescription UTF8String]);
     }
+    printf("UserInternal::Delete user future complete, deleting callback data\n");
+    delete callback_data;
+    printf("UserInternal::Delete user future complete, callback data deleted\n");
   }];
-  return MakeFuture(&futures, handle);
+  printf("UserInternal::Delete user Done, returning future\n");
+  return future;
 }
 
-UserMetadata User::metadata() const {
-  if (!ValidUser(auth_data_)) return UserMetadata();
+Future<void> UserInternal::DeleteLastResult() const {
+  return static_cast<const Future<void> &>(future_data_.future_impl.LastResult(kUserFn_Delete));
+}
 
-  FIRUserMetadata *meta = UserImpl(auth_data_).metadata;
+UserMetadata UserInternal::metadata() const {
+  if (!is_valid()) return UserMetadata();
+
+  FIRUserMetadata *meta = user_.metadata;
   if (!meta) return UserMetadata();
 
   UserMetadata data;
@@ -323,36 +754,30 @@ UserMetadata User::metadata() const {
   return data;
 }
 
-bool User::is_email_verified() const {
-  return ValidUser(auth_data_) ? UserImpl(auth_data_).emailVerified : false;
+bool UserInternal::is_email_verified() const { return is_valid() ? user_.emailVerified : false; }
+
+bool UserInternal::is_anonymous() const { return is_valid() ? user_.anonymous : false; }
+
+std::string UserInternal::uid() const { return is_valid() ? StringFromNSString(user_.uid) : ""; }
+
+std::string UserInternal::email() const {
+  return is_valid() ? StringFromNSString(user_.email) : "";
 }
 
-bool User::is_anonymous() const {
-  return ValidUser(auth_data_) ? UserImpl(auth_data_).anonymous : false;
+std::string UserInternal::display_name() const {
+  return is_valid() ? StringFromNSString(user_.displayName) : "";
 }
 
-std::string User::uid() const {
-  return ValidUser(auth_data_) ? StringFromNSString(UserImpl(auth_data_).uid) : "";
+std::string UserInternal::phone_number() const {
+  return is_valid() ? StringFromNSString(user_.phoneNumber) : "";
 }
 
-std::string User::email() const {
-  return ValidUser(auth_data_) ? StringFromNSString(UserImpl(auth_data_).email) : "";
+std::string UserInternal::photo_url() const {
+  return is_valid() ? StringFromNSUrl(user_.photoURL) : "";
 }
 
-std::string User::display_name() const {
-  return ValidUser(auth_data_) ? StringFromNSString(UserImpl(auth_data_).displayName) : "";
-}
-
-std::string User::phone_number() const {
-  return ValidUser(auth_data_) ? StringFromNSString(UserImpl(auth_data_).phoneNumber) : "";
-}
-
-std::string User::photo_url() const {
-  return ValidUser(auth_data_) ? StringFromNSUrl(UserImpl(auth_data_).photoURL) : "";
-}
-
-std::string User::provider_id() const {
-  return ValidUser(auth_data_) ? StringFromNSString(UserImpl(auth_data_).providerID) : "";
+std::string UserInternal::provider_id() const {
+  return is_valid() ? StringFromNSString(user_.providerID) : "";
 }
 
 }  // namespace auth

--- a/auth/src/user.cc
+++ b/auth/src/user.cc
@@ -19,20 +19,12 @@
 namespace firebase {
 namespace auth {
 
-AUTH_RESULT_FN(User, GetToken, std::string)
-AUTH_RESULT_FN(User, UpdateEmail, void)
-AUTH_RESULT_FN(User, UpdatePassword, void)
-AUTH_RESULT_FN(User, Reauthenticate, void)
-AUTH_RESULT_FN(User, SendEmailVerification, void)
-AUTH_RESULT_FN(User, UpdateUserProfile, void)
-AUTH_RESULT_FN(User, LinkAndRetrieveDataWithCredential, SignInResult)
-AUTH_RESULT_FN(User, Reload, void)
-AUTH_RESULT_FN(User, Delete, void)
-
-AUTH_RESULT_DEPRECATED_FN(User, ReauthenticateAndRetrieveData, SignInResult)
-AUTH_RESULT_DEPRECATED_FN(User, LinkWithCredential, User*)
-AUTH_RESULT_DEPRECATED_FN(User, Unlink, User*)
-AUTH_RESULT_DEPRECATED_FN(User, UpdatePhoneNumberCredential, User*)
+std::string UserInfoInterface::uid() const { return ""; }
+std::string UserInfoInterface::email() const { return ""; }
+std::string UserInfoInterface::display_name() const { return ""; }
+std::string UserInfoInterface::photo_url() const { return ""; }
+std::string UserInfoInterface::provider_id() const { return ""; }
+std::string UserInfoInterface::phone_number() const { return ""; }
 
 #if defined(INTERNAL_EXPERIMENTAL)
 // I'd like to change all the above functions to use LastResultProxy, as it


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Update auth internals to support returning Future<User> object for the new API while also support returning Future<User*> objects for the deprecated API on iOS.

Changes does not include the new Future<User> methods.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Locally run integration test on device.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
