### PR TITLE
Android Auth Google I/O rework

### DIFF
--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -114,8 +114,6 @@ METHOD_LOOKUP_DEFINITION(
     JNI_ID_TOKEN_LISTENER_CALLBACK_METHODS)
 
 static int g_initialized_count = 0;
-static const char* kErrorEmptyEmailPassword =
-    "Empty email or password are not allowed.";
 
 JNIEXPORT void JNICALL JniAuthStateListener_nativeOnAuthStateChanged(
     JNIEnv* env, jobject clazz, jlong callback_data);
@@ -532,7 +530,7 @@ Future<User*> Auth::SignInWithEmailAndPassword_DEPRECATED(
     futures.Complete(handle,
                      (!email || strlen(email) == 0) ? kAuthErrorMissingEmail
                                                     : kAuthErrorMissingPassword,
-                     kErrorEmptyEmailPassword);
+                     kErrorEmptyEmailPasswordErrorMessage);
     return MakeFuture(&futures, handle);
   }
   JNIEnv* env = Env(auth_data_);
@@ -568,7 +566,7 @@ Future<User*> Auth::CreateUserWithEmailAndPassword_DEPRECATED(
                                      (!email || strlen(email) == 0)
                                          ? kAuthErrorMissingEmail
                                          : kAuthErrorMissingPassword,
-                                     kErrorEmptyEmailPassword);
+                                     kErrorEmptyEmailPasswordErrorMessage);
     return MakeFuture(&auth_data_->future_impl, future_handle);
   }
   JNIEnv* env = Env(auth_data_);

