### PR TITLE
Kick off nightly packaging an hour earlier

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -5,7 +5,7 @@ on:
       # Run a full packaging step any time a new branch is merged into main.
       - main
   schedule:
-    - cron: "0 9 * * *"  # 9am UTC = 1am PST / 2am PDT
+    - cron: "0 8 * * *"  # 8am UTC = 12am PST / 1am PDT
   workflow_dispatch:
     inputs:
       preserveIntermediateArtifacts:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Run the nightly packaging an hour earlier, so that it can be ready on time for the summary, and EST timezones.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
