### PR TITLE
Firestore: Improve Android tests to use the new env() helper function rather than creating an Env on the stack

### DIFF
--- a/firestore/integration_test_internal/src/android/firestore_integration_test_android.cc
+++ b/firestore/integration_test_internal/src/android/firestore_integration_test_android.cc
@@ -143,5 +143,10 @@ void FirestoreAndroidIntegrationTest::Await(const Task& task) {
   }
 }
 
+jni::Env& FirestoreAndroidIntegrationTest::env() {
+  thread_local jni::Env env;
+  return env;
+}
+
 }  // namespace firestore
 }  // namespace firebase

--- a/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
+++ b/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
@@ -106,23 +106,27 @@ class FirestoreAndroidIntegrationTest : public FirestoreIntegrationTest {
   jni::Loader& loader() { return loader_; }
 
   /** Creates and returns a new Java `Exception` with a default message. */
-  static jni::Local<jni::Throwable> CreateException(jni::Env&);
+  static jni::Local<jni::Throwable> CreateException();
   /** Creates and returns a new Java `Exception` with the given message. */
-  static jni::Local<jni::Throwable> CreateException(jni::Env&,
-                                                    const std::string& message);
+  static jni::Local<jni::Throwable> CreateException(const std::string& message);
 
   /** Throws a Java `Exception` object with a default message. */
-  jni::Local<jni::Throwable> ThrowException(jni::Env&);
+  jni::Local<jni::Throwable> ThrowException();
   /** Throws a Java `Exception` object with the given message. */
-  jni::Local<jni::Throwable> ThrowException(jni::Env&,
-                                            const std::string& message);
+  jni::Local<jni::Throwable> ThrowException(const std::string& message);
 
   // Bring definitions of `Await()` from the superclass into this class so that
   // the definition below *overloads* instead of *hides* them.
   using FirestoreIntegrationTest::Await;
 
   /** Blocks until the given `Task` has completed or times out. */
-  static void Await(jni::Env& env, const jni::Task& task);
+  static void Await(const jni::Task& task);
+
+  /** Returns an Env object for the calling thread, creating it if necessary. */
+  static jni::Env& env() {
+    thread_local jni::Env env;
+    return env;
+  }
 
  private:
   void FailTestIfPendingException();

--- a/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
+++ b/firestore/integration_test_internal/src/android/firestore_integration_test_android.h
@@ -123,10 +123,7 @@ class FirestoreAndroidIntegrationTest : public FirestoreIntegrationTest {
   static void Await(const jni::Task& task);
 
   /** Returns an Env object for the calling thread, creating it if necessary. */
-  static jni::Env& env() {
-    thread_local jni::Env env;
-    return env;
-  }
+  static jni::Env& env();
 
  private:
   void FailTestIfPendingException();

--- a/firestore/integration_test_internal/src/android/firestore_integration_test_android_test.cc
+++ b/firestore/integration_test_internal/src/android/firestore_integration_test_android_test.cc
@@ -30,7 +30,6 @@ namespace firestore {
 namespace {
 
 using jni::ArrayList;
-using jni::Env;
 using jni::Global;
 using jni::Local;
 using jni::Object;
@@ -42,9 +41,7 @@ using ::testing::Not;
 using ::testing::StrEq;
 
 TEST_F(FirestoreAndroidIntegrationTest, ToDebugStringWithNonNull) {
-  Env env;
-
-  std::string debug_string = ToDebugString(env.NewStringUtf("Test Value"));
+  std::string debug_string = ToDebugString(env().NewStringUtf("Test Value"));
 
   EXPECT_EQ(debug_string, "Test Value");
 }
@@ -59,50 +56,45 @@ TEST_F(FirestoreAndroidIntegrationTest, ToDebugStringWithNull) {
 
 TEST_F(FirestoreAndroidIntegrationTest,
        ToDebugStringWithPendingExceptionAndNonNullObject) {
-  Env env;
-  Local<String> object = env.NewStringUtf("Test Value");
-  ThrowException(env);
-  ASSERT_FALSE(env.ok());
+  Local<String> object = env().NewStringUtf("Test Value");
+  ThrowException();
+  ASSERT_FALSE(env().ok());
 
   std::string debug_string = ToDebugString(object);
 
   EXPECT_EQ(debug_string, "Test Value");
-  env.ExceptionClear();
+  env().ExceptionClear();
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        ToDebugStringWithPendingExceptionAndNullObject) {
-  Env env;
   Object null_reference;
-  ThrowException(env);
-  ASSERT_FALSE(env.ok());
+  ThrowException();
+  ASSERT_FALSE(env().ok());
 
   std::string debug_string = ToDebugString(null_reference);
 
   EXPECT_EQ(debug_string, "null");
-  env.ExceptionClear();
+  env().ExceptionClear();
 }
 
 TEST_F(FirestoreAndroidIntegrationTest, JavaEqShouldReturnTrueForEqualObjects) {
-  Env env;
-  Local<String> object1 = env.NewStringUtf("string");
-  Local<String> object2 = env.NewStringUtf("string");
+  Local<String> object1 = env().NewStringUtf("string");
+  Local<String> object2 = env().NewStringUtf("string");
 
   EXPECT_THAT(object1, JavaEq(object2));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        JavaEqShouldReturnFalseForUnequalObjects) {
-  Env env;
-  Local<String> object1 = env.NewStringUtf("string1");
-  Local<String> object2 = env.NewStringUtf("string2");
+  Local<String> object1 = env().NewStringUtf("string1");
+  Local<String> object2 = env().NewStringUtf("string2");
 
   EXPECT_THAT(object1, Not(JavaEq(object2)));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        JavaEqShouldReturnTrueForTwoNullReferences) {
-  Env env;
   Local<Object> null_reference1;
   Local<Object> null_reference2;
 
@@ -111,9 +103,8 @@ TEST_F(FirestoreAndroidIntegrationTest,
 
 TEST_F(FirestoreAndroidIntegrationTest,
        JavaEqShouldReturnFalseIfExactlyOneObjectIsNull) {
-  Env env;
   Local<String> null_reference;
-  Local<String> non_null_reference = env.NewStringUtf("string2");
+  Local<String> non_null_reference = env().NewStringUtf("string2");
 
   EXPECT_THAT(null_reference, Not(JavaEq(non_null_reference)));
   EXPECT_THAT(non_null_reference, Not(JavaEq(null_reference)));
@@ -121,9 +112,8 @@ TEST_F(FirestoreAndroidIntegrationTest,
 
 TEST_F(FirestoreAndroidIntegrationTest,
        JavaEqShouldReturnFalseForObjectOfDifferentTypes) {
-  Env env;
-  Local<String> string_object = env.NewStringUtf("string2");
-  Local<ArrayList> list_object = ArrayList::Create(env);
+  Local<String> string_object = env().NewStringUtf("string2");
+  Local<ArrayList> list_object = ArrayList::Create(env());
 
   EXPECT_THAT(string_object, Not(JavaEq(list_object)));
   EXPECT_THAT(list_object, Not(JavaEq(string_object)));
@@ -131,8 +121,7 @@ TEST_F(FirestoreAndroidIntegrationTest,
 
 TEST_F(FirestoreAndroidIntegrationTest,
        RefersToSameJavaObjectAsShouldReturnTrueForSameObjects) {
-  Env env;
-  Local<String> object1 = env.NewStringUtf("string");
+  Local<String> object1 = env().NewStringUtf("string");
   Global<String> object2 = object1;
 
   EXPECT_THAT(object1, RefersToSameJavaObjectAs(object2));
@@ -148,19 +137,17 @@ TEST_F(FirestoreAndroidIntegrationTest,
 
 TEST_F(FirestoreAndroidIntegrationTest,
        RefersToSameJavaObjectAsShouldReturnFalseForDistinctObjects) {
-  Env env;
-  Local<String> object1 = env.NewStringUtf("test string");
-  Local<String> object2 = env.NewStringUtf("test string");
-  ASSERT_FALSE(env.IsSameObject(object1, object2));
+  Local<String> object1 = env().NewStringUtf("test string");
+  Local<String> object2 = env().NewStringUtf("test string");
+  ASSERT_FALSE(env().IsSameObject(object1, object2));
 
   EXPECT_THAT(object1, Not(RefersToSameJavaObjectAs(object2)));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        RefersToSameJavaObjectAsShouldReturnFalseIfExactlyOneObjectIsNull) {
-  Env env;
   Local<String> null_reference;
-  Local<String> non_null_reference = env.NewStringUtf("string2");
+  Local<String> non_null_reference = env().NewStringUtf("string2");
 
   EXPECT_THAT(null_reference,
               Not(RefersToSameJavaObjectAs(non_null_reference)));
@@ -170,42 +157,38 @@ TEST_F(FirestoreAndroidIntegrationTest,
 
 TEST_F(FirestoreAndroidIntegrationTest,
        ThrowExceptionWithNoMessageShouldSetPendingExceptionWithAMessage) {
-  Env env;
-  Local<Throwable> throw_exception_return_value = ThrowException(env);
-  Local<Throwable> actually_thrown_exception = env.ClearExceptionOccurred();
+  Local<Throwable> throw_exception_return_value = ThrowException();
+  Local<Throwable> actually_thrown_exception = env().ClearExceptionOccurred();
   ASSERT_TRUE(actually_thrown_exception);
   EXPECT_THAT(actually_thrown_exception,
               RefersToSameJavaObjectAs(throw_exception_return_value));
-  EXPECT_THAT(actually_thrown_exception.GetMessage(env), Not(IsEmpty()));
+  EXPECT_THAT(actually_thrown_exception.GetMessage(env()), Not(IsEmpty()));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        ThrowExceptionWithAMessageShouldSetPendingExceptionWithTheGivenMessage) {
-  Env env;
   Local<Throwable> throw_exception_return_value =
-      ThrowException(env, "my test message");
-  Local<Throwable> actually_thrown_exception = env.ClearExceptionOccurred();
+      ThrowException("my test message");
+  Local<Throwable> actually_thrown_exception = env().ClearExceptionOccurred();
   ASSERT_TRUE(actually_thrown_exception);
   EXPECT_THAT(actually_thrown_exception,
               RefersToSameJavaObjectAs(throw_exception_return_value));
-  EXPECT_THAT(actually_thrown_exception.GetMessage(env),
+  EXPECT_THAT(actually_thrown_exception.GetMessage(env()),
               StrEq("my test message"));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        CreateExceptionWithNoMessageShouldReturnAnExceptionWithAMessage) {
-  Env env;
-  Local<Throwable> exception = CreateException(env);
+  Local<Throwable> exception = CreateException();
   ASSERT_TRUE(exception);
-  EXPECT_THAT(exception.GetMessage(env), Not(IsEmpty()));
+  EXPECT_THAT(exception.GetMessage(env()), Not(IsEmpty()));
 }
 
 TEST_F(FirestoreAndroidIntegrationTest,
        CreateExceptionWithAMessageShouldReturnAnExceptionWithTheGivenMessage) {
-  Env env;
-  Local<Throwable> exception = CreateException(env, "my test message");
+  Local<Throwable> exception = CreateException("my test message");
   ASSERT_TRUE(exception);
-  EXPECT_THAT(exception.GetMessage(env), StrEq("my test message"));
+  EXPECT_THAT(exception.GetMessage(env()), StrEq("my test message"));
 }
 
 }  // namespace

--- a/firestore/integration_test_internal/src/android/geo_point_android_test.cc
+++ b/firestore/integration_test_internal/src/android/geo_point_android_test.cc
@@ -16,25 +16,20 @@
 
 #include "firestore/src/android/geo_point_android.h"
 
+#include "android/firestore_integration_test_android.h"
 #include "firebase/firestore/geo_point.h"
-#include "firestore/src/jni/env.h"
-#include "firestore_integration_test.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
 namespace firestore {
 namespace {
 
-using jni::Env;
-
-using GeoPointTest = FirestoreIntegrationTest;
+using GeoPointTest = FirestoreAndroidIntegrationTest;
 
 TEST_F(GeoPointTest, Converts) {
-  Env env;
-
   GeoPoint point{12.0, 34.0};
-  auto java_point = GeoPointInternal::Create(env, point);
-  EXPECT_EQ(point, java_point.ToPublic(env));
+  auto java_point = GeoPointInternal::Create(env(), point);
+  EXPECT_EQ(point, java_point.ToPublic(env()));
 }
 
 }  // namespace

--- a/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
+++ b/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
@@ -31,7 +31,6 @@ namespace firestore {
 
 namespace {
 
-using jni::Env;
 using jni::Global;
 using jni::Local;
 using jni::Method;
@@ -60,279 +59,254 @@ class JniRunnableTest : public FirestoreAndroidIntegrationTest {
     loader().LoadClass("java/lang/Thread$State", kThreadStateBlocked);
     ASSERT_TRUE(loader().ok());
   }
+
+  /**
+   * Returns the ID of the current Java thread.
+   */
+  static jlong GetCurrentThreadId() {
+    Local<Object> thread = env().Call(kCurrentThread);
+    return env().Call(thread, kThreadGetId);
+  }
+
+  /**
+   * Returns the ID of the Java main thread.
+   */
+  static jlong GetMainThreadId() {
+    Local<Object> main_looper = env().Call(kGetMainLooper);
+    Local<Object> main_thread = env().Call(main_looper, kLooperGetThread);
+    return env().Call(main_thread, kThreadGetId);
+  }
+
+  /**
+   * Returns whether or not the given thread is in the "blocked" state.
+   * See java.lang.Thread.State.BLOCKED.
+   */
+  static bool IsThreadBlocked(Object& thread) {
+    Local<Object> actual_state = env().Call(thread, kThreadGetState);
+    Local<Object> expected_state = env().Get(kThreadStateBlocked);
+    return Object::Equals(env(), expected_state, actual_state);
+  }
 };
 
-/**
- * Returns the ID of the current Java thread.
- */
-jlong GetCurrentThreadId(Env& env) {
-  Local<Object> thread = env.Call(kCurrentThread);
-  return env.Call(thread, kThreadGetId);
-}
-
-/**
- * Returns the ID of the Java main thread.
- */
-jlong GetMainThreadId(Env& env) {
-  Local<Object> main_looper = env.Call(kGetMainLooper);
-  Local<Object> main_thread = env.Call(main_looper, kLooperGetThread);
-  return env.Call(main_thread, kThreadGetId);
-}
-
-/**
- * Returns whether or not the given thread is in the "blocked" state.
- * See java.lang.Thread.State.BLOCKED.
- */
-bool IsThreadBlocked(Env& env, Object& thread) {
-  Local<Object> actual_state = env.Call(thread, kThreadGetState);
-  Local<Object> expected_state = env.Get(kThreadStateBlocked);
-  return Object::Equals(env, expected_state, actual_state);
-}
-
 TEST_F(JniRunnableTest, JavaRunCallsCppRun) {
-  Env env;
   bool invoked = false;
-  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
 
   EXPECT_TRUE(invoked);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 TEST_F(JniRunnableTest, JavaRunCallsCppRunOncePerInvocation) {
-  Env env;
   int invoke_count = 0;
-  auto runnable = MakeJniRunnable(env, [&invoke_count] { invoke_count++; });
+  auto runnable = MakeJniRunnable(env(), [&invoke_count] { invoke_count++; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
-  env.Call(java_runnable, kRunnableRun);
-  env.Call(java_runnable, kRunnableRun);
-  env.Call(java_runnable, kRunnableRun);
-  env.Call(java_runnable, kRunnableRun);
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
 
   EXPECT_EQ(invoke_count, 5);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 TEST_F(JniRunnableTest, JavaRunPropagatesExceptions) {
-  Env env;
-  Local<Throwable> exception = CreateException(env);
-  auto runnable = MakeJniRunnable(env, [exception] {
-    Env env;
-    env.Throw(exception);
-  });
+  Local<Throwable> exception = CreateException();
+  auto runnable =
+      MakeJniRunnable(env(), [exception] { env().Throw(exception); });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
 
-  Local<Throwable> thrown_exception = env.ClearExceptionOccurred();
+  Local<Throwable> thrown_exception = env().ClearExceptionOccurred();
   EXPECT_TRUE(thrown_exception);
-  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+  EXPECT_TRUE(env().IsSameObject(exception, thrown_exception));
 }
 
 TEST_F(JniRunnableTest, DetachCausesJavaRunToDoNothing) {
-  Env env;
   bool invoked = false;
-  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
-  runnable.Detach(env);
+  runnable.Detach(env());
 
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
   EXPECT_FALSE(invoked);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 TEST_F(JniRunnableTest, DetachCanBeInvokedMultipleTimes) {
-  Env env;
   bool invoked = false;
-  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
-  runnable.Detach(env);
-  runnable.Detach(env);
-  runnable.Detach(env);
+  runnable.Detach(env());
+  runnable.Detach(env());
+  runnable.Detach(env());
 
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
   EXPECT_FALSE(invoked);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 TEST_F(JniRunnableTest, DetachDetachesEvenIfAnExceptionIsPending) {
-  Env env;
   bool invoked = false;
-  auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+  auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
-  Local<Throwable> exception = CreateException(env);
-  env.Throw(exception);
-  EXPECT_FALSE(env.ok());
+  Local<Throwable> exception = ThrowException();
+  EXPECT_FALSE(env().ok());
 
-  runnable.Detach(env);
+  runnable.Detach(env());
 
-  env.ExceptionClear();
-  env.Call(java_runnable, kRunnableRun);
+  env().ExceptionClear();
+  env().Call(java_runnable, kRunnableRun);
   EXPECT_FALSE(invoked);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 // Verify that b/181129657 does not regress; that is, calling `Detach()` from
 // `Run()` should not deadlock.
 TEST_F(JniRunnableTest, DetachCanBeCalledFromRun) {
-  Env env;
   int run_count = 0;
-  auto runnable = MakeJniRunnable(env, [&run_count](JniRunnableBase& runnable) {
-    ++run_count;
-    Env env;
-    runnable.Detach(env);
-  });
+  auto runnable =
+      MakeJniRunnable(env(), [&run_count](JniRunnableBase& runnable) {
+        ++run_count;
+        runnable.Detach(env());
+      });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
 
   // Call `run()` twice to verify that the call to `Detach()` successfully
   // detaches and the second `run()` invocation does not call C++ `Run()`.
-  env.Call(java_runnable, kRunnableRun);
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
 
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
   EXPECT_EQ(run_count, 1);
 }
 
 TEST_F(JniRunnableTest, DestructionCausesJavaRunToDoNothing) {
-  Env env;
   bool invoked = false;
   Local<Object> java_runnable;
   {
-    auto runnable = MakeJniRunnable(env, [&invoked] { invoked = true; });
+    auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
     java_runnable = runnable.GetJavaRunnable();
   }
 
-  env.Call(java_runnable, kRunnableRun);
+  env().Call(java_runnable, kRunnableRun);
 
   EXPECT_FALSE(invoked);
-  EXPECT_TRUE(env.ok());
+  EXPECT_TRUE(env().ok());
 }
 
 TEST_F(JniRunnableTest, RunOnMainThreadRunsOnTheMainThread) {
-  Env env;
   jlong captured_thread_id = 0;
-  auto runnable = MakeJniRunnable(env, [&captured_thread_id] {
-    Env env;
-    captured_thread_id = GetCurrentThreadId(env);
+  auto runnable = MakeJniRunnable(env(), [&captured_thread_id] {
+    captured_thread_id = GetCurrentThreadId();
   });
 
-  Local<Task> task = runnable.RunOnMainThread(env);
+  Local<Task> task = runnable.RunOnMainThread(env());
 
-  Await(env, task);
-  EXPECT_EQ(captured_thread_id, GetMainThreadId(env));
+  Await(task);
+  EXPECT_EQ(captured_thread_id, GetMainThreadId());
 }
 
 TEST_F(JniRunnableTest, RunOnMainThreadTaskFailsIfRunThrowsException) {
-  Env env;
-  Global<Throwable> exception = CreateException(env);
-  auto runnable = MakeJniRunnable(env, [exception] {
-    Env env;
-    env.Throw(exception);
-  });
+  Global<Throwable> exception = CreateException();
+  auto runnable =
+      MakeJniRunnable(env(), [exception] { env().Throw(exception); });
 
-  Local<Task> task = runnable.RunOnMainThread(env);
+  Local<Task> task = runnable.RunOnMainThread(env());
 
-  Await(env, task);
-  Local<Throwable> thrown_exception = task.GetException(env);
+  Await(task);
+  Local<Throwable> thrown_exception = task.GetException(env());
   EXPECT_TRUE(thrown_exception);
-  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+  EXPECT_TRUE(env().IsSameObject(exception, thrown_exception));
 }
 
 TEST_F(JniRunnableTest, RunOnMainThreadRunsSynchronouslyFromMainThread) {
-  Env env;
   bool is_recursive_call = false;
   auto runnable =
-      MakeJniRunnable(env, [&is_recursive_call](JniRunnableBase& runnable) {
-        Env env;
-        EXPECT_EQ(GetCurrentThreadId(env), GetMainThreadId(env));
+      MakeJniRunnable(env(), [&is_recursive_call](JniRunnableBase& runnable) {
+        EXPECT_EQ(GetCurrentThreadId(), GetMainThreadId());
         if (is_recursive_call) {
           return;
         }
         is_recursive_call = true;
-        Local<Task> task = runnable.RunOnMainThread(env);
-        EXPECT_TRUE(task.IsComplete(env));
-        EXPECT_TRUE(task.IsSuccessful(env));
+        Local<Task> task = runnable.RunOnMainThread(env());
+        EXPECT_TRUE(task.IsComplete(env()));
+        EXPECT_TRUE(task.IsSuccessful(env()));
         is_recursive_call = false;
       });
 
-  Local<Task> task = runnable.RunOnMainThread(env);
+  Local<Task> task = runnable.RunOnMainThread(env());
 
-  Await(env, task);
+  Await(task);
 }
 
 TEST_F(JniRunnableTest, RunOnNewThreadRunsOnANonMainThread) {
-  Env env;
   jlong captured_thread_id = 0;
-  auto runnable = MakeJniRunnable(env, [&captured_thread_id] {
-    Env env;
-    captured_thread_id = GetCurrentThreadId(env);
+  auto runnable = MakeJniRunnable(env(), [&captured_thread_id] {
+    captured_thread_id = GetCurrentThreadId();
   });
 
-  Local<Task> task = runnable.RunOnNewThread(env);
+  Local<Task> task = runnable.RunOnNewThread(env());
 
-  Await(env, task);
+  Await(task);
   EXPECT_NE(captured_thread_id, 0);
-  EXPECT_NE(captured_thread_id, GetMainThreadId(env));
-  EXPECT_NE(captured_thread_id, GetCurrentThreadId(env));
+  EXPECT_NE(captured_thread_id, GetMainThreadId());
+  EXPECT_NE(captured_thread_id, GetCurrentThreadId());
 }
 
 TEST_F(JniRunnableTest, RunOnNewThreadTaskFailsIfRunThrowsException) {
-  Env env;
-  Global<Throwable> exception = CreateException(env);
-  auto runnable = MakeJniRunnable(env, [exception] {
-    Env env;
-    env.Throw(exception);
-  });
+  Global<Throwable> exception = CreateException();
+  auto runnable =
+      MakeJniRunnable(env(), [exception] { env().Throw(exception); });
 
-  Local<Task> task = runnable.RunOnNewThread(env);
+  Local<Task> task = runnable.RunOnNewThread(env());
 
-  Await(env, task);
-  Local<Throwable> thrown_exception = task.GetException(env);
+  Await(task);
+  Local<Throwable> thrown_exception = task.GetException(env());
   EXPECT_TRUE(thrown_exception);
-  EXPECT_TRUE(env.IsSameObject(exception, thrown_exception));
+  EXPECT_TRUE(env().IsSameObject(exception, thrown_exception));
 }
 
 TEST_F(JniRunnableTest, DetachReturnsAfterLastRunOnAnotherThreadCompletes) {
-  Env env;
   compat::Atomic<int32_t> runnable1_run_invoke_count;
   runnable1_run_invoke_count.store(0);
   Mutex detach_thread_mutex;
   Global<Object> detach_thread;
 
   auto runnable1 = MakeJniRunnable(
-      env, [&runnable1_run_invoke_count, &detach_thread, &detach_thread_mutex] {
+      env(),
+      [&runnable1_run_invoke_count, &detach_thread, &detach_thread_mutex] {
         runnable1_run_invoke_count.fetch_add(1);
-        Env env;
         // Wait for `detach()` to be called and start blocking; then, return to
         // allow `detach()` to unblock and do its job.
-        while (env.ok()) {
+        while (env().ok()) {
           MutexLock lock(detach_thread_mutex);
-          if (detach_thread && IsThreadBlocked(env, detach_thread)) {
+          if (detach_thread && IsThreadBlocked(detach_thread)) {
             break;
           }
         }
-        EXPECT_TRUE(env.ok()) << "IsThreadBlocked() failed with an exception";
+        EXPECT_TRUE(env().ok()) << "IsThreadBlocked() failed with an exception";
       });
 
-  auto runnable2 =
-      MakeJniRunnable(env, [&runnable1, &detach_thread, &detach_thread_mutex] {
-        Env env;
+  auto runnable2 = MakeJniRunnable(
+      env(), [&runnable1, &detach_thread, &detach_thread_mutex] {
         {
           MutexLock lock(detach_thread_mutex);
-          detach_thread = env.Call(kCurrentThread);
+          detach_thread = env().Call(kCurrentThread);
         }
-        runnable1.Detach(env);
-        EXPECT_TRUE(env.ok()) << "Detach() failed with an exception";
+        runnable1.Detach(env());
+        EXPECT_TRUE(env().ok()) << "Detach() failed with an exception";
       });
 
   // Wait for the `runnable1.Run()` to start to ensure that the lock is held.
-  Local<Task> task1 = runnable1.RunOnNewThread(env);
+  Local<Task> task1 = runnable1.RunOnNewThread(env());
   while (true) {
     if (runnable1_run_invoke_count.load() != 0) {
       break;
@@ -340,14 +314,14 @@ TEST_F(JniRunnableTest, DetachReturnsAfterLastRunOnAnotherThreadCompletes) {
   }
 
   // Start a new thread to call `runnable1.Detach()`.
-  Local<Task> task2 = runnable2.RunOnNewThread(env);
+  Local<Task> task2 = runnable2.RunOnNewThread(env());
 
-  Await(env, task1);
-  Await(env, task2);
+  Await(task1);
+  Await(task2);
 
   // Invoke `run()` again and ensure that `Detach()` successfully did its job;
   // that is, verify that `Run()` is not invoked.
-  env.Call(runnable1.GetJavaRunnable(), kRunnableRun);
+  env().Call(runnable1.GetJavaRunnable(), kRunnableRun);
   EXPECT_EQ(runnable1_run_invoke_count.load(), 1);
 }
 

--- a/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
+++ b/firestore/integration_test_internal/src/android/jni_runnable_android_test.cc
@@ -157,7 +157,8 @@ TEST_F(JniRunnableTest, DetachDetachesEvenIfAnExceptionIsPending) {
   bool invoked = false;
   auto runnable = MakeJniRunnable(env(), [&invoked] { invoked = true; });
   Local<Object> java_runnable = runnable.GetJavaRunnable();
-  Local<Throwable> exception = ThrowException();
+  Local<Throwable> exception = CreateException();
+  env().Throw(exception);
   EXPECT_FALSE(env().ok());
 
   runnable.Detach(env());

--- a/firestore/integration_test_internal/src/android/promise_android_test.cc
+++ b/firestore/integration_test_internal/src/android/promise_android_test.cc
@@ -61,10 +61,9 @@ class PromiseTest : public FirestoreAndroidIntegrationTest {
 
   void SetUp() override {
     FirestoreAndroidIntegrationTest::SetUp();
-    jni::Env env = GetEnv();
-    cancellation_token_source_ = CancellationTokenSource::Create(env);
+    cancellation_token_source_ = CancellationTokenSource::Create(env());
     task_completion_source_ = TaskCompletionSource::Create(
-        env, cancellation_token_source_.GetToken(env));
+        env(), cancellation_token_source_.GetToken(env()));
   }
 
   // An enum of asynchronous functions to use in tests, as required by
@@ -78,27 +77,21 @@ class PromiseTest : public FirestoreAndroidIntegrationTest {
   PromiseFactory<AsyncFn>& promises() { return promises_; }
 
   jni::Local<jni::Task> GetTask() {
-    jni::Env env = GetEnv();
-    return task_completion_source_.GetTask(env);
+    return task_completion_source_.GetTask(env());
   }
 
   void SetTaskResult(int result) {
-    jni::Env env = GetEnv();
-    task_completion_source_.SetResult(env, jni::Integer::Create(env, result));
+    task_completion_source_.SetResult(env(),
+                                      jni::Integer::Create(env(), result));
   }
 
   void SetTaskException(Error error_code, const std::string& error_message) {
-    jni::Env env = GetEnv();
     task_completion_source_.SetException(
-        env, ExceptionInternal::Create(env, error_code, error_message.c_str()));
+        env(),
+        ExceptionInternal::Create(env(), error_code, error_message.c_str()));
   }
 
-  void CancelTask() {
-    jni::Env env = GetEnv();
-    cancellation_token_source_.Cancel(env);
-  }
-
-  static jni::Env GetEnv() { return jni::Env(app_framework::GetJniEnv()); }
+  void CancelTask() { cancellation_token_source_.Cancel(env()); }
 
  private:
   PromiseFactory<AsyncFn> promises_;
@@ -236,8 +229,7 @@ class TestVoidCompletion : public TestCompletionBase<void, void> {
 };
 
 TEST_F(PromiseTest, FutureVoidShouldSucceedWhenTaskSucceeds) {
-  jni::Env env = GetEnv();
-  auto future = promises().NewFuture<void>(env, AsyncFn::kFn, GetTask());
+  auto future = promises().NewFuture<void>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   SetTaskResult(0);
@@ -249,9 +241,8 @@ TEST_F(PromiseTest, FutureVoidShouldSucceedWhenTaskSucceeds) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldSucceedWhenTaskSucceeds) {
-  jni::Env env = GetEnv();
   auto future =
-      promises().NewFuture<std::string, int>(env, AsyncFn::kFn, GetTask());
+      promises().NewFuture<std::string, int>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   SetTaskResult(42);
@@ -263,8 +254,7 @@ TEST_F(PromiseTest, FutureNonVoidShouldSucceedWhenTaskSucceeds) {
 }
 
 TEST_F(PromiseTest, FutureVoidShouldFailWhenTaskFails) {
-  jni::Env env = GetEnv();
-  auto future = promises().NewFuture<void>(env, AsyncFn::kFn, GetTask());
+  auto future = promises().NewFuture<void>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   SetTaskException(Error::kErrorFailedPrecondition, "Simulated failure");
@@ -277,9 +267,8 @@ TEST_F(PromiseTest, FutureVoidShouldFailWhenTaskFails) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldFailWhenTaskFails) {
-  jni::Env env = GetEnv();
   auto future =
-      promises().NewFuture<std::string, int>(env, AsyncFn::kFn, GetTask());
+      promises().NewFuture<std::string, int>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   SetTaskException(Error::kErrorFailedPrecondition, "Simulated failure");
@@ -292,8 +281,7 @@ TEST_F(PromiseTest, FutureNonVoidShouldFailWhenTaskFails) {
 }
 
 TEST_F(PromiseTest, FutureVoidShouldCancelWhenTaskCancels) {
-  jni::Env env = GetEnv();
-  auto future = promises().NewFuture<void>(env, AsyncFn::kFn, GetTask());
+  auto future = promises().NewFuture<void>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   CancelTask();
@@ -306,9 +294,8 @@ TEST_F(PromiseTest, FutureVoidShouldCancelWhenTaskCancels) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldCancelWhenTaskCancels) {
-  jni::Env env = GetEnv();
   auto future =
-      promises().NewFuture<std::string, int>(env, AsyncFn::kFn, GetTask());
+      promises().NewFuture<std::string, int>(env(), AsyncFn::kFn, GetTask());
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
   CancelTask();
@@ -321,9 +308,8 @@ TEST_F(PromiseTest, FutureNonVoidShouldCancelWhenTaskCancels) {
 }
 
 TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskSucceeds) {
-  jni::Env env = GetEnv();
   TestVoidCompletion completion;
-  auto future = promises().NewFuture<void, void>(env, AsyncFn::kFn, GetTask(),
+  auto future = promises().NewFuture<void, void>(env(), AsyncFn::kFn, GetTask(),
                                                  &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -337,9 +323,8 @@ TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskSucceeds) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskSucceeds) {
-  jni::Env env = GetEnv();
   TestCompletion<std::string, int> completion;
-  auto future = promises().NewFuture<std::string, int>(env, AsyncFn::kFn,
+  auto future = promises().NewFuture<std::string, int>(env(), AsyncFn::kFn,
                                                        GetTask(), &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -353,9 +338,8 @@ TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskSucceeds) {
 }
 
 TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskFails) {
-  jni::Env env = GetEnv();
   TestVoidCompletion completion;
-  auto future = promises().NewFuture<void, void>(env, AsyncFn::kFn, GetTask(),
+  auto future = promises().NewFuture<void, void>(env(), AsyncFn::kFn, GetTask(),
                                                  &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -369,9 +353,8 @@ TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskFails) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskFails) {
-  jni::Env env = GetEnv();
   TestCompletion<std::string, int> completion;
-  auto future = promises().NewFuture<std::string, int>(env, AsyncFn::kFn,
+  auto future = promises().NewFuture<std::string, int>(env(), AsyncFn::kFn,
                                                        GetTask(), &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -385,9 +368,8 @@ TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskFails) {
 }
 
 TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskCancels) {
-  jni::Env env = GetEnv();
   TestVoidCompletion completion;
-  auto future = promises().NewFuture<void, void>(env, AsyncFn::kFn, GetTask(),
+  auto future = promises().NewFuture<void, void>(env(), AsyncFn::kFn, GetTask(),
                                                  &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -401,9 +383,8 @@ TEST_F(PromiseTest, FutureVoidShouldCallCompletionWhenTaskCancels) {
 }
 
 TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskCancels) {
-  jni::Env env = GetEnv();
   TestCompletion<std::string, int> completion;
-  auto future = promises().NewFuture<std::string, int>(env, AsyncFn::kFn,
+  auto future = promises().NewFuture<std::string, int>(env(), AsyncFn::kFn,
                                                        GetTask(), &completion);
   EXPECT_EQ(future.status(), FutureStatus::kFutureStatusPending);
 
@@ -417,17 +398,15 @@ TEST_F(PromiseTest, FutureNonVoidShouldCallCompletionWhenTaskCancels) {
 }
 
 TEST_F(PromiseTest, RegisterForTaskShouldNotCrashIfFirestoreWasDeleted) {
-  jni::Env env = GetEnv();
   auto promise = promises().MakePromise<void>();
   DeleteFirestore(TestFirestore());
 
-  promise.RegisterForTask(env, AsyncFn::kFn, GetTask());
+  promise.RegisterForTask(env(), AsyncFn::kFn, GetTask());
 }
 
 TEST_F(PromiseTest, GetFutureShouldNotCrashIfFirestoreWasDeleted) {
-  jni::Env env = GetEnv();
   auto promise = promises().MakePromise<void>();
-  promise.RegisterForTask(env, AsyncFn::kFn, GetTask());
+  promise.RegisterForTask(env(), AsyncFn::kFn, GetTask());
   DeleteFirestore(TestFirestore());
 
   auto future = promise.GetFuture();

--- a/firestore/integration_test_internal/src/android/settings_android_test.cc
+++ b/firestore/integration_test_internal/src/android/settings_android_test.cc
@@ -16,9 +16,8 @@
 
 #include "firestore/src/android/settings_android.h"
 
+#include "android/firestore_integration_test_android.h"
 #include "firestore/src/include/firebase/firestore/settings.h"
-#include "firestore/src/jni/env.h"
-#include "firestore_integration_test.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -26,13 +25,9 @@ namespace firebase {
 namespace firestore {
 namespace {
 
-using jni::Env;
-
-using SettingsTestAndroid = FirestoreIntegrationTest;
+using SettingsTestAndroid = FirestoreAndroidIntegrationTest;
 
 TEST_F(SettingsTestAndroid, ConverterBoolsAllTrue) {
-  Env env;
-
   Settings settings;
   settings.set_host("foo");
   settings.set_ssl_enabled(true);
@@ -40,7 +35,7 @@ TEST_F(SettingsTestAndroid, ConverterBoolsAllTrue) {
   int64_t five_mb = 5 * 1024 * 1024;
   settings.set_cache_size_bytes(five_mb);
 
-  Settings result = SettingsInternal::Create(env, settings).ToPublic(env);
+  Settings result = SettingsInternal::Create(env(), settings).ToPublic(env());
 
   EXPECT_EQ(result.host(), "foo");
   EXPECT_TRUE(result.is_ssl_enabled());
@@ -49,14 +44,12 @@ TEST_F(SettingsTestAndroid, ConverterBoolsAllTrue) {
 }
 
 TEST_F(SettingsTestAndroid, ConverterBoolsAllFalse) {
-  Env env;
-
   Settings settings;
   settings.set_host("bar");
   settings.set_ssl_enabled(false);
   settings.set_persistence_enabled(false);
 
-  Settings result = SettingsInternal::Create(env, settings).ToPublic(env);
+  Settings result = SettingsInternal::Create(env(), settings).ToPublic(env());
 
   EXPECT_EQ("bar", result.host());
   EXPECT_FALSE(result.is_ssl_enabled());

--- a/firestore/integration_test_internal/src/android/snapshot_metadata_android_test.cc
+++ b/firestore/integration_test_internal/src/android/snapshot_metadata_android_test.cc
@@ -20,8 +20,6 @@
 #include "firebase_test_framework.h"
 #include "firestore/src/include/firebase/firestore/snapshot_metadata.h"
 #include "firestore/src/jni/declaration.h"
-#include "firestore/src/jni/env.h"
-#include "firestore_integration_test.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -32,29 +30,27 @@ using SnapshotMetadataAndroidTest = FirestoreAndroidIntegrationTest;
 
 using jni::Class;
 using jni::Constructor;
-using jni::Env;
 using jni::Local;
 
 TEST_F(SnapshotMetadataAndroidTest, Converts) {
-  Env env;
   Constructor<SnapshotMetadataInternal> ctor("(ZZ)V");
   loader().LoadClass("com/google/firebase/firestore/SnapshotMetadata", ctor);
   ASSERT_TRUE(loader().ok());
 
   {
     auto java_metadata =
-        env.New(ctor, /*has_pending_writes=*/true, /*is_from_cache=*/false);
-    SnapshotMetadata result = java_metadata.ToPublic(env);
-    EXPECT_TRUE(env.ok());
+        env().New(ctor, /*has_pending_writes=*/true, /*is_from_cache=*/false);
+    SnapshotMetadata result = java_metadata.ToPublic(env());
+    EXPECT_TRUE(env().ok());
     EXPECT_TRUE(result.has_pending_writes());
     EXPECT_FALSE(result.is_from_cache());
   }
 
   {
     auto java_metadata =
-        env.New(ctor, /*has_pending_writes=*/false, /*is_from_cache=*/true);
-    SnapshotMetadata result = java_metadata.ToPublic(env);
-    EXPECT_TRUE(env.ok());
+        env().New(ctor, /*has_pending_writes=*/false, /*is_from_cache=*/true);
+    SnapshotMetadata result = java_metadata.ToPublic(env());
+    EXPECT_TRUE(env().ok());
     EXPECT_FALSE(result.has_pending_writes());
     EXPECT_TRUE(result.is_from_cache());
   }

--- a/firestore/integration_test_internal/src/android/timestamp_android_test.cc
+++ b/firestore/integration_test_internal/src/android/timestamp_android_test.cc
@@ -16,25 +16,20 @@
 
 #include "firestore/src/android/timestamp_android.h"
 
+#include "android/firestore_integration_test_android.h"
 #include "firebase/firestore/timestamp.h"
-#include "firestore/src/jni/env.h"
-#include "firestore_integration_test.h"
 #include "gtest/gtest.h"
 
 namespace firebase {
 namespace firestore {
 namespace {
 
-using jni::Env;
-
-using TimestampTest = FirestoreIntegrationTest;
+using TimestampTest = FirestoreAndroidIntegrationTest;
 
 TEST_F(TimestampTest, Converts) {
-  Env env;
-
   Timestamp timestamp{1234, 5678};
-  auto java_timestamp = TimestampInternal::Create(env, timestamp);
-  EXPECT_EQ(timestamp, java_timestamp.ToPublic(env));
+  auto java_timestamp = TimestampInternal::Create(env(), timestamp);
+  EXPECT_EQ(timestamp, java_timestamp.ToPublic(env()));
 }
 
 }  // namespace

--- a/firestore/integration_test_internal/src/android/transaction_options_android_test.cc
+++ b/firestore/integration_test_internal/src/android/transaction_options_android_test.cc
@@ -17,8 +17,7 @@
 #include "firestore/src/android/transaction_options_android.h"
 #include "firestore/src/android/transaction_options_builder_android.h"
 
-#include "firestore/src/jni/env.h"
-#include "firestore_integration_test.h"
+#include "android/firestore_integration_test_android.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
 
@@ -26,40 +25,36 @@ namespace firebase {
 namespace firestore {
 namespace {
 
-using jni::Env;
 using jni::Local;
 
-using TransactionOptionsTestAndroid = FirestoreIntegrationTest;
+using TransactionOptionsTestAndroid = FirestoreAndroidIntegrationTest;
 
 TEST_F(TransactionOptionsTestAndroid, DefaultTransactionOptions) {
-  Env env;
   Local<TransactionOptionsBuilderInternal> builder =
-      TransactionOptionsBuilderInternal::Create(env);
+      TransactionOptionsBuilderInternal::Create(env());
 
-  Local<TransactionOptionsInternal> options = builder.Build(env);
+  Local<TransactionOptionsInternal> options = builder.Build(env());
 
-  EXPECT_EQ(options.GetMaxAttempts(env), 5);
+  EXPECT_EQ(options.GetMaxAttempts(env()), 5);
 }
 
 TEST_F(TransactionOptionsTestAndroid, SetMaxAttemptsReturnsSameInstance) {
-  Env env;
   Local<TransactionOptionsBuilderInternal> builder =
-      TransactionOptionsBuilderInternal::Create(env);
+      TransactionOptionsBuilderInternal::Create(env());
 
   Local<TransactionOptionsBuilderInternal> retval =
-      builder.SetMaxAttempts(env, 42);
+      builder.SetMaxAttempts(env(), 42);
 
-  EXPECT_TRUE(env.IsSameObject(builder, retval));
+  EXPECT_TRUE(env().IsSameObject(builder, retval));
 }
 
 TEST_F(TransactionOptionsTestAndroid, SetMaxAttempts) {
-  Env env;
   Local<TransactionOptionsBuilderInternal> builder =
-      TransactionOptionsBuilderInternal::Create(env);
+      TransactionOptionsBuilderInternal::Create(env());
 
-  builder.SetMaxAttempts(env, 42);
+  builder.SetMaxAttempts(env(), 42);
 
-  EXPECT_EQ(builder.Build(env).GetMaxAttempts(env), 42);
+  EXPECT_EQ(builder.Build(env()).GetMaxAttempts(env()), 42);
 }
 
 }  // namespace

--- a/firestore/integration_test_internal/src/firestore_test.cc
+++ b/firestore/integration_test_internal/src/firestore_test.cc
@@ -1850,14 +1850,13 @@ TEST_F(FirestoreTest, FirestoreCanBeDeletedFromTransaction) {
 #if defined(__ANDROID__)
 TEST_F(FirestoreAndroidIntegrationTest,
        CanDeleteFirestoreInstanceOnJavaMainThread) {
-  jni::Env env;
   Firestore* db = TestFirestore();
-  auto runnable = MakeJniRunnable(env, [db] { delete db; });
+  auto runnable = MakeJniRunnable(env(), [db] { delete db; });
 
-  jni::Local<jni::Task> task = runnable.RunOnMainThread(env);
+  jni::Local<jni::Task> task = runnable.RunOnMainThread(env());
 
-  Await(env, task);
-  EXPECT_TRUE(task.IsSuccessful(env));
+  Await(task);
+  EXPECT_TRUE(task.IsSuccessful(env()));
   DisownFirestore(db);  // Avoid double-deletion of the `db`.
 }
 #endif  // defined(__ANDROID__)

--- a/firestore/integration_test_internal/src/jni/task_test.cc
+++ b/firestore/integration_test_internal/src/jni/task_test.cc
@@ -78,7 +78,7 @@ TEST_F(TaskTest, GetResultShouldReturnTheResult) {
 
   Local<Object> actual_result = task.GetResult(env());
 
-  ASSERT_THAT(actual_result, RefersToSameJavaObjectAs(result));
+  ASSERT_THAT(actual_result, JavaEq(result));
 }
 
 TEST_F(TaskTest, GetExceptionShouldReturnTheException) {

--- a/firestore/integration_test_internal/src/jni/task_test.cc
+++ b/firestore/integration_test_internal/src/jni/task_test.cc
@@ -19,7 +19,6 @@
 #include "android/cancellation_token_source.h"
 #include "android/firestore_integration_test_android.h"
 #include "android/task_completion_source.h"
-#include "firestore/src/jni/env.h"
 #include "firestore/src/jni/object.h"
 #include "firestore/src/jni/ownership.h"
 #include "firestore/src/jni/string.h"
@@ -35,61 +34,58 @@ namespace {
 
 class TaskTest : public FirestoreAndroidIntegrationTest {
  protected:
-  Local<Task> CreateIncompleteTask(Env& env) {
-    return TaskCompletionSource::Create(env).GetTask(env);
+  static Local<Task> CreateIncompleteTask() {
+    return TaskCompletionSource::Create(env()).GetTask(env());
   }
 
   template <typename T>
-  Local<Task> CreateSuccessfulTask(Env& env, T result) {
-    auto tcs = TaskCompletionSource::Create(env);
-    tcs.SetResult(env, result);
-    return tcs.GetTask(env);
+  static Local<Task> CreateSuccessfulTask(T result) {
+    auto tcs = TaskCompletionSource::Create(env());
+    tcs.SetResult(env(), result);
+    return tcs.GetTask(env());
   }
 
-  Local<Task> CreateSuccessfulTask(Env& env) {
-    auto result = env.NewStringUtf("Fake Result");
-    return CreateSuccessfulTask(env, result);
+  static Local<Task> CreateSuccessfulTask() {
+    Local<String> result = env().NewStringUtf("Fake Result");
+    return CreateSuccessfulTask(result);
   }
 
-  Local<Task> CreateFailedTask(Env& env, Throwable exception) {
-    auto tcs = TaskCompletionSource::Create(env);
-    tcs.SetException(env, exception);
-    return tcs.GetTask(env);
+  static Local<Task> CreateFailedTask(const Throwable& exception) {
+    auto tcs = TaskCompletionSource::Create(env());
+    tcs.SetException(env(), exception);
+    return tcs.GetTask(env());
   }
 
-  Local<Task> CreateFailedTask(Env& env) {
-    auto exception = CreateException(env);
-    return CreateFailedTask(env, exception);
+  static Local<Task> CreateFailedTask() {
+    return CreateFailedTask(CreateException());
   }
 
-  Local<Task> CreateCancelledTask(Env& env) {
-    auto cts = CancellationTokenSource::Create(env);
-    auto tcs = TaskCompletionSource::Create(env, cts.GetToken(env));
-    cts.Cancel(env);
-    auto task = tcs.GetTask(env);
+  static Local<Task> CreateCancelledTask() {
+    auto cts = CancellationTokenSource::Create(env());
+    auto tcs = TaskCompletionSource::Create(env(), cts.GetToken(env()));
+    cts.Cancel(env());
+    auto task = tcs.GetTask(env());
     // Wait for the `Task` to be "completed" because `Cancel()` marks the `Task`
     // as "completed" asynchronously.
-    Await(env, task);
+    Await(task);
     return task;
   }
 };
 
 TEST_F(TaskTest, GetResultShouldReturnTheResult) {
-  Env env;
-  Local<String> result = env.NewStringUtf("Fake Result");
-  Local<Task> task = CreateSuccessfulTask(env, result);
+  Local<String> result = env().NewStringUtf("Fake Result");
+  Local<Task> task = CreateSuccessfulTask(result);
 
-  Local<Object> actual_result = task.GetResult(env);
+  Local<Object> actual_result = task.GetResult(env());
 
-  ASSERT_THAT(actual_result, JavaEq(result));
+  ASSERT_THAT(actual_result, RefersToSameJavaObjectAs(result));
 }
 
 TEST_F(TaskTest, GetExceptionShouldReturnTheException) {
-  Env env;
-  Local<Throwable> exception = CreateException(env);
-  Local<Task> task = CreateFailedTask(env, exception);
+  Local<Throwable> exception = CreateException();
+  Local<Task> task = CreateFailedTask(exception);
 
-  Local<Throwable> actual_exception = task.GetException(env);
+  Local<Throwable> actual_exception = task.GetException(env());
 
   ASSERT_THAT(actual_exception, JavaEq(exception));
 }
@@ -97,91 +93,79 @@ TEST_F(TaskTest, GetExceptionShouldReturnTheException) {
 // Tests for Task.IsComplete()
 
 TEST_F(TaskTest, IsCompleteShouldReturnFalseForIncompleteTask) {
-  Env env;
-  Local<Task> task = CreateIncompleteTask(env);
+  Local<Task> task = CreateIncompleteTask();
 
-  ASSERT_FALSE(task.IsComplete(env));
+  ASSERT_FALSE(task.IsComplete(env()));
 }
 
 TEST_F(TaskTest, IsCompleteShouldReturnTrueForSucceededTask) {
-  Env env;
-  Local<Task> task = CreateSuccessfulTask(env);
+  Local<Task> task = CreateSuccessfulTask();
 
-  ASSERT_TRUE(task.IsComplete(env));
+  ASSERT_TRUE(task.IsComplete(env()));
 }
 
 TEST_F(TaskTest, IsCompleteShouldReturnTrueForFailedTask) {
-  Env env;
-  Local<Task> task = CreateFailedTask(env);
+  Local<Task> task = CreateFailedTask();
 
-  ASSERT_TRUE(task.IsComplete(env));
+  ASSERT_TRUE(task.IsComplete(env()));
 }
 
 TEST_F(TaskTest, IsCompleteShouldReturnTrueForCanceledTask) {
-  Env env;
-  Local<Task> task = CreateCancelledTask(env);
+  Local<Task> task = CreateCancelledTask();
 
-  ASSERT_TRUE(task.IsComplete(env));
+  ASSERT_TRUE(task.IsComplete(env()));
 }
 
 // Tests for Task.IsSuccessful()
 
 TEST_F(TaskTest, IsSuccessfulShouldReturnFalseForIncompleteTask) {
-  Env env;
-  Local<Task> task = CreateIncompleteTask(env);
+  Local<Task> task = CreateIncompleteTask();
 
-  ASSERT_FALSE(task.IsSuccessful(env));
+  ASSERT_FALSE(task.IsSuccessful(env()));
 }
 
 TEST_F(TaskTest, IsSuccessfulShouldReturnTrueForSucceededTask) {
-  Env env;
-  Local<Task> task = CreateSuccessfulTask(env);
+  Local<Task> task = CreateSuccessfulTask();
 
-  ASSERT_TRUE(task.IsSuccessful(env));
+  ASSERT_TRUE(task.IsSuccessful(env()));
 }
 
 TEST_F(TaskTest, IsSuccessfulShouldReturnFalseForFailedTask) {
-  Env env;
-  Local<Task> task = CreateFailedTask(env);
+  Local<Task> task = CreateFailedTask();
 
-  ASSERT_FALSE(task.IsSuccessful(env));
+  ASSERT_FALSE(task.IsSuccessful(env()));
 }
 
 TEST_F(TaskTest, IsSuccessfulShouldReturnFalseForCanceledTask) {
-  Env env;
-  Local<Task> task = CreateCancelledTask(env);
+  Local<Task> task = CreateCancelledTask();
 
-  ASSERT_FALSE(task.IsSuccessful(env));
+  ASSERT_FALSE(task.IsSuccessful(env()));
 }
 
 // Tests for Task.IsCanceled()
 
 TEST_F(TaskTest, IsCanceledShouldReturnFalseForIncompleteTask) {
-  Env env;
-  Local<Task> task = CreateIncompleteTask(env);
+  Local<Task> task = CreateIncompleteTask();
 
-  ASSERT_FALSE(task.IsCanceled(env));
+  ASSERT_FALSE(task.IsCanceled(env()));
 }
 
 TEST_F(TaskTest, IsCanceledShouldReturnFalseForSucceededTask) {
-  Env env;
-  Local<Task> task = CreateSuccessfulTask(env);
+  Local<Task> task = CreateSuccessfulTask();
 
-  ASSERT_FALSE(task.IsCanceled(env));
+  ASSERT_FALSE(task.IsCanceled(env()));
 }
 
 TEST_F(TaskTest, IsCanceledShouldReturnFalseForFailedTask) {
-  Env env;
-  Local<Task> task = CreateFailedTask(env);
+  Local<Task> task = CreateFailedTask();
 
-  ASSERT_FALSE(task.IsCanceled(env));
+  ASSERT_FALSE(task.IsCanceled(env()));
 }
 
 TEST_F(TaskTest, IsCanceledShouldReturnTrueForCanceledTask) {
-  Env env;
-  Local<Task> task = CreateCancelledTask(env);
+  Local<Task> task = CreateCancelledTask();
 
-  ASSERT_TRUE(task.IsCanceled(env));
+  ASSERT_TRUE(task.IsCanceled(env()));
 }
 
 }  // namespace


### PR DESCRIPTION
Many of the Firestore integration tests for Android need an instance of `jni::Env`. The usual solution is create an instance as a local variable by simply declaring `jni::Env env`. This is a bit annoying because it adds clutter to the source code. Additionally, `jni::Env` instances are not allowed to be shared between threads, and having a local variable makes it easy to accidentally share instances with other threads.

To fix this, `FirestoreAndroidIntegrationTest` gains a new static member function named `env()` that returns a reference to an instance of `jni::Env`. By using a `thread_local` variable, it ensures that each thread gets its own instance. Then, (almost) all occurrences of `jni::Env env` have been removed from the tests, and where an instance was needed it just calls the `env()` function.