### PR TITLE
Fix `credential.is_valid()` crash on iOS

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -310,6 +310,7 @@ bool FirebaseAuthTest::WaitForCompletion(
     EXPECT_EQ(result_ptr->additional_user_info.provider_id, provider_id);
     EXPECT_EQ(result_ptr->user.uid(), auth_->current_user().uid());
     EXPECT_TRUE(auth_->current_user().is_valid());
+    EXPECT_TRUE(result_ptr->credential.is_valid());
   }
   return succeeded;
 }

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -273,6 +273,9 @@ bool FirebaseAuthTest::WaitForCompletion(
         EXPECT_TRUE(auth_->current_user().is_valid());
         EXPECT_EQ(future.result()->user.uid(), auth_->current_user().uid())
             << "User returned by Future doesn't match User in Auth";
+        // Expect no crash.
+        // TODO(b/281590792): Properly validate AuthResult fields case-by-case.
+        future.result()->credential.is_valid();
         succeeded = future.result()->user.is_valid() &&
                     auth_->current_user().is_valid();
       }
@@ -310,7 +313,9 @@ bool FirebaseAuthTest::WaitForCompletion(
     EXPECT_EQ(result_ptr->additional_user_info.provider_id, provider_id);
     EXPECT_EQ(result_ptr->user.uid(), auth_->current_user().uid());
     EXPECT_TRUE(auth_->current_user().is_valid());
-    EXPECT_TRUE(result_ptr->credential.is_valid());
+    // Expect no crash.
+    // TODO(b/281590792): Properly validate AuthResult fields case-by-case.
+    result_ptr->credential.is_valid();
   }
   return succeeded;
 }
