### PR TITLE
Skip a UMP test that doesn't work on iOS simulator.

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -3024,7 +3024,7 @@ TEST_F(FirebaseGmaUmpTest, TestUmpCallbacksOnWrongInstance) {
 TEST_F(FirebaseGmaUmpTest, TestUmpMethodsReturnOperationInProgress) {
   SKIP_TEST_ON_DESKTOP;
   SKIP_TEST_ON_IOS_SIMULATOR;  // LoadAndShowConsentFormIfRequired
-			       // is too quick on simulator.
+                               // is too quick on simulator.
 
   using firebase::gma::ump::ConsentFormStatus;
   using firebase::gma::ump::ConsentRequestParameters;

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -3023,6 +3023,8 @@ TEST_F(FirebaseGmaUmpTest, TestUmpCallbacksOnWrongInstance) {
 
 TEST_F(FirebaseGmaUmpTest, TestUmpMethodsReturnOperationInProgress) {
   SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_IOS_SIMULATOR;  // LoadAndShowConsentFormIfRequired
+			       // is too quick on simulator.
 
   using firebase::gma::ump::ConsentFormStatus;
   using firebase::gma::ump::ConsentRequestParameters;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The OperationInProgress test fails on iOS simulator due to the LoadAndShow method being too quick, so disable it on that platform.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
