### PR TITLE
fix: Disable OR Query test until follow up PR fixes problem

### DIFF
--- a/firestore/integration_test_internal/src/filter_test.cc
+++ b/firestore/integration_test_internal/src/filter_test.cc
@@ -23,9 +23,7 @@ namespace {
 
 using FilterTest = FirestoreIntegrationTest;
 
-#if false
-
-TEST_F(FilterTest, CopyConstructorReturnsEqualObject) {
+TEST_F(FilterTest, DISABLED_CopyConstructorReturnsEqualObject) {
   const Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -40,7 +38,7 @@ TEST_F(FilterTest, CopyConstructorReturnsEqualObject) {
   EXPECT_EQ(filter3a, filter3b);
 }
 
-TEST_F(FilterTest, CopyAssignementReturnsEqualObject) {
+TEST_F(FilterTest, DISABLED_CopyAssignementReturnsEqualObject) {
   const Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2 = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -71,7 +69,7 @@ TEST_F(FilterTest, CopyAssignementReturnsEqualObject) {
   EXPECT_EQ(filter, filter3);
 }
 
-TEST_F(FilterTest, MoveConstructorReturnsEqualObject) {
+TEST_F(FilterTest, DISABLED_MoveConstructorReturnsEqualObject) {
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -89,7 +87,7 @@ TEST_F(FilterTest, MoveConstructorReturnsEqualObject) {
   EXPECT_EQ(filter3b, Filter::And(filter1b, filter2b));
 }
 
-TEST_F(FilterTest, MoveAssignmentReturnsEqualObject) {
+TEST_F(FilterTest, DISABLED_MoveAssignmentReturnsEqualObject) {
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -107,7 +105,7 @@ TEST_F(FilterTest, MoveAssignmentReturnsEqualObject) {
   EXPECT_EQ(filter3b, Filter::And(filter1b, filter2b));
 }
 
-TEST_F(FilterTest, MoveAssignmentAppliedToSelfReturnsEqualObject) {
+TEST_F(FilterTest, DISABLED_MoveAssignmentAppliedToSelfReturnsEqualObject) {
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -124,7 +122,7 @@ TEST_F(FilterTest, MoveAssignmentAppliedToSelfReturnsEqualObject) {
   EXPECT_EQ(filter3, Filter::And(filter1, filter2));
 }
 
-TEST_F(FilterTest, IdenticalFilterShouldBeEqual) {
+TEST_F(FilterTest, DISABLED_IdenticalFilterShouldBeEqual) {
   FieldPath foo_path{std::vector<std::string>{"foo"}};
 
   Filter filter1a = Filter::ArrayContains("foo", FieldValue::Integer(42));
@@ -289,7 +287,7 @@ TEST_F(FilterTest, IdenticalFilterShouldBeEqual) {
   EXPECT_TRUE(filter11a != filter12a);
 }
 
-TEST_F(FilterTest, DifferentValuesAreNotEqual) {
+TEST_F(FilterTest, DISABLED_DifferentValuesAreNotEqual) {
   Filter filter1a = Filter::ArrayContains("foo", FieldValue::Integer(24));
   Filter filter1b = Filter::ArrayContains("foo", FieldValue::Integer(42));
   Filter filter1c = Filter::ArrayContains("bar", FieldValue::Integer(42));
@@ -352,7 +350,7 @@ TEST_F(FilterTest, DifferentValuesAreNotEqual) {
   EXPECT_TRUE(filter7b != filter7c);
 }
 
-TEST_F(FilterTest, CompositesWithOneFilterAreTheSameAsFilter) {
+TEST_F(FilterTest, DISABLED_CompositesWithOneFilterAreTheSameAsFilter) {
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::Or(filter1);
   Filter filter3 = Filter::And(filter1);
@@ -364,7 +362,7 @@ TEST_F(FilterTest, CompositesWithOneFilterAreTheSameAsFilter) {
   EXPECT_FALSE(filter1 != filter3);
 }
 
-TEST_F(FilterTest, EmptyCompositeIsIgnoredByCompositesAndQueries) {
+TEST_F(FilterTest, DISABLED_EmptyCompositeIsIgnoredByCompositesAndQueries) {
   Filter filter1 = Filter::And();
   Filter filter2 = Filter::And(Filter::And(), Filter::And());
   Filter filter3 = Filter::And(Filter::Or(), Filter::Or());
@@ -394,7 +392,7 @@ TEST_F(FilterTest, EmptyCompositeIsIgnoredByCompositesAndQueries) {
   EXPECT_EQ(collection, query6);
 }
 
-TEST_F(FilterTest, CompositeComparison) {
+TEST_F(FilterTest, DISABLED_CompositeComparison) {
   Filter filter1 = Filter::ArrayContains("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter3 = Filter::NotEqualTo("foo", FieldValue::Integer(42));
@@ -442,7 +440,7 @@ TEST_F(FilterTest, CompositeComparison) {
   EXPECT_NE(or3, or4);
 }
 
-TEST_F(FilterTest, QueryWhereComposite) {
+TEST_F(FilterTest, DISABLED_QueryWhereComposite) {
   MapFieldValue doc_aaa = {{"x", FieldValue::String("a")},
                            {"y", FieldValue::String("a")},
                            {"z", FieldValue::String("a")}};
@@ -527,7 +525,7 @@ TEST_F(FilterTest, QueryWhereComposite) {
             QuerySnapshotToValues(snapshot7));
 }
 
-TEST_F(FilterTest, QueryEmptyWhereComposite) {
+TEST_F(FilterTest, DISABLED_QueryEmptyWhereComposite) {
   MapFieldValue doc = {{"foo", FieldValue::String("bar")}};
   CollectionReference collection = Collection({{"x", doc}});
 
@@ -545,8 +543,6 @@ TEST_F(FilterTest, QueryEmptyWhereComposite) {
       ReadDocuments(collection.Where(Filter::Or(Filter::And(), Filter::And())));
   EXPECT_EQ(std::vector<MapFieldValue>({doc}), QuerySnapshotToValues(s4));
 }
-
-#endif
 
 }  // namespace
 

--- a/firestore/integration_test_internal/src/filter_test.cc
+++ b/firestore/integration_test_internal/src/filter_test.cc
@@ -15,6 +15,7 @@
  */
 
 #include "firebase/firestore.h"
+#include "firebase_test_framework.h"
 #include "firestore_integration_test.h"
 
 namespace firebase {
@@ -39,7 +40,7 @@ TEST_F(FilterTest, CopyConstructorReturnsEqualObject) {
 }
 
 TEST_F(FilterTest, CopyAssignementReturnsEqualObject) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   const Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2 = Filter::ArrayContainsAny(
@@ -72,7 +73,7 @@ TEST_F(FilterTest, CopyAssignementReturnsEqualObject) {
 }
 
 TEST_F(FilterTest, MoveConstructorReturnsEqualObject) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
@@ -92,7 +93,7 @@ TEST_F(FilterTest, MoveConstructorReturnsEqualObject) {
 }
 
 TEST_F(FilterTest, MoveAssignmentReturnsEqualObject) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
@@ -112,7 +113,7 @@ TEST_F(FilterTest, MoveAssignmentReturnsEqualObject) {
 }
 
 TEST_F(FilterTest, MoveAssignmentAppliedToSelfReturnsEqualObject) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::ArrayContainsAny(
@@ -131,7 +132,7 @@ TEST_F(FilterTest, MoveAssignmentAppliedToSelfReturnsEqualObject) {
 }
 
 TEST_F(FilterTest, IdenticalFilterShouldBeEqual) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   FieldPath foo_path{std::vector<std::string>{"foo"}};
 
@@ -298,7 +299,7 @@ TEST_F(FilterTest, IdenticalFilterShouldBeEqual) {
 }
 
 TEST_F(FilterTest, DifferentValuesAreNotEqual) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1a = Filter::ArrayContains("foo", FieldValue::Integer(24));
   Filter filter1b = Filter::ArrayContains("foo", FieldValue::Integer(42));
@@ -363,7 +364,7 @@ TEST_F(FilterTest, DifferentValuesAreNotEqual) {
 }
 
 TEST_F(FilterTest, CompositesWithOneFilterAreTheSameAsFilter) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::Or(filter1);
@@ -377,7 +378,7 @@ TEST_F(FilterTest, CompositesWithOneFilterAreTheSameAsFilter) {
 }
 
 TEST_F(FilterTest, EmptyCompositeIsIgnoredByCompositesAndQueries) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1 = Filter::And();
   Filter filter2 = Filter::And(Filter::And(), Filter::And());
@@ -409,7 +410,7 @@ TEST_F(FilterTest, EmptyCompositeIsIgnoredByCompositesAndQueries) {
 }
 
 TEST_F(FilterTest, CompositeComparison) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   Filter filter1 = Filter::ArrayContains("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::EqualTo("foo", FieldValue::Integer(42));
@@ -459,7 +460,7 @@ TEST_F(FilterTest, CompositeComparison) {
 }
 
 TEST_F(FilterTest, QueryWhereComposite) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   MapFieldValue doc_aaa = {{"x", FieldValue::String("a")},
                            {"y", FieldValue::String("a")},
@@ -546,7 +547,7 @@ TEST_F(FilterTest, QueryWhereComposite) {
 }
 
 TEST_F(FilterTest, QueryEmptyWhereComposite) {
-  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+  SKIP_TEST_ON_ANDROID // b/293326241: The Android implementation is failing.
 
   MapFieldValue doc = {{"foo", FieldValue::String("bar")}};
   CollectionReference collection = Collection({{"x", doc}});

--- a/firestore/integration_test_internal/src/filter_test.cc
+++ b/firestore/integration_test_internal/src/filter_test.cc
@@ -23,7 +23,7 @@ namespace {
 
 using FilterTest = FirestoreIntegrationTest;
 
-TEST_F(FilterTest, DISABLED_CopyConstructorReturnsEqualObject) {
+TEST_F(FilterTest, CopyConstructorReturnsEqualObject) {
   const Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -38,7 +38,9 @@ TEST_F(FilterTest, DISABLED_CopyConstructorReturnsEqualObject) {
   EXPECT_EQ(filter3a, filter3b);
 }
 
-TEST_F(FilterTest, DISABLED_CopyAssignementReturnsEqualObject) {
+TEST_F(FilterTest, CopyAssignementReturnsEqualObject) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   const Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2 = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -69,7 +71,9 @@ TEST_F(FilterTest, DISABLED_CopyAssignementReturnsEqualObject) {
   EXPECT_EQ(filter, filter3);
 }
 
-TEST_F(FilterTest, DISABLED_MoveConstructorReturnsEqualObject) {
+TEST_F(FilterTest, MoveConstructorReturnsEqualObject) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -87,7 +91,9 @@ TEST_F(FilterTest, DISABLED_MoveConstructorReturnsEqualObject) {
   EXPECT_EQ(filter3b, Filter::And(filter1b, filter2b));
 }
 
-TEST_F(FilterTest, DISABLED_MoveAssignmentReturnsEqualObject) {
+TEST_F(FilterTest, MoveAssignmentReturnsEqualObject) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2a = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -105,7 +111,9 @@ TEST_F(FilterTest, DISABLED_MoveAssignmentReturnsEqualObject) {
   EXPECT_EQ(filter3b, Filter::And(filter1b, filter2b));
 }
 
-TEST_F(FilterTest, DISABLED_MoveAssignmentAppliedToSelfReturnsEqualObject) {
+TEST_F(FilterTest, MoveAssignmentAppliedToSelfReturnsEqualObject) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::ArrayContainsAny(
       "bar", {FieldValue::Integer(4), FieldValue::Integer(2)});
@@ -122,7 +130,9 @@ TEST_F(FilterTest, DISABLED_MoveAssignmentAppliedToSelfReturnsEqualObject) {
   EXPECT_EQ(filter3, Filter::And(filter1, filter2));
 }
 
-TEST_F(FilterTest, DISABLED_IdenticalFilterShouldBeEqual) {
+TEST_F(FilterTest, IdenticalFilterShouldBeEqual) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   FieldPath foo_path{std::vector<std::string>{"foo"}};
 
   Filter filter1a = Filter::ArrayContains("foo", FieldValue::Integer(42));
@@ -287,7 +297,9 @@ TEST_F(FilterTest, DISABLED_IdenticalFilterShouldBeEqual) {
   EXPECT_TRUE(filter11a != filter12a);
 }
 
-TEST_F(FilterTest, DISABLED_DifferentValuesAreNotEqual) {
+TEST_F(FilterTest, DifferentValuesAreNotEqual) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1a = Filter::ArrayContains("foo", FieldValue::Integer(24));
   Filter filter1b = Filter::ArrayContains("foo", FieldValue::Integer(42));
   Filter filter1c = Filter::ArrayContains("bar", FieldValue::Integer(42));
@@ -350,7 +362,9 @@ TEST_F(FilterTest, DISABLED_DifferentValuesAreNotEqual) {
   EXPECT_TRUE(filter7b != filter7c);
 }
 
-TEST_F(FilterTest, DISABLED_CompositesWithOneFilterAreTheSameAsFilter) {
+TEST_F(FilterTest, CompositesWithOneFilterAreTheSameAsFilter) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::Or(filter1);
   Filter filter3 = Filter::And(filter1);
@@ -362,7 +376,9 @@ TEST_F(FilterTest, DISABLED_CompositesWithOneFilterAreTheSameAsFilter) {
   EXPECT_FALSE(filter1 != filter3);
 }
 
-TEST_F(FilterTest, DISABLED_EmptyCompositeIsIgnoredByCompositesAndQueries) {
+TEST_F(FilterTest, EmptyCompositeIsIgnoredByCompositesAndQueries) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1 = Filter::And();
   Filter filter2 = Filter::And(Filter::And(), Filter::And());
   Filter filter3 = Filter::And(Filter::Or(), Filter::Or());
@@ -392,7 +408,9 @@ TEST_F(FilterTest, DISABLED_EmptyCompositeIsIgnoredByCompositesAndQueries) {
   EXPECT_EQ(collection, query6);
 }
 
-TEST_F(FilterTest, DISABLED_CompositeComparison) {
+TEST_F(FilterTest, CompositeComparison) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   Filter filter1 = Filter::ArrayContains("foo", FieldValue::Integer(42));
   Filter filter2 = Filter::EqualTo("foo", FieldValue::Integer(42));
   Filter filter3 = Filter::NotEqualTo("foo", FieldValue::Integer(42));
@@ -440,7 +458,9 @@ TEST_F(FilterTest, DISABLED_CompositeComparison) {
   EXPECT_NE(or3, or4);
 }
 
-TEST_F(FilterTest, DISABLED_QueryWhereComposite) {
+TEST_F(FilterTest, QueryWhereComposite) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   MapFieldValue doc_aaa = {{"x", FieldValue::String("a")},
                            {"y", FieldValue::String("a")},
                            {"z", FieldValue::String("a")}};
@@ -525,7 +545,9 @@ TEST_F(FilterTest, DISABLED_QueryWhereComposite) {
             QuerySnapshotToValues(snapshot7));
 }
 
-TEST_F(FilterTest, DISABLED_QueryEmptyWhereComposite) {
+TEST_F(FilterTest, QueryEmptyWhereComposite) {
+  GTEST_SKIP() << "b/293326241: The Android implementation is failing.";
+
   MapFieldValue doc = {{"foo", FieldValue::String("bar")}};
   CollectionReference collection = Collection({{"x", doc}});
 

--- a/firestore/integration_test_internal/src/filter_test.cc
+++ b/firestore/integration_test_internal/src/filter_test.cc
@@ -23,6 +23,8 @@ namespace {
 
 using FilterTest = FirestoreIntegrationTest;
 
+#if false
+
 TEST_F(FilterTest, CopyConstructorReturnsEqualObject) {
   const Filter filter1a = Filter::EqualTo("foo", FieldValue::Integer(42));
   const Filter filter2a = Filter::ArrayContainsAny(
@@ -543,6 +545,8 @@ TEST_F(FilterTest, QueryEmptyWhereComposite) {
       ReadDocuments(collection.Where(Filter::Or(Filter::And(), Filter::And())));
   EXPECT_EQ(std::vector<MapFieldValue>({doc}), QuerySnapshotToValues(s4));
 }
+
+#endif
 
 }  // namespace
 


### PR DESCRIPTION
Failing tests will be disabled in this PR.

Before next release, a second PR needs to be merged: https://github.com/firebase/firebase-cpp-sdk/pull/1405

Otherwise, OR Query needs to be rolled back prior to release.

b/293326241