### PR TITLE
Remove "_DEPRECATED" from LinkAndRetrieveDataWithCredential

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -972,9 +972,8 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential_DEPRECATED) {
   firebase::auth::Credential credential =
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
-  WaitForCompletion(
-      user->LinkAndRetrieveDataWithCredential(credential),
-      "LinkAndRetrieveDataWithCredential");
+  WaitForCompletion(user->LinkAndRetrieveDataWithCredential(credential),
+                    "LinkAndRetrieveDataWithCredential");
   WaitForCompletion(user->Unlink_DEPRECATED(credential.provider().c_str()),
                     "Unlink");
   SignOut();

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -973,8 +973,8 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential_DEPRECATED) {
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
   WaitForCompletion(
-      user->LinkAndRetrieveDataWithCredential_DEPRECATED(credential),
-      "LinkAndRetrieveDataWithCredential_DEPRECATED");
+      user->LinkAndRetrieveDataWithCredential(credential),
+      "LinkAndRetrieveDataWithCredential");
   WaitForCompletion(user->Unlink_DEPRECATED(credential.provider().c_str()),
                     "Unlink");
   SignOut();

--- a/auth/src/android/user_android.cc
+++ b/auth/src/android/user_android.cc
@@ -541,14 +541,14 @@ Future<User*> User::LinkWithCredential_DEPRECATED(
   return MakeFuture(&futures, handle);
 }
 
