### PR TITLE
Fix iOS test version from deprecated 16.5 to 16.6.

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -174,7 +174,7 @@ TEST_DEVICES = {
   "emulator_32bit": {"type": "virtual", "image":"system-images;android-30;google_apis;x86"},
   "ios_min": {"type": "ftl", "device": "model=iphone8,version=14.7"},
   "ios_target": {"type": "ftl", "device": "model=iphone13pro,version=15.7"},
-  "ios_latest": {"type": "ftl", "device": "model=iphone11pro,version=16.5"},
+  "ios_latest": {"type": "ftl", "device": "model=iphone11pro,version=16.6"},
   "simulator_min": {"type": "virtual", "name":"iPhone 8", "version":"15.2"},
   "simulator_target": {"type": "virtual", "name":"iPhone 8", "version":"16.1"},
   "simulator_latest": {"type": "virtual", "name":"iPhone 11", "version":"16.1"},


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

iOS 16.5 is deprecated on FTL. This updates the "ios_latest" device to 16.6.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
