### PR TITLE
Add support for symbols with {lambda...#1} to merge_libraries.py

### DIFF
--- a/scripts/merge_libraries.py
+++ b/scripts/merge_libraries.py
@@ -418,7 +418,7 @@ def get_top_level_namespaces(demangled_symbols):
   # It will specifically not match second-level or deeper namespaces:
   #   matched_namespace::unmatched_namespace::Class::Method()
   regex_top_level_namespaces = re.compile(
-      r"(?<![a-zA-Z0-9_])(?<!::)([a-zA-Z_~\{\$][a-zA-Z0-9_\{\}]*)::(?=[a-zA-Z_~` \{\}\$])")
+      r"(?<![a-zA-Z0-9_])(?<!::)([a-zA-Z_~\{\$][a-zA-Z0-9_\{\}\#]*)::(?=[a-zA-Z_~` \{\$])")
   found_namespaces = set()
   for cppsymbol in demangled_symbols:
     m = regex_top_level_namespaces.findall(cppsymbol)

--- a/scripts/merge_libraries.py
+++ b/scripts/merge_libraries.py
@@ -418,7 +418,7 @@ def get_top_level_namespaces(demangled_symbols):
   # It will specifically not match second-level or deeper namespaces:
   #   matched_namespace::unmatched_namespace::Class::Method()
   regex_top_level_namespaces = re.compile(
-      r"(?<![a-zA-Z0-9_])(?<!::)([a-zA-Z_~\$][a-zA-Z0-9_]*)::(?=[a-zA-Z_~` \$])")
+      r"(?<![a-zA-Z0-9_])(?<!::)([a-zA-Z_~\{\$][a-zA-Z0-9_\{\}]*)::(?=[a-zA-Z_~` \{\}\$])")
   found_namespaces = set()
   for cppsymbol in demangled_symbols:
     m = regex_top_level_namespaces.findall(cppsymbol)

--- a/scripts/merge_libraries_test.py
+++ b/scripts/merge_libraries_test.py
@@ -51,8 +51,12 @@ class MergeLibrariesTest(absltest.TestCase):
         "topleveldestructor::~topleveldestructor()": {"topleveldestructor"},
         "rtti::RttiClass::`RTTI Class Hierarchy Descriptor'": {"rtti"},
         "toplevelrtti::`RTTI Class Hierarchy Descriptor'": {"toplevelrtti"},
+        # Test some complicated grpc cases that required special handling.
         "public: virtual enum grpc_security_level __cdecl grpc_call_credentials::min_security_level(void) const": {
           "grpc_call_credentials"
+        },
+        "grpc_slice_malloc_large::{lambda(grpc_slice_refcount*)#1}::_FUN(grpc_slice_refcount*)": {
+          "grpc_slice_malloc_large"
         },
         # std namespaces are used by get_top_level_namespaces but not by add_automatic_namespaces
         "std::dont_use_this<std::other_thing>()": {"std"},


### PR DESCRIPTION
Add support for symbols like this one, which is referenced by the Firestore iOS SDK on Linux:

`grpc_slice_malloc_large::{lambda(grpc_slice_refcount*)#1}::_FUN(grpc_slice_refcount*)`

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


C++ packaging run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/4756815007
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
