### PR TITLE
Fix App Check on 32 bit desktop

### DIFF
--- a/app_check/src/desktop/app_check_desktop.cc
+++ b/app_check/src/desktop/app_check_desktop.cc
@@ -53,8 +53,9 @@ ReferenceCountedFutureImpl* AppCheckInternal::future() {
 }
 
 bool AppCheckInternal::HasValidCacheToken() const {
-  // Get the current time, in milliseconds
-  int64_t current_time = std::time(nullptr) * 1000;
+  // Get the current time, in milliseconds (Done in two lines because of x86)
+  int64_t current_time = std::time(nullptr);
+  current_time *= 1000;
   // TODO(amaurice): Add some additional time to the check
   return cached_token_.expire_time_millis > current_time;
 }

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -629,6 +629,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
+    - App Check (Desktop): Fixed expired tokens being cached on 32-bit systems.
     - Remote Config (Desktop): Fixed handling of time zones on Windows when the
       time zone name in the current system language contains an accented
       character or apostrophe. This adds a requirement for applications using


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

App Check on 32 bit desktop systems was incorrectly calculating the current time as negative, leading to tokens never being expired.  Fixed by converting the time to 64 bit earlier.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running locally.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
