### PR TITLE
Update ios and tvos simulator versions for GitHub runners (a second time)

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -176,9 +176,9 @@ TEST_DEVICES = {
   "ios_target": {"type": "ftl", "device": "model=iphone13pro,version=15.7"},
   "ios_latest": {"type": "ftl", "device": "model=iphone11pro,version=16.3"},
   "simulator_min": {"type": "virtual", "name":"iPhone 8", "version":"15.2"},
-  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"15.2"},
-  "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"15.4"},
-  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"15.2"},
+  "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"16.1"},
+  "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"16.1"},
+  "tvos_simulator": {"type": "virtual", "name":"Apple TV", "version":"16.1"},
 }
 
 


### PR DESCRIPTION
### Description
This is a followup to #1326.
That change updated from 16.1, 16.2 to 15.2, 15.4
This change updates ios simulator versions to 16.1, 16.1

Previously it was only the test that required 16.2 that was [failing](https://github.com/firebase/firebase-cpp-sdk/actions/runs/5001905633/jobs/8962904059) due to no simulator, and now there has also been a test run that [failed](https://github.com/firebase/firebase-cpp-sdk/actions/runs/5014197576/jobs/8989088252) because 15.x was unavailable. So stick to 16.1 as a version that is known to work.

Also note that ios 16.1 is associated with [xcode 14.1](https://developer.apple.com/documentation/xcode-release-notes/xcode-14_1-release-notes), and the two failing runs linked above both mention xcode 14.1 as available.
***
### Testing
Integration test run: https://github.com/firebase/firebase-cpp-sdk/actions/runs/5019927558
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
