### PR TITLE
Fix issue with linking email to anonymous accounts on desktop

### DIFF
--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -126,6 +126,7 @@ set(desktop_SRCS
     src/desktop/rpcs/reset_password_request.cc
     src/desktop/rpcs/secure_token_request.cc
     src/desktop/rpcs/set_account_info_request.cc
+    src/desktop/rpcs/sign_up_request.cc
     src/desktop/rpcs/sign_up_new_user_request.cc
     src/desktop/rpcs/verify_assertion_request.cc
     src/desktop/rpcs/verify_custom_token_request.cc

--- a/auth/src/desktop/get_account_info_result.cc
+++ b/auth/src/desktop/get_account_info_result.cc
@@ -59,6 +59,10 @@ void GetAccountInfoResult::MergeToUser(UserView::Writer& user) const {
       user_impl_.has_email_password_credential;
   user->creation_timestamp = user_impl_.creation_timestamp;
   user->last_sign_in_timestamp = user_impl_.last_sign_in_timestamp;
+  // If the account info has an email, make sure is_anonymous is false
+  if (!user_impl_.email.empty() && user_impl_.has_email_password_credential) {
+    user->is_anonymous = false;
+  }
 
   user.ResetUserInfos(provider_data_);
 }

--- a/auth/src/desktop/rpcs/sign_up_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_request.cc
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "auth/src/desktop/rpcs/sign_up_request.h"
+
+#include <string>
+
+#include "app/src/assert.h"
+#include "app/src/include/firebase/app.h"
+
+namespace firebase {
+namespace auth {
+
+SignUpRequest::SignUpRequest(::firebase::App& app, const char* api_key)
+    : AuthRequest(app, request_resource_data, true) {
+  FIREBASE_ASSERT_RETURN_VOID(api_key);
+
+  std::string url(
+      "https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=");
+  url.append(api_key);
+  set_url(url.c_str());
+
+  application_data_->returnSecureToken = true;
+}
+
+std::unique_ptr<SignUpRequest>
+SignUpRequest::CreateLinkWithEmailAndPasswordRequest(::firebase::App& app,
+                                                     const char* api_key,
+                                                     const char* email,
+                                                     const char* password) {
+  auto request =
+      std::unique_ptr<SignUpRequest>(new SignUpRequest(app, api_key));
+
+  if (email) {
+    request->application_data_->email = email;
+  } else {
+    LogError("No email given");
+  }
+  if (password) {
+    request->application_data_->password = password;
+  } else {
+    LogError("No password given");
+  }
+  request->UpdatePostFields();
+  return request;
+}
+
+}  // namespace auth
+}  // namespace firebase

--- a/auth/src/desktop/rpcs/sign_up_request.cc
+++ b/auth/src/desktop/rpcs/sign_up_request.cc
@@ -16,6 +16,7 @@
 
 #include "auth/src/desktop/rpcs/sign_up_request.h"
 
+#include <memory>
 #include <string>
 
 #include "app/src/assert.h"

--- a/auth/src/desktop/rpcs/sign_up_request.h
+++ b/auth/src/desktop/rpcs/sign_up_request.h
@@ -17,6 +17,8 @@
 #ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_REQUEST_H_
 #define FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_REQUEST_H_
 
+#include <memory>
+
 #include "app/src/include/firebase/app.h"
 #include "auth/request_generated.h"
 #include "auth/request_resource.h"

--- a/auth/src/desktop/rpcs/sign_up_request.h
+++ b/auth/src/desktop/rpcs/sign_up_request.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_REQUEST_H_
+#define FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_REQUEST_H_
+
+#include "app/src/include/firebase/app.h"
+#include "auth/request_generated.h"
+#include "auth/request_resource.h"
+#include "auth/src/desktop/rpcs/auth_request.h"
+
+namespace firebase {
+namespace auth {
+
+// Represents the request payload for the signUp HTTP API. Use this to
+// upgrade anonymous accounts with email and password. The full specification of
+// the HTTP API can be found at
+// https://cloud.google.com/identity-platform/docs/reference/rest/v1/accounts/signUp
+class SignUpRequest : public AuthRequest {
+ private:
+  explicit SignUpRequest(::firebase::App& app, const char* api_key);
+  static std::unique_ptr<SignUpRequest> CreateRequest(::firebase::App& app,
+                                                      const char* api_key);
+
+ public:
+  // Initializer for linking an email and password to an account.
+  static std::unique_ptr<SignUpRequest> CreateLinkWithEmailAndPasswordRequest(
+      ::firebase::App& app, const char* api_key, const char* email,
+      const char* password);
+
+  void SetIdToken(const char* id_token) {
+    if (id_token) {
+      application_data_->idToken = id_token;
+      UpdatePostFields();
+    } else {
+      LogError("No id token given.");
+    }
+  }
+};
+
+}  // namespace auth
+}  // namespace firebase
+
+#endif  // FIREBASE_AUTH_SRC_DESKTOP_RPCS_SIGN_UP_REQUEST_H_

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -257,42 +257,44 @@ void TriggerSaveUserFlow(AuthData* const auth_data) {
   }
 }
 
