### PR TITLE
Default no-op for deprecated virtual function

### DIFF
--- a/auth/src/include/firebase/auth/credential.h
+++ b/auth/src/include/firebase/auth/credential.h
@@ -528,7 +528,7 @@ class PhoneAuthProvider {
     ///
     /// @param[in] credential The completed credential from the phone number
     ///    verification flow.
-    virtual void OnVerificationCompleted(Credential credential) = 0;
+    virtual void OnVerificationCompleted(Credential credential) {}
 
     /// @brief Phone number auto-verification succeeded.
     ///


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

`Listener::OnVerificationCompleted(Credential)` is going to be deprecated and should not be required to implement in the derived class.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Integration test.

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
