### PR TITLE
Remove the debug part of RemoteConfig file manager path

### DIFF
--- a/remote_config/src/desktop/file_manager.cc
+++ b/remote_config/src/desktop/file_manager.cc
@@ -37,7 +37,7 @@ namespace internal {
 RemoteConfigFileManager::RemoteConfigFileManager(const std::string& filename,
                                                  const firebase::App& app) {
   std::string app_data_prefix = std::string(app.options().package_name()) +
-                                "/" + app.name() + "/" + "TẽstPạth";
+                                "/" + app.name();
   std::string file_path =
       AppDataDir(app_data_prefix.c_str(), /*should_create=*/true) + "/" +
       filename;


### PR DESCRIPTION
### Description
This is a followup to #1316 to remove a debug line that was accidentally left in.
***
### Testing
N/A
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
