### PR TITLE
Auth I/O '23 - update other SDK iTests to use new API

### DIFF
--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -496,8 +496,8 @@ void FirebaseAppCheckTest::SignIn() {
     return;
   }
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "
@@ -517,8 +517,7 @@ void FirebaseAppCheckTest::SignOut() {
   }
   if (auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(auth_->current_user().Delete(),
-                      "DeleteAnonymousUser");
+    WaitForCompletion(auth_->current_user().Delete(), "DeleteAnonymousUser");
     // If there was a problem deleting the user, try to sign out at least.
     if (auth_->current_user().is_valid()) {
       auth_->SignOut();

--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -491,7 +491,7 @@ void FirebaseAppCheckTest::CleanupFirestore(int expected_error = 0) {
 }
 
 void FirebaseAppCheckTest::SignIn() {
-  if (auth_->current_user_DEPRECATED() != nullptr) {
+  if (auth_->current_user().is_valid()) {
     // Already signed in.
     return;
   }
@@ -511,16 +511,16 @@ void FirebaseAppCheckTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (auth_->current_user_DEPRECATED() == nullptr) {
+  if (!auth_->current_user().is_valid()) {
     // Already signed out.
     return;
   }
-  if (auth_->current_user_DEPRECATED()->is_anonymous()) {
+  if (auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(auth_->current_user_DEPRECATED()->Delete(),
+    WaitForCompletion(auth_->current_user().Delete(),
                       "DeleteAnonymousUser");
     // If there was a problem deleting the user, try to sign out at least.
-    if (auth_->current_user_DEPRECATED()) {
+    if (auth_->current_user().is_valid()) {
       auth_->SignOut();
     }
   } else {
@@ -529,11 +529,11 @@ void FirebaseAppCheckTest::SignOut() {
     auth_->SignOut();
 
     // Wait for the sign-out to finish.
-    while (auth_->current_user_DEPRECATED() != nullptr) {
+    while (auth_->current_user().is_valid()) {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_EQ(auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_FALSE(auth_->current_user().is_valid());
 }
 
 firebase::database::DatabaseReference FirebaseAppCheckTest::CreateWorkingPath(
@@ -645,7 +645,7 @@ TEST_F(FirebaseAppCheckTest, TestSignIn) {
   InitializeAppCheckWithDebug();
   InitializeApp();
   InitializeAuth();
-  EXPECT_NE(auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseAppCheckTest, TestDebugProviderValidToken) {

--- a/auth/tests/auth_test.cc
+++ b/auth/tests/auth_test.cc
@@ -124,7 +124,7 @@ class AuthTest : public ::testing::Test {
   void MakeAuth() {
     firebase_app_ = testing::CreateApp();
     firebase_auth_ = Auth::GetAuth(firebase_app_);
-    if (firebase_auth_->current_user_DEPRECATED()) {
+    if (firebase_auth_->current_user().is_vaild()) {
       firebase_auth_->SignOut();
     }
   }
@@ -510,16 +510,16 @@ TEST_F(AuthTest, TestCurrentUserAndSignOut) {
   MakeAuth();
 
   // No user is signed in.
-  EXPECT_EQ(nullptr, firebase_auth_->current_user_DEPRECATED());
+  EXPECT_FALSE(firebase_auth_->current_user().is_valid());
 
   // Now sign-in, say anonymously.
   Future<User*> result = firebase_auth_->SignInAnonymously_DEPRECATED();
   MaybeWaitForFuture(result);
-  EXPECT_NE(nullptr, firebase_auth_->current_user_DEPRECATED());
+  EXPECT_TRUE(firebase_auth_->current_user().is_valid());
 
   // Now sign-out.
   firebase_auth_->SignOut();
-  EXPECT_EQ(nullptr, firebase_auth_->current_user_DEPRECATED());
+  EXPECT_FALSE(firebase_auth_->current_user().is_valid());
 }
 
 TEST_F(AuthTest, TestSendPasswordResetEmailSucceeded) {

--- a/auth/tests/auth_test.cc
+++ b/auth/tests/auth_test.cc
@@ -124,7 +124,7 @@ class AuthTest : public ::testing::Test {
   void MakeAuth() {
     firebase_app_ = testing::CreateApp();
     firebase_auth_ = Auth::GetAuth(firebase_app_);
-    if (firebase_auth_->current_user().is_vaild()) {
+    if (firebase_auth_->current_user().is_valid()) {
       firebase_auth_->SignOut();
     }
   }

--- a/database/integration_test/src/integration_test.cc
+++ b/database/integration_test/src/integration_test.cc
@@ -315,13 +315,13 @@ void FirebaseDatabaseTest::TerminateDatabase() {
 }
 
 void FirebaseDatabaseTest::SignIn() {
-  if (shared_auth_->current_user_DEPRECATED() != nullptr) {
+  if (shared_auth_->current_user().is_valid()) {
     // Already signed in.
     return;
   }
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      shared_auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      shared_auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "
@@ -335,13 +335,13 @@ void FirebaseDatabaseTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED() == nullptr) {
+  if (!shared_auth_->current_user().is_valid()) {
     // Already signed out.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED()->is_anonymous()) {
+  if (shared_auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(shared_auth_->current_user_DEPRECATED()->Delete(),
+    WaitForCompletion(shared_auth_->current_user().Delete(),
                       "DeleteAnonymousUser");
   } else {
     // If not signed in anonymously (e.g. if the tests were modified to sign in
@@ -349,11 +349,11 @@ void FirebaseDatabaseTest::SignOut() {
     shared_auth_->SignOut();
 
     // Wait for the sign-out to finish.
-    while (shared_auth_->current_user_DEPRECATED() != nullptr) {
+    while (shared_auth_->current_user().is_valid()) {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_EQ(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_FALSE(shared_auth_->current_user().is_valid());
 }
 
 firebase::database::DatabaseReference FirebaseDatabaseTest::CreateWorkingPath(
@@ -371,7 +371,7 @@ TEST_F(FirebaseDatabaseTest, TestInitializeAndTerminate) {
 }
 
 TEST_F(FirebaseDatabaseTest, TestSignIn) {
-  EXPECT_NE(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(shared_auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseDatabaseTest, TestCreateWorkingPath) {

--- a/firestore/integration_test/src/integration_test.cc
+++ b/firestore/integration_test/src/integration_test.cc
@@ -277,8 +277,8 @@ void FirebaseFirestoreBasicTest::SignIn() {
     return;
   }
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      shared_auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      shared_auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "

--- a/firestore/integration_test/src/integration_test.cc
+++ b/firestore/integration_test/src/integration_test.cc
@@ -272,7 +272,7 @@ void FirebaseFirestoreBasicTest::TerminateFirestore() {
 }
 
 void FirebaseFirestoreBasicTest::SignIn() {
-  if (shared_auth_->current_user_DEPRECATED() != nullptr) {
+  if (shared_auth_->current_user().is_valid()) {
     // Already signed in.
     return;
   }
@@ -292,14 +292,14 @@ void FirebaseFirestoreBasicTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED() == nullptr) {
+  if (!shared_auth_->current_user().is_valid()) {
     // Already signed out.
     return;
   }
 
-  if (shared_auth_->current_user_DEPRECATED()->is_anonymous()) {
+  if (shared_auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(shared_auth_->current_user_DEPRECATED()->Delete(),
+    WaitForCompletion(shared_auth_->current_user().Delete(),
                       "DeleteAnonymousUser");
   } else {
     // If not signed in anonymously (e.g. if the tests were modified to sign in
@@ -307,11 +307,11 @@ void FirebaseFirestoreBasicTest::SignOut() {
     shared_auth_->SignOut();
 
     // Wait for the sign-out to finish.
-    while (shared_auth_->current_user_DEPRECATED() != nullptr) {
+    while (shared_auth_->current_user().is_valid()) {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_EQ(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_FALSE(shared_auth_->current_user().is_valid());
 }
 
 firebase::firestore::CollectionReference
@@ -345,7 +345,7 @@ TEST_F(FirebaseFirestoreBasicTest, TestInitializeAndTerminate) {
 }
 
 TEST_F(FirebaseFirestoreBasicTest, TestSignIn) {
-  EXPECT_NE(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(shared_auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseFirestoreBasicTest, TestAppAndSettings) {

--- a/firestore/integration_test_internal/src/firestore_test.cc
+++ b/firestore/integration_test_internal/src/firestore_test.cc
@@ -1537,7 +1537,7 @@ TEST_F(FirestoreIntegrationTest, AuthWorks) {
   WriteDocument(doc, MapFieldValue{{"foo", FieldValue::Integer(42)}});
 
   // Signing in should trigger an AuthStateListener event.
-  auto signin = auth->SignInAnonymously_DEPRECATED();
+  auto signin = auth->SignInAnonymously();
   Stopwatch stopwatch;
   Await(signin);
   stopwatch.stop();

--- a/firestore/integration_test_internal/src/integration_test.cc
+++ b/firestore/integration_test_internal/src/integration_test.cc
@@ -280,8 +280,8 @@ void FirebaseFirestoreBasicTest::SignIn() {
     return;
   }
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      shared_auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      shared_auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "

--- a/firestore/integration_test_internal/src/integration_test.cc
+++ b/firestore/integration_test_internal/src/integration_test.cc
@@ -275,7 +275,7 @@ void FirebaseFirestoreBasicTest::TerminateFirestore() {
 }
 
 void FirebaseFirestoreBasicTest::SignIn() {
-  if (shared_auth_->current_user_DEPRECATED() != nullptr) {
+  if (shared_auth_->current_user().is_valid) {
     // Already signed in.
     return;
   }
@@ -295,14 +295,14 @@ void FirebaseFirestoreBasicTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED() == nullptr) {
+  if (!shared_auth_->current_user().is_valid()) {
     // Already signed out.
     return;
   }
 
-  if (shared_auth_->current_user_DEPRECATED()->is_anonymous()) {
+  if (shared_auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(shared_auth_->current_user_DEPRECATED()->Delete(),
+    WaitForCompletion(shared_auth_->current_user().Delete(),
                       "DeleteAnonymousUser");
   } else {
     // If not signed in anonymously (e.g. if the tests were modified to sign in
@@ -310,11 +310,11 @@ void FirebaseFirestoreBasicTest::SignOut() {
     shared_auth_->SignOut();
 
     // Wait for the sign-out to finish.
-    while (shared_auth_->current_user_DEPRECATED() != nullptr) {
+    while (shared_auth_->current_user().is_valid()) {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_EQ(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_FALSE(shared_auth_->current_user().is_valid);
 }
 
 firebase::firestore::CollectionReference
@@ -349,7 +349,7 @@ TEST_F(FirebaseFirestoreBasicTest, TestInitializeAndTerminate) {
 
 TEST_F(FirebaseFirestoreBasicTest, TestSignIn) {
   SKIP_TEST_ON_QUICK_CHECK;
-  EXPECT_NE(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(shared_auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseFirestoreBasicTest, TestAppAndSettings) {

--- a/firestore/integration_test_internal/src/integration_test.cc
+++ b/firestore/integration_test_internal/src/integration_test.cc
@@ -275,7 +275,7 @@ void FirebaseFirestoreBasicTest::TerminateFirestore() {
 }
 
 void FirebaseFirestoreBasicTest::SignIn() {
-  if (shared_auth_->current_user().is_valid) {
+  if (shared_auth_->current_user().is_valid()) {
     // Already signed in.
     return;
   }
@@ -314,7 +314,7 @@ void FirebaseFirestoreBasicTest::SignOut() {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_FALSE(shared_auth_->current_user().is_valid);
+  EXPECT_FALSE(shared_auth_->current_user().is_valid());
 }
 
 firebase::firestore::CollectionReference

--- a/functions/integration_test/src/integration_test.cc
+++ b/functions/integration_test/src/integration_test.cc
@@ -252,7 +252,7 @@ TEST_F(FirebaseFunctionsTest, TestInitializeAndTerminate) {
 
 TEST_F(FirebaseFunctionsTest, TestSignIn) {
   SignIn();
-  EXPECT_TRUE(auth_->current_user().is_valid);
+  EXPECT_TRUE(auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseFunctionsTest, TestFunction) {

--- a/functions/integration_test/src/integration_test.cc
+++ b/functions/integration_test/src/integration_test.cc
@@ -252,7 +252,7 @@ TEST_F(FirebaseFunctionsTest, TestInitializeAndTerminate) {
 
 TEST_F(FirebaseFunctionsTest, TestSignIn) {
   SignIn();
-  EXPECT_NE(auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(auth_->current_user().is_valid);
 }
 
 TEST_F(FirebaseFunctionsTest, TestFunction) {

--- a/functions/integration_test/src/integration_test.cc
+++ b/functions/integration_test/src/integration_test.cc
@@ -184,8 +184,8 @@ void FirebaseFunctionsTest::Terminate() {
 
 void FirebaseFunctionsTest::SignIn() {
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -271,7 +271,7 @@ void FirebaseStorageTest::TerminateStorage() {
 }
 
 void FirebaseStorageTest::SignIn() {
-  if (shared_auth_->current_user_DEPRECATED() != nullptr) {
+  if (shared_auth_->current_user().is_valid()) {
     // Already signed in.
     return;
   }
@@ -291,13 +291,13 @@ void FirebaseStorageTest::SignOut() {
     // Auth is not set up.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED() == nullptr) {
+  if (!shared_auth_->current_user().is_valid()) {
     // Already signed out.
     return;
   }
-  if (shared_auth_->current_user_DEPRECATED()->is_anonymous()) {
+  if (shared_auth_->current_user().is_anonymous()) {
     // If signed in anonymously, delete the anonymous user.
-    WaitForCompletion(shared_auth_->current_user_DEPRECATED()->Delete(),
+    WaitForCompletion(shared_auth_->current_user().Delete(),
                       "DeleteAnonymousUser");
   } else {
     // If not signed in anonymously (e.g. if the tests were modified to sign in
@@ -305,11 +305,11 @@ void FirebaseStorageTest::SignOut() {
     shared_auth_->SignOut();
 
     // Wait for the sign-out to finish.
-    while (shared_auth_->current_user_DEPRECATED() != nullptr) {
+    while (shared_auth_->current_user().is_valid()) {
       if (ProcessEvents(100)) break;
     }
   }
-  EXPECT_EQ(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_FALSE(shared_auth_->current_user().is_valid());
 }
 
 firebase::storage::StorageReference FirebaseStorageTest::CreateFolder() {
@@ -330,7 +330,7 @@ TEST_F(FirebaseStorageTest, TestInitializeAndTerminate) {
 }
 
 TEST_F(FirebaseStorageTest, TestSignIn) {
-  EXPECT_NE(shared_auth_->current_user_DEPRECATED(), nullptr);
+  EXPECT_TRUE(shared_auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseStorageTest, TestCreateWorkingFolder) {

--- a/storage/integration_test/src/integration_test.cc
+++ b/storage/integration_test/src/integration_test.cc
@@ -276,8 +276,8 @@ void FirebaseStorageTest::SignIn() {
     return;
   }
   LogDebug("Signing in.");
-  firebase::Future<firebase::auth::User*> sign_in_future =
-      shared_auth_->SignInAnonymously_DEPRECATED();
+  firebase::Future<firebase::auth::AuthResult> sign_in_future =
+      shared_auth_->SignInAnonymously();
   WaitForCompletion(sign_in_future, "SignInAnonymously");
   if (sign_in_future.error() != 0) {
     FAIL() << "Ensure your application has the Anonymous sign-in provider "


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Numerous product SDKs have iTests which interact with Auth. In a previous feature branch change these tests were changed to use `Future<User*> Auth::current_user_DEPRECATED()`, for instance, as the new Auth API wasn't yet written.

This PR updates the tests to use the new APIs, such as `Future<AuthResult> Auth::current_user()`.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[Integration Test Run](https://github.com/firebase/firebase-cpp-sdk/actions/runs/4689751055)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
