### PR TITLE
Update to June 2022 release of boringssl.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,7 +267,6 @@ if(DESKTOP)
     set(BORINGSSL_ROOT_DIR ${PROJECT_BINARY_DIR}/external/src/boringssl CACHE STRING "" FORCE)
     set(BORINGSSL_BINARY_DIR ${PROJECT_BINARY_DIR}/external/src/boringssl-build CACHE STRING "" FORCE)
     set(OPENSSL_ROOT_DIR ${BORINGSSL_ROOT_DIR} CACHE STRING "" FORCE)
-    message("BoringSSL directory: ${BORINGSSL_ROOT_DIR}")
 
     # The call below to build_external_dependencies will make sure that these
     # libraries exist before the libraries are imported via add_library.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,9 +264,10 @@ if(DESKTOP)
 
   if(FIREBASE_USE_BORINGSSL)
     # Use BoringSSL instead of OpenSSL.
-    set(BORINGSSL_ROOT_DIR ${PROJECT_BINARY_DIR}/external/src/boringssl/src CACHE STRING "" FORCE)
+    set(BORINGSSL_ROOT_DIR ${PROJECT_BINARY_DIR}/external/src/boringssl CACHE STRING "" FORCE)
     set(BORINGSSL_BINARY_DIR ${PROJECT_BINARY_DIR}/external/src/boringssl-build CACHE STRING "" FORCE)
     set(OPENSSL_ROOT_DIR ${BORINGSSL_ROOT_DIR} CACHE STRING "" FORCE)
+    message("BoringSSL directory: ${BORINGSSL_ROOT_DIR}")
 
     # The call below to build_external_dependencies will make sure that these
     # libraries exist before the libraries are imported via add_library.

--- a/cmake/external/boringssl.cmake
+++ b/cmake/external/boringssl.cmake
@@ -18,8 +18,7 @@ if(TARGET boringssl OR NOT DOWNLOAD_BORINGSSL)
   return()
 endif()
 
-#set(patch_file
-#  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/boringssl/0001-disable-warnings.patch)
+set(patch_file ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/boringssl/0001-disable-warnings.patch)
 
 set(boringssl_commit_tag fips-20220613)
 

--- a/cmake/external/boringssl.cmake
+++ b/cmake/external/boringssl.cmake
@@ -18,10 +18,10 @@ if(TARGET boringssl OR NOT DOWNLOAD_BORINGSSL)
   return()
 endif()
 
-set(patch_file 
-  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/boringssl/0001-disable-warnings.patch)
+#set(patch_file
+#  ${CMAKE_CURRENT_LIST_DIR}/../../scripts/git/patches/boringssl/0001-disable-warnings.patch)
 
-set(boringssl_commit_tag 83da28a68f32023fd3b95a8ae94991a07b1f6c62)
+set(boringssl_commit_tag fips-20220613)
 
 ExternalProject_Add(
   boringssl

--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -112,17 +112,17 @@ function(download_external_sources)
     if (FIREBASE_USE_BORINGSSL)
       # CMake's find_package(OpenSSL) doesn't quite work right with BoringSSL
       # unless the header file contains OPENSSL_VERSION_NUMBER.
-      file(READ ${PROJECT_BINARY_DIR}/external/src/boringssl/src/include/openssl/opensslv.h TMP_HEADER_CONTENTS)
+      file(READ ${PROJECT_BINARY_DIR}/external/src/boringssl/include/openssl/opensslv.h TMP_HEADER_CONTENTS)
       if (NOT TMP_HEADER_CONTENTS MATCHES OPENSSL_VERSION_NUMBER)
-        file(APPEND ${PROJECT_BINARY_DIR}/external/src/boringssl/src/include/openssl/opensslv.h
+        file(APPEND ${PROJECT_BINARY_DIR}/external/src/boringssl/include/openssl/opensslv.h
         "\n#ifndef OPENSSL_VERSION_NUMBER\n# define OPENSSL_VERSION_NUMBER  0x10010107L\n#endif\n")
       endif()
       # Also add an #include <stdlib.h> since openssl has it and boringssl
       # doesn't, and some of our code depends on the transitive dependency (this
       # is a bug).
-      file(READ ${PROJECT_BINARY_DIR}/external/src/boringssl/src/include/openssl/rand.h TMP_HEADER2_CONTENTS)
+      file(READ ${PROJECT_BINARY_DIR}/external/src/boringssl/include/openssl/rand.h TMP_HEADER2_CONTENTS)
       if (NOT TMP_HEADER2_CONTENTS MATCHES "<stdlib.h>")
-        file(APPEND ${PROJECT_BINARY_DIR}/external/src/boringssl/src/include/openssl/rand.h
+        file(APPEND ${PROJECT_BINARY_DIR}/external/src/boringssl/include/openssl/rand.h
         "\n#include <stdlib.h>\n")
       endif()
     endif()
@@ -241,7 +241,7 @@ function(build_external_dependencies)
   if(NOT ANDROID AND NOT IOS)
     if (FIREBASE_USE_BORINGSSL)
       execute_process(
-        COMMAND ${ENV_COMMAND} cmake -DOPENSSL_NO_ASM=TRUE ${CMAKE_SUB_CONFIGURE_OPTIONS} ../boringssl/src
+        COMMAND ${ENV_COMMAND} cmake -DOPENSSL_NO_ASM=TRUE ${CMAKE_SUB_CONFIGURE_OPTIONS} ../boringssl
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/external/src/boringssl-build
         RESULT_VARIABLE boringssl_configure_status
       )

--- a/scripts/git/patches/boringssl/0001-disable-warnings.patch
+++ b/scripts/git/patches/boringssl/0001-disable-warnings.patch
@@ -1,5 +1,5 @@
---- a/src/CMakeLists.txt
-+++ b/src/CMakeLists.txt
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
 @@ -193,6 +193,11 @@ elseif(MSVC)
                # possible loss of data
        "C4244" # 'function' : conversion from 'int' to 'uint8_t',

--- a/scripts/git/patches/boringssl/0001-disable-warnings.patch
+++ b/scripts/git/patches/boringssl/0001-disable-warnings.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -193,6 +193,11 @@ elseif(MSVC)
+@@ -197,6 +197,11 @@ elseif(MSVC)
                # possible loss of data
        "C4244" # 'function' : conversion from 'int' to 'uint8_t',
                # possible loss of data


### PR DESCRIPTION
In this release, the "src" directory is removed from boringssl, so there are some CMake and patch changes necessary for compatibility.

### Description
> Provide details of the change, and generalize the change in the PR title above.

There are a number of issues with newer Xcode and other compilers that are fixed in newer boringssl releases. This updates to the last 2022 release (from a 2019 version used before).
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Running expanded integration tests in this PR. Also running packaging [workflow](https://github.com/firebase/firebase-cpp-sdk/actions/runs/5381916010) and [tests](https://github.com/firebase/firebase-cpp-sdk/actions/runs/5384312567)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
