### PR TITLE
Switch to node 18, node 16 no longer works with Firebase CLI.

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -343,10 +343,10 @@ jobs:
           if [[ "${{ job.status }}" != "success" ]]; then
             exit 1
           fi
-      - name: Set up Node (16)
+      - name: Set up Node (18)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Setup Firestore Emulator
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -762,10 +762,10 @@ jobs:
           timeout_minutes: 15
           max_attempts: 3
           command: scripts/gha/install_test_workflow_prereqs.sh -p Desktop -t true -a '${{ matrix.arch }}' -s '${{ matrix.ssl_variant }}'
-      - name: Set up Node (16)
+      - name: Set up Node (18)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Setup Firestore Emulator
         uses: nick-invision/retry@v2
         with:
@@ -1155,10 +1155,10 @@ jobs:
         run: |
           echo "device_type=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.ios_device }} -get_device_type)" >> $GITHUB_OUTPUT
           echo "device=$( python scripts/gha/print_matrix_configuration.py -k ${{ matrix.ios_device }} -get_ftl_device_list)" >> $GITHUB_OUTPUT
-      - name: Set up Node (16)
+      - name: Set up Node (18)
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Setup java for Firestore emulator
         uses: actions/setup-java@v3
         with:


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Firebase CLI (and Firestore emulator) now require Node 18 minimum, so install that on our runners instead of 16.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Tests in this PR, this should also fix the Firestore desktop nightlies.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