-template <typename ResultT>
+template <typename ResponseT, typename ResultT>
 void PerformSignUpFlow(AuthDataHandle<ResultT, SignUpRequest>* const handle) {
-  const auto response = GetResponse<SignUpNewUserResponse>(*handle->request);
+  FIREBASE_ASSERT_RETURN_VOID(handle && handle->request);
 
-  if (response.IsSuccessful()) {
-    // Call GetAccountInfo to get more information, since SignUp doesn't include
-    // everything we need.
-    typedef GetAccountInfoRequest RequestT;
-    auto request = std::unique_ptr<GetAccountInfoRequest>(
-        new RequestT(*handle->auth_data->app, GetApiKey(*handle->auth_data),
-                     response.id_token().c_str()));  // NOLINT
+  const auto response = GetResponse<ResponseT>(*handle->request);
+  const AuthenticationResult auth_response =
+      CompleteSignInFlow(handle->auth_data, response);
 
-    const auto callback =
-        [](AuthDataHandle<ResultT, RequestT>* const inner_handle) {
-          const GetAccountInfoResult account_info =
-              GetAccountInfo(*inner_handle->request);
-
-          if (account_info.IsValid()) {
-            account_info.MergeToCurrentUser(inner_handle->auth_data);
-            TriggerSaveUserFlow(inner_handle->auth_data);
-            NotifyIdTokenListeners(inner_handle->auth_data);
-            CompleteSetAccountInfoPromise(
-                &inner_handle->promise, &inner_handle->auth_data->current_user);
-          } else {
-            SignOutIfUserNoLongerValid(inner_handle->auth_data->auth,
-                                       account_info.error());
-            FailPromise(&inner_handle->promise, account_info.error());
-          }
-        };
-
-    CallAsyncWithFreshToken(handle->auth_data, handle->promise,
-                            std::move(request), callback);
-
+  if (auth_response.IsValid()) {
+    const AuthResult auth_result =
+        auth_response.SetAsCurrentUser(handle->auth_data);
+    // The usual SignIn flow doesn't trigger this, but since this is used
+    // to upgrade anonymous accounts, it is needed for SignUp
+    NotifyIdTokenListeners(handle->auth_data);
+    CompletePromise(&handle->promise, auth_result);
   } else {
-    SignOutIfUserNoLongerValid(handle->auth_data->auth, response.error_code());
-    FailPromise(&handle->promise, response.error_code());
+    FailPromise(&handle->promise, auth_response.error());
+  }
+}
+
+template <typename ResponseT, typename ResultT>
+void PerformSignUpFlow_DEPRECATED(
+    AuthDataHandle<ResultT, SignUpRequest>* const handle) {
+  FIREBASE_ASSERT_RETURN_VOID(handle && handle->request);
+
+  const auto response = GetResponse<ResponseT>(*handle->request);
+  const AuthenticationResult auth_response =
+      CompleteSignInFlow(handle->auth_data, response);
+
+  if (auth_response.IsValid()) {
+    const SignInResult sign_in_result =
+        auth_response.SetAsCurrentUser_DEPRECATED(handle->auth_data);
+    // The usual SignIn flow doesn't trigger this, but since this is used
+    // to upgrade anonymous accounts, it is needed for SignUp
+    NotifyIdTokenListeners(handle->auth_data);
+    CompletePromise(&handle->promise, sign_in_result);
+  } else {
+    FailPromise(&handle->promise, auth_response.error());
   }
 }
 
@@ -353,7 +355,7 @@ Future<ResultT> DoLinkWithEmailAndPassword(
       email_credential->GetPassword().c_str());
 
   return CallAsyncWithFreshToken(auth_data, promise, std::move(request),
-                                 PerformSignUpFlow<ResultT>);
+                                 PerformSignUpFlow<SignUpNewUserResponse>);
 }
 
 // Calls setAccountInfo endpoint to link the current user with the given email
@@ -375,8 +377,9 @@ Future<ResultT> DoLinkWithEmailAndPassword_DEPRECATED(
       email_credential->GetEmail().c_str(),
       email_credential->GetPassword().c_str());
 
