### PR TITLE
Improve the iOS simulator install logic

### DIFF
--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -499,12 +499,22 @@ def _create_and_boot_simulator(apple_platform, device_name, device_os):
 
   if not device_id:
     # download and create device
-    os.environ["GEM_HOME"] = "$HOME/.gem"
-    args = ["gem", "install", "xcode-install"]
-    logging.info("Download xcode-install: %s", " ".join(args))
+    args = ["brew", "install", "xcodesorg/made/xcodes"]
+    logging.info("Download xcodes: %s", " ".join(args))
     subprocess.run(args=args, check=True)
 
-    args = ["xcversion", "simulators", "--install=%s %s" % (apple_platform, device_os)]
+    # Get the set of available versions for the given Apple platform
+    args = ["xcodes", "runtimes"]
+    runtimes = subprocess.run(args=args, capture_output=True, text=True, check=True)
+    available_versions = re.findall('{0} ([\d|.]+)'.format(apple_platform), runtimes.stdout.strip())
+    logging.info("Found available versions for %s: %s", apple_platform, ", ".join(available_versions))
+
+    # If the requested version is available, use it, otherwise default to the latest
+    if (device_os not in available_versions):
+      logging.warning("Unable to find version %s, will fall back to %s", device_os, available_versions[-1])
+      device_os = available_versions[-1]
+
+    args = ["xcodes", "runtimes", "install", "%s %s" % (apple_platform, device_os)]
     logging.info("Download simulator: %s", " ".join(args))
     subprocess.run(args=args, check=False)
     


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add logic to check which versions of iOS/tvOS are available, and fallback to the latest if the requested one isn't available. Also change to using xcodes to install iOS simulators, since xcode-install has been deprecated in favor of it.

This is the same change as https://github.com/firebase/firebase-unity-sdk/pull/774, but for the C++ repo.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