-Future<SignInResult> User::LinkAndRetrieveDataWithCredential_DEPRECATED(
+Future<SignInResult> User::LinkAndRetrieveDataWithCredential(
     const Credential& credential) {
   if (!ValidUser(auth_data_)) {
     return Future<SignInResult>();
   }
   ReferenceCountedFutureImpl& futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<SignInResult>(
-      kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED);
+      kUserFn_LinkAndRetrieveDataWithCredential);
   JNIEnv* env = Env(auth_data_);
 
   jobject pending_result = env->CallObjectMethod(

--- a/auth/src/data.h
+++ b/auth/src/data.h
@@ -60,7 +60,7 @@ enum AuthApiFunction {
   kUserFn_UpdateUserProfile,
   kUserFn_LinkWithCredential,
   kUserFn_LinkWithCredential_DEPRECATED,
-  kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED,
+  kUserFn_LinkAndRetrieveDataWithCredential,
   kUserFn_LinkWithProvider,
   kUserFn_LinkWithProvider_DEPRECATED,
   kUserFn_ReauthenticateWithProvider,

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -1095,11 +1095,11 @@ Future<User*> User::LinkWithCredential_DEPRECATED(
                                      credential.impl_);
 }
 
-Future<SignInResult> User::LinkAndRetrieveDataWithCredential_DEPRECATED(
+Future<SignInResult> User::LinkAndRetrieveDataWithCredential(
     const Credential& credential) {
   Promise<SignInResult> promise(
       &auth_data_->future_impl,
-      kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED);
+      kUserFn_LinkAndRetrieveDataWithCredential);
   if (!ValidateCurrentUser(&promise, auth_data_)) {
     return promise.LastResult();
   }

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -1097,9 +1097,8 @@ Future<User*> User::LinkWithCredential_DEPRECATED(
 
 Future<SignInResult> User::LinkAndRetrieveDataWithCredential(
     const Credential& credential) {
-  Promise<SignInResult> promise(
-      &auth_data_->future_impl,
-      kUserFn_LinkAndRetrieveDataWithCredential);
+  Promise<SignInResult> promise(&auth_data_->future_impl,
+                                kUserFn_LinkAndRetrieveDataWithCredential);
   if (!ValidateCurrentUser(&promise, auth_data_)) {
     return promise.LastResult();
   }

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -426,8 +426,8 @@ class User : public UserInfoInterface {
   ///
   /// Data from the Identity Provider used to sign-in is returned in the
   /// @ref AdditionalUserInfo inside @ref SignInResult.
-  FIREBASE_DEPRECATED Future<SignInResult>
-  LinkAndRetrieveDataWithCredential(const Credential& credential);
+  FIREBASE_DEPRECATED Future<SignInResult> LinkAndRetrieveDataWithCredential(
+      const Credential& credential);
 
   /// @deprecated
   ///

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -427,14 +427,14 @@ class User : public UserInfoInterface {
   /// Data from the Identity Provider used to sign-in is returned in the
   /// @ref AdditionalUserInfo inside @ref SignInResult.
   FIREBASE_DEPRECATED Future<SignInResult>
-  LinkAndRetrieveDataWithCredential_DEPRECATED(const Credential& credential);
+  LinkAndRetrieveDataWithCredential(const Credential& credential);
 
   /// @deprecated
   ///
   /// Get results of the most recent call to
-  /// @ref LinkAndRetrieveDataWithCredential_DEPRECATED.
+  /// @ref LinkAndRetrieveDataWithCredential.
   FIREBASE_DEPRECATED Future<SignInResult>
-  LinkAndRetrieveDataWithCredentialLastResult_DEPRECATED() const;
+  LinkAndRetrieveDataWithCredentialLastResult() const;
 
   ///
   /// @param[in] provider Contains information on the auth provider to link

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -217,14 +217,14 @@ Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential)
   return MakeFuture(&futures, handle);
 }
 
-Future<SignInResult> User::LinkAndRetrieveDataWithCredential_DEPRECATED(
+Future<SignInResult> User::LinkAndRetrieveDataWithCredential(
     const Credential &credential) {
   if (!ValidUser(auth_data_)) {
     return Future<SignInResult>();
   }
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
-      kUserFn_LinkAndRetrieveDataWithCredential_DEPRECATED, SignInResult());
+      kUserFn_LinkAndRetrieveDataWithCredential, SignInResult());
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
       linkWithCredential:CredentialFromImpl(credential.impl_)

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -217,8 +217,7 @@ Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential)
   return MakeFuture(&futures, handle);
 }
 
-Future<SignInResult> User::LinkAndRetrieveDataWithCredential(
-    const Credential &credential) {
+Future<SignInResult> User::LinkAndRetrieveDataWithCredential(const Credential &credential) {
   if (!ValidUser(auth_data_)) {
     return Future<SignInResult>();
   }

--- a/auth/src/user.cc
+++ b/auth/src/user.cc
@@ -33,7 +33,10 @@ AUTH_RESULT_FN(User, Delete, void)
 AUTH_RESULT_FN(User, UpdatePhoneNumberCredential, User)
 
 AUTH_RESULT_DEPRECATED_FN(User, LinkWithCredential, User*)
-AUTH_RESULT_DEPRECATED_FN(User, LinkAndRetrieveDataWithCredential, SignInResult)
+// LinkAndRetrieveDataWithCredential is deprecated but there is no conflict,
+// therefore no need of DEPRECATED suffix. Put it here for easier removal in the
+// future.
+AUTH_RESULT_FN(User, LinkAndRetrieveDataWithCredential, SignInResult)
 AUTH_RESULT_DEPRECATED_FN(User, ReauthenticateAndRetrieveData, SignInResult)
 AUTH_RESULT_DEPRECATED_FN(User, Unlink, User*)
 AUTH_RESULT_DEPRECATED_FN(User, UpdatePhoneNumberCredential, User*)

--- a/auth/tests/desktop/user_desktop_test.cc
+++ b/auth/tests/desktop/user_desktop_test.cc
@@ -691,7 +691,7 @@ TEST_F(UserDesktopTest, TestLinkWithCredentialAndRetrieveData) {
   const Credential credential =
       GoogleAuthProvider::GetCredential("fake_id_token", "");
   const SignInResult sign_in_result = WaitForFuture(
-      firebase_user_->LinkAndRetrieveDataWithCredential_DEPRECATED(credential));
+      firebase_user_->LinkAndRetrieveDataWithCredential(credential));
   EXPECT_FALSE(sign_in_result.user->is_anonymous());
   VerifyUser(*sign_in_result.user);
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

No need a DEPRECATED suffix for `LinkAndRetrieveDataWithCredential()` since there's no conflict in a new overloaded version of the method.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


GA
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
