### PR TITLE
Firestore: add helper functions for integration testing Java exceptions in Android

### DIFF
--- a/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
+++ b/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
@@ -74,6 +74,26 @@ MATCHER_P(JavaEq,
   return jni::Object::Equals(env, object, arg);
 }
 
+/**
+ * A gmock matcher that compares two Java objects for equality using the ==
+ * operator; that is, that they both refer to the _same_ Java object.
+ *
+ * Example:
+ *
+ * jni::Env env;
+ * jni::Local<jni::String> object1 = env.NewStringUtf("string");
+ * jni::Local<jni::String> object2 = object1;
+ * EXPECT_THAT(object1, RefersToSameJavaObjectAs(object2));
+ */
+MATCHER_P(RefersToSameJavaObjectAs,
+          object,
+          std::string("is ") + (negation ? "not " : "") +
+              " referring to the same object as " + ToDebugString(object)) {
+  jni::Env env;
+  jni::ExceptionClearGuard block(env);
+  return env.IsSameObject(arg, object);
+}
+
 /** Adds Android-specific functionality to `FirestoreIntegrationTest`. */
 class FirestoreAndroidIntegrationTest : public FirestoreIntegrationTest {
  public:
@@ -85,9 +105,17 @@ class FirestoreAndroidIntegrationTest : public FirestoreIntegrationTest {
 
   jni::Loader& loader() { return loader_; }
 
-  /** Creates and returns a new Java `Exception` object with a message. */
-  jni::Local<jni::Throwable> CreateException(jni::Env& env,
-                                             const std::string& message);
+  /** Creates and returns a new Java `Exception` with a default message. */
+  static jni::Local<jni::Throwable> CreateException(jni::Env&);
+  /** Creates and returns a new Java `Exception` with the given message. */
+  static jni::Local<jni::Throwable> CreateException(jni::Env&,
+                                                    const std::string& message);
+
+  /** Throws a Java `Exception` object with a default message. */
+  jni::Local<jni::Throwable> ThrowException(jni::Env&);
+  /** Throws a Java `Exception` object with the given message. */
+  jni::Local<jni::Throwable> ThrowException(jni::Env&,
+                                            const std::string& message);
 
   // Bring definitions of `Await()` from the superclass into this class so that
   // the definition below *overloads* instead of *hides* them.
@@ -97,7 +125,10 @@ class FirestoreAndroidIntegrationTest : public FirestoreIntegrationTest {
   static void Await(jni::Env& env, const jni::Task& task);
 
  private:
+  void FailTestIfPendingException();
+
   jni::Loader loader_;
+  jni::Global<jni::Throwable> last_thrown_exception_;
 };
 
 }  // namespace firestore

--- a/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
+++ b/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
@@ -119,7 +119,7 @@ TEST_F(JniRunnableTest, JavaRunCallsCppRunOncePerInvocation) {
 
 TEST_F(JniRunnableTest, JavaRunPropagatesExceptions) {
   Env env;
-  Local<Throwable> exception = CreateException(env, "Forced exception");
+  Local<Throwable> exception = CreateException(env);
   auto runnable = MakeJniRunnable(env, [exception] {
     Env env;
     env.Throw(exception);
@@ -166,7 +166,7 @@ TEST_F(JniRunnableTest, DetachDetachesEvenIfAnExceptionIsPending) {
   bool invoked = false;
   auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
-  Local<Throwable> exception = CreateException(env, "Forced exception");
+  Local<Throwable> exception = CreateException(env);
   env.Throw(exception);
   EXPECT_FALSE(env.ok());
 
@@ -230,7 +230,7 @@ TEST_F(JniRunnableTest, RunOnMainThreadRunsOnTheMainThread) {
 
 TEST_F(JniRunnableTest, RunOnMainThreadTaskFailsIfRunThrowsException) {
   Env env;
-  Global<Throwable> exception = CreateException(env, "Forced exception");
+  Global<Throwable> exception = CreateException(env);
   auto runnable = MakeJniRunnable(env, [exception] {
     Env env;
     env.Throw(exception);
@@ -284,7 +284,7 @@ TEST_F(JniRunnableTest, RunOnNewThreadRunsOnANonMainThread) {
 
 TEST_F(JniRunnableTest, RunOnNewThreadTaskFailsIfRunThrowsException) {
   Env env;
-  Global<Throwable> exception = CreateException(env, "Forced exception");
+  Global<Throwable> exception = CreateException(env);
   auto runnable = MakeJniRunnable(env, [exception] {
     Env env;
     env.Throw(exception);

--- a/firestore/integration_test_internal/src/jni/task_test.cc
+++ b/firestore/integration_test_internal/src/jni/task_test.cc
@@ -58,7 +58,7 @@ class TaskTest : public FirestoreAndroidIntegrationTest {
   }
 
   Local<Task> CreateFailedTask(Env& env) {
-    auto exception = CreateException(env, "Test Exception");
+    auto exception = CreateException(env);
     return CreateFailedTask(env, exception);
   }
 
@@ -86,7 +86,7 @@ TEST_F(TaskTest, GetResultShouldReturnTheResult) {
 
 TEST_F(TaskTest, GetExceptionShouldReturnTheException) {
   Env env;
-  Local<Throwable> exception = CreateException(env, "Test Exception");
+  Local<Throwable> exception = CreateException(env);
   Local<Task> task = CreateFailedTask(env, exception);
 
   Local<Throwable> actual_exception = task.GetException(env);


### PR DESCRIPTION
Add member functions to `FirestoreAndroidIntegrationTest`: `CreateException()` and `ThrowException()`, as well as the `RefersToSameJavaObjectAs` googlemock matcher.