### PR TITLE
Modify heartbeat local storage to use wide strings on Windows.

### DIFF
--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -143,7 +143,7 @@ App* App::Create(const AppOptions& options, const char* name) {  // NOLINT
     app = new App();
     app->name_ = name;
     app->options_ = options_with_defaults;
-    std::string unique_name = app->name_ + "." + app->options_.package_name();
+    std::string unique_name = std::string(app->options_.package_name()) + "." + app->name_;
     app = app_common::AddApp(app, &app->init_results_);
     app->internal_->heartbeat_controller_ =
         std::make_shared<heartbeat::HeartbeatController>(

--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -143,7 +143,8 @@ App* App::Create(const AppOptions& options, const char* name) {  // NOLINT
     app = new App();
     app->name_ = name;
     app->options_ = options_with_defaults;
-    std::string unique_name = std::string(app->options_.package_name()) + "." + app->name_;
+    std::string unique_name =
+        std::string(app->options_.package_name()) + "." + app->name_;
     app = app_common::AddApp(app, &app->init_results_);
     app->internal_->heartbeat_controller_ =
         std::make_shared<heartbeat::HeartbeatController>(

--- a/app/src/app_desktop.cc
+++ b/app/src/app_desktop.cc
@@ -143,10 +143,11 @@ App* App::Create(const AppOptions& options, const char* name) {  // NOLINT
     app = new App();
     app->name_ = name;
     app->options_ = options_with_defaults;
+    std::string unique_name = app->name_ + "." + app->options_.package_name();
     app = app_common::AddApp(app, &app->init_results_);
     app->internal_->heartbeat_controller_ =
         std::make_shared<heartbeat::HeartbeatController>(
-            name, *app_common::FindAppLoggerByName(name),
+            unique_name, *app_common::FindAppLoggerByName(name),
             app->internal_->date_provider_);
 #ifndef SWIG
     // Log a heartbeat after creating an App. In the Unity SDK this will happen

--- a/app/src/filesystem_desktop_windows.cc
+++ b/app/src/filesystem_desktop_windows.cc
@@ -203,7 +203,7 @@ std::string AppDataDir(const char* app_name, bool should_create,
   // Debugging: Add international characters in the string.
   base_dir += L"/";
   base_dir += L"T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
-  if (should_create) Mkdir(base_dir);
+  if (should_create) Mkdir(base_dir, out_error);
 
   std::wstring current_path = base_dir;
   if (should_create) {

--- a/app/src/filesystem_desktop_windows.cc
+++ b/app/src/filesystem_desktop_windows.cc
@@ -200,6 +200,11 @@ std::string AppDataDir(const char* app_name, bool should_create,
 
   if (base_dir.empty()) return "";
 
+  // Debugging: Add international characters in the string.
+  base_dir += L"/";
+  base_dir += L"T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
+  if (should_create) Mkdir(base_dir);
+
   std::wstring current_path = base_dir;
   if (should_create) {
     // App name might contain path separators. Split it to get list of subdirs.

--- a/app/src/filesystem_desktop_windows.cc
+++ b/app/src/filesystem_desktop_windows.cc
@@ -200,10 +200,6 @@ std::string AppDataDir(const char* app_name, bool should_create,
 
   if (base_dir.empty()) return "";
 
-  // Debugging: Add international characters in the string.
-  base_dir += L"/T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
-  if (should_create) Mkdir(base_dir, nullptr);
-
   std::wstring current_path = base_dir;
   if (should_create) {
     // App name might contain path separators. Split it to get list of subdirs.

--- a/app/src/filesystem_desktop_windows.cc
+++ b/app/src/filesystem_desktop_windows.cc
@@ -201,9 +201,8 @@ std::string AppDataDir(const char* app_name, bool should_create,
   if (base_dir.empty()) return "";
 
   // Debugging: Add international characters in the string.
-  //base_dir += L"/";
-  //base_dir += L"T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
-  //if (should_create) Mkdir(base_dir, out_error);
+  base_dir += L"/T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
+  if (should_create) Mkdir(base_dir, nullptr);
 
   std::wstring current_path = base_dir;
   if (should_create) {

--- a/app/src/filesystem_desktop_windows.cc
+++ b/app/src/filesystem_desktop_windows.cc
@@ -201,9 +201,9 @@ std::string AppDataDir(const char* app_name, bool should_create,
   if (base_dir.empty()) return "";
 
   // Debugging: Add international characters in the string.
-  base_dir += L"/";
-  base_dir += L"T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
-  if (should_create) Mkdir(base_dir, out_error);
+  //base_dir += L"/";
+  //base_dir += L"T\x1EBDstP\x1EA1th";  // "TestPath" with some squiggles.
+  //if (should_create) Mkdir(base_dir, out_error);
 
   std::wstring current_path = base_dir;
   if (should_create) {

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -41,7 +41,7 @@ using com::google::firebase::cpp::heartbeat::VerifyLoggedHeartbeatsBuffer;
 // Using an anonymous namespace for helper to construct filename
 namespace {
 
-const char kHeartbeatDir[] = "firebase-heartbeat";
+const char kHeartbeatDir[] = "firebase-hẽạrtbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
 #if FIREBASE_PLATFORM_WINDOWS

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -45,12 +45,12 @@ const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
 #if FIREBASE_PLATFORM_WINDOWS
-std::wstring GetFilename() const { return filename_; }
+std::wstring HeartbeatStorageDesktop::GetFilename() const { return filename_; }
 
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::wstring empty_string;
 #else
-std::string GetFilename() const { return filename_; }
+std::string HeartbeatStorageDesktop::GetFilename() const { return filename_; }
 
 std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::string empty_string;

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -69,8 +69,8 @@ std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   std::string final_path_utf8 =
       app_dir + "/" + kHeartbeatFilenamePrefix + app_id_without_symbols;
 #if FIREBASE_PLATFORM_WINDOWS
-  std::wstring_convert<std::codecvt_utf8_utf16<wchar_t>> final_path_utf16;
-  return final_path_utf16.from_bytes(final_path_utf8);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> final_path_w;
+  return final_path_w.from_bytes(final_path_utf8);
 #else
   return final_path_utf8;
 #endif

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -44,7 +44,7 @@ namespace {
 const char kHeartbeatDir[] = "firebase-hẽạrtbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
-#if FIREBASE_PLATFORM_WINDOWS
+#if 0&&FIREBASE_PLATFORM_WINDOWS
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::wstring empty_string;
 #else
@@ -68,7 +68,7 @@ std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   // Note: fstream will convert / to \ if needed on windows.
   std::string final_path_utf8 =
       app_dir + "/" + kHeartbeatFilenamePrefix + app_id_without_symbols;
-#if FIREBASE_PLATFORM_WINDOWS
+#if 0&&FIREBASE_PLATFORM_WINDOWS
   std::wstring_convert<std::codecvt_utf8<wchar_t>> final_path_w;
   return final_path_w.from_bytes(final_path_utf8);
 #else
@@ -129,7 +129,7 @@ bool HeartbeatStorageDesktop::ReadTo(LoggedHeartbeats& heartbeats_output) {
   return true;
 }
 
-#if FIREBASE_PLATFORM_WINDOWS
+#if 0&&FIREBASE_PLATFORM_WINDOWS
 std::wstring HeartbeatStorageDesktop::GetFilename() const { return filename_; }
 #else
 std::string HeartbeatStorageDesktop::GetFilename() const { return filename_; }

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -44,7 +44,7 @@ namespace {
 const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
-#if 0&&FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::wstring empty_string;
 #else
@@ -68,7 +68,7 @@ std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   // Note: fstream will convert / to \ if needed on windows.
   std::string final_path_utf8 =
       app_dir + "/" + kHeartbeatFilenamePrefix + app_id_without_symbols;
-#if 0&&FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
   std::wstring_convert<std::codecvt_utf8<wchar_t>> final_path_w;
   return final_path_w.from_bytes(final_path_utf8);
 #else
@@ -129,7 +129,7 @@ bool HeartbeatStorageDesktop::ReadTo(LoggedHeartbeats& heartbeats_output) {
   return true;
 }
 
-#if 0&&FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
 std::wstring HeartbeatStorageDesktop::GetFilename() const { return filename_; }
 #else
 std::string HeartbeatStorageDesktop::GetFilename() const { return filename_; }

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -44,20 +44,22 @@ namespace {
 const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
-#ifdef FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
+  const std::wstring empty_string;
 #else   // FIREBASE_PLATFORM_WINDOWS
 std::string CreateFilename(const std::string& app_id, const Logger& logger) {
+  const std::string empty_string;
 #endif  // FIREBASE_PLATFORM_WINDOWS
   std::string error;
   std::string app_dir =
       AppDataDir(kHeartbeatDir, /*should_create=*/true, &error);
   if (!error.empty()) {
     logger.LogError(error.c_str());
-    return "";
+    return empty_string;
   }
   if (app_dir.empty()) {
-    return "";
+    return empty_string;
   }
 
   // Remove any symbols from app_id that might not be allowed in filenames.

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -45,13 +45,9 @@ const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
 #if FIREBASE_PLATFORM_WINDOWS
-std::wstring HeartbeatStorageDesktop::GetFilename() const { return filename_; }
-
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::wstring empty_string;
 #else
-std::string HeartbeatStorageDesktop::GetFilename() const { return filename_; }
-
 std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::string empty_string;
 #endif  // FIREBASE_PLATFORM_WINDOWS
@@ -132,6 +128,12 @@ bool HeartbeatStorageDesktop::ReadTo(LoggedHeartbeats& heartbeats_output) {
   delete[] buffer;
   return true;
 }
+
+#if FIREBASE_PLATFORM_WINDOWS
+std::wstring HeartbeatStorageDesktop::GetFilename() const { return filename_; }
+#else
+std::string HeartbeatStorageDesktop::GetFilename() const { return filename_; }
+#endif  // FIREBASE_PLATFORM_WINDOWS
 
 bool HeartbeatStorageDesktop::Write(const LoggedHeartbeats& heartbeats) const {
   // Clear the file before writing.

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -41,7 +41,7 @@ using com::google::firebase::cpp::heartbeat::VerifyLoggedHeartbeatsBuffer;
 // Using an anonymous namespace for helper to construct filename
 namespace {
 
-const char kHeartbeatDir[] = "firebase-hẽạrtbeat";
+const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
 #if 0&&FIREBASE_PLATFORM_WINDOWS

--- a/app/src/heartbeat/heartbeat_storage_desktop.cc
+++ b/app/src/heartbeat/heartbeat_storage_desktop.cc
@@ -45,9 +45,13 @@ const char kHeartbeatDir[] = "firebase-heartbeat";
 const char kHeartbeatFilenamePrefix[] = "heartbeats-";
 
 #if FIREBASE_PLATFORM_WINDOWS
+std::wstring GetFilename() const { return filename_; }
+
 std::wstring CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::wstring empty_string;
-#else   // FIREBASE_PLATFORM_WINDOWS
+#else
+std::string GetFilename() const { return filename_; }
+
 std::string CreateFilename(const std::string& app_id, const Logger& logger) {
   const std::string empty_string;
 #endif  // FIREBASE_PLATFORM_WINDOWS

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -60,7 +60,7 @@ class HeartbeatStorageDesktop {
       const LoggedHeartbeats& heartbeats_struct) const;
 
   // local variables for state
-#ifdef FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring filename_;

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "app/logged_heartbeats_generated.h"
+#include "app/src/include/firebase/internal/platform.h"
 #include "app/src/logger.h"
 
 namespace firebase {
@@ -52,8 +53,6 @@ class HeartbeatStorageDesktop {
   // write operation fails.
   bool Write(const LoggedHeartbeats& heartbeats) const;
 
-  const char* GetFilename() const;
-
  private:
   LoggedHeartbeats LoggedHeartbeatsFromFlatbuffer(
       const LoggedHeartbeatsFlatbuffer& heartbeats_fb) const;
@@ -61,7 +60,13 @@ class HeartbeatStorageDesktop {
       const LoggedHeartbeats& heartbeats_struct) const;
 
   // local variables for state
+#ifdef FIREBASE_PLATFORM_WINDOWS
+  // Use a wide string on Windows, to support international characters in the
+  // path.
+  std::wstring filename_;
+#else   // FIREBASE_PLATFORM_WINDOWS
   std::string filename_;
+#endif  // FIREBASE_PLATFORM_WINDOWS
   const Logger& logger_;
 };
 

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -60,6 +60,7 @@ class HeartbeatStorageDesktop {
 #else
   std::string GetFilename() const;
 #endif  // FIREBASE_PLATFORM_WINDOWS
+
  private:
   LoggedHeartbeats LoggedHeartbeatsFromFlatbuffer(
       const LoggedHeartbeatsFlatbuffer& heartbeats_fb) const;

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -53,7 +53,7 @@ class HeartbeatStorageDesktop {
   // write operation fails.
   bool Write(const LoggedHeartbeats& heartbeats) const;
 
-#if FIREBASE_PLATFORM_WINDOWS
+#if 0&&FIREBASE_PLATFORM_WINDOWS
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring GetFilename() const;
@@ -68,7 +68,7 @@ class HeartbeatStorageDesktop {
       const LoggedHeartbeats& heartbeats_struct) const;
 
   // local variables for state
-#if FIREBASE_PLATFORM_WINDOWS
+#if 0&&FIREBASE_PLATFORM_WINDOWS
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring filename_;

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -59,7 +59,7 @@ class HeartbeatStorageDesktop {
   std::wstring GetFilename() const;
 #else
   std::string GetFilename() const;
-#endif // FIREBASE_PLATFORM_WINDOWS
+#endif  // FIREBASE_PLATFORM_WINDOWS
  private:
   LoggedHeartbeats LoggedHeartbeatsFromFlatbuffer(
       const LoggedHeartbeatsFlatbuffer& heartbeats_fb) const;

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -53,7 +53,7 @@ class HeartbeatStorageDesktop {
   // write operation fails.
   bool Write(const LoggedHeartbeats& heartbeats) const;
 
-#if 0&&FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring GetFilename() const;
@@ -68,7 +68,7 @@ class HeartbeatStorageDesktop {
       const LoggedHeartbeats& heartbeats_struct) const;
 
   // local variables for state
-#if 0&&FIREBASE_PLATFORM_WINDOWS
+#if FIREBASE_PLATFORM_WINDOWS
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring filename_;

--- a/app/src/heartbeat/heartbeat_storage_desktop.h
+++ b/app/src/heartbeat/heartbeat_storage_desktop.h
@@ -53,6 +53,13 @@ class HeartbeatStorageDesktop {
   // write operation fails.
   bool Write(const LoggedHeartbeats& heartbeats) const;
 
+#if FIREBASE_PLATFORM_WINDOWS
+  // Use a wide string on Windows, to support international characters in the
+  // path.
+  std::wstring GetFilename() const;
+#else
+  std::string GetFilename() const;
+#endif // FIREBASE_PLATFORM_WINDOWS
  private:
   LoggedHeartbeats LoggedHeartbeatsFromFlatbuffer(
       const LoggedHeartbeatsFlatbuffer& heartbeats_fb) const;
@@ -64,7 +71,7 @@ class HeartbeatStorageDesktop {
   // Use a wide string on Windows, to support international characters in the
   // path.
   std::wstring filename_;
-#else   // FIREBASE_PLATFORM_WINDOWS
+#else
   std::string filename_;
 #endif  // FIREBASE_PLATFORM_WINDOWS
   const Logger& logger_;

--- a/app/tests/heartbeat_storage_desktop_test.cc
+++ b/app/tests/heartbeat_storage_desktop_test.cc
@@ -22,6 +22,7 @@
 
 #include "app/logged_heartbeats_generated.h"
 #include "app/src/filesystem.h"
+#include "app/src/include/firebase/internal/platform.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
@@ -129,10 +130,17 @@ TEST_F(HeartbeatStorageDesktopTest, ReadNonexistentFile) {
 TEST_F(HeartbeatStorageDesktopTest, FilenameIgnoresSymbolsInAppId) {
   std::string app_id = "idstart/\\?%*:|\"<>.,;=idend";
   HeartbeatStorageDesktop storage = HeartbeatStorageDesktop(app_id, logger_);
+#if FIREBASE_PLATFORM_WINDOWS
+  std::wstring filename = storage.GetFilename();
+  // Verify that the actual filename contains the non-symbol characters in
+  // app_id.
+  EXPECT_TRUE(filename.find(L"idstartidend") != std::string::npos) << filename;
+#else
   std::string filename = storage.GetFilename();
   // Verify that the actual filename contains the non-symbol characters in
   // app_id.
   EXPECT_TRUE(filename.find("idstartidend") != std::string::npos) << filename;
+#endif
 }
 
 TEST_F(HeartbeatStorageDesktopTest, ReadCorruptedData) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Two changes in this PR:
- Add Windows international path support to the heartbeat storage library.
- Ensure that multiple desktop apps don't write to the same heartbeat file by adding the package name to the heartbeat filename. Previously, only the app name (which is usually "__FIRAPPDEFAULT") was used, so if there were multiple apps installed on a machine (even completely unrelated apps), they would all use the same heartbeat file.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

The integration test in this PR was run with added international characters in the path. (That test change has since been reverted.) Additionally, it was run manually *without* the wstring fix to verify that writing the heartbeat data to an international path returned an error prior to this fix, and this change actualy fixes it.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
