### PR TITLE
Distribute FTL tests amongst different device models

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1043,7 +1043,7 @@ jobs:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
           testapp_dir: testapps
           test_type: "game-loop"
-          test_devices: ${{ steps.device-info.outputs.device }}
+          test_devices: '${{ steps.device-info.outputs.device }}'
           test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py
@@ -1188,7 +1188,7 @@ jobs:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
           testapp_dir: testapps
           test_type: "game-loop"
-          test_devices: ${{ steps.device-info.outputs.device }}
+          test_devices: '${{ steps.device-info.outputs.device }}'
           test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1044,7 +1044,7 @@ jobs:
           testapp_dir: testapps
           test_type: "game-loop"
           test_devices: ${{ steps.device-info.outputs.device }}
-	  test_device_selection: random
+          test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py
           additional_flags: '--client-details matrixLabel=android-${{ github.run_id }}-${{ matrix.build_os }}-${{ matrix.android_device }}'
@@ -1189,7 +1189,7 @@ jobs:
           testapp_dir: testapps
           test_type: "game-loop"
           test_devices: ${{ steps.device-info.outputs.device }}
-	  test_device_selection: random
+          test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py
           additional_flags: '--client-details matrixLabel=ios-${{ github.run_id }}-${{ matrix.build_os }}-${{ matrix.ios_device }}'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1020,7 +1020,7 @@ jobs:
         id: device-info
         run: |
           echo "device_type=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.android_device }} -get_device_type)" >> $GITHUB_OUTPUT
-          echo "device=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.android_device }} -get_ftl_device)" >> $GITHUB_OUTPUT
+          echo "device=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.android_device }} -get_ftl_device_list)" >> $GITHUB_OUTPUT
       - name: Setup java 8 for test_simulator.py
         uses: actions/setup-java@v3
         with:
@@ -1037,13 +1037,14 @@ jobs:
             --ci
       - id: ftl_test
         if: steps.device-info.outputs.device_type == 'ftl'
-        uses: FirebaseExtended/github-actions/firebase-test-lab@v1.2
+        uses: FirebaseExtended/github-actions/firebase-test-lab@add_random_device_selection
         timeout-minutes: 90
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
           testapp_dir: testapps
           test_type: "game-loop"
           test_devices: ${{ steps.device-info.outputs.device }}
+	  test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py
           additional_flags: '--client-details matrixLabel=android-${{ github.run_id }}-${{ matrix.build_os }}-${{ matrix.android_device }}'
@@ -1148,7 +1149,7 @@ jobs:
         id: device-info
         run: |
           echo "device_type=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.ios_device }} -get_device_type)" >> $GITHUB_OUTPUT
-          echo "device=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.ios_device }} -get_ftl_device)" >> $GITHUB_OUTPUT
+          echo "device=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.ios_device }} -get_ftl_device_list)" >> $GITHUB_OUTPUT
       - name: Set up Node (16)
         uses: actions/setup-node@v3
         with:
@@ -1181,13 +1182,14 @@ jobs:
             --ci
       - id: ftl_test
         if: steps.device-info.outputs.device_type == 'ftl'
-        uses: FirebaseExtended/github-actions/firebase-test-lab@v1.2
+        uses: FirebaseExtended/github-actions/firebase-test-lab@add_random_device_selection
         timeout-minutes: 90
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
           testapp_dir: testapps
           test_type: "game-loop"
           test_devices: ${{ steps.device-info.outputs.device }}
+	  test_device_selection: random
           max_attempts: 3
           validator: ${GITHUB_WORKSPACE}/scripts/gha/integration_testing/ftl_gha_validator.py
           additional_flags: '--client-details matrixLabel=ios-${{ github.run_id }}-${{ matrix.build_os }}-${{ matrix.ios_device }}'

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1037,7 +1037,7 @@ jobs:
             --ci
       - id: ftl_test
         if: steps.device-info.outputs.device_type == 'ftl'
