### PR TITLE
Fix for gma android failing assert

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -919,18 +919,15 @@ TEST_F(FirebaseGmaTest, TestNativeAdLoad) {
     EXPECT_FALSE(result_ptr->response_info().ToString().empty());
 
     // Check image assets.
-    EXPECT_FALSE(native_ad->icon().image_uri().empty());
-    EXPECT_GT(native_ad->icon().scale(), 0);
-    EXPECT_FALSE(native_ad->images().empty());
-
     // Native ads usually contain only one large image asset.
     // Check the validity of the first asset from the vector.
+    EXPECT_FALSE(native_ad->images().empty());
     EXPECT_FALSE(native_ad->images().at(0).image_uri().empty());
     EXPECT_GT(native_ad->images().at(0).scale(), 0);
 
-    // When the NativeAd is loaded, try loading icon image asset.
+    // Try loading large image asset.
     firebase::Future<firebase::gma::ImageResult> load_image_future =
-        native_ad->icon().LoadImage();
+        native_ad->images().at(0).LoadImage();
     WaitForCompletion(load_image_future, "LoadImage");
     const firebase::gma::ImageResult* img_result_ptr =
         load_image_future.result();

--- a/gma/src/android/gma_android.cc
+++ b/gma/src/android/gma_android.cc
@@ -907,7 +907,6 @@ void JNI_NativeAd_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
   FIREBASE_ASSERT(env);
   FIREBASE_ASSERT(data_ptr);
   FIREBASE_ASSERT(native_internal_data_ptr);
-  FIREBASE_ASSERT(j_icon);
   FIREBASE_ASSERT(j_images);
   FIREBASE_ASSERT(j_response_info);
 
@@ -915,12 +914,16 @@ void JNI_NativeAd_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
       reinterpret_cast<internal::NativeAdInternalAndroid*>(
           native_internal_data_ptr);
 
-  NativeAdImageInternal icon_internal;
-  icon_internal.native_ad_image = j_icon;
+  // getIcon() is nullable and a valid ad can exist without an icon image.
+  if (j_icon != nullptr) {
+    NativeAdImageInternal icon_internal;
+    icon_internal.native_ad_image = j_icon;
 
-  // Invoke a friend of NativeAdInternal to update its icon image asset.
-  GmaInternal::InsertNativeInternalImage(native_ad_internal, icon_internal,
-                                         true, true);
+    // Invoke a friend of NativeAdInternal to update its icon image asset.
+    GmaInternal::InsertNativeInternalImage(native_ad_internal, icon_internal,
+                                           true, true);
+    env->DeleteLocalRef(j_icon);
+  }
 
   const size_t len = env->GetArrayLength(j_images);
   // Loop through images array.
@@ -936,7 +939,7 @@ void JNI_NativeAd_completeLoadedAd(JNIEnv* env, jclass clazz, jlong data_ptr,
       reinterpret_cast<FutureCallbackData<AdResult>*>(data_ptr);
   GmaInternal::CompleteLoadAdFutureSuccess(
       callback_data, ResponseInfoInternal({j_response_info}));
-  env->DeleteLocalRef(j_icon);
+
   env->DeleteLocalRef(j_response_info);
 }
 

--- a/gma/src/ios/native_ad_internal_ios.mm
+++ b/gma/src/ios/native_ad_internal_ios.mm
@@ -222,9 +222,13 @@ void NativeAdInternalIOS::NativeAdDidReceiveAd(GADNativeAd *ad) {
   firebase::MutexLock lock(mutex_);
   native_ad_ = ad;
 
-  NativeAdImageInternal icon_internal;
-  icon_internal.native_ad_image = ad.icon;
-  GmaInternal::InsertNativeInternalImage(this, icon_internal, true, true );
+  NSObject *gad_icon = ad.icon;
+  if (gad_icon != nil)
+  {
+    NativeAdImageInternal icon_internal;
+    icon_internal.native_ad_image = gad_icon;
+    GmaInternal::InsertNativeInternalImage(this, icon_internal, true, true );
+  }
 
   NSArray *gad_images = ad.images;
   for(NSObject *gad_image in gad_images)


### PR DESCRIPTION
### Description
Fix for gma android failing assert

***
### Testing
None.

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
NativeAd's getIcon() for android and icon() for iOS are nullable API methods and this indicates that ads returned will not always guarantee the availability of an icon asset. This PR relaxes the restriction which expects an icon asset at all times and processes the contents of an icon asset, only when a valid icon image asset is returned by andriod/iOS layers.
Ref: https://developers.google.com/admob/ios/api/reference/Classes/GADNativeAd#icon

Also updates the integration test to look for a large image asset rather than an icon asset, as the test ad unit ids are always expected to return a valid large image asset on a successful ad load.
