### PR TITLE
Add a dependency on absl_variant

### DIFF
--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -311,6 +311,15 @@ if(FIRESTORE_USE_EXTERNAL_CMAKE_BUILD)
   )
 endif()
 
+# Add absl_variant as a dependency, as symbols around ThrowBadVariantAccess
+# are missing otherwise.
+if(IOS)
+  target_link_libraries(firebase_firestore
+    PUBLIC
+      absl_variant
+  )
+endif()
+
 # Public C++ headers all refer to each other relative to the src/include
 # directory, while private headers are relative to the entire C++ SDK
 # directory.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

There is a problem with missing absl_variant symbols in Firestore iOS, caused by the update to the latest iOS release.  We already include it in the desktop builds.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

C++ tests
Unity: https://github.com/firebase/firebase-unity-sdk/actions/runs/5126771518
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
