### PR TITLE
[Auth] PhoneAuthOptions struct for VerifyPhoneNumber

### DIFF
--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -417,7 +417,8 @@ void FirebaseAppCheckTest::SignOut() {
   }
   if (auth_->current_user_DEPRECATED()->is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(auth_->current_user_DEPRECATED()->Delete(), "DeleteAnonymousUser");
+    WaitForCompletion(auth_->current_user_DEPRECATED()->Delete(),
+                      "DeleteAnonymousUser");
     // If there was a problem deleting the user, try to sign out at least.
     if (auth_->current_user_DEPRECATED()) {
       auth_->SignOut();

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -1116,13 +1116,16 @@ TEST_F(FirebaseAuthTest, TestPhoneAuth) {
   LogDebug("Creating listener.");
   PhoneListener listener;
   LogDebug("Calling VerifyPhoneNumber.");
+
   // Randomly choose one of the phone numbers to avoid collisions.
-  const int random_phone_number =
+  const int random_phone_number_index =
       app_framework::GetCurrentTimeInMicroseconds() %
       kPhoneAuthTestNumPhoneNumbers;
-  phone_provider.VerifyPhoneNumber(
-      kPhoneAuthTestPhoneNumbers[random_phone_number], kPhoneAuthTimeoutMs,
-      nullptr, &listener);
+  firebase::auth::PhoneAuthOptions phone_options;
+  phone_options.phone_number =
+      kPhoneAuthTestPhoneNumbers[random_phone_number_index];
+  phone_options.timeout_milliseconds = kPhoneAuthTimeoutMs;
+  phone_provider.VerifyPhoneNumber(phone_options, &listener);
 
   // Wait for OnCodeSent() callback.
   int wait_ms = 0;

--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -1012,7 +1012,8 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   JNIEnv* env = GetJniEnv();
 
   PhoneAuthOptions options;
-  options.force_resending_token = const_cast<ForceResendingToken*>(force_resending_token);
+  options.force_resending_token =
+      const_cast<ForceResendingToken*>(force_resending_token);
   options.timeout_milliseconds = auto_verify_time_out_ms;
   if (phone_number != nullptr) {
     options.phone_number = phone_number;

--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -972,21 +972,13 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   JNIEnv* env = GetJniEnv();
 
   PhoneAuthOptions options;
-  if (force_resending_token != nullptr) {
-    options.force_resending_token =
-        new ForceResendingToken(*force_resending_token);
-  }
-
+  options.force_resending_token = (ForceResendingToken*)force_resending_token;
+  options.timeout_milliseconds = auto_verify_time_out_ms;
   if (phone_number != nullptr) {
     options.phone_number = phone_number;
   }
 
-  options.timeout_milliseconds = auto_verify_time_out_ms;
   VerifyPhoneNumber(options, listener);
-  if (options.force_resending_token != nullptr) {
-    delete options.force_resending_token;
-    options.force_resending_token = nullptr;
-  }
 }
 
 Credential PhoneAuthProvider::GetCredential(const char* verification_id,

--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -972,7 +972,7 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   JNIEnv* env = GetJniEnv();
 
   PhoneAuthOptions options;
-  options.force_resending_token = (ForceResendingToken*)force_resending_token;
+  options.force_resending_token = const_cast<ForceResendingToken*>(force_resending_token);
   options.timeout_milliseconds = auto_verify_time_out_ms;
   if (phone_number != nullptr) {
     options.phone_number = phone_number;

--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -978,7 +978,7 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   }
 
   if (phone_number != nullptr) {
-    options.phone_number = *phone_number;
+    options.phone_number = phone_number;
   }
 
   options.timeout_milliseconds = auto_verify_time_out_ms;

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -59,6 +59,19 @@ void ClearUserInfos(AuthData* auth_data) {
   auth_data->user_infos.clear();
 }
 
+//
+// PhoneAuthOptions
+//
+PhoneAuthOptions::PhoneAuthOptions() {
+  require_sms_validation = false;
+  force_resending_token = nullptr;
+  timeout_milliseconds = 0;
+  ui_parent = nullptr;
+}
+
+//
+// PhoneAuthProvider
+//
 void PhoneAuthProvider::Listener::OnCodeSent(
     const std::string& /*verification_id*/,
     const ForceResendingToken& /*force_resending_token*/) {}

--- a/auth/src/common.cc
+++ b/auth/src/common.cc
@@ -63,7 +63,6 @@ void ClearUserInfos(AuthData* auth_data) {
 // PhoneAuthOptions
 //
 PhoneAuthOptions::PhoneAuthOptions() {
-  require_sms_validation = false;
   force_resending_token = nullptr;
   timeout_milliseconds = 0;
   ui_parent = nullptr;

--- a/auth/src/desktop/auth_providers/phone_auth_provider.cc
+++ b/auth/src/desktop/auth_providers/phone_auth_provider.cc
@@ -61,6 +61,20 @@ PhoneAuthProvider::PhoneAuthProvider() : data_(nullptr) {}
 PhoneAuthProvider::~PhoneAuthProvider() {}
 
 void PhoneAuthProvider::VerifyPhoneNumber(
+    const PhoneAuthOptions& options, PhoneAuthProvider::Listener* listener) {
+  FIREBASE_ASSERT_RETURN_VOID(listener != nullptr);
+
+  // Mock the tokens by sending a new one whenever it's unspecified.
+  ForceResendingToken token;
+  if (options.force_resending_token != nullptr) {
+    token = *options.force_resending_token;
+  }
+
+  listener->OnCodeAutoRetrievalTimeOut(kMockVerificationId);
+  listener->OnCodeSent(kMockVerificationId, token);
+}
+
+void PhoneAuthProvider::VerifyPhoneNumber(
     const char* /*phone_number*/, uint32_t /*auto_verify_time_out_ms*/,
     const ForceResendingToken* force_resending_token, Listener* listener) {
   FIREBASE_ASSERT_RETURN_VOID(listener != nullptr);

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -661,6 +661,10 @@ struct PhoneAuthOptions {
   /// Sets the context to which the callbacks are scoped, and with which app
   /// verification will be completed.
   ///
+  /// On Android, the context should be a jobject referencing an Android
+  /// Activity. On Apple platforms, this should be a pointer to UIView.
+  /// For any other platforms, the context is ignored.
+  ///
   /// If ui_parent isn’t defined (ie: nullptr or nil) then the FirebaseApp’s
   /// default Activity or UIView will be used.
   UIParent ui_parent;

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -24,6 +24,15 @@
 #include "firebase/auth/types.h"
 #include "firebase/internal/common.h"
 
+#if FIREBASE_PLATFORM_ANDROID
+#include <jni.h>
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+extern "C" {
+#include <objc/objc.h>
+}  // extern "C"
+#endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
+        // FIREBASE_PLATFORM_TVOS
+
 namespace firebase {
 
 // Predeclarations.
@@ -36,6 +45,18 @@ class Future;
 
 namespace auth {
 
+#if FIREBASE_PLATFORM_ANDROID
+/// An Android Activity from Java.
+typedef jobject UIParent;
+#elif FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
+/// A pointer to a UIView.
+typedef id UIParent;
+#else
+/// A void pointer for stub classes.
+typedef void* AdParent;
+#endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
+        // FIREBASE_PLATFORM_TVOS
+
 // Predeclarations.
 class Auth;
 class User;
@@ -43,6 +64,7 @@ class User;
 // Opaque internal types.
 struct AuthData;
 class ForceResendingTokenData;
+struct PhoneAuthOptions;
 struct PhoneAuthProviderData;
 struct PhoneListenerData;
 
@@ -534,6 +556,9 @@ class PhoneAuthProvider {
   /// in Android SDK</a>
   static const uint32_t kMaxTimeoutMs;
 
+  /// @deprecated This is a deprecated method. Please use @ref
+  /// VerifyPhoneNumber(const PhoneAuthOptions&, Listener*) instead.
+  ///
   /// Start the phone number authentication operation.
   ///
   /// @param[in] phone_number The phone number identifier supplied by the user.
@@ -556,6 +581,11 @@ class PhoneAuthProvider {
                          uint32_t auto_verify_time_out_ms,
                          const ForceResendingToken* force_resending_token,
                          Listener* listener);
+
+  /// Start the phone number authentication operation.
+  /// @param[in] phone_number The phone number identifier supplied by the user.
+  void VerifyPhoneNumber(const PhoneAuthOptions& options,
+                         PhoneAuthProvider::Listener* listener);
 
   /// Generate a credential for the given phone number.
   ///
@@ -589,6 +619,52 @@ class PhoneAuthProvider {
   ~PhoneAuthProvider();
 
   PhoneAuthProviderData* data_;
+};
+
+/// Options object for configuring phone validation flows in @ref
+/// PhoneAuthProvider.
+struct PhoneAuthOptions {
+  // Constructor
+  PhoneAuthOptions();
+
+  /// Specifies whether to force an SMS to be sent for second factor validation.
+  ///
+  /// This value is supported on Android devices only.
+  bool require_sms_validation;
+
+  /// @brief Sets the @ref PhoneAuthProvider::ForceResendingToken to force
+  /// another verification SMS to be sent before the auto-retrieval timeout.
+  ///
+  /// If nullptr, assume this is a new phone number to verify. If not-NULL,
+  /// bypass the verification session deduping and force resending a new SMS.
+  /// This token is received in @ref PhoneAuthProvider::Listener::OnCodeSent.
+  /// This should only be used when the user presses a Resend SMS button.
+  PhoneAuthProvider::ForceResendingToken* force_resending_token;
+
+  /// The phone number for sign-in, sign-up, or second factor enrollment.
+  std::string phone_number;
+
+  /// The maximum amount of time you’re willing to wait for SMS auto-retrieval
+  /// to be completed by the SDK.
+  ///
+  /// This value is supported on Android devices only.
+  ///
+  /// The minimum timeout is 30 seconds, and the maximum timeout is 2 minutes.
+  /// If you specified a positive value less than 30 seconds, the SDK will
+  /// default to 30 seconds. Specifying a timeout that is greater than 120
+  /// seconds will result in an IllegalArgumentException being thrown.
+  ///
+  /// Use 0 to disable SMS-auto-retrieval. This will also cause
+  /// @ref PhoneAuthProvider.Listener.OnCodeAutoRetrievalTimeOut to be called
+  /// immediately.
+  uint64_t timeout_milliseconds;
+
+  /// Sets the context to which the callbacks are scoped, and with which app
+  /// verification will be completed.
+  ///
+  /// If ui_parent isn’t defined (ie: nullptr or nil) then the FirebaseApp’s
+  /// default Activity or UIView will be used.
+  UIParent ui_parent;
 };
 
 /// @brief Use a server auth code provided by Google Play Games to authenticate.

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -53,7 +53,7 @@ typedef jobject UIParent;
 typedef id UIParent;
 #else
 /// A void pointer for stub classes.
-typedef void* AdParent;
+typedef void* UIParent;
 #endif  // FIREBASE_PLATFORM_ANDROID, FIREBASE_PLATFORM_IOS,
         // FIREBASE_PLATFORM_TVOS
 

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -583,7 +583,11 @@ class PhoneAuthProvider {
                          Listener* listener);
 
   /// Start the phone number authentication operation.
-  /// @param[in] phone_number The phone number identifier supplied by the user.
+  ///
+  /// @param[in] options The PhoneAuthOptions struct with a verification
+  /// configuration.
+  /// @param[in,out] listener Class that receives notification whenever an SMS
+  ///    verification event occurs.
   void VerifyPhoneNumber(const PhoneAuthOptions& options,
                          PhoneAuthProvider::Listener* listener);
 

--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -627,11 +627,6 @@ struct PhoneAuthOptions {
   // Constructor
   PhoneAuthOptions();
 
-  /// Specifies whether to force an SMS to be sent for second factor validation.
-  ///
-  /// This value is supported on Android devices only.
-  bool require_sms_validation;
-
   /// @brief Sets the @ref PhoneAuthProvider::ForceResendingToken to force
   /// another verification SMS to be sent before the auto-retrieval timeout.
   ///
@@ -657,7 +652,7 @@ struct PhoneAuthOptions {
   /// Use 0 to disable SMS-auto-retrieval. This will also cause
   /// @ref PhoneAuthProvider.Listener.OnCodeAutoRetrievalTimeOut to be called
   /// immediately.
-  uint64_t timeout_milliseconds;
+  uint32_t timeout_milliseconds;
 
   /// Sets the context to which the callbacks are scoped, and with which app
   /// verification will be completed.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add a new `PhoneAuthProvider::VerifyPhoneNumber` method that takes a `PhoneAuthOptions` structure.

For the C++ implementation on Android, update the current `VerifyPhoneNumber` method to call into the new offering. The older Android SDK `VerifyPhoneNumber` method is deprecated and will probably be removed from the Android SDK at Google I/O, so let's fix this before it becomes a problem.

It's a known issue that the desktop builds fail on this PR. This is due to some SDKs currently using `current_user_DEPRECATED` in the Auth API. The toolchains throw warnings for using a deprecated API, and the toolchains are configured to error-out on warnings. This will be fixed in subsequent PR.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

[Integration Test CI](https://github.com/firebase/firebase-cpp-sdk/actions/runs/4619094116)

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***