-        uses: FirebaseExtended/github-actions/firebase-test-lab@add_random_device_selection
+        uses: FirebaseExtended/github-actions/firebase-test-lab@v1.3
         timeout-minutes: 90
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}
@@ -1182,7 +1182,7 @@ jobs:
             --ci
       - id: ftl_test
         if: steps.device-info.outputs.device_type == 'ftl'
-        uses: FirebaseExtended/github-actions/firebase-test-lab@add_random_device_selection
+        uses: FirebaseExtended/github-actions/firebase-test-lab@v1.3
         timeout-minutes: 90
         with:
           credentials_json: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_CREDENTIALS }}

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -244,29 +244,7 @@ def get_test_device(device_type):
   if not isinstance(device_entry, list):
     # If None or just a dictionary (not in an array)
     return device_entry
-
-  selection = -1
-  # Check if a selection was already made on this machine. If so,
-  # load it and use it. Otherwise, make a random selection and save
-  # the index to ~/.ftl_test_devices/<device_type>.txt.
-  saved_selections_dir = os.path.join(os.path.expanduser("~"),
-                                      ".ftl_test_devices")
-  if not os.path.isdir(saved_selections_dir):
-    os.makedirs(saved_selections_dir)
-  saved_selection_file = os.path.join(saved_selections_dir,
-                                      "%s.txt" % device_type)
-  if os.path.isfile(saved_selection_file):
-    with open(saved_selection_file, 'r') as f:
-      try:
-        selection = int(f.readline())
-        if selection >= len(device_entry): selection = -1
-      except ValueError:
-        selection = -1
-  if selection < 0:
-    selection = random.randint(0, len(device_entry)-1)
-    with open(saved_selection_file, 'w') as f:
-      f.write("%d\n" % selection)
-  return device_entry[selection]
+  return random.choice(device_entry)
 
 
 def get_value(workflow, test_matrix, parm_key, config_parms_only=False):

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -169,6 +169,8 @@ BUILD_CONFIGS = {
 # For each device type, one entry from the list will be used for each
 # run. If there is only one device type listed, it will be chosen by
 # default.
+#
+# Note: All entries in a given list must have the same type, (ftl or virtual).
 TEST_DEVICES = {
   "android_target": [
       {"type": "ftl", "device": "model=blueline,version=28"}, # Pixel 3

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -432,6 +432,9 @@ def main():
   if args.get_ftl_device:
     print(get_test_device(args.parm_key).get("device"))
     return
+  if args.get_ftl_device_list:
+    print(";".join([entry.get("device") for entry in TEST_DEVICES.get(args.parm_key)]))
+    return
 
   if args.expanded:
     test_matrix = EXPANDED_KEY
@@ -461,6 +464,8 @@ def parse_cmdline_args():
   parser.add_argument('-o', '--override', help='Override existing value with provided value')
   parser.add_argument('-get_device_type', action='store_true', help='Get the device type, used with -k $device')
   parser.add_argument('-get_ftl_device', action='store_true', help='Get the ftl test device, used with -k $device')
+  parser.add_argument('-get_ftl_device_list', action='store_true',
+                      help='Get the FTL device list (semicolon-delimited) for the given -k $device')
   parser.add_argument('-t', '--device_type', default=['real', 'virtual'], help='Test on which type of mobile devices')
   parser.add_argument('--apis', default=PARAMETERS["integration_tests"]["config"]["apis"],
                       help='Exclude platform based on apis. Certain platform does not support all apis. e.g. tvOS does not support messaging')

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -174,9 +174,11 @@ BUILD_CONFIGS = {
 TEST_DEVICES = {
   "android_target": [
       {"type": "ftl", "device": "model=blueline,version=28"}, # Pixel 3
-      {"type": "ftl", "device": "model=dreamline,version=28"},  # Galaxy S8
-      {"type": "ftl", "device": "model=harpia,version=28"},  # Galaxy Tab S3
+      {"type": "ftl", "device": "model=dreamlte,version=28"},  # Galaxy S8
+      {"type": "ftl", "device": "model=gts3lltevzw,version=28"},  # Galaxy Tab S3
       {"type": "ftl", "device": "model=vivo_1906,version=28"},  # vivo 1906
+      {"type": "ftl", "device": "model=SH-01L,version=28"},  # AQUOS sense2 SH-01L
+      {"type": "ftl", "device": "model=PD1901,version=28"},  # VIVO 1901
   ],
   "android_latest": [
       {"type": "ftl", "device": "model=oriole,version=33"},  # Pixel 6
@@ -184,6 +186,10 @@ TEST_DEVICES = {
       {"type": "ftl", "device": "model=lynx,version=33"},  # Pixel 7a
       {"type": "ftl", "device": "model=cheetah,version=33"},  # Pixel 7 Pro
       {"type": "ftl", "device": "model=felix,version=33"},  # Pixel Fold
+      {"type": "ftl", "device": "model=tangorpro,version=33"},  # Pixel Tablet
+      {"type": "ftl", "device": "model=gts8uwifi,version=33"},  # Galaxy Tab S8 Ultra
+      {"type": "ftl", "device": "model=b0q,version=33"},  # Galaxy S22 Ultra
+      {"type": "ftl", "device": "model=b4q,version=33"},  # Galaxy Z Flip4
   ],
   "emulator_ftl_target": [
       {"type": "ftl", "device": "model=Pixel2,version=28"},

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -49,7 +49,7 @@ from absl import flags
 from absl import logging
 from print_matrix_configuration import PARAMETERS
 from print_matrix_configuration import BUILD_CONFIGS
-from print_matrix_configuration import get_test_devices
+from print_matrix_configuration import get_test_device
 
 import glob
 import re

--- a/scripts/gha/summarize_test_results.py
+++ b/scripts/gha/summarize_test_results.py
@@ -49,7 +49,7 @@ from absl import flags
 from absl import logging
 from print_matrix_configuration import PARAMETERS
 from print_matrix_configuration import BUILD_CONFIGS
-from print_matrix_configuration import TEST_DEVICES
+from print_matrix_configuration import get_test_devices
 
 import glob
 import re
@@ -388,8 +388,8 @@ def combine_config(platform, config, config_value, k):
   if len(config_value) > 1 and len(config) == len(config_value):
     config = ["All %d %s" % (len(config_value), config_name)]
   elif config_name == "ios_device":
-    ftl_devices = set(filter(lambda device: TEST_DEVICES.get(device).get("type") in "ftl", config_value))
-    simulators = set(filter(lambda device: TEST_DEVICES.get(device).get("type") in "virtual", config_value))
+    ftl_devices = set(filter(lambda device: get_test_device(device).get("type") in "ftl", config_value))
+    simulators = set(filter(lambda device: get_test_device(device).get("type") in "virtual", config_value))
     if len(ftl_devices) > 1 and ftl_devices.issubset(set(config)):
       config.insert(0, "All %d FTL Devices" % len(ftl_devices))
       config = [x for x in config if (x not in ftl_devices)]
@@ -397,8 +397,8 @@ def combine_config(platform, config, config_value, k):
       config.insert(0, "All %d Local Simulators" % len(simulators))
       config = [x for x in config if (x not in simulators)]
   elif config_name == "android_device":
-    ftl_devices = set(filter(lambda device: TEST_DEVICES.get(device).get("type") in "ftl", config_value))
-    emulators = set(filter(lambda device: TEST_DEVICES.get(device).get("type") in "virtual", config_value))
+    ftl_devices = set(filter(lambda device: get_test_device(device).get("type") in "ftl", config_value))
+    emulators = set(filter(lambda device: get_test_device(device).get("type") in "virtual", config_value))
     if len(ftl_devices) > 1 and ftl_devices.issubset(set(config)):
       config.insert(0, "All %d FTL Devices" % len(ftl_devices))
       config = [x for x in config if (x not in ftl_devices)]


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Distributing the load will help prevent issues with a single FTL device type from bottlenecking the tests.

Depends on https://github.com/FirebaseExtended/github-actions/pull/7 being merged and a new release of the firebase-test-lab action created.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Running expanded tests on this PR.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
