### PR TITLE
On Ubuntu, GetTimezone should return the long time zone name.

### DIFF
--- a/app/src/locale.cc
+++ b/app/src/locale.cc
@@ -31,6 +31,7 @@
 #include <icu.h>
 #elif FIREBASE_PLATFORM_LINUX
 #include <stdio.h>
+
 #include <clocale>
 #include <ctime>
 #else
@@ -189,8 +190,8 @@ std::string GetTimezone() {
     if (fgets(buf, kBufSize, tz_file)) {
       // Remove a trailing '\n', if any.
       size_t len = strlen(buf);
-      if (buf[len-1] == '\n') {
-        buf[len-1] = '\0';
+      if (buf[len - 1] == '\n') {
+        buf[len - 1] = '\0';
       }
       return std::string(buf);
     }

--- a/app/src/locale.cc
+++ b/app/src/locale.cc
@@ -185,7 +185,7 @@ std::string GetTimezone() {
   FILE* tz_file = fopen("/etc/timezone", "r");
   if (tz_file) {
     const size_t kBufSize = 128;
-    char buf[128];
+    char buf[kBufSize];
     if (fgets(buf, kBufSize, tz_file)) {
       // Remove a trailing '\n', if any.
       size_t len = strlen(buf);

--- a/app/src/locale.cc
+++ b/app/src/locale.cc
@@ -30,6 +30,7 @@
 #define UCHAR_TYPE wchar_t
 #include <icu.h>
 #elif FIREBASE_PLATFORM_LINUX
+#include <stdio.h>
 #include <clocale>
 #include <ctime>
 #else
@@ -180,6 +181,20 @@ std::string GetTimezone() {
   return iana_tz_utf8;
 
 #elif FIREBASE_PLATFORM_LINUX
+  // Ubuntu: Check /etc/timezone for the full time zone name.
+  FILE* tz_file = fopen("/etc/timezone", "r");
+  if (tz_file) {
+    const size_t kBufSize = 128;
+    char buf[128];
+    if (fgets(buf, kBufSize, tz_file)) {
+      // Remove a trailing '\n', if any.
+      size_t len = strlen(buf);
+      if (buf[len-1] == '\n') {
+        buf[len-1] = '\0';
+      }
+      return std::string(buf);
+    }
+  }
   // If TZ environment variable is defined and not empty, use it, else use
   // tzname.
   return (getenv("TZ") && *getenv("TZ")) ? getenv("TZ")


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

This file is usually located in /etc/timezone and contains something like "America/Los Angeles" rather than "PDT" or "GMT", which is less preferred.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Unit test on Linux shows the new time zone name returned.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
