### PR TITLE
Patch flatbuffers to fix a warning that occurs with some compiler versions

### DIFF
--- a/cmake/external/flatbuffers.cmake
+++ b/cmake/external/flatbuffers.cmake
@@ -19,14 +19,17 @@ if(TARGET flatbuffers OR NOT DOWNLOAD_FLATBUFFERS)
 endif()
 
 set(version 99aa1ef21dd9dc3f9d4fb0eb82f4b59d0bb5e4c5)
+set(patch_file
+  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/flatbuffers/0001-remove-unused-var.patch)
 
 ExternalProject_Add(
   flatbuffers
 
-  DOWNLOAD_DIR ${FIREBASE_DOWNLOAD_DIR}
-  DOWNLOAD_NAME flatbuffers-${version}.tar.gz
-  URL https://github.com/google/flatbuffers/archive/${version}.tar.gz
+  DOWNLOAD_COMMAND
+    COMMAND git init flatbuffers
+    COMMAND cd flatbuffers && git fetch --depth=1 https://github.com/google/flatbuffers.git ${version} && git reset --hard FETCH_HEAD
 
+  PATCH_COMMAND git apply ${patch_file} && git gc --aggressive
   PREFIX ${PROJECT_BINARY_DIR}
 
   CONFIGURE_COMMAND ""

--- a/scripts/git/patches/flatbuffers/0001-remove-unused-var.patch
+++ b/scripts/git/patches/flatbuffers/0001-remove-unused-var.patch
@@ -1,0 +1,32 @@
+From b08adb291f3ae0a2626d50eb8abecbc3a0de63d9 Mon Sep 17 00:00:00 2001
+From: "almostmatt@google.com" <almostmatt@google.com>
+Date: Fri, 21 Apr 2023 14:31:06 -0400
+Subject: [PATCH] remove unused var
+
+---
+ src/idl_gen_rust.cpp | 2 --
+ 1 file changed, 2 deletions(-)
+
+diff --git a/src/idl_gen_rust.cpp b/src/idl_gen_rust.cpp
+index 55b8439b..48539d52 100644
+--- a/src/idl_gen_rust.cpp
++++ b/src/idl_gen_rust.cpp
+@@ -406,7 +406,6 @@ class RustGenerator : public BaseGenerator {
+     // example: f(A, D::E)          -> super::D::E
+     // does not include leaf object (typically a struct type).
+ 
+-    size_t i = 0;
+     std::stringstream stream;
+ 
+     auto s = src->components.begin();
+@@ -417,7 +416,6 @@ class RustGenerator : public BaseGenerator {
+       if (*s != *d) { break; }
+       ++s;
+       ++d;
+-      ++i;
+     }
+ 
+     for (; s != src->components.end(); ++s) { stream << "super::"; }
+-- 
+2.40.1.606.ga4b1b128d6-goog
+


### PR DESCRIPTION
### Description
Add a patch to the flatbuffers version that we are pinned to that fixes an unused-variable warning.
Without this, after updating to xcode 14.3 a newer c compiler fails the build due to this warning about flatbuffers source.

In the flatbuffers repo this unused variable is not removed until much later when the relevant code is basically completely rewritten. So pinning to a newer version of flatbuffers can have other side effects. (Including requiring a newer version of cmake) 

The content of the cmake/external/flatbuffers file is basically copied from the similar websockets file which also applies a patch.
***
### Testing
Verified that local builds fail without this patch and succeed with this patch.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
