### PR TITLE
Fixes for the App Check Android testapp

### DIFF
--- a/app_check/integration_test/build.gradle
+++ b/app_check/integration_test/build.gradle
@@ -68,6 +68,7 @@ android {
         "-DFIREBASE_INCLUDE_FUNCTIONS=ON",
         "-DFIREBASE_INCLUDE_FIRESTORE=ON"
     }
+    multiDexEnabled true
   }
   externalNativeBuild.cmake {
     path 'CMakeLists.txt'
@@ -78,6 +79,9 @@ android {
       proguardFile getDefaultProguardFile('proguard-android.txt')
       proguardFile file('proguard.pro')
     }
+  }
+  lintOptions {
+    abortOnError false
   }
 }
 

--- a/app_check/integration_test/src/integration_test.cc
+++ b/app_check/integration_test/src/integration_test.cc
@@ -750,8 +750,24 @@ TEST_F(FirebaseAppCheckTest, DISABLED_TestDatabaseFailure) {
   firebase::database::DatabaseReference ref = CreateWorkingPath();
   const char* test_name = test_info_->name();
   firebase::Future<void> f = ref.Child(test_name).SetValue("test");
-  // It is unclear if this should fail, or hang, so disabled for now.
-  WaitForCompletion(f, "SetString");
+#if FIREBASE_PLATFORM_ANDROID
+  // On Android the future will not complete. This is present in the
+  // underlying Android SDK, so work around it here.
+  ASSERT_EQ(f.status(), firebase::kFutureStatusPending);
+  std::this_thread::sleep_for(std::chrono::milliseconds(2000));
+  ASSERT_EQ(f.status(), firebase::kFutureStatusPending);
+  // Likewise, removal won't finish, so don't wait for it.
+  if (!database_cleanup_.empty()) {
+    LogDebug("Cleaning up Database...");
+    for (int i = 0; i < database_cleanup_.size(); ++i) {
+      database_cleanup_[i].RemoveValue();
+    }
+    database_cleanup_.clear();
+  }
+#else
+  WaitForCompletion(f, "SetString", firebase::database::kErrorDisconnected);
+  CleanupDatabase(firebase::database::kErrorOperationFailed);
+#endif
 }
 
 TEST_F(FirebaseAppCheckTest, DISABLED_TestDatabaseCreateWorkingPath) {

--- a/app_check/src/android/app_check_android.cc
+++ b/app_check/src/android/app_check_android.cc
@@ -63,11 +63,13 @@ METHOD_LOOKUP_DEFINITION(app_check,
   X(ResetAppCheckState, "resetAppCheckState", "()V")
 // clang-format on
 
-METHOD_LOOKUP_DECLARATION(default_app_check_impl, DEFAULT_APP_CHECK_IMPL_METHODS)
-METHOD_LOOKUP_DEFINITION(default_app_check_impl,
-                         PROGUARD_KEEP_CLASS
-                         "com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck",
-                         DEFAULT_APP_CHECK_IMPL_METHODS)
+METHOD_LOOKUP_DECLARATION(default_app_check_impl,
+                          DEFAULT_APP_CHECK_IMPL_METHODS)
+METHOD_LOOKUP_DEFINITION(
+    default_app_check_impl,
+    PROGUARD_KEEP_CLASS
+    "com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck",
+    DEFAULT_APP_CHECK_IMPL_METHODS)
 
 // clang-format off
 #define JNI_APP_CHECK_PROVIDER_FACTORY_METHODS(X)                              \
@@ -380,10 +382,9 @@ AppCheckInternal::~AppCheckInternal() {
     // is a DefaultFirebaseAppCheck (instead of a FirebaseAppCheck)
     // which is currently true, but may not be in the future.
     // We will have to rely on tests to detect if this changes.
-    env->CallVoidMethod(
-      app_check_impl_,
-      default_app_check_impl::GetMethodId(
-        default_app_check_impl::kResetAppCheckState));
+    env->CallVoidMethod(app_check_impl_,
+                        default_app_check_impl::GetMethodId(
+                            default_app_check_impl::kResetAppCheckState));
     FIREBASE_ASSERT(!util::CheckAndClearJniExceptions(env));
 
     env->DeleteGlobalRef(app_check_impl_);

--- a/app_check/src/android/app_check_android.cc
+++ b/app_check/src/android/app_check_android.cc
@@ -59,6 +59,17 @@ METHOD_LOOKUP_DEFINITION(app_check,
                          APP_CHECK_METHODS)
 
 // clang-format off
+#define DEFAULT_APP_CHECK_IMPL_METHODS(X)               \
+  X(ResetAppCheckState, "resetAppCheckState", "()V")
+// clang-format on
+
+METHOD_LOOKUP_DECLARATION(default_app_check_impl, DEFAULT_APP_CHECK_IMPL_METHODS)
+METHOD_LOOKUP_DEFINITION(default_app_check_impl,
+                         PROGUARD_KEEP_CLASS
+                         "com/google/firebase/appcheck/internal/DefaultFirebaseAppCheck",
+                         DEFAULT_APP_CHECK_IMPL_METHODS)
+
+// clang-format off
 #define JNI_APP_CHECK_PROVIDER_FACTORY_METHODS(X)                              \
   X(Constructor, "<init>", "(JJ)V")
 // clang-format on
@@ -159,11 +170,13 @@ bool CacheAppCheckMethodIds(
             FIREBASE_ARRAYSIZE(kNativeJniAppCheckListenerMethods)))) {
     return false;
   }
-  return app_check::CacheMethodIds(env, activity);
+  return app_check::CacheMethodIds(env, activity) &&
+         default_app_check_impl::CacheMethodIds(env, activity);
 }
 
 void ReleaseAppCheckClasses(JNIEnv* env) {
   app_check::ReleaseClass(env);
+  default_app_check_impl::ReleaseClass(env);
   jni_provider_factory::ReleaseClass(env);
   jni_provider::ReleaseClass(env);
   jni_app_check_listener::ReleaseClass(env);
@@ -359,6 +372,20 @@ AppCheckInternal::~AppCheckInternal() {
     env->DeleteGlobalRef(j_app_check_listener_);
   }
   if (app_check_impl_ != nullptr) {
+    // The Android App Check library holds onto the provider,
+    // which can be a problem if it tries to call up to C++
+    // after being deleted. So we use a hidden function meant
+    // for testing purposes to clear out the App Check state,
+    // to prevent this. Note, this assumes that the java object
+    // is a DefaultFirebaseAppCheck (instead of a FirebaseAppCheck)
+    // which is currently true, but may not be in the future.
+    // We will have to rely on tests to detect if this changes.
+    env->CallVoidMethod(
+      app_check_impl_,
+      default_app_check_impl::GetMethodId(
+        default_app_check_impl::kResetAppCheckState));
+    FIREBASE_ASSERT(!util::CheckAndClearJniExceptions(env));
+
     env->DeleteGlobalRef(app_check_impl_);
   }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Contains a couple fixes for the App Check Android testapp:
 - Turn on multidex support and off lint warnings in the gradle file, because of firestore
 - Change the database test to handle that Android doesn't complete tasks with a bad app check
 - Clean the Android App Check state on cleanup of the C++ App Check, to prevent it from calling up to C++ afterwards
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building and running the testapp locally
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [x] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
