### PR TITLE
build: pass along the CMake path

### DIFF
--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -241,7 +241,7 @@ function(build_external_dependencies)
   if(NOT ANDROID AND NOT IOS)
     if (FIREBASE_USE_BORINGSSL)
       execute_process(
-        COMMAND ${ENV_COMMAND} cmake -DOPENSSL_NO_ASM=TRUE ${CMAKE_SUB_CONFIGURE_OPTIONS} ../boringssl
+        COMMAND ${ENV_COMMAND} ${CMAKE_COMMAND} -DOPENSSL_NO_ASM=TRUE ${CMAKE_SUB_CONFIGURE_OPTIONS} ../boringssl
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/external/src/boringssl-build
         RESULT_VARIABLE boringssl_configure_status
       )
@@ -255,7 +255,7 @@ function(build_external_dependencies)
       endif()
     
       execute_process(
-        COMMAND ${ENV_COMMAND} cmake --build . ${CMAKE_SUB_BUILD_OPTIONS} --target ssl crypto -- ${cmake_build_args}
+        COMMAND ${ENV_COMMAND} ${CMAKE_COMMAND} --build . ${CMAKE_SUB_BUILD_OPTIONS} --target ssl crypto -- ${cmake_build_args}
         WORKING_DIRECTORY ${PROJECT_BINARY_DIR}/external/src/boringssl-build
         RESULT_VARIABLE boringssl_build_status
       )


### PR DESCRIPTION
### Description
When building the subproject, we would invoke `cmake` directly, relying on the path lookup of the tool, which may or may not match the currently executing CMake.  Use `CMAKE_COMMAND` which gives us the path to the current CMake executable ensuring that we use the same CMake for building the dependencies.

***
### Testing
Local run of the CMake configure step.

***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
