### PR TITLE
format_code.py: fix NameError when --d is specified

### DIFF
--- a/scripts/format_code.py
+++ b/scripts/format_code.py
@@ -165,7 +165,7 @@ def list_files_from_directory(path, recurse):
   filenames = []
   for root, dirs, files in os.walk(path):
     for filename in files:
-      if(FILE_PATHS_TO_IGNORE.match(line)):
+      if(FILE_PATHS_TO_IGNORE.match(filename)):
         continue
       if filename.endswith(FILE_TYPE_EXTENSIONS):
         full_path = os.path.join(root, filename)


### PR DESCRIPTION
This PR fixes an apparent copy/paste error in `format_code.py` in the `list_files_from_directory()` function where it uses a local variable named `line`, that doesn't exist. The _correct_ local variable name is `filename`.

The result of this bug is that when `--d` is specified as a command-line argument the app crashes with a `NameError`:

```
$ python3 scripts/format_code.py --verbose --d firestore/src --r
Searching files in directory: "firestore/src"
Traceback (most recent call last):
  File "scripts/format_code.py", line 276, in <module>
    app.run(main)
  File "site-packages/absl/app.py", line 308, in run
    _run_main(main, args)
  File "site-packages/absl/app.py", line 254, in _run_main
    sys.exit(main(argv))
  File "scripts/format_code.py", line 223, in main
    filenames += directory_search_list_files()
  File "scripts/format_code.py", line 191, in directory_search_list_files
    filenames += list_files_from_directory(directory, FLAGS.r)
  File "scripts/format_code.py", line 168, in list_files_from_directory
    if(FILE_PATHS_TO_IGNORE.match(line)):
NameError: name 'line' is not defined. Did you mean: 'slice'?
```