### PR TITLE
Fix use of handle in AppCheck block

### DIFF
--- a/app_check/src/ios/app_check_ios.mm
+++ b/app_check/src/ios/app_check_ios.mm
@@ -176,7 +176,7 @@ void AppCheckInternal::SetTokenAutoRefreshEnabled(bool is_token_auto_refresh_ena
 }
 
 Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
-  SafeFutureHandle<AppCheckToken> handle =
+  __block SafeFutureHandle<AppCheckToken> handle =
       future()->SafeAlloc<AppCheckToken>(kAppCheckFnGetAppCheckToken);
 
   [impl()

--- a/app_check/src/ios/app_check_ios.mm
+++ b/app_check/src/ios/app_check_ios.mm
@@ -179,8 +179,6 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
   SafeFutureHandle<AppCheckToken> handle =
       future()->SafeAlloc<AppCheckToken>(kAppCheckFnGetAppCheckToken);
 
-  // __block allows handle to be referenced inside the objective C completion.
-  __block SafeFutureHandle<AppCheckToken>* handle_in_block = &handle;
   [impl()
       tokenForcingRefresh:force_refresh
                completion:^(FIRAppCheckToken* _Nullable token, NSError* _Nullable error) {
@@ -190,18 +188,18 @@ Future<AppCheckToken> AppCheckInternal::GetAppCheckToken(bool force_refresh) {
                    int error_code = firebase::app_check::internal::AppCheckErrorFromNSError(error);
                    std::string error_message = util::NSStringToString(error.localizedDescription);
 
-                   future()->CompleteWithResult(*handle_in_block, error_code, error_message.c_str(),
+                   future()->CompleteWithResult(handle, error_code, error_message.c_str(),
                                                 cpp_token);
                    return;
                  }
                  if (token == nil) {
                    NSLog(@"App Check token is nil.");
-                   future()->CompleteWithResult(*handle_in_block, kAppCheckErrorUnknown,
+                   future()->CompleteWithResult(handle, kAppCheckErrorUnknown,
                                                 "AppCheck GetToken returned an empty token.",
                                                 cpp_token);
                    return;
                  }
-                 future()->CompleteWithResult(*handle_in_block, kAppCheckErrorNone, cpp_token);
+                 future()->CompleteWithResult(handle, kAppCheckErrorNone, cpp_token);
                }];
   return MakeFuture(future(), handle);
 }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

GetAppCheckToken on iOS was using a pointer for a local variable, which could be deleted by the time it is used. Instead, use the handle directly in the block, which should keep it alive as expected.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running the Unity testapp locally
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
