### PR TITLE
Support international paths on Windows in app

### DIFF
--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -45,8 +45,7 @@ namespace rest {
 // This file isn't opened until the first call to ReadBody().
 // Note that on Windows, the filename will be UTF-8 encoded
 // and needs to be converted to utf16.
-RequestFile::RequestFile(const char* filename, size_t offset)
-{
+RequestFile::RequestFile(const char* filename, size_t offset) : file_size_(0) {
 #if FIREBASE_PLATFORM_WINDOWS
   std::string filename_utf8(filename);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_to_utf16;
@@ -55,7 +54,6 @@ RequestFile::RequestFile(const char* filename, size_t offset)
 #else
   file_ = fopen(filename, "rb");
 #endif
-  file_size_ = 0;
   options_.stream_post_fields = true;
   // If the file exists, seek to the end of the file and get the size.
   if (file_ && fseeko(file_, 0, SEEK_END) == 0) {

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -32,10 +32,10 @@
 #define ftello _ftelli64
 
 // Also include files needed for path conversion.
-#include <codecvt>
-#include <locale>
-#include <string>
-#include <wchar>
+#include <codecvt>  // NOLINT
+#include <locale>  // NOLINT
+#include <string>  // NOLINT
+#include <wchar>  // NOLINT
 #endif  // FIREBASE_PLATFORM_WINDOWS
 
 namespace firebase {

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -30,6 +30,12 @@
 #if FIREBASE_PLATFORM_WINDOWS
 #define fseeko _fseeki64
 #define ftello _ftelli64
+
+// Also include files needed for path conversion.
+#include <codecvt>
+#include <locale>
+#include <string>
+#include <wchar>
 #endif  // FIREBASE_PLATFORM_WINDOWS
 
 namespace firebase {
@@ -37,8 +43,19 @@ namespace rest {
 
 // Create a request that will read from the specified file.
 // This file isn't opened until the first call to ReadBody().
+// Note that on Windows, the filename will be UTF-8 encoded
+// and needs to be converted to utf16.
 RequestFile::RequestFile(const char* filename, size_t offset)
-    : file_(fopen(filename, "rb")), file_size_(0) {
+{
+#if FIREBASE_PLATFORM_WINDOWS
+  std::string filename_utf8(filename);
+  std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_to_utf16;
+  std::wstring filename_utf16 = utf8_to_utf16.from_bytes(filename_utf8);
+  file_ = _wfopen(filename_utf16.c_str(), "rb");
+#else
+  file_ = fopen(filename, "rb");
+#endif
+  file_size_ = 0;
   options_.stream_post_fields = true;
   // If the file exists, seek to the end of the file and get the size.
   if (file_ && fseeko(file_, 0, SEEK_END) == 0) {

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -50,7 +50,7 @@ RequestFile::RequestFile(const char* filename, size_t offset) : file_size_(0) {
   std::string filename_utf8(filename);
   std::wstring_convert<std::codecvt_utf8<wchar_t>> utf8_to_utf16;
   std::wstring filename_utf16 = utf8_to_utf16.from_bytes(filename_utf8);
-  file_ = _wfopen(filename_utf16.c_str(), "rb");
+  file_ = _wfopen(filename_utf16.c_str(), L"rb");
 #else
   file_ = fopen(filename, "rb");
 #endif

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -32,10 +32,10 @@
 #define ftello _ftelli64
 
 // Also include files needed for path conversion.
-#include <codecvt>  // NOLINT
-#include <locale>  // NOLINT
-#include <string>  // NOLINT
-#include <wchar>  // NOLINT
+#include <codecvt>
+#include <locale>
+#include <string>
+#include <wchar.h>  // NOLINT
 #endif  // FIREBASE_PLATFORM_WINDOWS
 
 namespace firebase {

--- a/app/rest/request_file.cc
+++ b/app/rest/request_file.cc
@@ -32,10 +32,11 @@
 #define ftello _ftelli64
 
 // Also include files needed for path conversion.
+#include <wchar.h>  // NOLINT
+
 #include <codecvt>
 #include <locale>
 #include <string>
-#include <wchar.h>  // NOLINT
 #endif  // FIREBASE_PLATFORM_WINDOWS
 
 namespace firebase {

--- a/app/src/log.cc
+++ b/app/src/log.cc
@@ -113,7 +113,7 @@ static void LogToFile(LogLevel log_level, const char* format, va_list args) {
     MutexLock lock(*g_log_mutex);
     if (!log_file) {
 #if FIREBASE_PLATFORM_WINDOWS
-      log_file = _wfopen(FIREBASE_LOG_FILENAME_W, "wt");
+      log_file = _wfopen(FIREBASE_LOG_FILENAME_W, L"wt");
 #else
       log_file = fopen(FIREBASE_LOG_FILENAME, "wt");
 #endif


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

App has two places it writes to files: in the rest library's FileRequest class (used by Storage's UploadFile), and the log code when logging to file. Update both of these to use a UTF16 path on Windows. For FileRequest, we convert the path (UTF8) into UTF16 before loading it on Windows. For log, we just store the log filename as a wide string as well.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Integration tests in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
