### PR TITLE
Fix for a deadlock in JniResultCallback

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -629,6 +629,8 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
+    - General (Android): Fix for deadlock within JniResultCallback, commonly
+      seen within Messaging, but affecting other products as well.
     - Database/Firestore (Desktop): Fixed a crash on Windows when the user's
       home directory contains non-ANSI characters (Unicode above U+00FF).
     - Storage (Desktop): Fixed a crash on Windows when uploading files from a


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

JniResultCallback was using two separate locks, with no guarantee on which will be grabbed first. This could cause a deadlock, leading to ANRs.  Fix this by just using a single lock.

Addresses issues like: https://github.com/firebase/quickstart-unity/issues/1286

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building locally, plus GHA tests
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
