### PR TITLE
Clean up JNI task listeners per object

### DIFF
--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -342,5 +342,17 @@ std::vector<std::string> SplitString(const std::string& s,
   return split_parts;
 }
 
+std::string CreateApiIdentifier(const char* api_id, void* object) {
+  std::string created;
+  created.reserve(strlen(api_id) +
+                  16 /* hex characters in the pointer */ +
+                  1 /* null terminator */);
+  snprintf(&(created[0]), created.capacity(), "%s0x%016llx",
+           api_id,
+           static_cast<unsigned long long>(  // NOLINT
+               reinterpret_cast<intptr_t>(object)));
+  return created;
+}
+
 // NOLINTNEXTLINE - allow namespace overridden
 }  // namespace firebase

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -344,11 +344,9 @@ std::vector<std::string> SplitString(const std::string& s,
 
 std::string CreateApiIdentifier(const char* api_id, void* object) {
   std::string created;
-  created.reserve(strlen(api_id) +
-                  16 /* hex characters in the pointer */ +
+  created.reserve(strlen(api_id) + 16 /* hex characters in the pointer */ +
                   1 /* null terminator */);
-  snprintf(&(created[0]), created.capacity(), "%s0x%016llx",
-           api_id,
+  snprintf(&(created[0]), created.capacity(), "%s0x%016llx", api_id,
            static_cast<unsigned long long>(  // NOLINT
                reinterpret_cast<intptr_t>(object)));
   return created;

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -342,14 +342,18 @@ std::vector<std::string> SplitString(const std::string& s,
   return split_parts;
 }
 
+// Id used as part of the logic to make unique api identifiers.
+static int g_api_identifier_count = 0;
+
 std::string CreateApiIdentifier(const char* api_id, void* object) {
   std::string created;
-  created.reserve(strlen(api_id) + 2 /* 0x */ +
-                  16 /* hex characters in the pointer */ +
-                  1 /* null terminator */);
-  snprintf(&(created[0]), created.capacity(), "%s0x%016llx", api_id,
-           static_cast<unsigned long long>(  // NOLINT
-               reinterpret_cast<intptr_t>(object)));
+  const char* format = "%s0x%016llx_%d";
+  unsigned long long object_ptr =
+      static_cast<unsigned long long>(reinterpret_cast<intptr_t>(object));
+  int extra_id = g_api_identifier_count++;
+  int size = snprintf(nullptr, 0, format, api_id, object_ptr, extra_id) + 1;
+  created.reserve(size);
+  snprintf(&(created[0]), size, format, api_id, object_ptr, extra_id);
   return created;
 }
 

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -348,9 +348,9 @@ static int g_api_identifier_count = 0;
 std::string CreateApiIdentifier(const char* api_id, void* object) {
   std::string created;
   const char* format = "%s0x%016llx_%d";
-  unsigned long long object_ptr =  // NOLINT
+  unsigned long long object_ptr =       // NOLINT
       static_cast<unsigned long long>(  // NOLINT
-        reinterpret_cast<intptr_t>(object));
+          reinterpret_cast<intptr_t>(object));
   int extra_id = g_api_identifier_count++;
   int size = snprintf(nullptr, 0, format, api_id, object_ptr, extra_id) + 1;
   created.reserve(size);

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -348,8 +348,9 @@ static int g_api_identifier_count = 0;
 std::string CreateApiIdentifier(const char* api_id, void* object) {
   std::string created;
   const char* format = "%s0x%016llx_%d";
-  unsigned long long object_ptr =
-      static_cast<unsigned long long>(reinterpret_cast<intptr_t>(object));
+  unsigned long long object_ptr =  // NOLINT
+      static_cast<unsigned long long>(  // NOLINT
+        reinterpret_cast<intptr_t>(object));
   int extra_id = g_api_identifier_count++;
   int size = snprintf(nullptr, 0, format, api_id, object_ptr, extra_id) + 1;
   created.reserve(size);

--- a/app/src/util.cc
+++ b/app/src/util.cc
@@ -344,7 +344,8 @@ std::vector<std::string> SplitString(const std::string& s,
 
 std::string CreateApiIdentifier(const char* api_id, void* object) {
   std::string created;
-  created.reserve(strlen(api_id) + 16 /* hex characters in the pointer */ +
+  created.reserve(strlen(api_id) + 2 /* 0x */ +
+                  16 /* hex characters in the pointer */ +
                   1 /* null terminator */);
   snprintf(&(created[0]), created.capacity(), "%s0x%016llx", api_id,
            static_cast<unsigned long long>(  // NOLINT

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -240,6 +240,7 @@ std::vector<std::string> SplitString(const std::string& s, char delimiter);
 
 // Helper function to combine a string and other object into a unique
 // identifier. Primarily used to manage listening to JNI Tasks on Android.
+// Note that repeated calls are expected to return different values.
 std::string CreateApiIdentifier(const char* api_id, void* object);
 
 }  // namespace firebase

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -238,8 +238,8 @@ class StaticFutureData {
 // delimiter. Returns a vector of constituent parts.
 std::vector<std::string> SplitString(const std::string& s, char delimiter);
 
-// Helper function to combine a string and other object into a unique identifier.
-// Primarily used to manage listening to JNI Tasks on Android.
+// Helper function to combine a string and other object into a unique
+// identifier. Primarily used to manage listening to JNI Tasks on Android.
 std::string CreateApiIdentifier(const char* api_id, void* object);
 
 }  // namespace firebase

--- a/app/src/util.h
+++ b/app/src/util.h
@@ -238,7 +238,10 @@ class StaticFutureData {
 // delimiter. Returns a vector of constituent parts.
 std::vector<std::string> SplitString(const std::string& s, char delimiter);
 
-// NOLINTNEXTLINE - allow namespace overridden
+// Helper function to combine a string and other object into a unique identifier.
+// Primarily used to manage listening to JNI Tasks on Android.
+std::string CreateApiIdentifier(const char* api_id, void* object);
+
 }  // namespace firebase
 
 #endif  // FIREBASE_APP_SRC_UTIL_H_

--- a/app/tests/util_test.cc
+++ b/app/tests/util_test.cc
@@ -54,5 +54,10 @@ TEST(UtilTest, SplitStringDelimetersOnly) {
   EXPECT_THAT(SplitString("///", '/'), IsEmpty());
 }
 
+TEST(UtilTest, CreateApiIdentifierUnique) {
+  EXPECT_STRNE(CreateApiIdentifier("Test", &v1).c_str(),
+               CreateApiIdentifier("Test", &v2).c_str());
+}
+
 }  // namespace
 }  // namespace firebase

--- a/app/tests/util_test.cc
+++ b/app/tests/util_test.cc
@@ -55,8 +55,15 @@ TEST(UtilTest, SplitStringDelimetersOnly) {
 }
 
 TEST(UtilTest, CreateApiIdentifierUnique) {
+  int v1, v2;
   EXPECT_STRNE(CreateApiIdentifier("Test", &v1).c_str(),
                CreateApiIdentifier("Test", &v2).c_str());
+}
+
+TEST(UtilTest, CreateApiIdentifierReallyUnique) {
+  int v1;
+  EXPECT_STRNE(CreateApiIdentifier("Test", &v1).c_str(),
+               CreateApiIdentifier("Test", &v1).c_str());
 }
 
 }  // namespace

--- a/app_check/src/android/app_check_android.h
+++ b/app_check/src/android/app_check_android.h
@@ -15,6 +15,7 @@
 #ifndef FIREBASE_APP_CHECK_SRC_ANDROID_APP_CHECK_ANDROID_H_
 #define FIREBASE_APP_CHECK_SRC_ANDROID_APP_CHECK_ANDROID_H_
 
+#include <string>
 #include <vector>
 
 #include "app/src/future_manager.h"
@@ -70,6 +71,9 @@ class AppCheckInternal {
   Mutex listeners_mutex_;
 
   FutureManager future_manager_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/app_check/src/android/common_android.cc
+++ b/app_check/src/android/common_android.cc
@@ -152,7 +152,8 @@ void AndroidAppCheckProvider::GetToken(
         new TokenResultCallbackData(completion_callback);
     util::RegisterCallbackOnTask(
         env, j_task, TokenResultCallback,
-        reinterpret_cast<void*>(completion_callback_data), jni_task_id_.c_str());
+        reinterpret_cast<void*>(completion_callback_data),
+        jni_task_id_.c_str());
   } else {
     AppCheckToken empty_token;
     completion_callback(empty_token, kAppCheckErrorUnknown, error.c_str());

--- a/app_check/src/android/common_android.h
+++ b/app_check/src/android/common_android.h
@@ -61,6 +61,9 @@ class AndroidAppCheckProvider : public AppCheckProvider {
 
  private:
   jobject android_provider_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -111,15 +111,8 @@ Auth::Auth(App* app, void* auth_impl) : auth_data_(new AuthData) {
   auth_data_->user_impl = nullptr;
   InitPlatformAuth(auth_data_);
 
-  std::string* future_id = &auth_data_->future_api_id;
   static const char* kApiIdentifier = "Auth";
-  future_id->reserve(strlen(kApiIdentifier) +
-                     16 /* hex characters in the pointer */ +
-                     1 /* null terminator */);
-  snprintf(&((*future_id)[0]), future_id->capacity(), "%s0x%016llx",
-           kApiIdentifier,
-           static_cast<unsigned long long>(  // NOLINT
-               reinterpret_cast<intptr_t>(this)));
+  auth_data_->future_api_id = CreateApiIdentifier(kApiIdentifier, this);
 
   // Cleanup this object if app is destroyed.
   CleanupNotifier* notifier = CleanupNotifier::FindByOwner(app);

--- a/database/src/android/database_android.h
+++ b/database/src/android/database_android.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 #include <vector>
 
 #include "app/src/cleanup_notifier.h"

--- a/database/src/android/database_android.h
+++ b/database/src/android/database_android.h
@@ -42,10 +42,6 @@ namespace internal {
 // For constructing, copying or moving DatabaseReferences atomically.
 extern Mutex g_database_reference_constructor_mutex;
 
-// Used for registering global callbacks. See
-// firebase::util::RegisterCallbackOnTask for context.
-extern const char kApiIdentifier[];
-
 // This is the Android implementation of Database.
 class DatabaseInternal {
  public:
@@ -183,6 +179,10 @@ class DatabaseInternal {
 
   Logger* logger() { return &logger_; }
 
+  // Used for registering global callbacks. See
+  // firebase::util::RegisterCallbackOnTask for context.
+  const char* jni_task_id() { return jni_task_id_.c_str(); }
+
  private:
   static bool Initialize(App* app);
   static void ReleaseClasses(App* app);
@@ -222,6 +222,9 @@ class DatabaseInternal {
   std::string constructor_url_;
 
   Logger logger_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/database/src/android/database_reference_android.cc
+++ b/database/src/android/database_reference_android.cc
@@ -329,7 +329,7 @@ Future<void> DatabaseReferenceInternal::RemoveValue() {
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(
           new FutureCallbackData(handle, ref_future(), db_)),
-      kApiIdentifier);
+      db_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
   return MakeFuture(ref_future(), handle);
@@ -358,7 +358,7 @@ Future<void> DatabaseReferenceInternal::SetValue(Variant value) {
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(
             new FutureCallbackData(handle, ref_future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     env->DeleteLocalRef(task);
     if (value_obj) env->DeleteLocalRef(value_obj);
   }
@@ -391,7 +391,7 @@ Future<void> DatabaseReferenceInternal::SetPriority(Variant priority) {
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(
             new FutureCallbackData(handle, ref_future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     util::CheckAndClearJniExceptions(env);
     env->DeleteLocalRef(task);
     if (priority_obj) env->DeleteLocalRef(priority_obj);
@@ -432,7 +432,7 @@ Future<void> DatabaseReferenceInternal::SetValueAndPriority(Variant value,
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(
             new FutureCallbackData(handle, ref_future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     env->DeleteLocalRef(task);
     if (value_obj) env->DeleteLocalRef(value_obj);
     if (priority_obj) env->DeleteLocalRef(priority_obj);
@@ -464,7 +464,7 @@ Future<void> DatabaseReferenceInternal::UpdateChildren(Variant values) {
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(
             new FutureCallbackData(handle, ref_future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     env->DeleteLocalRef(task);
     if (values_obj) env->DeleteLocalRef(values_obj);
   }

--- a/database/src/android/disconnection_android.cc
+++ b/database/src/android/disconnection_android.cc
@@ -120,7 +120,7 @@ Future<void> DisconnectionHandlerInternal::Cancel() {
       env, task, FutureCallback,
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(handle, future(), db_)),
-      kApiIdentifier);
+      db_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
   return MakeFuture(future(), handle);
@@ -141,7 +141,7 @@ Future<void> DisconnectionHandlerInternal::RemoveValue() {
       env, task, FutureCallback,
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(handle, future(), db_)),
-      kApiIdentifier);
+      db_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   return MakeFuture(future(), handle);
 }
@@ -166,7 +166,7 @@ Future<void> DisconnectionHandlerInternal::SetValue(Variant value) {
         env, task, FutureCallback,
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(new FutureCallbackData(handle, future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     util::CheckAndClearJniExceptions(env);
     env->DeleteLocalRef(task);
     if (value_obj) env->DeleteLocalRef(value_obj);
@@ -211,7 +211,7 @@ Future<void> DisconnectionHandlerInternal::SetValueAndPriority(
         env, task, FutureCallback,
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(new FutureCallbackData(handle, future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     env->DeleteLocalRef(task);
     if (value_obj) env->DeleteLocalRef(value_obj);
   }
@@ -240,7 +240,7 @@ Future<void> DisconnectionHandlerInternal::UpdateChildren(Variant values) {
         env, task, FutureCallback,
         // FutureCallback will delete the newed FutureCallbackData.
         reinterpret_cast<void*>(new FutureCallbackData(handle, future(), db_)),
-        kApiIdentifier);
+        db_->jni_task_id());
     env->DeleteLocalRef(task);
     if (values_obj) env->DeleteLocalRef(values_obj);
   }

--- a/functions/src/android/callable_reference_android.cc
+++ b/functions/src/android/callable_reference_android.cc
@@ -188,7 +188,7 @@ Future<HttpsCallableResult> HttpsCallableReferenceInternal::Call() {
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), functions_, kCallableReferenceFnCall)),
-      kApiIdentifier);
+      functions_->jni_task_id());
 
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
@@ -219,7 +219,7 @@ Future<HttpsCallableResult> HttpsCallableReferenceInternal::Call(
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), functions_, kCallableReferenceFnCall)),
-      kApiIdentifier);
+      functions_->jni_task_id());
 
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);

--- a/functions/src/android/functions_android.h
+++ b/functions/src/android/functions_android.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 
 #include "app/src/cleanup_notifier.h"
 #include "app/src/future_manager.h"

--- a/functions/src/android/functions_android.h
+++ b/functions/src/android/functions_android.h
@@ -34,10 +34,6 @@ namespace firebase {
 namespace functions {
 namespace internal {
 
-// Used for registering global callbacks. See
-// firebase::util::RegisterCallbackOnTask for context.
-extern const char kApiIdentifier[];
-
 class FunctionsInternal {
  public:
   // Build a Functions.
@@ -77,6 +73,10 @@ class FunctionsInternal {
   // objects.
   CleanupNotifier& cleanup() { return cleanup_; }
 
+  // Used for registering global callbacks. See
+  // firebase::util::RegisterCallbackOnTask for context.
+  const char* jni_task_id() { return jni_task_id_.c_str(); }
+
  private:
   // Initialize JNI for all classes.
   static bool Initialize(App* app);
@@ -97,6 +97,9 @@ class FunctionsInternal {
   FutureManager future_manager_;
 
   CleanupNotifier cleanup_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -136,6 +136,7 @@ void TokenResultCallback(JNIEnv* env, jobject result,
 InstallationsInternal::InstallationsInternal(const firebase::App& app)
     : app_(app), future_impl_(kInstallationsFnCount) {
   ReferenceCountLock<ReferenceCount> lock(&initializer_);
+  static const char* kApiIdentifier = "Installations";
   LogDebug("%s API Initializing", kApiIdentifier);
   JNIEnv* env = app_.GetJNIEnv();
 
@@ -156,7 +157,6 @@ InstallationsInternal::InstallationsInternal(const firebase::App& app)
     }
   }
 
-  static const char* kApiIdentifier = "Installations";
   jni_task_id_ = CreateApiIdentifier(kApiIdentifier, this);
 
   // Create the underlying Installations java object.

--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -57,8 +57,6 @@ using firebase::internal::ReferenceCountLock;
 
 ReferenceCount internal::InstallationsInternal::initializer_;  // NOLINT
 
-static const char* kApiIdentifier = "Installations";
-
 template <typename T>
 struct FISDataHandle {
   FISDataHandle(ReferenceCountedFutureImpl* _future_api,
@@ -158,7 +156,10 @@ InstallationsInternal::InstallationsInternal(const firebase::App& app)
     }
   }
 
-  // Create the remote config class.
+  static const char* kApiIdentifier = "Installations";
+  jni_task_id_ = CreateApiIdentifier(kApiIdentifier, this);
+
+  // Create the underlying Installations java object.
   jobject platform_app = app_.GetPlatformApp();
 
   jclass installations_class = installations::GetClass();
@@ -172,7 +173,10 @@ InstallationsInternal::InstallationsInternal(const firebase::App& app)
   LogDebug("%s API Initialized", kApiIdentifier);
 }
 
-InstallationsInternal::~InstallationsInternal() {}
+InstallationsInternal::~InstallationsInternal() {
+  JNIEnv* env = app_.GetJNIEnv();
+  util::CancelCallbacks(env, jni_task_id_);
+}
 
 bool InstallationsInternal::Initialized() const {
   return internal_obj_ != nullptr;
@@ -212,7 +216,7 @@ Future<std::string> InstallationsInternal::GetId() {
 
   util::RegisterCallbackOnTask(env, task, StringResultCallback,
                                reinterpret_cast<void*>(data_handle),
-                               kApiIdentifier);
+                               jni_task_id_);
 
   env->DeleteLocalRef(task);
 
@@ -237,7 +241,7 @@ Future<std::string> InstallationsInternal::GetToken(bool forceRefresh) {
 
   util::RegisterCallbackOnTask(env, task, TokenResultCallback,
                                reinterpret_cast<void*>(data_handle),
-                               kApiIdentifier);
+                               jni_task_id_);
 
   env->DeleteLocalRef(task);
 
@@ -259,7 +263,7 @@ Future<void> InstallationsInternal::Delete() {
 
   util::RegisterCallbackOnTask(env, task, CompleteVoidCallback,
                                reinterpret_cast<void*>(data_handle),
-                               kApiIdentifier);
+                               jni_task_id_);
 
   env->DeleteLocalRef(task);
 

--- a/installations/src/android/installations_android.cc
+++ b/installations/src/android/installations_android.cc
@@ -175,7 +175,7 @@ InstallationsInternal::InstallationsInternal(const firebase::App& app)
 
 InstallationsInternal::~InstallationsInternal() {
   JNIEnv* env = app_.GetJNIEnv();
-  util::CancelCallbacks(env, jni_task_id_);
+  util::CancelCallbacks(env, jni_task_id_.c_str());
 }
 
 bool InstallationsInternal::Initialized() const {
@@ -216,7 +216,7 @@ Future<std::string> InstallationsInternal::GetId() {
 
   util::RegisterCallbackOnTask(env, task, StringResultCallback,
                                reinterpret_cast<void*>(data_handle),
-                               jni_task_id_);
+                               jni_task_id_.c_str());
 
   env->DeleteLocalRef(task);
 
@@ -241,7 +241,7 @@ Future<std::string> InstallationsInternal::GetToken(bool forceRefresh) {
 
   util::RegisterCallbackOnTask(env, task, TokenResultCallback,
                                reinterpret_cast<void*>(data_handle),
-                               jni_task_id_);
+                               jni_task_id_.c_str());
 
   env->DeleteLocalRef(task);
 
@@ -263,7 +263,7 @@ Future<void> InstallationsInternal::Delete() {
 
   util::RegisterCallbackOnTask(env, task, CompleteVoidCallback,
                                reinterpret_cast<void*>(data_handle),
-                               jni_task_id_);
+                               jni_task_id_.c_str());
 
   env->DeleteLocalRef(task);
 

--- a/installations/src/android/installations_android.h
+++ b/installations/src/android/installations_android.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_INSTALLATIONS_SRC_ANDROID_INSTALLATIONS_ANDROID_H_
 #define FIREBASE_INSTALLATIONS_SRC_ANDROID_INSTALLATIONS_ANDROID_H_
 
+#include <string>
+
 #include "app/src/reference_count.h"
 #include "app/src/reference_counted_future_impl.h"
 #include "app/src/util_android.h"
@@ -60,6 +62,9 @@ class InstallationsInternal {
   ReferenceCountedFutureImpl future_impl_;
 
   jobject internal_obj_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/remote_config/src/android/remote_config_android.h
+++ b/remote_config/src/android/remote_config_android.h
@@ -15,6 +15,8 @@
 #ifndef FIREBASE_REMOTE_CONFIG_SRC_ANDROID_REMOTE_CONFIG_ANDROID_H_
 #define FIREBASE_REMOTE_CONFIG_SRC_ANDROID_REMOTE_CONFIG_ANDROID_H_
 
+#include <string>
+
 #include "app/meta/move.h"
 #include "app/src/cleanup_notifier.h"
 #include "app/src/include/firebase/internal/common.h"

--- a/remote_config/src/android/remote_config_android.h
+++ b/remote_config/src/android/remote_config_android.h
@@ -124,6 +124,9 @@ class RemoteConfigInternal {
   // If a fetch was throttled, this is set to the time when throttling is
   // finished, in milliseconds since epoch.
   int64_t throttled_end_time_ = 0;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/storage/src/android/storage_android.h
+++ b/storage/src/android/storage_android.h
@@ -19,6 +19,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 
 #include "app/src/cleanup_notifier.h"
 #include "app/src/future_manager.h"

--- a/storage/src/android/storage_android.h
+++ b/storage/src/android/storage_android.h
@@ -55,10 +55,6 @@ METHOD_LOOKUP_DECLARATION(cpp_byte_downloader, CPP_BYTE_DOWNLOADER_METHODS)
 // clang-format on
 METHOD_LOOKUP_DECLARATION(cpp_byte_uploader, CPP_BYTE_UPLOADER_METHODS)
 
-// Used for registering global callbacks. See
-// firebase::util::RegisterCallbackOnTask for context.
-extern const char kApiIdentifier[];
-
 class StorageInternal {
  public:
   // Build a Storage. A nullptr or empty url uses the default getInstance.
@@ -114,6 +110,10 @@ class StorageInternal {
   // objects.
   CleanupNotifier& cleanup() { return cleanup_; }
 
+  // Used for registering global callbacks. See
+  // firebase::util::RegisterCallbackOnTask for context.
+  const char* jni_task_id() { return jni_task_id_.c_str(); }
+
  private:
   // Initialize JNI for all classes.
   static bool Initialize(App* app);
@@ -135,6 +135,9 @@ class StorageInternal {
   std::string url_;
 
   CleanupNotifier cleanup_;
+
+  // String to be used when registering for JNI task callbacks.
+  std::string jni_task_id_;
 };
 
 }  // namespace internal

--- a/storage/src/android/storage_reference_android.cc
+++ b/storage/src/android/storage_reference_android.cc
@@ -349,7 +349,7 @@ Future<void> StorageReferenceInternal::Delete() {
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), storage_, kStorageReferenceFnDelete)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
   return DeleteLastResult();
@@ -391,7 +391,7 @@ Future<size_t> StorageReferenceInternal::GetFile(const char* path,
       reinterpret_cast<void*>(new FutureCallbackData(handle, future(), storage_,
                                                      kStorageReferenceFnGetFile,
                                                      java_listener)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   if (controller_out) {
     controller_out->internal_->AssignTask(storage_, task);
   }
@@ -454,7 +454,7 @@ Future<size_t> StorageReferenceInternal::GetBytes(void* buffer,
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), storage_, kStorageReferenceFnGetBytes,
           java_listener, buffer, buffer_size, byte_downloader)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   if (controller_out) {
     controller_out->internal_->AssignTask(storage_, task);
   }
@@ -480,7 +480,7 @@ Future<std::string> StorageReferenceInternal::GetDownloadUrl() {
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), storage_, kStorageReferenceFnGetDownloadUrl)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   env->DeleteLocalRef(task);
   util::CheckAndClearJniExceptions(env);
 
@@ -504,7 +504,7 @@ Future<Metadata> StorageReferenceInternal::GetMetadata() {
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), storage_, kStorageReferenceFnGetMetadata)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
   return GetMetadataLastResult();
@@ -530,7 +530,7 @@ Future<Metadata> StorageReferenceInternal::UpdateMetadata(
       // FutureCallback will delete the newed FutureCallbackData.
       reinterpret_cast<void*>(new FutureCallbackData(
           handle, future(), storage_, kStorageReferenceFnUpdateMetadata)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   util::CheckAndClearJniExceptions(env);
   env->DeleteLocalRef(task);
   return UpdateMetadataLastResult();
@@ -607,7 +607,7 @@ Future<Metadata> StorageReferenceInternal::PutBytes(
           reinterpret_cast<void*>(new FutureCallbackData(
               handle, future_impl, storage_, kStorageReferenceFnPutBytes,
               java_listener, nullptr, 0, nullptr, env->NewGlobalRef(uploader))),
-          kApiIdentifier);
+          storage_->jni_task_id());
       if (controller_out) controller_out->internal_->AssignTask(storage_, task);
       env->DeleteLocalRef(task);
     }
@@ -641,7 +641,7 @@ Future<Metadata> StorageReferenceInternal::PutFile(const char* path,
       reinterpret_cast<void*>(new FutureCallbackData(handle, future(), storage_,
                                                      kStorageReferenceFnPutFile,
                                                      java_listener)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   if (controller_out) {
     controller_out->internal_->AssignTask(storage_, task);
   }
@@ -672,7 +672,7 @@ Future<Metadata> StorageReferenceInternal::PutFile(const char* path,
       reinterpret_cast<void*>(new FutureCallbackData(handle, future(), storage_,
                                                      kStorageReferenceFnPutFile,
                                                      java_listener)),
-      kApiIdentifier);
+      storage_->jni_task_id());
   if (controller_out) {
     controller_out->internal_->AssignTask(storage_, task);
   }


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add logic to the products that use objects to clean any pending Task listeners on destruction of that object.  Refactor the string creation logic from Auth to a utility function so all the products can use the same.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
