### PR TITLE
Add missing Remote Config classes to proguard

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -630,6 +630,8 @@ code.
 ### Upcoming Release
 -   Changes
     - App Check (Desktop): Fixed expired tokens being cached on 32-bit systems.
+    - Remote Config (Android): Fixed the ConfigUpdate classes being missing
+      from the proguard files.
     - Remote Config (Desktop): Fixed handling of time zones on Windows when the
       time zone name in the current system language contains an accented
       character or apostrophe. This adds a requirement for applications using

--- a/remote_config/src/android/remote_config_android.cc
+++ b/remote_config/src/android/remote_config_android.cc
@@ -171,6 +171,7 @@ METHOD_LOOKUP_DECLARATION(jni_config_update_listener,
                           JNI_CONFIG_UPDATE_LISTENER_METHODS)
 METHOD_LOOKUP_DEFINITION(
     jni_config_update_listener,
+    PROGUARD_KEEP_CLASS
     "com/google/firebase/remoteconfig/internal/cpp/JniConfigUpdateListener",
     JNI_CONFIG_UPDATE_LISTENER_METHODS)
 
@@ -195,6 +196,7 @@ static const JNINativeMethod kNativeJniConfigUpdateListenerMethods[] = {
 
 METHOD_LOOKUP_DECLARATION(config_update, CONFIG_UPDATE_METHODS)
 METHOD_LOOKUP_DEFINITION(config_update,
+                         PROGUARD_KEEP_CLASS
                          "com/google/firebase/remoteconfig/ConfigUpdate",
                          CONFIG_UPDATE_METHODS)
 
@@ -208,6 +210,7 @@ METHOD_LOOKUP_DECLARATION(config_update_listener_registration,
                           CONFIG_UPDATE_LISTENER_REGISTRATION_METHODS)
 METHOD_LOOKUP_DEFINITION(
     config_update_listener_registration,
+    PROGUARD_KEEP_CLASS
     "com/google/firebase/remoteconfig/ConfigUpdateListenerRegistration",
     CONFIG_UPDATE_LISTENER_REGISTRATION_METHODS)
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

ConfigUpdateListenerRegistration is missing from the proguard file for Remote Config, causing it to potentially be stripped when building with minification.  Add the necessary parts so that it gets added to the generated proguard file.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Building locally and verifying the lines get added to the proguard file.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

https://github.com/firebase/firebase-unity-sdk/issues/753

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
