### PR TITLE
.gitignore: add CMakeUserPresets.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,9 @@
 .DS_Store
 
+# CMake "user presets" files
+# https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html
+CMakeUserPresets.json
+
 # Python byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]


### PR DESCRIPTION
Ignore `CMakeUserPresets.json`, as documented at https://cmake.org/cmake/help/latest/manual/cmake-presets.7.html#build-preset. This allows developers to use their own CMake "presets" without having them show up as "modified" files in Git.