@@ -369,6 +374,7 @@ TEST_F(FirebaseAuthTest, TestInitialization) {
 
 TEST_F(FirebaseAuthTest, TestAnonymousSignin) {
   // Test notification on SignIn().
+
   WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
   EXPECT_TRUE(auth_->current_user().is_valid());
   EXPECT_TRUE(auth_->current_user().is_anonymous());

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -275,7 +275,7 @@ bool FirebaseAuthTest::WaitForCompletion(
             << "User returned by Future doesn't match User in Auth";
         // Expect no crash.
         // TODO(b/281590792): Properly validate AuthResult fields case-by-case.
-        future.result()->credential.is_valid();
+        (void)future.result()->credential.is_valid();
         succeeded = future.result()->user.is_valid() &&
                     auth_->current_user().is_valid();
       }
@@ -315,7 +315,7 @@ bool FirebaseAuthTest::WaitForCompletion(
     EXPECT_TRUE(auth_->current_user().is_valid());
     // Expect no crash.
     // TODO(b/281590792): Properly validate AuthResult fields case-by-case.
-    result_ptr->credential.is_valid();
+    (void)result_ptr->credential.is_valid();
   }
   return succeeded;
 }

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -456,8 +456,8 @@ Future<User> Auth::SignInWithCredential(const Credential &credential) {
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User>(kAuthFn_SignInWithCredential, User());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
 
   [AuthImpl(auth_data_)
@@ -473,8 +473,8 @@ Future<User *> Auth::SignInWithCredential_DEPRECATED(const Credential &credentia
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User *>(kAuthFn_SignInWithCredential_DEPRECATED, nullptr);
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
 
   [AuthImpl(auth_data_)
@@ -491,8 +491,8 @@ Future<AuthResult> Auth::SignInAndRetrieveDataWithCredential(const Credential &c
   const auto handle =
       futures.SafeAlloc<AuthResult>(kAuthFn_SignInAndRetrieveDataWithCredential, AuthResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
 
   [AuthImpl(auth_data_)
@@ -510,8 +510,8 @@ Future<SignInResult> Auth::SignInAndRetrieveDataWithCredential_DEPRECATED(
   const auto handle = futures.SafeAlloc<SignInResult>(
       kAuthFn_SignInAndRetrieveDataWithCredential_DEPRECATED, SignInResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
 
   [AuthImpl(auth_data_)

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -455,6 +455,10 @@ Future<User *> Auth::SignInWithCustomToken_DEPRECATED(const char *token) {
 Future<User> Auth::SignInWithCredential(const Credential &credential) {
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User>(kAuthFn_SignInWithCredential, User());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
 
   [AuthImpl(auth_data_)
       signInWithCredential:CredentialFromImpl(credential.impl_)
@@ -468,6 +472,10 @@ Future<User> Auth::SignInWithCredential(const Credential &credential) {
 Future<User *> Auth::SignInWithCredential_DEPRECATED(const Credential &credential) {
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User *>(kAuthFn_SignInWithCredential_DEPRECATED, nullptr);
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
 
   [AuthImpl(auth_data_)
       signInWithCredential:CredentialFromImpl(credential.impl_)
@@ -482,6 +490,10 @@ Future<AuthResult> Auth::SignInAndRetrieveDataWithCredential(const Credential &c
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle =
       futures.SafeAlloc<AuthResult>(kAuthFn_SignInAndRetrieveDataWithCredential, AuthResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
 
   [AuthImpl(auth_data_)
       signInWithCredential:CredentialFromImpl(credential.impl_)
@@ -497,6 +509,10 @@ Future<SignInResult> Auth::SignInAndRetrieveDataWithCredential_DEPRECATED(
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<SignInResult>(
       kAuthFn_SignInAndRetrieveDataWithCredential_DEPRECATED, SignInResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
 
   [AuthImpl(auth_data_)
       signInWithCredential:CredentialFromImpl(credential.impl_)

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -97,8 +97,8 @@ static inline FIRAuthCredential *_Nullable CredentialFromImpl(void *_Nullable im
 
 /// Convert from the void* credential implementation pointer into the Obj-C
 /// FIRPhoneAuthCredential pointer.
-static inline FIRPhoneAuthCredential *_Nonnull PhoneAuthCredentialFromImpl(void *_Nonnull impl) {
-  return static_cast<FIRPhoneAuthCredentialPointer *>(impl)->get();
+static inline FIRPhoneAuthCredential *_Nullable PhoneAuthCredentialFromImpl(void *_Nullable impl) {
+  return impl ? static_cast<FIRPhoneAuthCredentialPointer *>(impl)->get() : nil;
 }
 
 AuthError AuthErrorFromNSError(NSError *_Nullable error);

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -91,8 +91,8 @@ static inline FIRAuth *_Nonnull AuthImpl(AuthData *_Nonnull auth_data) {
 
 /// Convert from the void* credential implementation pointer into the Obj-C
 /// FIRAuthCredential pointer.
-static inline FIRAuthCredential *_Nonnull CredentialFromImpl(void *_Nonnull impl) {
-  return static_cast<FIRAuthCredentialPointer *>(impl)->get();
+static inline FIRAuthCredential *_Nullable CredentialFromImpl(void *_Nullable impl) {
+  return impl ? static_cast<FIRAuthCredentialPointer *>(impl)->get() : nil;
 }
 
 /// Convert from the void* credential implementation pointer into the Obj-C

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -195,8 +195,8 @@ Future<AuthResult> User::LinkWithCredential(const Credential &credential) {
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<AuthResult>(kUserFn_LinkWithCredential, AuthResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
@@ -214,8 +214,8 @@ Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential)
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User *>(kUserFn_LinkWithCredential_DEPRECATED);
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   [UserImpl(auth_data_)
       linkWithCredential:CredentialFromImpl(credential.impl_)
@@ -233,8 +233,8 @@ Future<SignInResult> User::LinkAndRetrieveDataWithCredential(const Credential &c
   const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
       kUserFn_LinkAndRetrieveDataWithCredential, SignInResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
@@ -292,8 +292,8 @@ Future<User> User::UpdatePhoneNumberCredential(const PhoneAuthCredential &creden
 
 #if FIREBASE_PLATFORM_IOS
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   FIRPhoneAuthCredential *objc_credential = PhoneAuthCredentialFromImpl(credential.impl_);
   [UserImpl(auth_data_)
@@ -319,8 +319,8 @@ Future<User *> User::UpdatePhoneNumberCredential_DEPRECATED(const Credential &cr
 
 #if FIREBASE_PLATFORM_IOS
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   FIRAuthCredential *objc_credential = CredentialFromImpl(credential.impl_);
   if ([objc_credential isKindOfClass:[FIRPhoneAuthCredential class]]) {
@@ -362,8 +362,8 @@ Future<void> User::Reauthenticate(const Credential &credential) {
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<void>(kUserFn_Reauthenticate);
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
 
   [UserImpl(auth_data_)
@@ -384,8 +384,8 @@ Future<AuthResult> User::ReauthenticateAndRetrieveData(const Credential &credent
   const auto handle = auth_data_->future_impl.SafeAlloc<AuthResult>(
       kUserFn_ReauthenticateAndRetrieveData, AuthResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
@@ -405,8 +405,8 @@ Future<SignInResult> User::ReauthenticateAndRetrieveData_DEPRECATED(const Creden
   const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
       kUserFn_ReauthenticateAndRetrieveData_DEPRECATED, SignInResult());
   if (!credential.is_valid()) {
-      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
-      return MakeFuture(&futures, handle);
+    futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+    return MakeFuture(&futures, handle);
   }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -194,6 +194,10 @@ Future<AuthResult> User::LinkWithCredential(const Credential &credential) {
   }
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<AuthResult>(kUserFn_LinkWithCredential, AuthResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
       linkWithCredential:CredentialFromImpl(credential.impl_)
@@ -209,6 +213,10 @@ Future<User *> User::LinkWithCredential_DEPRECATED(const Credential &credential)
   }
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<User *>(kUserFn_LinkWithCredential_DEPRECATED);
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   [UserImpl(auth_data_)
       linkWithCredential:CredentialFromImpl(credential.impl_)
               completion:^(FIRAuthDataResult *_Nullable auth_result, NSError *_Nullable error) {
@@ -224,6 +232,10 @@ Future<SignInResult> User::LinkAndRetrieveDataWithCredential(const Credential &c
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
       kUserFn_LinkAndRetrieveDataWithCredential, SignInResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
       linkWithCredential:CredentialFromImpl(credential.impl_)
@@ -279,6 +291,10 @@ Future<User> User::UpdatePhoneNumberCredential(const PhoneAuthCredential &creden
   const auto handle = futures.SafeAlloc<User>(kUserFn_UpdatePhoneNumberCredential);
 
 #if FIREBASE_PLATFORM_IOS
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   FIRPhoneAuthCredential *objc_credential = PhoneAuthCredentialFromImpl(credential.impl_);
   [UserImpl(auth_data_)
       updatePhoneNumberCredential:objc_credential
@@ -302,6 +318,10 @@ Future<User *> User::UpdatePhoneNumberCredential_DEPRECATED(const Credential &cr
   const auto handle = futures.SafeAlloc<User *>(kUserFn_UpdatePhoneNumberCredential_DEPRECATED);
 
 #if FIREBASE_PLATFORM_IOS
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   FIRAuthCredential *objc_credential = CredentialFromImpl(credential.impl_);
   if ([objc_credential isKindOfClass:[FIRPhoneAuthCredential class]]) {
     [UserImpl(auth_data_)
@@ -341,6 +361,10 @@ Future<void> User::Reauthenticate(const Credential &credential) {
   }
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = futures.SafeAlloc<void>(kUserFn_Reauthenticate);
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
 
   [UserImpl(auth_data_)
       reauthenticateWithCredential:CredentialFromImpl(credential.impl_)
@@ -359,6 +383,10 @@ Future<AuthResult> User::ReauthenticateAndRetrieveData(const Credential &credent
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = auth_data_->future_impl.SafeAlloc<AuthResult>(
       kUserFn_ReauthenticateAndRetrieveData, AuthResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
       reauthenticateWithCredential:CredentialFromImpl(credential.impl_)
@@ -376,6 +404,10 @@ Future<SignInResult> User::ReauthenticateAndRetrieveData_DEPRECATED(const Creden
   ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
   const auto handle = auth_data_->future_impl.SafeAlloc<SignInResult>(
       kUserFn_ReauthenticateAndRetrieveData_DEPRECATED, SignInResult());
+  if (!credential.is_valid()) {
+      futures.Complete(handle, kAuthErrorInvalidCredential, "Invalid credential is not allowed.");
+      return MakeFuture(&futures, handle);
+  }
   AuthData *auth_data = auth_data_;
   [UserImpl(auth_data)
       reauthenticateWithCredential:CredentialFromImpl(credential.impl_)

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -627,6 +627,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### 11.0.1
+-   Changes
+    - Auth (iOS): Fixed a crash calling credential.is_valid() when an AuthResult
+      contains an invalid Credential, such as when signing in anonymously.
+
 ### 11.0.0
 -   Changes
     - General: Update minimum supported C++ standard to C++14.

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -629,8 +629,8 @@ code.
 ## Release Notes
 ### 11.0.1
 -   Changes
-    - Auth (iOS): Fixed a crash calling credential.is_valid() when an AuthResult
-      contains an invalid Credential, such as when signing in anonymously.
+    - Auth (iOS): Fixed a crash in `Credential::is_valid()` when an `AuthResult`
+      contains an invalid credential, such as when signing in anonymously.
 
 ### 11.0.0
 -   Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

- null check `Credential.impl_` in `CredentialFromImpl()` and `PhoneAuthCredentialFromImpl()`
- Check if Auth API received an invalid Credential
- Add a basic test to just verify if `Credential.is_valid()` crashes. More comprehensive test should be added through b/281590792

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


GHA
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
