### PR TITLE
Remove validation tests on inequality restrictions

### DIFF
--- a/firestore/integration_test_internal/src/validation_test.cc
+++ b/firestore/integration_test_internal/src/validation_test.cc
@@ -966,32 +966,6 @@ TEST_F(ValidationTest, QueryOrderByKeyBoundsMustBeStringsWithoutSlashes) {
                ErrorMessage(ErrorCase::kQueryInvalidBoundWithSlash));
 }
 
-TEST_F(ValidationTest, QueriesWithDifferentInequalityFieldsFail) {
-  EXPECT_ERROR(Collection()
-                   .WhereGreaterThan("x", FieldValue::Integer(32))
-                   .WhereLessThan("y", FieldValue::String("cat")),
-               ErrorMessage(ErrorCase::kQueryDifferentInequalityFields));
-}
-
-TEST_F(ValidationTest, QueriesWithInequalityDifferentThanFirstOrderByFail) {
-  CollectionReference collection = Collection();
-  std::string reason =
-      ErrorMessage(ErrorCase::kQueryInequalityOrderByDifferentFields);
-  EXPECT_ERROR(
-      collection.WhereGreaterThan("x", FieldValue::Integer(32)).OrderBy("y"),
-      reason);
-  EXPECT_ERROR(
-      collection.OrderBy("y").WhereGreaterThan("x", FieldValue::Integer(32)),
-      reason);
-  EXPECT_ERROR(collection.WhereGreaterThan("x", FieldValue::Integer(32))
-                   .OrderBy("y")
-                   .OrderBy("x"),
-               reason);
-  EXPECT_ERROR(collection.OrderBy("y").OrderBy("x").WhereGreaterThan(
-                   "x", FieldValue::Integer(32)),
-               reason);
-}
-
 TEST_F(ValidationTest, QueriesMustNotSpecifyStartingOrEndingPointAfterOrderBy) {
   CollectionReference collection = Collection();
   Query query = collection.OrderBy("foo");


### PR DESCRIPTION
Android and iOS SDKs added multiple inequality support recently https://github.com/firebase/firebase-ios-sdk/pull/11626, https://github.com/firebase/firebase-android-sdk/pull/5194, where 2 restrictions get lifted on inequality queries:
- All inequality filters must reference the same field.
- The first ordering must be the same field as an inequality filter

The validation tests on above restrictions can be removed now.