### PR TITLE
Use namespaces in the default providers

### DIFF
--- a/app_check/src/include/firebase/app_check/app_attest_provider.h
+++ b/app_check/src/include/firebase/app_check/app_attest_provider.h
@@ -37,7 +37,7 @@ class AppAttestProviderFactory : public AppCheckProviderFactory {
   /// Gets the AppCheckProvider associated with the given
   /// {@link App} instance, or creates one if none
   /// already exists.
-  AppCheckProvider* CreateProvider(App* app) override;
+  firebase::app_check::AppCheckProvider* CreateProvider(App* app) override;
 
  private:
   AppAttestProviderFactory();

--- a/app_check/src/include/firebase/app_check/debug_provider.h
+++ b/app_check/src/include/firebase/app_check/debug_provider.h
@@ -43,7 +43,7 @@ class DebugAppCheckProviderFactory : public AppCheckProviderFactory {
   /// Gets the AppCheckProvider associated with the given
   /// {@link App} instance, or creates one if none
   /// already exists.
-  AppCheckProvider* CreateProvider(App* app) override;
+  firebase::app_check::AppCheckProvider* CreateProvider(App* app) override;
 
  private:
   DebugAppCheckProviderFactory();

--- a/app_check/src/include/firebase/app_check/device_check_provider.h
+++ b/app_check/src/include/firebase/app_check/device_check_provider.h
@@ -37,7 +37,7 @@ class DeviceCheckProviderFactory : public AppCheckProviderFactory {
   /// Gets the AppCheckProvider associated with the given
   /// {@link App} instance, or creates one if none
   /// already exists.
-  AppCheckProvider* CreateProvider(App* app) override;
+  firebase::app_check::AppCheckProvider* CreateProvider(App* app) override;
 
  private:
   DeviceCheckProviderFactory();

--- a/app_check/src/include/firebase/app_check/play_integrity_provider.h
+++ b/app_check/src/include/firebase/app_check/play_integrity_provider.h
@@ -37,7 +37,7 @@ class PlayIntegrityProviderFactory : public AppCheckProviderFactory {
   /// Gets the AppCheckProvider associated with the given
   /// {@link App} instance, or creates one if none
   /// already exists.
-  AppCheckProvider* CreateProvider(App* app) override;
+  firebase::app_check::AppCheckProvider* CreateProvider(App* app) override;
 
  private:
   PlayIntegrityProviderFactory();


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The swig generation has problems understanding the AppCheckProvider type, so use the full namespace in the header files, which shouldn't affect the C++ side at all.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
