### PR TITLE
Wrap the App Check Obj C pointers to fix memory issues

### DIFF
--- a/app_check/src/ios/debug_provider_ios.h
+++ b/app_check/src/ios/debug_provider_ios.h
@@ -17,6 +17,8 @@
 
 #include <map>
 
+#include "app/memory/unique_ptr.h"
+#include "app/src/util_ios.h"
 #include "firebase/app_check.h"
 
 #ifdef __OBJC__
@@ -26,6 +28,10 @@
 namespace firebase {
 namespace app_check {
 namespace internal {
+
+// This defines the class FIRAppCheckDebugProviderFactoryPointer, which is a C++-compatible
+// wrapper around the FIRAppCheckDebugProviderFactory Obj-C class.
+OBJ_C_PTR_WRAPPER(FIRAppCheckDebugProviderFactory);
 
 class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
  public:
@@ -37,8 +43,11 @@ class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
 
  private:
 #ifdef __OBJC__
-  FIRAppCheckDebugProviderFactory* ios_provider_factory_;
+  FIRAppCheckDebugProviderFactory* ios_provider_factory() const { return ios_provider_factory_->get(); }
 #endif  // __OBJC__
+
+  // Object lifetime managed by Objective C ARC.
+  UniquePtr<FIRAppCheckDebugProviderFactoryPointer> ios_provider_factory_;
 
   std::map<App*, AppCheckProvider*> created_providers_;
 };

--- a/app_check/src/ios/debug_provider_ios.h
+++ b/app_check/src/ios/debug_provider_ios.h
@@ -29,8 +29,9 @@ namespace firebase {
 namespace app_check {
 namespace internal {
 
-// This defines the class FIRAppCheckDebugProviderFactoryPointer, which is a C++-compatible
-// wrapper around the FIRAppCheckDebugProviderFactory Obj-C class.
+// This defines the class FIRAppCheckDebugProviderFactoryPointer, which is a
+// C++-compatible wrapper around the FIRAppCheckDebugProviderFactory Obj-C
+// class.
 OBJ_C_PTR_WRAPPER(FIRAppCheckDebugProviderFactory);
 
 class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
@@ -43,7 +44,9 @@ class DebugAppCheckProviderFactoryInternal : public AppCheckProviderFactory {
 
  private:
 #ifdef __OBJC__
-  FIRAppCheckDebugProviderFactory* ios_provider_factory() const { return ios_provider_factory_->get(); }
+  FIRAppCheckDebugProviderFactory* ios_provider_factory() const {
+    return ios_provider_factory_->get();
+  }
 #endif  // __OBJC__
 
   // Object lifetime managed by Objective C ARC.

--- a/app_check/src/ios/debug_provider_ios.mm
+++ b/app_check/src/ios/debug_provider_ios.mm
@@ -59,7 +59,7 @@ void DebugAppCheckProvider::GetToken(
 
 DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal()
     : created_providers_() {
-  ios_provider_factory_ = [[FIRAppCheckDebugProviderFactory alloc] init];
+  ios_provider_factory_ = MakeUnique<FIRAppCheckDebugProviderFactoryPointer>([[FIRAppCheckDebugProviderFactory alloc] init]);
 }
 
 DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {
@@ -78,7 +78,7 @@ AppCheckProvider* DebugAppCheckProviderFactoryInternal::CreateProvider(App* app)
   }
   // Otherwise, create a new provider
   FIRAppCheckDebugProvider* ios_provider =
-      [ios_provider_factory_ createProviderWithApp:app->GetPlatformApp()];
+      [ios_provider_factory() createProviderWithApp:app->GetPlatformApp()];
   AppCheckProvider* cpp_provider = new internal::DebugAppCheckProvider(ios_provider);
   created_providers_[app] = cpp_provider;
   return cpp_provider;

--- a/app_check/src/ios/debug_provider_ios.mm
+++ b/app_check/src/ios/debug_provider_ios.mm
@@ -59,7 +59,8 @@ void DebugAppCheckProvider::GetToken(
 
 DebugAppCheckProviderFactoryInternal::DebugAppCheckProviderFactoryInternal()
     : created_providers_() {
-  ios_provider_factory_ = MakeUnique<FIRAppCheckDebugProviderFactoryPointer>([[FIRAppCheckDebugProviderFactory alloc] init]);
+  ios_provider_factory_ = MakeUnique<FIRAppCheckDebugProviderFactoryPointer>(
+      [[FIRAppCheckDebugProviderFactory alloc] init]);
 }
 
 DebugAppCheckProviderFactoryInternal::~DebugAppCheckProviderFactoryInternal() {

--- a/app_check/src/ios/device_check_provider_ios.h
+++ b/app_check/src/ios/device_check_provider_ios.h
@@ -29,8 +29,8 @@ namespace firebase {
 namespace app_check {
 namespace internal {
 
-// This defines the class FIRDeviceCheckProviderFactoryPointer, which is a C++-compatible
-// wrapper around the FIRDeviceCheckProviderFactory Obj-C class.
+// This defines the class FIRDeviceCheckProviderFactoryPointer, which is a
+// C++-compatible wrapper around the FIRDeviceCheckProviderFactory Obj-C class.
 OBJ_C_PTR_WRAPPER(FIRDeviceCheckProviderFactory);
 
 class DeviceCheckProviderFactoryInternal : public AppCheckProviderFactory {
@@ -43,7 +43,9 @@ class DeviceCheckProviderFactoryInternal : public AppCheckProviderFactory {
 
  private:
 #ifdef __OBJC__
-  FIRDeviceCheckProviderFactory* ios_provider_factory() const { return ios_provider_factory_->get(); }
+  FIRDeviceCheckProviderFactory* ios_provider_factory() const {
+    return ios_provider_factory_->get();
+  }
 #endif  // __OBJC__
 
   // Object lifetime managed by Objective C ARC.

--- a/app_check/src/ios/device_check_provider_ios.h
+++ b/app_check/src/ios/device_check_provider_ios.h
@@ -17,6 +17,8 @@
 
 #include <map>
 
+#include "app/memory/unique_ptr.h"
+#include "app/src/util_ios.h"
 #include "firebase/app_check.h"
 
 #ifdef __OBJC__
@@ -26,6 +28,10 @@
 namespace firebase {
 namespace app_check {
 namespace internal {
+
+// This defines the class FIRDeviceCheckProviderFactoryPointer, which is a C++-compatible
+// wrapper around the FIRDeviceCheckProviderFactory Obj-C class.
+OBJ_C_PTR_WRAPPER(FIRDeviceCheckProviderFactory);
 
 class DeviceCheckProviderFactoryInternal : public AppCheckProviderFactory {
  public:
@@ -37,8 +43,11 @@ class DeviceCheckProviderFactoryInternal : public AppCheckProviderFactory {
 
  private:
 #ifdef __OBJC__
-  FIRDeviceCheckProviderFactory* ios_provider_factory_;
+  FIRDeviceCheckProviderFactory* ios_provider_factory() const { return ios_provider_factory_->get(); }
 #endif  // __OBJC__
+
+  // Object lifetime managed by Objective C ARC.
+  UniquePtr<FIRDeviceCheckProviderFactoryPointer> ios_provider_factory_;
 
   std::map<App*, AppCheckProvider*> created_providers_;
 };

--- a/app_check/src/ios/device_check_provider_ios.mm
+++ b/app_check/src/ios/device_check_provider_ios.mm
@@ -58,7 +58,7 @@ void DeviceCheckProvider::GetToken(
 }
 
 DeviceCheckProviderFactoryInternal::DeviceCheckProviderFactoryInternal() : created_providers_() {
-  ios_provider_factory_ = [[FIRDeviceCheckProviderFactory alloc] init];
+  ios_provider_factory_ = MakeUnique<FIRDeviceCheckProviderFactoryPointer>([[FIRDeviceCheckProviderFactory alloc] init]);
 }
 
 DeviceCheckProviderFactoryInternal::~DeviceCheckProviderFactoryInternal() {
@@ -77,7 +77,7 @@ AppCheckProvider* DeviceCheckProviderFactoryInternal::CreateProvider(App* app) {
   }
   // Otherwise, create a new provider
   FIRDeviceCheckProvider* ios_provider =
-      [ios_provider_factory_ createProviderWithApp:app->GetPlatformApp()];
+      [ios_provider_factory() createProviderWithApp:app->GetPlatformApp()];
   AppCheckProvider* cpp_provider = new internal::DeviceCheckProvider(ios_provider);
   created_providers_[app] = cpp_provider;
   return cpp_provider;

--- a/app_check/src/ios/device_check_provider_ios.mm
+++ b/app_check/src/ios/device_check_provider_ios.mm
@@ -58,7 +58,8 @@ void DeviceCheckProvider::GetToken(
 }
 
 DeviceCheckProviderFactoryInternal::DeviceCheckProviderFactoryInternal() : created_providers_() {
-  ios_provider_factory_ = MakeUnique<FIRDeviceCheckProviderFactoryPointer>([[FIRDeviceCheckProviderFactory alloc] init]);
+  ios_provider_factory_ = MakeUnique<FIRDeviceCheckProviderFactoryPointer>(
+      [[FIRDeviceCheckProviderFactory alloc] init]);
 }
 
 DeviceCheckProviderFactoryInternal::~DeviceCheckProviderFactoryInternal() {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

We need to make sure the sizeof objects are the same regardless of definitions, so wrap the Obj C objects with a pointer than can always be present.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running tests locally
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
