### PR TITLE
Fix PhoneAuthOptions Timeout overflow on some platforms

### DIFF
--- a/auth/src/android/credential_android.cc
+++ b/auth/src/android/credential_android.cc
@@ -955,7 +955,7 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   jobject timeout = env->NewObject(
       util::long_class::GetClass(),
       util::long_class::GetMethodId(util::long_class::kConstructor),
-      options.timeout_milliseconds);
+      static_cast<jlong>(options.timeout_milliseconds));
   if (util::CheckAndClearJniExceptions(env)) {
     listener->OnVerificationFailed(
         "VerifyPhoneNumber: couldn't convert timeout to java.lang.Long.");
@@ -988,7 +988,7 @@ void PhoneAuthProvider::VerifyPhoneNumber(
   if (util::CheckAndClearJniExceptions(env)) {
     env->DeleteLocalRef(builder);
     listener->OnVerificationFailed(
-        "VerifyPhoneNumber: builder faild to create PhoneAuhtOptions");
+        "VerifyPhoneNumber: builder failed to create PhoneAuthOptions");
     return;
   }
   env->DeleteLocalRef(builder);
@@ -1003,7 +1003,7 @@ void PhoneAuthProvider::VerifyPhoneNumber(
     // If an error occurred with the call to verifyPhoneNumber, inform the
     // listener that it failed.
     listener->OnVerificationFailed(
-        "VerifyPhoneNumber: Android to verify the given phone number");
+        "VerifyPhoneNumber: Android failed to verify the given phone number");
   }
 
   env->DeleteLocalRef(phone_auth_options);

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -627,6 +627,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    - Auth (Android): Fixed an issue where VerifyPhoneNumber's internal
+      builder failed to create PhoneAuthOptions.
+
 ### 11.2.0
 -   Changes
     - General (Android): Update to Firebase Android BoM version 32.1.1.

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -630,7 +630,7 @@ code.
 ### Upcoming Release
 -   Changes
     - Auth (Android): Fixed an issue where VerifyPhoneNumber's internal
-      builder failed to create PhoneAuthOptions.
+      builder failed to create PhoneAuthOptions with certain compiler settings.
 
 ### 11.2.0
 -   Changes


### PR DESCRIPTION
### Description
On some platforms there was previously an issue with the code to convert TimeoutMilliseconds from uint32_t to java long, causing it to become a negative value and then getting rejected by Android validation.
Example: https://github.com/firebase/firebase-unity-sdk/issues/764

I was able to reproduce the original issue with the Unity Auth testapp, which calls VerifyPhoneNumber with a PhoneAuthOptions.
The visible error was: "VerifyPhoneNumber: builder faild to create PhoneAuhtOptions"
Looking into the android logcat, the internal error was: "We only support 0-120 seconds for sms-auto-retrieval timeout"

This change should fix this by having an explicit cast from uint32_t to jlong before passing the timeout into the java long constructor. This should make the code work regardless of whether jlong is a 32 bit or 64 bit number.
***
### Testing

I verified the fix by building the unity sdk with this change included and running the Unity auth testapp. VerifyPhoneNumber ran successfully on my device.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
