### PR TITLE
Mila/multi db add get instance header

### DIFF
--- a/firestore/integration_test_internal/src/validation_test.cc
+++ b/firestore/integration_test_internal/src/validation_test.cc
@@ -408,10 +408,34 @@ TEST_F(ValidationTest, DisableSslWithoutSettingHostFails) {
 
 TEST_F(ValidationTest, FirestoreGetInstanceWithNullAppFails) {
   EXPECT_ERROR(
-      Firestore::GetInstance(/*app=*/nullptr, /*init_result=*/nullptr),
-      "firebase::App instance cannot be null. Use "
-      "firebase::App::GetInstance() without arguments if you'd like to use "
-      "the default instance.");
+      Firestore::GetInstance(/*app=*/(App*)nullptr, /*init_result=*/(InitResult*)nullptr),
+      "firebase::App instance cannot be null. Use other "
+      "firebase::App::GetInstance() if you'd like to use the default "
+      "instance.");
+}
+
+TEST_F(ValidationTest, FirestoreGetInstanceWithNullDatabaseNameFails) {
+  EXPECT_ERROR(
+      Firestore::GetInstance(/*db_name=*/(char*)nullptr, /*init_result=*/(InitResult*)nullptr),
+      "Provided database ID must not be null. Use other "
+      "firebase::App::GetInstance() if you'd like to use the default "
+      "database ID.");
+}
+
+TEST_F(ValidationTest, FirestoreGetInstanceWithNonNullDatabaseIdButNullAppFails) {
+  EXPECT_ERROR(
+      Firestore::GetInstance(/*app=*/(App*)nullptr, "foo", /*init_result=*/(InitResult*)nullptr),
+      "firebase::App instance cannot be null. Use other "
+      "firebase::App::GetInstance() if you'd like to use the default "
+      "instance.");
+}
+
+TEST_F(ValidationTest, FirestoreGetInstanceWithNonNullAppButNullDatabaseNameFails) {
+  EXPECT_ERROR(
+      Firestore::GetInstance(app(), /*db_name=*/(char*)nullptr, /*init_result=*/(InitResult*)nullptr),
+      "Provided database ID must not be null. Use other "
+      "firebase::App::GetInstance() if you'd like to use the default "
+      "database ID.");
 }
 
 TEST_F(ValidationTest,

--- a/firestore/src/common/firestore.cc
+++ b/firestore/src/common/firestore.cc
@@ -101,9 +101,18 @@ InitResult CheckInitialized(const FirestoreInternal& firestore) {
 void ValidateApp(App* app) {
   if (!app) {
     SimpleThrowInvalidArgument(
-        "firebase::App instance cannot be null. Use "
-        "firebase::App::GetInstance() without arguments if you'd like to use "
-        "the default instance.");
+        "firebase::App instance cannot be null. Use other "
+        "firebase::App::GetInstance() if you'd like to use the default "
+        "instance.");
+  }
+}
+
+void ValidateDatabase(const char* db_name) {
+  if (!db_name) {
+    SimpleThrowInvalidArgument(
+        "Provided database ID must not be null. Use other "
+        "firebase::App::GetInstance() if you'd like to use the default "
+        "database ID.");
   }
 }
 
@@ -133,15 +142,19 @@ Firestore* Firestore::GetInstance(InitResult* init_result_out) {
   return Firestore::GetInstance(app, init_result_out);
 }
 
-Firestore* Firestore::GetInstance(App* app,const char* db_name,InitResult* init_result_out) {
+Firestore* Firestore::GetInstance(App* app, const char* db_name, InitResult* init_result_out) {
+  ValidateApp(app);
+  ValidateDatabase(db_name);
   //TODO(Mila): Implement code
-  return nullptr;
+  return Firestore::GetInstance(app, init_result_out);
 }
 
 Firestore* Firestore::GetInstance(const char* db_name,InitResult* init_result_out) {
+  ValidateDatabase(db_name);
   //TODO(Mila): Implement code
-  return nullptr;
-} 
+  App* app = App::GetInstance();
+  return Firestore::GetInstance(app, init_result_out);
+}
 
 Firestore* Firestore::CreateFirestore(App* app,
                                       FirestoreInternal* internal,

--- a/firestore/src/common/firestore.cc
+++ b/firestore/src/common/firestore.cc
@@ -133,6 +133,16 @@ Firestore* Firestore::GetInstance(InitResult* init_result_out) {
   return Firestore::GetInstance(app, init_result_out);
 }
 
+Firestore* Firestore::GetInstance(App* app,const char* db_name,InitResult* init_result_out) {
+  //TODO(Mila): Implement code
+  return nullptr;
+}
+
+Firestore* Firestore::GetInstance(const char* db_name,InitResult* init_result_out) {
+  //TODO(Mila): Implement code
+  return nullptr;
+} 
+
 Firestore* Firestore::CreateFirestore(App* app,
                                       FirestoreInternal* internal,
                                       InitResult* init_result_out) {

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -179,7 +179,6 @@ class Firestore {
   static Firestore* GetInstance(const char* db_name,
                                 InitResult* init_result_out = nullptr);
 
-
   /**
    * @brief Destructor for the Firestore object.
    *

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -89,7 +89,8 @@ class TransactionManager;
 class Firestore {
  public:
   /**
-   * @brief Returns an instance of Firestore corresponding to the given App.
+   * @brief Returns an instance of Firestore corresponding to the given App
+   * with default database ID.
    *
    * Firebase Firestore uses firebase::App to communicate with Firebase
    * Authentication to authenticate users to the Firestore server backend.
@@ -104,13 +105,15 @@ class Firestore {
    * succeeded, or firebase::kInitResultFailedMissingDependency on Android if
    * Google Play services is not available on the current device.
    *
-   * @return An instance of Firestore corresponding to the given App.
+   * @return An instance of Firestore corresponding to the given App with
+   * default database ID.
    */
   static Firestore* GetInstance(::firebase::App* app,
                                 InitResult* init_result_out = nullptr);
 
   /**
-   * @brief Returns an instance of Firestore corresponding to the default App.
+   * @brief Returns an instance of Firestore corresponding to the default App
+   * with default database ID.
    *
    * Firebase Firestore uses the default App to communicate with Firebase
    * Authentication to authenticate users to the Firestore server backend.
@@ -122,9 +125,60 @@ class Firestore {
    * succeeded, or firebase::kInitResultFailedMissingDependency on Android if
    * Google Play services is not available on the current device.
    *
-   * @return An instance of Firestore corresponding to the default App.
+   * @return An instance of Firestore corresponding to the default App
+   * with default database ID.
    */
   static Firestore* GetInstance(InitResult* init_result_out = nullptr);
+
+  /**
+   * @brief Returns an instance of Firestore corresponding to the given App with
+   * the given database ID.
+   *
+   * Firebase Firestore uses firebase::App to communicate with Firebase
+   * Authentication to authenticate users to the Firestore server backend.
+   *
+   * If you call GetInstance() multiple times with the same App, you will get
+   * the same instance of Firestore.
+   *
+   * @param[in] app Your instance of firebase::App. Firebase Firestore will use
+   * this to communicate with Firebase Authentication.
+   * @param[in] db_name Name of the database. Firebase Firestore will use
+   * this to communicate with Firebase Authentication.
+   * @param[out] init_result_out If provided, the initialization result will be
+   * written here. Will be set to firebase::kInitResultSuccess if initialization
+   * succeeded, or firebase::kInitResultFailedMissingDependency on Android if
+   * Google Play services is not available on the current device.
+   *
+   * @return An instance of Firestore corresponding to the given App with
+   * the given database ID.
+   */
+  static Firestore* GetInstance(::firebase::App* app,
+                                const char* db_name,
+                                InitResult* init_result_out = nullptr);
+
+  /**
+   * @brief Returns an instance of Firestore corresponding to the default App
+   * with the given database ID.
+   *
+   * Firebase Firestore uses firebase::App to communicate with Firebase
+   * Authentication to authenticate users to the Firestore server backend.
+   *
+   * If you call GetInstance() multiple times with the same App, you will get
+   * the same instance of Firestore.
+   *
+   * @param[in] db_name Name of the database. Firebase Firestore will use
+   * this to communicate with Firebase Authentication.
+   * @param[out] init_result_out If provided, the initialization result will be
+   * written here. Will be set to firebase::kInitResultSuccess if initialization
+   * succeeded, or firebase::kInitResultFailedMissingDependency on Android if
+   * Google Play services is not available on the current device.
+   *
+   * @return An instance of Firestore corresponding to the default App with
+   * the given database ID.
+   */
+  static Firestore* GetInstance(const char* db_name,
+                                InitResult* init_result_out = nullptr);
+
 
   /**
    * @brief Destructor for the Firestore object.


### PR DESCRIPTION
Add 2 overloading methods to the firestore.h file, as proposed in Firestore Multi Database API Proposal:
```
static Firestore* GetInstance(const char* db_name,
                              InitResult* init_result_out = nullptr);
static Firestore* GetInstance(::firebase::App* app,
                              const char* db_name,
                              InitResult* init_result_out = nullptr);
```
This is only a definition, actual implementation will be pushed up in following PRs.