### PR TITLE
Pass database_id from GetInstance() down to CreateFirestore()

### DIFF
--- a/firestore/integration_test_internal/src/util/integration_test_util.cc
+++ b/firestore/integration_test_internal/src/util/integration_test_util.cc
@@ -37,7 +37,8 @@ struct TestFriend {
   static FirestoreInternal* CreateTestFirestoreInternal(App* app) {
 #if !defined(__ANDROID__)
     return new FirestoreInternal(
-        app, /*database_id=*/"(default)",absl::make_unique<credentials::EmptyAuthCredentialsProvider>(),
+        app, /*database_id=*/"(default)",
+        absl::make_unique<credentials::EmptyAuthCredentialsProvider>(),
         absl::make_unique<credentials::EmptyAppCheckCredentialsProvider>());
 #else
     return new FirestoreInternal(app);

--- a/firestore/integration_test_internal/src/util/integration_test_util.cc
+++ b/firestore/integration_test_internal/src/util/integration_test_util.cc
@@ -37,7 +37,7 @@ struct TestFriend {
   static FirestoreInternal* CreateTestFirestoreInternal(App* app) {
 #if !defined(__ANDROID__)
     return new FirestoreInternal(
-        app, absl::make_unique<credentials::EmptyAuthCredentialsProvider>(),
+        app, /*database_id=*/"(default)",absl::make_unique<credentials::EmptyAuthCredentialsProvider>(),
         absl::make_unique<credentials::EmptyAppCheckCredentialsProvider>());
 #else
     return new FirestoreInternal(app);

--- a/firestore/integration_test_internal/src/validation_test.cc
+++ b/firestore/integration_test_internal/src/validation_test.cc
@@ -441,11 +441,35 @@ TEST_F(ValidationTest,
 }
 
 TEST_F(ValidationTest,
+       FirestoreGetInstanceWithNoArgumentsReturnsNonNullInstance) {
+  InitResult result;
+  EXPECT_NO_THROW(Firestore::GetInstance(&result));
+  EXPECT_EQ(kInitResultSuccess, result);
+  EXPECT_NE(Firestore::GetInstance(), nullptr);
+}
+
+TEST_F(ValidationTest,
        FirestoreGetInstanceWithNonNullAppReturnsNonNullInstance) {
   InitResult result;
   EXPECT_NO_THROW(Firestore::GetInstance(app(), &result));
   EXPECT_EQ(kInitResultSuccess, result);
   EXPECT_NE(Firestore::GetInstance(app()), nullptr);
+}
+
+TEST_F(ValidationTest,
+       FirestoreGetInstanceWithAppAndDatabaseNameReturnsNonNullInstance) {
+  InitResult result;
+  EXPECT_NO_THROW(Firestore::GetInstance(app(), "foo", &result));
+  EXPECT_EQ(kInitResultSuccess, result);
+  EXPECT_NE(Firestore::GetInstance(app(), "foo"), nullptr);
+}
+
+TEST_F(ValidationTest,
+       FirestoreGetInstanceWithDatabaseNameReturnsNonNullInstance) {
+  InitResult result;
+  EXPECT_NO_THROW(Firestore::GetInstance("foo", &result));
+  EXPECT_EQ(kInitResultSuccess, result);
+  EXPECT_NE(Firestore::GetInstance("foo"), nullptr);
 }
 
 TEST_F(ValidationTest, CollectionPathsMustBeOddLength) {

--- a/firestore/src/common/firestore.cc
+++ b/firestore/src/common/firestore.cc
@@ -118,20 +118,18 @@ void ValidateDatabase(const char* db_name) {
 
 }  // namespace
 
-Firestore* Firestore::GetInstance(App* app, InitResult* init_result_out) {
-  ValidateApp(app);
-
-  MutexLock lock(*g_firestores_lock);
-
-  Firestore* from_cache = FindFirestoreInCache(app, init_result_out);
-  if (from_cache) {
-    return from_cache;
+Firestore* Firestore::GetInstance(InitResult* init_result_out) {
+  App* app = App::GetInstance();
+  if (!app) {
+    SimpleThrowInvalidArgument(
+        "Failed to get firebase::App instance. Please call "
+        "firebase::App::Create before using Firestore");
   }
-  return Firestore::GetInstance(app, kDefault, init_result_out);
+  return Firestore::GetInstance(app, kDefaultDatabase, init_result_out);
 }
 
 Firestore* Firestore::GetInstance(App* app, InitResult* init_result_out) {
-  return Firestore::GetInstance(app, kDefault, init_result_out);
+  return Firestore::GetInstance(app, kDefaultDatabase, init_result_out);
 }
 
 Firestore* Firestore::GetInstance(const char* db_name,

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -73,7 +73,7 @@ class TransactionManager;
 }  // namespace csharp
 
 /** The default name for "unset" database ID in resource names. */
-static const char* kDefault = "(default)";
+static const char* kDefaultDatabase = "(default)";
 
 /**
  * @brief Entry point for the Firebase Firestore C++ SDK.
@@ -495,7 +495,7 @@ class Firestore {
   friend class csharp::ApiHeaders;
   friend class csharp::TransactionManager;
 
-  Firestore(::firebase::App* app, const char* database_id);
+  Firestore(::firebase::App* app, const char* database_id = kDefaultDatabase);
 
   explicit Firestore(FirestoreInternal* internal);
 

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -495,8 +495,8 @@ class Firestore {
   friend class csharp::ApiHeaders;
   friend class csharp::TransactionManager;
 
-  Firestore(::firebase::App* app, const char* database_id = kDefaultDatabase);
-
+  explicit Firestore(::firebase::App* app,
+                     const char* database_id = kDefaultDatabase);
   explicit Firestore(FirestoreInternal* internal);
 
   static Firestore* CreateFirestore(::firebase::App* app,

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -72,6 +72,9 @@ class TransactionManager;
 
 }  // namespace csharp
 
+/** The default name for "unset" database ID in resource names. */
+static const char* kDefault = "(default)";
+
 /**
  * @brief Entry point for the Firebase Firestore C++ SDK.
  *
@@ -492,7 +495,8 @@ class Firestore {
   friend class csharp::ApiHeaders;
   friend class csharp::TransactionManager;
 
-  explicit Firestore(::firebase::App* app);
+  Firestore(::firebase::App* app, const char* database_id);
+
   explicit Firestore(FirestoreInternal* internal);
 
   static Firestore* CreateFirestore(::firebase::App* app,

--- a/firestore/src/main/firestore_main.cc
+++ b/firestore/src/main/firestore_main.cc
@@ -101,18 +101,20 @@ void ValidateDoubleSlash(const char* path) {
 
 }  // namespace
 
-FirestoreInternal::FirestoreInternal(App* app, const char*  database_id)
-    : FirestoreInternal{app, database_id,CreateCredentialsProvider(*app),
+FirestoreInternal::FirestoreInternal(App* app, const char* database_id)
+    : FirestoreInternal{app, database_id, CreateCredentialsProvider(*app),
                         CreateAppCheckCredentialsProvider(*app)} {}
 
 FirestoreInternal::FirestoreInternal(
     App* app,
-    const char*  database_id,
+    const char* database_id,
     std::unique_ptr<AuthCredentialsProvider> auth_credentials,
     std::unique_ptr<AppCheckCredentialsProvider> app_check_credentials)
     : app_(NOT_NULL(app)),
-      firestore_core_(CreateFirestore(
-          app, database_id,std::move(auth_credentials), std::move(app_check_credentials))),
+      firestore_core_(CreateFirestore(app,
+                                      database_id,
+                                      std::move(auth_credentials),
+                                      std::move(app_check_credentials))),
       transaction_executor_(absl::ShareUniquePtr(Executor::CreateConcurrent(
           "com.google.firebase.firestore.transaction", /*threads=*/5))) {
   ApplyDefaultSettings();
@@ -122,7 +124,6 @@ FirestoreInternal::FirestoreInternal(
 #else
   App::RegisterLibrary("fire-fst", kFirestoreVersionString, nullptr);
 #endif
-
 }
 
 FirestoreInternal::~FirestoreInternal() {
@@ -133,14 +134,14 @@ FirestoreInternal::~FirestoreInternal() {
 
 std::shared_ptr<api::Firestore> FirestoreInternal::CreateFirestore(
     App* app,
-    const char*  database_id,
+    const char* database_id,
     std::unique_ptr<AuthCredentialsProvider> auth_credentials,
     std::unique_ptr<AppCheckCredentialsProvider> app_check_credentials) {
   const AppOptions& opt = app->options();
   return std::make_shared<api::Firestore>(
-      DatabaseId{opt.project_id(),database_id }, app->name(), std::move(auth_credentials),
-      std::move(app_check_credentials), CreateWorkerQueue(),
-      CreateFirebaseMetadataProvider(*app), this);
+      DatabaseId{opt.project_id(), database_id}, app->name(),
+      std::move(auth_credentials), std::move(app_check_credentials),
+      CreateWorkerQueue(), CreateFirebaseMetadataProvider(*app), this);
 }
 
 CollectionReference FirestoreInternal::Collection(

--- a/firestore/src/main/firestore_main.cc
+++ b/firestore/src/main/firestore_main.cc
@@ -101,17 +101,18 @@ void ValidateDoubleSlash(const char* path) {
 
 }  // namespace
 
-FirestoreInternal::FirestoreInternal(App* app)
-    : FirestoreInternal{app, CreateCredentialsProvider(*app),
+FirestoreInternal::FirestoreInternal(App* app, const char*  database_id)
+    : FirestoreInternal{app, database_id,CreateCredentialsProvider(*app),
                         CreateAppCheckCredentialsProvider(*app)} {}
 
 FirestoreInternal::FirestoreInternal(
     App* app,
+    const char*  database_id,
     std::unique_ptr<AuthCredentialsProvider> auth_credentials,
     std::unique_ptr<AppCheckCredentialsProvider> app_check_credentials)
     : app_(NOT_NULL(app)),
       firestore_core_(CreateFirestore(
-          app, std::move(auth_credentials), std::move(app_check_credentials))),
+          app, database_id,std::move(auth_credentials), std::move(app_check_credentials))),
       transaction_executor_(absl::ShareUniquePtr(Executor::CreateConcurrent(
           "com.google.firebase.firestore.transaction", /*threads=*/5))) {
   ApplyDefaultSettings();
@@ -121,6 +122,7 @@ FirestoreInternal::FirestoreInternal(
 #else
   App::RegisterLibrary("fire-fst", kFirestoreVersionString, nullptr);
 #endif
+
 }
 
 FirestoreInternal::~FirestoreInternal() {
@@ -131,11 +133,12 @@ FirestoreInternal::~FirestoreInternal() {
 
 std::shared_ptr<api::Firestore> FirestoreInternal::CreateFirestore(
     App* app,
+    const char*  database_id,
     std::unique_ptr<AuthCredentialsProvider> auth_credentials,
     std::unique_ptr<AppCheckCredentialsProvider> app_check_credentials) {
   const AppOptions& opt = app->options();
   return std::make_shared<api::Firestore>(
-      DatabaseId{opt.project_id()}, app->name(), std::move(auth_credentials),
+      DatabaseId{opt.project_id(),database_id }, app->name(), std::move(auth_credentials),
       std::move(app_check_credentials), CreateWorkerQueue(),
       CreateFirebaseMetadataProvider(*app), this);
 }

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -55,7 +55,7 @@ class Executor;
 class FirestoreInternal {
  public:
   // Note: call `set_firestore_public` immediately after construction.
-  explicit FirestoreInternal(App* app);
+  FirestoreInternal(App* app, const char* database_id);
   ~FirestoreInternal();
 
   FirestoreInternal(const FirestoreInternal&) = delete;
@@ -150,12 +150,14 @@ class FirestoreInternal {
 
   FirestoreInternal(
       App* app,
+      const char*  database_id,
       std::unique_ptr<credentials::AuthCredentialsProvider> auth_credentials,
       std::unique_ptr<credentials::AppCheckCredentialsProvider>
           app_check_credentials);
 
   std::shared_ptr<api::Firestore> CreateFirestore(
       App* app,
+      const char* database_id,
       std::unique_ptr<credentials::AuthCredentialsProvider> auth_credentials,
       std::unique_ptr<credentials::AppCheckCredentialsProvider>
           app_check_credentials);

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -150,7 +150,7 @@ class FirestoreInternal {
 
   FirestoreInternal(
       App* app,
-      const char*  database_id,
+      const char* database_id,
       std::unique_ptr<credentials::AuthCredentialsProvider> auth_credentials,
       std::unique_ptr<credentials::AppCheckCredentialsProvider>
           app_check_credentials);

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -30,7 +30,6 @@
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"
 #include "firestore/src/common/event_listener.h"
-#include "firestore/src/include/firebase/firestore.h"
 #include "firestore/src/include/firebase/firestore/collection_reference.h"
 #include "firestore/src/include/firebase/firestore/document_reference.h"
 #include "firestore/src/include/firebase/firestore/load_bundle_task_progress.h"
@@ -56,8 +55,7 @@ class Executor;
 class FirestoreInternal {
  public:
   // Note: call `set_firestore_public` immediately after construction.
-  explicit FirestoreInternal(App* app,
-                             const char* database_id = kDefaultDatabase);
+  FirestoreInternal(App* app, const char* database_id);
   ~FirestoreInternal();
 
   FirestoreInternal(const FirestoreInternal&) = delete;

--- a/firestore/src/main/firestore_main.h
+++ b/firestore/src/main/firestore_main.h
@@ -30,6 +30,7 @@
 #include "app/src/future_manager.h"
 #include "app/src/include/firebase/app.h"
 #include "firestore/src/common/event_listener.h"
+#include "firestore/src/include/firebase/firestore.h"
 #include "firestore/src/include/firebase/firestore/collection_reference.h"
 #include "firestore/src/include/firebase/firestore/document_reference.h"
 #include "firestore/src/include/firebase/firestore/load_bundle_task_progress.h"
@@ -55,7 +56,8 @@ class Executor;
 class FirestoreInternal {
  public:
   // Note: call `set_firestore_public` immediately after construction.
-  FirestoreInternal(App* app, const char* database_id);
+  explicit FirestoreInternal(App* app,
+                             const char* database_id = kDefaultDatabase);
   ~FirestoreInternal();
 
   FirestoreInternal(const FirestoreInternal&) = delete;


### PR DESCRIPTION
Passing database_id as an additional parameter all the way down to iOS `CreateFirestore` function.
Passing the database_id parameter only, no implementation change yet.