### PR TITLE
Firestore: integration_test_internal/build.gradle: improvements for local dev: targets and abiFilters

### DIFF
--- a/firestore/integration_test_internal/build.gradle
+++ b/firestore/integration_test_internal/build.gradle
@@ -52,6 +52,14 @@ android {
     }
   }
 
+  Properties localProperties = new Properties()
+  try {
+    localProperties.load(project.rootProject.file('local.properties').newDataInputStream())
+  } catch (FileNotFoundException e) {
+    // Ignore the situation where local.properties does not exist, effectively treating it the same
+    // as if it existed but was empty.
+  }
+
   defaultConfig {
     applicationId 'com.google.firebase.cpp.firestore.testapp'
     minSdkVersion 19
@@ -60,6 +68,13 @@ android {
     versionName '1.0'
     externalNativeBuild.cmake {
       arguments "-DFIREBASE_CPP_SDK_DIR=$gradle.firebase_cpp_sdk_dir"
+      // Only build the targets that Firestore needs, instead of everything.
+      targets 'firebase_firestore', 'firebase_auth', 'android_integration_test_main'
+      // Add the line `abiFilter=<abi>` to `local.properties` to speed up local builds by only
+      // building the required ABI, where `<abi>` is x86, x86_64, or arm64-v8a (for Mac M1).
+      if (localProperties["abiFilter"] != null) {
+        abiFilters localProperties["abiFilter"]
+      }
     }
     multiDexEnabled true
   }


### PR DESCRIPTION
Improve the local development build times for the Firestore integration tests on Android by (a) specifying `targets` to only build the required cmake targets and (b) specifying `abiFilters` conveniently in `local.properties` to only compile the ABI that is actually needed for local development (e.g. "x86", "x86_64", "arm64-v8a").