### PR TITLE
Add a GitHub warning to the iOS simulator logic

### DIFF
--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -512,6 +512,8 @@ def _create_and_boot_simulator(apple_platform, device_name, device_os):
     # If the requested version is available, use it, otherwise default to the latest
     if (device_os not in available_versions):
       logging.warning("Unable to find version %s, will fall back to %s", device_os, available_versions[-1])
+      if FLAGS.ci:
+        print("::warning ::Unable to find version %s, will fall back to %s" % (device_os, available_versions[-1]))
       device_os = available_versions[-1]
 
     args = ["xcodes", "runtimes", "install", "%s %s" % (apple_platform, device_os)]

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -513,7 +513,7 @@ def _create_and_boot_simulator(apple_platform, device_name, device_os):
     if (device_os not in available_versions):
       logging.warning("Unable to find version %s, will fall back to %s", device_os, available_versions[-1])
       if FLAGS.ci:
-        print("::warning ::Unable to find version %s, will fall back to %s" % (device_os, available_versions[-1]))
+        print("::warning ::Unable to find %s version %s, will fall back to %s" % (apple_platform, device_os, available_versions[-1]))
       device_os = available_versions[-1]
 
     args = ["xcodes", "runtimes", "install", "%s %s" % (apple_platform, device_os)]

--- a/scripts/gha/test_simulator.py
+++ b/scripts/gha/test_simulator.py
@@ -80,6 +80,7 @@ import json
 import os
 import pathlib
 import platform
+import re
 import shutil
 import signal
 import subprocess


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Adds a GitHub warning to the iOS simulator logic, as a follow up to https://github.com/firebase/firebase-cpp-sdk/pull/1368
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
