### PR TITLE
Release load_ad futures in flaky gma tests

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -1734,6 +1734,7 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
   EXPECT_FALSE(result_ptr->response_info().response_id().empty());
   EXPECT_FALSE(result_ptr->response_info().ToString().empty());
 
+  load_ad_future.Release();
   delete interstitial;
 }
 
@@ -1827,6 +1828,9 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdErrorLoadInProgress) {
   const firebase::gma::ResponseInfo response_info =
       result_ptr->ad_error().response_info();
   EXPECT_TRUE(response_info.adapter_responses().empty());
+
+  first_load_ad.Release();
+  second_load_ad.Release();
   delete interstitial_ad;
 }
 
@@ -1841,12 +1845,12 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdErrorBadAdUnitId) {
 
   // Load the interstitial ad.
   firebase::gma::AdRequest request = GetAdRequest();
-  firebase::Future<firebase::gma::AdResult> load_ad =
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
       interstitial_ad->LoadAd(kBadAdUnit, request);
-  WaitForCompletion(load_ad, "LoadAd",
+  WaitForCompletion(load_ad_future, "LoadAd",
                     firebase::gma::kAdErrorCodeInvalidRequest);
 
-  const firebase::gma::AdResult* result_ptr = load_ad.result();
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_FALSE(result_ptr->is_successful());
   EXPECT_EQ(result_ptr->ad_error().code(),
@@ -1856,6 +1860,8 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdErrorBadAdUnitId) {
   const firebase::gma::ResponseInfo response_info =
       result_ptr->ad_error().response_info();
   EXPECT_TRUE(response_info.adapter_responses().empty());
+
+  load_ad_future.Release();
   delete interstitial_ad;
 }
 
@@ -2011,6 +2017,9 @@ TEST_F(FirebaseGmaTest, TestRewardedAdErrorLoadInProgress) {
   const firebase::gma::ResponseInfo response_info =
       result_ptr->ad_error().response_info();
   EXPECT_TRUE(response_info.adapter_responses().empty());
+
+  first_load_ad.Release();
+  second_load_ad.Release();
   delete rewarded;
 }
 
@@ -2023,12 +2032,12 @@ TEST_F(FirebaseGmaTest, TestRewardedAdErrorBadAdUnitId) {
 
   // Load the rewarded ad.
   firebase::gma::AdRequest request = GetAdRequest();
-  firebase::Future<firebase::gma::AdResult> load_ad =
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
       rewarded->LoadAd(kBadAdUnit, request);
-  WaitForCompletion(load_ad, "LoadAd",
+  WaitForCompletion(load_ad_future, "LoadAd",
                     firebase::gma::kAdErrorCodeInvalidRequest);
 
-  const firebase::gma::AdResult* result_ptr = load_ad.result();
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_FALSE(result_ptr->is_successful());
   EXPECT_EQ(result_ptr->ad_error().code(),
@@ -2038,6 +2047,8 @@ TEST_F(FirebaseGmaTest, TestRewardedAdErrorBadAdUnitId) {
   const firebase::gma::ResponseInfo response_info =
       result_ptr->ad_error().response_info();
   EXPECT_TRUE(response_info.adapter_responses().empty());
+
+  load_ad_future.Release();
   delete rewarded;
 }
 
@@ -2253,12 +2264,12 @@ TEST_F(FirebaseGmaTest, TestNativeAdErrorBadAdUnitId) {
 
   // Load the native ad.
   firebase::gma::AdRequest request = GetAdRequest();
-  firebase::Future<firebase::gma::AdResult> load_ad =
+  firebase::Future<firebase::gma::AdResult> load_ad_future =
       native_ad->LoadAd(kBadAdUnit, request);
-  WaitForCompletion(load_ad, "LoadAd",
+  WaitForCompletion(load_ad_future, "LoadAd",
                     firebase::gma::kAdErrorCodeInvalidRequest);
 
-  const firebase::gma::AdResult* result_ptr = load_ad.result();
+  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
   ASSERT_NE(result_ptr, nullptr);
   EXPECT_FALSE(result_ptr->is_successful());
   EXPECT_EQ(result_ptr->ad_error().code(),
@@ -2268,6 +2279,8 @@ TEST_F(FirebaseGmaTest, TestNativeAdErrorBadAdUnitId) {
   const firebase::gma::ResponseInfo response_info =
       result_ptr->ad_error().response_info();
   EXPECT_TRUE(response_info.adapter_responses().empty());
+
+  load_ad_future.Release();
   delete native_ad;
 }
 


### PR DESCRIPTION
### Description
Adds missing future release on some of the gma integration tests.

***
### Testing
None.

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
None.