-  return CallAsyncWithFreshToken(auth_data, promise, std::move(request),
-                                 PerformSignUpFlow<ResultT>);
+  return CallAsyncWithFreshToken(
+      auth_data, promise, std::move(request),
+      PerformSignUpFlow_DEPRECATED<SignUpNewUserResponse>);
 }
 
 // Checks that the given provider wasn't already linked to the currently

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -277,6 +277,7 @@ void PerformSignUpFlow(AuthDataHandle<ResultT, SignUpRequest>* const handle) {
           if (account_info.IsValid()) {
             account_info.MergeToCurrentUser(inner_handle->auth_data);
             TriggerSaveUserFlow(inner_handle->auth_data);
+            NotifyIdTokenListeners(inner_handle->auth_data);
             CompleteSetAccountInfoPromise(
                 &inner_handle->promise, &inner_handle->auth_data->current_user);
           } else {

--- a/auth/tests/desktop/user_desktop_test.cc
+++ b/auth/tests/desktop/user_desktop_test.cc
@@ -569,7 +569,9 @@ TEST_F(UserDesktopTest, TestLinkWithCredential_OauthCredential) {
 TEST_F(UserDesktopTest, TestLinkWithCredential_EmailCredential) {
   FakeSetT fakes;
   const auto api_url =
-      std::string("https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=") + API_KEY;
+      std::string(
+          "https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=") +
+      API_KEY;
   fakes[api_url] =
       FakeSuccessfulResponse("SignupNewUserResponse",
                              " \"idToken\": \"idtoken123\","
@@ -587,9 +589,9 @@ TEST_F(UserDesktopTest, TestLinkWithCredential_EmailCredential) {
                              "   \"idToken\": \"new_fake_token\","
                              "   \"passwordHash\": \"new_fake_hash\","
                              "   \"emailVerified\": false," +
-                             GetFakeProviderInfo() +
-                             "  }"
-                             " ]");
+                                 GetFakeProviderInfo() +
+                                 "  }"
+                                 " ]");
   InitializeConfigWithFakes(fakes);
 
   // Response contains a new ID token, but user should have stayed the same.

--- a/auth/tests/desktop/user_desktop_test.cc
+++ b/auth/tests/desktop/user_desktop_test.cc
@@ -567,8 +567,30 @@ TEST_F(UserDesktopTest, TestLinkWithCredential_OauthCredential) {
 }
 
 TEST_F(UserDesktopTest, TestLinkWithCredential_EmailCredential) {
-  InitializeConfigWithAFake(GetUrlForApi(API_KEY, "setAccountInfo"),
-                            FakeSetAccountInfoResponse());
+  FakeSetT fakes;
+  const auto api_url =
+      std::string("https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=") + API_KEY;
+  fakes[api_url] =
+      FakeSuccessfulResponse("SignupNewUserResponse",
+                             " \"idToken\": \"idtoken123\","
+                             " \"refreshToken\": \"refreshtoken123\","
+                             " \"expiresIn\": \"3600\","
+                             " \"localId\": \"localid123\"");
+  fakes[GetUrlForApi(API_KEY, "getAccountInfo")] =
+      FakeSuccessfulResponse("GetAccountInfoResponse",
+                             " \"users\": ["
+                             "  {"
+                             "   \"localId\": \"localid123\","
+                             "   \"lastLoginAt\": \"123\","
+                             "   \"createdAt\": \"456\","
+                             "   \"email\": \"new_fake_email@example.com\","
+                             "   \"idToken\": \"new_fake_token\","
+                             "   \"passwordHash\": \"new_fake_hash\","
+                             "   \"emailVerified\": false," +
+                             GetFakeProviderInfo() +
+                             "  }"
+                             " ]");
+  InitializeConfigWithFakes(fakes);
 
   // Response contains a new ID token, but user should have stayed the same.
   id_token_listener.ExpectChanges(1);
@@ -840,18 +862,6 @@ TEST_F(UserDesktopTestSignOutOnError, Unlink) {
       kAuthErrorUserNotFound, [&] {
         sem_.Post();
         return firebase_user_->Unlink_DEPRECATED("fake_provider_id");
-      });
-  sem_.Wait();
-}
-
-TEST_F(UserDesktopTestSignOutOnError, LinkWithEmail) {
-  CheckSignOutIfUserIsInvalid(
-      GetUrlForApi(API_KEY, "setAccountInfo"), "USER_NOT_FOUND",
-      kAuthErrorUserNotFound, [&] {
-        sem_.Post();
-        return firebase_user_->LinkWithCredential_DEPRECATED(
-            EmailAuthProvider::GetCredential("fake_email@example.com",
-                                             "fake_password"));
       });
   sem_.Wait();
 }

--- a/auth/tests/user_test.cc
+++ b/auth/tests/user_test.cc
@@ -411,7 +411,9 @@ TEST_F(UserTest, TestLinkWithCredential) {
       "futuregeneric:{ticker:1}},"
       "    {fake:'FIRUser.linkWithCredential:completion:',"
       "     futuregeneric:{ticker:1}},"
-      "    {fake:'https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=not_a_real_api_key',"
+      "    "
+      "{fake:'https://identitytoolkit.googleapis.com/v1/"
+      "accounts:signUp?key=not_a_real_api_key',"
       "     httpresponse: {"
       "       header: ['HTTP/1.1 200 Ok','Server:mock server 101'],"
       "       body: ['{"
@@ -435,8 +437,7 @@ TEST_F(UserTest, TestLinkWithCredential) {
       "     }"
       "    }"
       "  ]"
-      "}"
-  );
+      "}");
 
   Future<User*> result = firebase_user_->LinkWithCredential_DEPRECATED(
       EmailAuthProvider::GetCredential("i@email.com", "pw"));

--- a/auth/tests/user_test.cc
+++ b/auth/tests/user_test.cc
@@ -402,18 +402,41 @@ TEST_F(UserTest, TestSendEmailVerification) {
 }
 
 TEST_F(UserTest, TestLinkWithCredential) {
-  const std::string config =
-      std::string(
-          "{"
-          "  config:["
-          "    {fake:'FirebaseUser.linkWithCredential', "
-          "futuregeneric:{ticker:1}},"
-          "    {fake:'FIRUser.linkWithCredential:completion:',"
-          "     futuregeneric:{ticker:1}},") +
-      SET_ACCOUNT_INFO_SUCCESSFUL_RESPONSE +
+  // Under the hood, since this is linking an email/password,
+  // it is expecting a signUp call, followed by a getAccountInfo.
+  firebase::testing::cppsdk::ConfigSet(
+      "{"
+      "  config:["
+      "    {fake:'FirebaseUser.linkWithCredential', "
+      "futuregeneric:{ticker:1}},"
+      "    {fake:'FIRUser.linkWithCredential:completion:',"
+      "     futuregeneric:{ticker:1}},"
+      "    {fake:'https://identitytoolkit.googleapis.com/v1/accounts:signUp?key=not_a_real_api_key',"
+      "     httpresponse: {"
+      "       header: ['HTTP/1.1 200 Ok','Server:mock server 101'],"
+      "       body: ['{"
+      " \"kind\": \"identitytoolkit#SignupNewUserResponse\","
+      " \"idToken\": \"idtoken123\","
+      " \"refreshToken\": \"refreshtoken123\","
+      " \"expiresIn\": \"3600\","
+      " \"localId\": \"localid123\""
+      "}',]"
+      "     }"
+      "    },"
+      "    {fake:'https://www.googleapis.com/identitytoolkit/v3/relyingparty/"
+      "getAccountInfo?key=not_a_real_api_key',"
+      "     httpresponse: {"
+      "       header: ['HTTP/1.1 200 Ok','Server:mock server 101'],"
+      "       body: ['{"
+      "         \"users\": [{"
+      "           \"localId\": \"localid123\""
+      "         }]}',"
+      "       ]"
+      "     }"
+      "    }"
       "  ]"
-      "}";
-  firebase::testing::cppsdk::ConfigSet(config.c_str());
+      "}"
+  );
 
   Future<User*> result = firebase_user_->LinkWithCredential_DEPRECATED(
       EmailAuthProvider::GetCredential("i@email.com", "pw"));

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -634,6 +634,9 @@ code.
 ### Upcoming Release
 -   Changes
     - General (iOS): Update to Firebase Cocoapods version 10.17.0.
+    - Auth: Fix a bug where anonymous account can't be linked with
+      email password credential. For background, see
+      [Email Enumeration Protection](https://cloud.google.com/identity-platform/docs/admin/email-enumeration-protection#overview)
     
 ### 11.6.0
 -   Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Changes to email enumeration protection broke some functionality on the backend with email accounts. One of those is upgrading anonymous accounts to have email and password.  This can be fixed by using a slightly different rest call, so this makes that change for desktop, mobile platforms will be fixed in the underlying mobile SDKs.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Testing locally with a custom project that has email enumeration protection turned on.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
