### PR TITLE
Firestore: Small Count API documentation improvements

### DIFF
--- a/firestore/src/include/firebase/firestore/aggregate_source.h
+++ b/firestore/src/include/firebase/firestore/aggregate_source.h
@@ -32,7 +32,7 @@ enum class AggregateSource {
    * considering any local state. That is, documents in the local cache are not
    * taken into consideration, neither are local modifications not yet
    * synchronized with the server. Previously-downloaded results, if any, are
-   * not used: every request using this source necessarily involves a round trip
+   * not used. Every request using this source necessarily involves a round trip
    * to the server.
    *
    * The AggregateQuery will fail if the server cannot be reached, such as if

--- a/firestore/src/include/firebase/firestore/query.h
+++ b/firestore/src/include/firebase/firestore/query.h
@@ -152,8 +152,8 @@ class Query {
    *
    * Using the returned query to count the documents is efficient because only
    * the final count, not the documents' data, is downloaded. The returned query
-   * can count the documents if the result set would be prohibitively large to
-   * download entirely (thousands of documents).
+   * can count the documents in cases where the result set is prohibitively
+   * large to download entirely (thousands of documents).
    *
    * @return An aggregate query that counts the documents in the result set of
    * this query.

--- a/firestore/src/include/firebase/firestore/query.h
+++ b/firestore/src/include/firebase/firestore/query.h
@@ -152,8 +152,8 @@ class Query {
    *
    * Using the returned query to count the documents is efficient because only
    * the final count, not the documents' data, is downloaded. The returned query
-   * can even count the documents if the result set would be prohibitively large
-   * to download entirely (e.g. thousands of documents).
+   * can count the documents if the result set would be prohibitively large to
+   * download entirely (thousands of documents).
    *
    * @return An aggregate query that counts the documents in the result set of
    * this query.


### PR DESCRIPTION
Apply the feedback to the count API documentation as suggested in https://github.com/firebase/firebase-js-sdk/pull/6608. This is a port of https://github.com/firebase/firebase-js-sdk/pull/7933.