--- a/auth/src/android/common_android.cc
+++ b/auth/src/android/common_android.cc
@@ -472,7 +472,7 @@ void SetImplFromLocalRef(JNIEnv* env, jobject j_local, void** impl) {
 // Reads the `AuthResult` in `result` and initialize the `User*` in `void_data`.
 void ReadSignInResult(jobject result, FutureCallbackData<SignInResult>* d,
                       bool success, void* void_data) {
-  JNIEnv* env = d->env;
+  JNIEnv* env = Env(d->auth_data);
 
   // Update the currently signed-in user on success.
   // Note: `result` is only valid when success is true.
@@ -483,9 +483,13 @@ void ReadSignInResult(jobject result, FutureCallbackData<SignInResult>* d,
     util::CheckAndClearJniExceptions(env);
 
     // Update our pointer to the Android FirebaseUser that we're wrapping.
-    // Note: Cannot call UpdateCurrentUser(d->auth_data) because the Java
+    // Note: Cannot call UpdateCurrentUser(env, d->auth_data) because the Java
     //       Auth class has not been updated at this point.
-    SetUserImpl(d->auth_data, j_user);
+    SetImplFromLocalRef(env, j_user,
+                        &d->auth_data->deprecated_fields.android_user_impl);
+    SetUserImpl(env, d->auth_data,
+                static_cast<jobject>(
+                    d->auth_data->deprecated_fields.android_user_impl));
 
     // Grab the additional user info too.
     // Additional user info is not guaranteed to exist, so could be nullptr.
@@ -519,9 +523,13 @@ void ReadUserFromSignInResult(jobject result, FutureCallbackData<User*>* d,
     util::CheckAndClearJniExceptions(env);
 
     // Update our pointer to the Android FirebaseUser that we're wrapping.
-    // Note: Cannot call UpdateCurrentUser(d->auth_data) because the Java
+    // Note: Cannot call UpdateCurrentUser(env, d->auth_data) because the Java
     //       Auth class has not been updated at this point.
-    SetUserImpl(d->auth_data, j_user);
+    SetImplFromLocalRef(env, j_user,
+                        &d->auth_data->deprecated_fields.android_user_impl);
+    SetUserImpl(env, d->auth_data,
+                static_cast<jobject>(
+                    d->auth_data->deprecated_fields.android_user_impl));
   }
 
   // Return a pointer to the current user, if the current user is valid.

--- a/auth/src/android/common_android.cc
+++ b/auth/src/android/common_android.cc
@@ -472,7 +472,7 @@ void SetImplFromLocalRef(JNIEnv* env, jobject j_local, void** impl) {
 // Reads the `AuthResult` in `result` and initialize the `User*` in `void_data`.
 void ReadSignInResult(jobject result, FutureCallbackData<SignInResult>* d,
                       bool success, void* void_data) {
-  JNIEnv* env = Env(d->auth_data);
+  JNIEnv* env = d->env;
 
   // Update the currently signed-in user on success.
   // Note: `result` is only valid when success is true.
@@ -485,7 +485,7 @@ void ReadSignInResult(jobject result, FutureCallbackData<SignInResult>* d,
     // Update our pointer to the Android FirebaseUser that we're wrapping.
     // Note: Cannot call UpdateCurrentUser(d->auth_data) because the Java
     //       Auth class has not been updated at this point.
-    SetImplFromLocalRef(env, j_user, &d->auth_data->user_impl);
+    SetUserImpl(d->auth_data, j_user);
 
     // Grab the additional user info too.
     // Additional user info is not guaranteed to exist, so could be nullptr.
@@ -521,7 +521,7 @@ void ReadUserFromSignInResult(jobject result, FutureCallbackData<User*>* d,
     // Update our pointer to the Android FirebaseUser that we're wrapping.
     // Note: Cannot call UpdateCurrentUser(d->auth_data) because the Java
     //       Auth class has not been updated at this point.
-    SetImplFromLocalRef(env, j_user, &d->auth_data->user_impl);
+    SetUserImpl(d->auth_data, j_user);
   }
 
   // Return a pointer to the current user, if the current user is valid.

--- a/auth/src/android/common_android.h
+++ b/auth/src/android/common_android.h
@@ -172,10 +172,6 @@ class UserInternal {
   // Used to support older method invocation of provider_data_DEPRECATED().
   std::vector<UserInfoInterface*> user_infos_;
 
-  // Guard the creation and deletion of the vector of UserInfoInterface*
-  // allocations in provider_data_DEPRECATED().
-  Mutex user_info_mutex_deprecated_;
-
   // Guard against changes to the user_ object.
   Mutex user_mutex_;
 

--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -1026,8 +1026,8 @@ Future<SignInResult> FederatedOAuthProvider::SignIn(AuthData* auth_data) {
 
     if (!CheckAndCompleteFutureOnError(env, &future_impl, future_handle)) {
       RegisterFederatedAuthProviderCallback(
-          Env(auth_data), auth_data, task, future_handle,
-          auth_data->future_api_id, &auth_data->future_impl, ReadSignInResult);
+          auth_data, task, future_handle, auth_data->future_api_id,
+          &auth_data->future_impl, ReadSignInResult);
     }
     env->DeleteLocalRef(task);
   }
@@ -1043,23 +1043,22 @@ Future<SignInResult> FederatedOAuthProvider::Link(AuthData* auth_data,
   const auto future_handle = future_impl.SafeAlloc<SignInResult>(
       kUserFn_LinkWithProvider_DEPRECATED, SignInResult());
 
+  JNIEnv* env = Env(auth_data);
   jobject oauthprovider = ConstructOAuthProvider(auth_data, provider_data_);
-  if (!CheckAndCompleteFutureOnError(user_internal->env_, &future_impl,
-                                     future_handle)) {
-    jobject task = user_internal->env_->CallObjectMethod(
+  if (!CheckAndCompleteFutureOnError(env, &future_impl, future_handle)) {
+    jobject task = env->CallObjectMethod(
         user_internal->user_,
         user_idp::GetMethodId(user_idp::kStartActivityForLinkWithProvider),
         auth_data->app->activity(), oauthprovider);
-    if (!CheckAndCompleteFutureOnError(user_internal->env_, &future_impl,
-                                       future_handle)) {
+    if (!CheckAndCompleteFutureOnError(env, &future_impl, future_handle)) {
       RegisterFederatedAuthProviderCallback(
-          Env(auth_data), auth_data, task, future_handle,
-          auth_data->future_api_id, &auth_data->future_impl, ReadSignInResult);
+          auth_data, task, future_handle, auth_data->future_api_id,
+          &auth_data->future_impl, ReadSignInResult);
     }
-    Env(auth_data)->DeleteLocalRef(task);
+    env->DeleteLocalRef(task);
   }
 
-  user_internal->env_->DeleteLocalRef(oauthprovider);
+  env->DeleteLocalRef(oauthprovider);
   return MakeFuture(&future_impl, future_handle);
 }
 
@@ -1070,24 +1069,23 @@ Future<SignInResult> FederatedOAuthProvider::Reauthenticate(
   const auto future_handle = future_impl.SafeAlloc<SignInResult>(
       kUserFn_ReauthenticateWithProvider_DEPRECATED, SignInResult());
 
+  JNIEnv* env = Env(auth_data);
   jobject oauthprovider = ConstructOAuthProvider(auth_data, provider_data_);
-  if (!CheckAndCompleteFutureOnError(user_internal->env_, &future_impl,
-                                     future_handle)) {
-    jobject task = user_internal->env_->CallObjectMethod(
+  if (!CheckAndCompleteFutureOnError(env, &future_impl, future_handle)) {
+    jobject task = env->CallObjectMethod(
         user_internal->user_,
         user_idp::GetMethodId(
             user_idp::kStartActivityForReauthenticateWithProvider),
         auth_data->app->activity(), oauthprovider);
-    if (!CheckAndCompleteFutureOnError(user_internal->env_, &future_impl,
-                                       future_handle)) {
+    if (!CheckAndCompleteFutureOnError(env, &future_impl, future_handle)) {
       RegisterFederatedAuthProviderCallback(
-          Env(auth_data), auth_data, task, future_handle,
-          auth_data->future_api_id, &auth_data->future_impl, ReadSignInResult);
+          auth_data, task, future_handle, auth_data->future_api_id,
+          &auth_data->future_impl, ReadSignInResult);
     }
-    user_internal->env_->DeleteLocalRef(task);
+    env->DeleteLocalRef(task);
   }
 
-  user_internal->env_->DeleteLocalRef(oauthprovider);
+  env->DeleteLocalRef(oauthprovider);
   return MakeFuture(&future_impl, future_handle);
 }
 

--- a/auth/src/android/user_android.cc
+++ b/auth/src/android/user_android.cc
@@ -237,6 +237,16 @@ User::User(AuthData *auth_data, UserInternal *user_internal) {
   }
 }
 
+User::User(const User &user) {
+  assert(user.auth_data_);
+  auth_data_ = user.auth_data_;
+  if (user.user_internal_ != nullptr) {
+    user_internal_ = new UserInternal(auth_data_, user.user_internal_->user_);
+  } else {
+    user_internal_ = new UserInternal(auth_data_, nullptr);
+  }
+}
+
 User::~User() {
   delete user_internal_;
   user_internal_ = nullptr;
@@ -252,7 +262,7 @@ User &User::operator=(const User &user) {
   if (user.user_internal_ != nullptr) {
     user_internal_ = new UserInternal(auth_data_, user.user_internal_->user_);
   } else {
-    user_internal_ = new UserInternal(user.auth_data_, nullptr);
+    user_internal_ = new UserInternal(auth_data_, nullptr);
   }
 
   return *this;
@@ -490,8 +500,14 @@ UserInternal::UserInternal(AuthData *auth_data, jobject user)
 
 UserInternal::UserInternal(const UserInternal &user_internal)
     : auth_data_(user_internal.auth_data_),
-      user_(user_internal.user_),
+      user_(nullptr),
       future_data_(kUserFnCount) {
+  assert(auth_data_);
+  JNIEnv *env = Env(auth_data_);
+  if (user_internal.user_ != nullptr) {
+    user_ = env->NewGlobalRef(user_internal.user_);
+    assert(env->ExceptionCheck() == false);
+  }
   assign_future_id(this, &future_api_id_);
 }
 

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -22,13 +22,15 @@ namespace firebase {
 namespace auth {
 
 const char* kUserNotInitializedErrorMessage =
-    "Operation attmpted on an invalid User object.";
+    "Operation attempted on an invalid User object.";
 const char* kPhoneAuthNotSupportedErrorMessage =
     "Phone Auth is not supported on this platform.";
 const char* kAuthInvalidParameterErrorMessage =
     "A parameter pass to the auth method is null or invalid.";
 extern const char* kInvalidCredentialErrorMessage =
     "The provided credential does not match the required type.";
+extern const char* kErrorEmptyEmailPasswordErrorMessage =
+    "Empty email or password are not allowed.";
 
 // static member variables
 const uint32_t PhoneAuthProvider::kMaxTimeoutMs = 3000;

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -25,6 +25,10 @@ const char* kUserNotInitializedErrorMessage =
     "Operation attmpted on an invalid User object.";
 const char* kPhoneAuthNotSupportedErrorMessage =
     "Phone Auth is not supported on this platform.";
+const char* kAuthInvalidParameterErrorMessage =
+    "A parameter pass to the auth method is null or invalid.";
+extern const char* kInvalidCredentialErrorMessage =
+    "The provided credential does not match the required type.";
 
 // static member variables
 const uint32_t PhoneAuthProvider::kMaxTimeoutMs = 3000;

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -28,6 +28,8 @@ namespace auth {
 // the AdErrorCode enumeration in the C++ API.
 extern const char* kUserNotInitializedErrorMessage;
 extern const char* kPhoneAuthNotSupportedErrorMessage;
+extern const char* kAuthInvalidParameterErrorMessage;
+extern const char* kInvalidCredentialErrorMessage;
 
 // Enumeration for Credential API functions that return a Future.
 // This allows us to hold a Future for the most recent call to that API.
@@ -44,12 +46,6 @@ struct FutureData {
 
   // Handle calls from Futures that the API returns.
   ReferenceCountedFutureImpl future_impl;
-};
-
-template <class T>
-struct FutureCallbackData {
-  FutureData* future_data;
-  SafeFutureHandle<T> future_handle;
 };
 
 // Create a future and update the corresponding last result.

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -30,6 +30,7 @@ extern const char* kUserNotInitializedErrorMessage;
 extern const char* kPhoneAuthNotSupportedErrorMessage;
 extern const char* kAuthInvalidParameterErrorMessage;
 extern const char* kInvalidCredentialErrorMessage;
+extern const char* kErrorEmptyEmailPasswordErrorMessage;
 
 // Enumeration for Credential API functions that return a Future.
 // This allows us to hold a Future for the most recent call to that API.

--- a/auth/src/common.h
+++ b/auth/src/common.h
@@ -127,9 +127,6 @@ void NotifyAuthStateListeners(AuthData* auth_data);
 // Notify all the listeners of the ID token change.
 void NotifyIdTokenListeners(AuthData* auth_data);
 
-// Synchronize the current user.
-void UpdateCurrentUser(AuthData* auth_data);
-
 // Get a FutureImpl to use for Credential methods that return Futures.
 ReferenceCountedFutureImpl* GetCredentialFutureImpl();
 

--- a/auth/src/data.h
+++ b/auth/src/data.h
@@ -198,7 +198,10 @@ struct AuthData {
   bool destructing;
 
   // Mutex protecting destructing
-  Mutex desctruting_mutex;
+  Mutex destructing_mutex;
+
+  // Mutex guarding the auth object for standard API operations.
+  Mutex auth_mutex;
 
   // Sets if the Id Token Listener is expecting a callback.
   // Used to workaround an issue where the Id Token is not reset with a new one,

--- a/auth/src/data.h
+++ b/auth/src/data.h
@@ -39,6 +39,9 @@ struct AuthDataDeprecatedFields {
   // pointer the platform specific user object, which is updated on User
   // operations.
   UserInternal* user_internal_deprecated;
+
+  // JNI reference to the user object in the Firebase Android SDK.
+  void* android_user_impl;
 };
 
 // Enumeration for API functions that return a Future.

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -511,7 +511,7 @@ void AssignLoadedData(const Future<std::string>& future, AuthData* auth_data) {
 
 void HandleLoadedData(const Future<std::string>& future, void* auth_data) {
   auto cast_auth_data = static_cast<AuthData*>(auth_data);
-  MutexLock destructing_lock(cast_auth_data->desctruting_mutex);
+  MutexLock destructing_lock(cast_auth_data->destructing_mutex);
   if (cast_auth_data->destructing) {
     // If auth is destructing, abort.
     return;

--- a/auth/src/include/firebase/auth/types.h
+++ b/auth/src/include/firebase/auth/types.h
@@ -429,8 +429,11 @@ enum AuthError {
 
 #endif  // INTERNAL_EXEPERIMENTAL
 
-  /// An operation was attempted on an invalid User.
+  /// Indicates that an operation was attempted on an invalid User.
   kAuthErrorInvalidUser,
+
+  /// Indicates that an invalid parameter was passed to an auth method.
+  kAuthErrorInvalidParameter,
 };
 
 /// @brief Contains information required to authenticate with a third party

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -386,7 +386,7 @@ class User : public UserInfoInterface {
   /// platforms. On other platforms this method will return a Future with a
   /// preset error code: kAuthErrorUnimplemented.
   FIREBASE_DEPRECATED Future<SignInResult> LinkWithProvider_DEPRECATED(
-      FederatedAuthProvider* provider) const;
+      FederatedAuthProvider* provider);
 
   /// @deprecated This is a deprecated method. Please use @ref Unlink(const
   /// char*) instead.
@@ -523,11 +523,6 @@ class User : public UserInfoInterface {
   virtual std::string phone_number() const;
 
  private:
-  // @deprecated User references to auth_data should only be needed during
-  // the Google I/O 23 breaking changes deprecation window.
-  //
-  // Internal only.
-  //
   // Constructor of an internal opaque type. Memory ownership of UserInternal
   // passes to to this User object.
   User(AuthData* auth_data, UserInternal* user_internal);

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -163,10 +163,6 @@ class UserInternal {
   // Used to support older method invocation of provider_data_DEPRECATED().
   std::vector<UserInfoInterface *> user_infos_;
 
-  // Guard the creation and deletion of the vector of UserInfoInterface*
-  // allocations in provider_data_DEPRECATED().
-  Mutex user_info_mutex_deprecated_;
-
   // Guard against changes to the user_ object.
   Mutex user_mutex_;
 };

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -54,6 +54,14 @@ struct AuthDataIos {
   FIRCPPAuthListenerHandlePointer listener_handle;
 };
 
+// Struct to contain the data required to complete
+// futures asynchronously on iOS.
+template <class T>
+struct FutureCallbackData {
+  FutureData *future_data;
+  SafeFutureHandle<T> future_handle;
+};
+
 // Contains the interface between the public API and the underlying
 // Obj-C SDK FirebaseUser implemention.
 class UserInternal {
@@ -160,6 +168,8 @@ class UserInternal {
   Mutex user_mutex_;
 };
 
+/// @deprecated
+///
 /// Replace the platform-dependent FIRUser object.
 /// Note: this function is only used to support DEPRECATED methods which return User*. This
 /// functionality should be removed when those deprecated methods are removed.

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -48,6 +48,9 @@ OBJ_C_PTR_WRAPPER(FIRAuthCredential);
 OBJ_C_PTR_WRAPPER(FIRUser);
 OBJ_C_PTR_WRAPPER(FIRCPPAuthListenerHandle);
 
+// Synchronize the current user.
+void UpdateCurrentUser(AuthData *auth_data);
+
 // Auth implementation on iOS.
 struct AuthDataIos {
   FIRAuthPointer fir_auth;

--- a/auth/src/ios/credential_ios.mm
+++ b/auth/src/ios/credential_ios.mm
@@ -170,10 +170,12 @@ Credential OAuthProvider::GetCredential(const char* provider_id, const char* id_
 
 // static
 Future<Credential> GameCenterAuthProvider::GetCredential() {
-  auto future_api = GetCredentialFutureImpl();
-  FIREBASE_ASSERT(future_api != nullptr);
+  ReferenceCountedFutureImpl* future_impl = GetCredentialFutureImpl();
+  FIREBASE_ASSERT(future_impl != nullptr);
+  const auto future_handle =
+      future_impl->SafeAlloc<Credential>(kCredentialFn_GameCenterGetCredential);
+  Future<Credential> future = MakeFuture(future_impl, future_handle);
 
-  const auto handle = future_api->SafeAlloc<Credential>(kCredentialFn_GameCenterGetCredential);
   /**
    Linking GameKit.framework without using it on macOS results in App Store rejection.
    Thus we don't link GameKit.framework to our SDK directly. `optionalLocalPlayer` is used for
@@ -184,20 +186,19 @@ Future<Credential> GameCenterAuthProvider::GetCredential() {
 
   // Early-out if GameKit is not linked
   if (!optionalLocalPlayer) {
-    future_api->Complete(handle, kAuthErrorInvalidCredential,
-                         "GameCenter authentication is unavailable - missing GameKit capability.");
-    return MakeFuture(future_api, handle);
+    future_impl->Complete(future_handle, kAuthErrorInvalidCredential,
+                          "GameCenter authentication is unavailable - missing GameKit capability.");
+  } else {
+    [FIRGameCenterAuthProvider
+        getCredentialWithCompletion:^(FIRAuthCredential* _Nullable credential,
+                                      NSError* _Nullable error) {
+          Credential result(new FIRAuthCredentialPointer(credential));
+          future_impl->CompleteWithResult(
+              future_handle, AuthErrorFromNSError(error),
+              util::NSStringToString(error.localizedDescription).c_str(), result);
+        }];
   }
-
-  [FIRGameCenterAuthProvider getCredentialWithCompletion:^(FIRAuthCredential* _Nullable credential,
-                                                           NSError* _Nullable error) {
-    Credential result(new FIRAuthCredentialPointer(credential));
-    future_api->CompleteWithResult(handle, AuthErrorFromNSError(error),
-                                   util::NSStringToString(error.localizedDescription).c_str(),
-                                   result);
-  }];
-
-  return MakeFuture(future_api, handle);
+  return future;
 }
 
 // static
@@ -407,19 +408,19 @@ void FederatedOAuthProvider::SetProviderData(const FederatedOAuthProviderData& p
 // current API.
 void LinkWithProviderGetCredentialCallback(FIRAuthCredential* _Nullable credential,
                                            NSError* _Nullable error,
-                                           SafeFutureHandle<SignInResult> handle,
+                                           SafeFutureHandle<SignInResult> future_handle,
                                            ReferenceCountedFutureImpl& future_impl,
                                            AuthData* auth_data, FIRUser* user,
                                            const FIROAuthProvider* ios_auth_provider) {
   if (error && error.code != 0) {
     error = RemapBadProviderIDErrors(error);
-    future_impl.CompleteWithResult(handle, AuthErrorFromNSError(error),
+    future_impl.CompleteWithResult(future_handle, AuthErrorFromNSError(error),
                                    util::NSStringToString(error.localizedDescription).c_str(),
                                    SignInResult());
   } else {
     [user linkWithCredential:credential
                   completion:^(FIRAuthDataResult* _Nullable auth_result, NSError* _Nullable error) {
-                    SignInResultWithProviderCallback(auth_result, error, handle, future_impl,
+                    SignInResultWithProviderCallback(auth_result, error, future_handle, future_impl,
                                                      auth_data, ios_auth_provider);
                   }];
   }
@@ -430,20 +431,20 @@ void LinkWithProviderGetCredentialCallback(FIRAuthCredential* _Nullable credenti
 // accessible via their current API.
 void ReauthenticateWithProviderGetCredentialCallback(FIRAuthCredential* _Nullable credential,
                                                      NSError* _Nullable error,
-                                                     SafeFutureHandle<SignInResult> handle,
+                                                     SafeFutureHandle<SignInResult> future_handle,
                                                      ReferenceCountedFutureImpl& future_impl,
                                                      AuthData* auth_data, FIRUser* user,
                                                      const FIROAuthProvider* ios_auth_provider) {
   if (error && error.code != 0) {
     error = RemapBadProviderIDErrors(error);
-    future_impl.CompleteWithResult(handle, AuthErrorFromNSError(error),
+    future_impl.CompleteWithResult(future_handle, AuthErrorFromNSError(error),
                                    util::NSStringToString(error.localizedDescription).c_str(),
                                    SignInResult());
   } else {
     [user reauthenticateWithCredential:credential
                             completion:^(FIRAuthDataResult* _Nullable auth_result,
                                          NSError* _Nullable error) {
-                              SignInResultWithProviderCallback(auth_result, error, handle,
+                              SignInResultWithProviderCallback(auth_result, error, future_handle,
                                                                future_impl, auth_data,
                                                                ios_auth_provider);
                             }];
@@ -452,9 +453,11 @@ void ReauthenticateWithProviderGetCredentialCallback(FIRAuthCredential* _Nullabl
 
 Future<SignInResult> FederatedOAuthProvider::SignIn(AuthData* auth_data) {
   assert(auth_data);
-  ReferenceCountedFutureImpl& futures = auth_data->future_impl;
-  const auto handle =
-      futures.SafeAlloc<SignInResult>(kAuthFn_SignInWithProvider_DEPRECATED, SignInResult());
+  ReferenceCountedFutureImpl& future_impl = auth_data->future_impl;
+  const auto future_handle =
+      future_impl.SafeAlloc<SignInResult>(kAuthFn_SignInWithProvider_DEPRECATED, SignInResult());
+  Future<SignInResult> future = MakeFuture(&future_impl, future_handle);
+
   FIROAuthProvider* ios_provider = (FIROAuthProvider*)[FIROAuthProvider
       providerWithProviderID:@(provider_data_.provider_id.c_str())
                         auth:AuthImpl(auth_data)];
@@ -465,24 +468,25 @@ Future<SignInResult> FederatedOAuthProvider::SignIn(AuthData* auth_data) {
         signInWithProvider:ios_provider
                 UIDelegate:nullptr
                 completion:^(FIRAuthDataResult* _Nullable auth_result, NSError* _Nullable error) {
-                  SignInResultWithProviderCallback(auth_result, error, handle, futures, auth_data,
-                                                   ios_provider);
+                  SignInResultWithProviderCallback(auth_result, error, future_handle, future_impl,
+                                                   auth_data, ios_provider);
                 }];
-    return MakeFuture(&futures, handle);
   } else {
-    Future<SignInResult> future = MakeFuture(&futures, handle);
-    futures.CompleteWithResult(handle, kAuthErrorFailure, "Internal error constructing provider.",
-                               SignInResult());
-    return future;
+    future_impl.CompleteWithResult(future_handle, kAuthErrorFailure,
+                                   "Internal error constructing provider.", SignInResult());
   }
+  return future;
 }
 
 Future<SignInResult> FederatedOAuthProvider::Link(AuthData* auth_data,
                                                   UserInternal* user_internal) {
   assert(auth_data);
   assert(user_internal);
-  auto handle = user_internal->future_data_.future_impl.SafeAlloc<SignInResult>(
-      kUserFn_LinkWithProvider_DEPRECATED, SignInResult());
+  ReferenceCountedFutureImpl& future_impl = user_internal->future_data_.future_impl;
+  auto future_handle =
+      future_impl.SafeAlloc<SignInResult>(kUserFn_LinkWithProvider_DEPRECATED, SignInResult());
+  Future<SignInResult> future = MakeFuture(&future_impl, future_handle);
+
 #if FIREBASE_PLATFORM_IOS
   FIROAuthProvider* ios_provider = (FIROAuthProvider*)[FIROAuthProvider
       providerWithProviderID:@(provider_data_.provider_id.c_str())
@@ -493,36 +497,36 @@ Future<SignInResult> FederatedOAuthProvider::Link(AuthData* auth_data,
     FIRUser* user = user_internal->user_;
     // TODO(b/138788092) invoke FIRUser linkWithProvider instead, once that method is added to the
     // iOS SDK.
-    [ios_provider
-        getCredentialWithUIDelegate:nullptr
-                         completion:^(FIRAuthCredential* _Nullable credential,
-                                      NSError* _Nullable error) {
-                           LinkWithProviderGetCredentialCallback(
-                               credential, error, handle, user_internal->future_data_.future_impl,
-                               auth_data, user, ios_provider);
-                         }];
-    return MakeFuture(&user_internal->future_data_.future_impl, handle);
+    [ios_provider getCredentialWithUIDelegate:nullptr
+                                   completion:^(FIRAuthCredential* _Nullable credential,
+                                                NSError* _Nullable error) {
+                                     LinkWithProviderGetCredentialCallback(
+                                         credential, error, future_handle,
+                                         user_internal->future_data_.future_impl, auth_data, user,
+                                         ios_provider);
+                                   }];
   } else {
-    Future<SignInResult> future = MakeFuture(&user_internal->future_data_.future_impl, handle);
-    user_internal->future_data_.future_impl.CompleteWithResult(
-        handle, kAuthErrorFailure, "Internal error constructing provider.", SignInResult());
-    return future;
+    future_impl.CompleteWithResult(future_handle, kAuthErrorFailure,
+                                   "Internal error constructing provider.", SignInResult());
   }
 
 #else   // non-iOS Apple platforms (eg: tvOS)
-  Future<SignInResult> future = MakeFuture(&user_internal->future_data_.future_impl, handle);
-  user_internal->future_data_.future_impl.Complete(
-      handle, kAuthErrorApiNotAvailable,
-      "OAuth provider linking is not supported on non-iOS Apple platforms.");
+  future_impl.CompleteWithResult(
+      future_handle, kAuthErrorApiNotAvailable,
+      "OAuth provider linking is not supported on non-iOS Apple platforms.", SignInResult());
 #endif  // FIREBASE_PLATFORM_IOS
+  return future;
 }
 
 Future<SignInResult> FederatedOAuthProvider::Reauthenticate(AuthData* auth_data,
                                                             UserInternal* user_internal) {
   assert(auth_data);
   assert(user_internal);
-  auto handle = user_internal->future_data_.future_impl.SafeAlloc<SignInResult>(
+  ReferenceCountedFutureImpl& future_impl = user_internal->future_data_.future_impl;
+  auto future_handle = future_impl.SafeAlloc<SignInResult>(
       kUserFn_ReauthenticateWithProvider_DEPRECATED, SignInResult());
+  Future<SignInResult> future = MakeFuture(&future_impl, future_handle);
+
 #if FIREBASE_PLATFORM_IOS
   FIROAuthProvider* ios_provider = (FIROAuthProvider*)[FIROAuthProvider
       providerWithProviderID:@(provider_data_.provider_id.c_str())
@@ -533,28 +537,23 @@ Future<SignInResult> FederatedOAuthProvider::Reauthenticate(AuthData* auth_data,
     FIRUser* user = user_internal->user_;
     // TODO(b/138788092) invoke FIRUser:reuthenticateWithProvider instead, once that method is added
     // to the iOS SDK.
-    [ios_provider
-        getCredentialWithUIDelegate:nullptr
-                         completion:^(FIRAuthCredential* _Nullable credential,
-                                      NSError* _Nullable error) {
-                           ReauthenticateWithProviderGetCredentialCallback(
-                               credential, error, handle, user_internal->future_data_.future_impl,
-                               auth_data, user, ios_provider);
-                         }];
-    return MakeFuture(&user_internal->future_data_.future_impl, handle);
+    [ios_provider getCredentialWithUIDelegate:nullptr
+                                   completion:^(FIRAuthCredential* _Nullable credential,
+                                                NSError* _Nullable error) {
+                                     ReauthenticateWithProviderGetCredentialCallback(
+                                         credential, error, future_handle, future_impl, auth_data,
+                                         user, ios_provider);
+                                   }];
   } else {
-    Future<SignInResult> future = MakeFuture(&user_internal->future_data_.future_impl, handle);
-    user_internal->future_data_.future_impl.CompleteWithResult(
-        handle, kAuthErrorFailure, "Internal error constructing provider.", SignInResult());
-    return future;
+    future_impl.CompleteWithResult(future_handle, kAuthErrorFailure,
+                                   "Internal error constructing provider.", SignInResult());
   }
-
 #else   // non-iOS Apple platforms (eg: tvOS)
-  Future<SignInResult> future = MakeFuture(&user_internal->future_data_.future_impl, handle);
-  user_internal->future_data_.future_impl.Complete(
-      handle, kAuthErrorApiNotAvailable,
-      "OAuth reauthentication is not supported on non-iOS Apple platforms.");
+  future_impl.CompleteWithResult(
+      future_handle, kAuthErrorApiNotAvailable,
+      "OAuth reauthentication is not supported on non-iOS Apple platforms.", SignInResult());
 #endif  // FIREBASE_PLATFORM_IOS
+  return future;
 }
 
 }  // namespace auth

--- a/auth/src/ios/credential_ios.mm
+++ b/auth/src/ios/credential_ios.mm
@@ -522,7 +522,7 @@ Future<SignInResult> FederatedOAuthProvider::Reauthenticate(AuthData* auth_data,
   assert(auth_data);
   assert(user_internal);
   auto handle = user_internal->future_data_.future_impl.SafeAlloc<SignInResult>(
-      kUserFn_LinkWithProvider_DEPRECATED, SignInResult());
+      kUserFn_ReauthenticateWithProvider_DEPRECATED, SignInResult());
 #if FIREBASE_PLATFORM_IOS
   FIROAuthProvider* ios_provider = (FIROAuthProvider*)[FIROAuthProvider
       providerWithProviderID:@(provider_data_.provider_id.c_str())

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -532,11 +532,9 @@ Future<SignInResult> UserInternal::LinkAndRetrieveDataWithCredential_DEPRECATED(
 
   [user_ linkWithCredential:CredentialFromImpl(credential.impl_)
                  completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
-                   NSLog(@"DEDB Completion auth_result: %p error: %p\n", auth_result, error);
                    SignInResultCallback(auth_result, error, callback_data->future_handle,
                                         callback_data->future_data->future_impl, auth_data);
-                   NSLog(@"DEDB Completion SignInResultCallback returned\n");
-                   // delete callback_data;
+                   delete callback_data;
                  }];
   return future;
 }

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -171,7 +171,7 @@ Future<SignInResult> User::LinkAndRetrieveDataWithCredentialLastResult_DEPRECATE
   return user_internal_->LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED();
 }
 
-Future<SignInResult> User::LinkWithProvider_DEPRECATED(FederatedAuthProvider *provider) const {
+Future<SignInResult> User::LinkWithProvider_DEPRECATED(FederatedAuthProvider *provider) {
   assert(user_internal_);
   return user_internal_->LinkWithProvider_DEPRECATED(auth_data_, provider);
 }
@@ -516,9 +516,7 @@ Future<User *> UserInternal::LinkWithCredentialLastResult_DEPRECATED() const {
 
 Future<SignInResult> UserInternal::LinkAndRetrieveDataWithCredential_DEPRECATED(
     AuthData *auth_data, const Credential &credential) {
-  // MutexLock user_info_lock(user_mutex_);
   if (!is_valid()) {
-    printf("DEDB LinkAndRetrieveDataWithCredential_DEPRECATED user is not valid\n");
     SafeFutureHandle<SignInResult> future_handle = future_data_.future_impl.SafeAlloc<SignInResult>(
         kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED);
     Future<SignInResult> future = MakeFuture(&future_data_.future_impl, future_handle);
@@ -550,7 +548,19 @@ Future<SignInResult> UserInternal::LinkAndRetrieveDataWithCredentialLastResult_D
 
 Future<SignInResult> UserInternal::LinkWithProvider_DEPRECATED(AuthData *auth_data,
                                                                FederatedAuthProvider *provider) {
-  FIREBASE_ASSERT_RETURN(Future<SignInResult>(), provider);
+  if (!is_valid() || provider == nullptr) {
+    SafeFutureHandle<SignInResult> future_handle =
+        future_data_.future_impl.SafeAlloc<SignInResult>(kUserFn_LinkWithProvider_DEPRECATED);
+    Future<SignInResult> future = MakeFuture(&future_data_.future_impl, future_handle);
+    if (!is_valid()) {
+      CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                     &future_data_, SignInResult());
+    } else {
+      CompleteFuture(kAuthErrorInvalidParameter, kUserNotInitializedErrorMessage, future_handle,
+                     &future_data_, SignInResult());
+    }
+    return future;
+  }
   return provider->Link(auth_data, this);
 }
 
@@ -610,7 +620,7 @@ Future<User *> UserInternal::UpdatePhoneNumberCredential_DEPRECATED(AuthData *au
                               delete callback_data;
                             }];
   } else {
-    CompleteFuture(kAuthErrorInvalidCredential, kInvalidCredentialMessage,
+    CompleteFuture(kAuthErrorInvalidCredential, kInvalidCredentialErrorMessage,
                    callback_data->future_handle, &future_data_, (User *)nullptr);
   }
   return future;
@@ -711,7 +721,19 @@ Future<SignInResult> UserInternal::ReauthenticateAndRetrieveDataLastResult_DEPRE
 
 Future<SignInResult> UserInternal::ReauthenticateWithProvider_DEPRECATED(
     AuthData *auth_data, FederatedAuthProvider *provider) {
-  FIREBASE_ASSERT_RETURN(Future<SignInResult>(), provider);
+  if (!is_valid() || provider == nullptr) {
+    SafeFutureHandle<SignInResult> future_handle = future_data_.future_impl.SafeAlloc<SignInResult>(
+        kUserFn_ReauthenticateWithProvider_DEPRECATED);
+    Future<SignInResult> future = MakeFuture(&future_data_.future_impl, future_handle);
+    if (!is_valid()) {
+      CompleteFuture(kAuthErrorInvalidUser, kUserNotInitializedErrorMessage, future_handle,
+                     &future_data_, SignInResult());
+    } else {
+      CompleteFuture(kAuthErrorInvalidParameter, kUserNotInitializedErrorMessage, future_handle,
+                     &future_data_, SignInResult());
+    }
+    return future;
+  }
   return provider->Reauthenticate(auth_data, this);
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Removes the need for User objects to be stored in AuthData, unlocking ability for there to be more than one User object at a time.

Continues to store a User in Auth, though, to maintain the implementation of the newly deprecated methods which return a User*.

Added a RetainUser integration test.


[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Locally tested on an iOS and Android device.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***
