### PR TITLE
Clean up handling of GMA NoFill errors.

### DIFF
--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -907,10 +907,10 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletionAnyResult(load_ad_future,
-                               "LoadAd (ignoring NoFill error)");
-    EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-                load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
+    WaitForCompletion(load_ad_future,
+		      "LoadAd (ignoring NoFill error)",
+		      {firebase::gma::kAdErrorCodeNone,
+		       firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     // In UI mode, or in non-UI mode if a NoFill error didn't occur, check that
@@ -942,9 +942,9 @@ TEST_F(FirebaseGmaTest, TestNativeAdLoad) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletionAnyResult(load_ad_future, "LoadAd (ignoring NoFill error)");
-  EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-              load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
+  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
+		    {firebase::gma::kAdErrorCodeNone,
+		     firebase::gma::kAdErrorCodeNoFill});
 
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
@@ -1943,10 +1943,10 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadEmptyRequest) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletionAnyResult(load_ad_future,
-                               "LoadAd (ignoring NoFill error)");
-    EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-                load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
+    WaitForCompletion(load_ad_future,
+		      "LoadAd (ignoring NoFill error)",
+		      {firebase::gma::kAdErrorCodeNone,
+		       firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     // In UI mode, or in non-UI mode if a NoFill error didn't occur, check that
@@ -2120,10 +2120,9 @@ TEST_F(FirebaseGmaTest, TestNativeAdLoadEmptyRequest) {
       native_ad->LoadAd(kNativeAdUnit, request);
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletionAnyResult(load_ad_future, "LoadAd (ignoring NoFill error)");
-  EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-              load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
-
+  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
+		      {firebase::gma::kAdErrorCodeNone,
+		       firebase::gma::kAdErrorCodeNoFill});
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
     ASSERT_NE(result_ptr, nullptr);
@@ -2155,9 +2154,9 @@ TEST_F(FirebaseGmaTest, TestNativeRecordImpression) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletionAnyResult(load_ad_future, "LoadAd (ignoring NoFill error)");
-  EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-              load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
+  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
+		    {firebase::gma::kAdErrorCodeNone,
+		     firebase::gma::kAdErrorCodeNoFill});
 
   // Proceed verifying the RecordImpression, only when loadAd is successful.
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
@@ -2206,9 +2205,9 @@ TEST_F(FirebaseGmaTest, TestNativePerformClick) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletionAnyResult(load_ad_future, "LoadAd (ignoring NoFill error)");
-  EXPECT_TRUE(load_ad_future.error() == firebase::gma::kAdErrorCodeNone ||
-              load_ad_future.error() == firebase::gma::kAdErrorCodeNoFill);
+  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
+		    {firebase::gma::kAdErrorCodeNone,
+		     firebase::gma::kAdErrorCodeNoFill});
 
   // Proceed verifying the PerformClick, only when loadAd is successful.
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -2434,7 +2434,7 @@ TEST_F(FirebaseGmaTest, TestRewardedAdStress) {
     firebase::gma::AdRequest request = GetAdRequest();
     firebase::Future<firebase::gma::AdResult> future =
         rewarded->LoadAd(kRewardedAdUnit, request);
-    WaitForCompletionAnyResult(
+    WaitForCompletion(
         future, "TestRewardedAdStress LoadAd",
         {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
     // Stress tests may exhaust the ad pool. If so, loadAd will return
@@ -2758,11 +2758,10 @@ TEST_F(FirebaseGmaUmpTest, TestUmpLoadFormUnderAgeOfConsent) {
                     "RequestConsentInfoUpdate");
 
   firebase::Future<void> load_future = consent_info_->LoadConsentForm();
-  WaitForCompletion(
-      load_future,
-      "LoadConsentForm" {firebase::gma::ump::kConsentFormErrorUnavailable,
-                         firebase::gma::ump::kConsentFormErrorTimeout,
-                         firebase::gma::ump::kConsentFormSuccess});
+  WaitForCompletion(load_future, "LoadConsentForm",
+                    {firebase::gma::ump::kConsentFormErrorUnavailable,
+                     firebase::gma::ump::kConsentFormErrorTimeout,
+                     firebase::gma::ump::kConsentFormSuccess});
 }
 
 TEST_F(FirebaseGmaUmpTest, TestUmpLoadFormUnavailableDebugNonEEA) {

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -873,15 +873,28 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
   firebase::Future<firebase::gma::AdResult> load_ad_future =
       interstitial->LoadAd(kInterstitialAdUnit, GetAdRequest());
 
-  WaitForCompletion(load_ad_future, "LoadAd");
-  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
-  ASSERT_NE(result_ptr, nullptr);
-  EXPECT_TRUE(result_ptr->is_successful());
-  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
-  EXPECT_FALSE(
-      result_ptr->response_info().mediation_adapter_class_name().empty());
-  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
-  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+  // This test behaves differently if it's running in UI mode
+  // (manually on a device) or in non-UI mode (via automated tests).
+  if (ShouldRunUITests()) {
+    // Run in manual mode: fail if any error occurs.
+    WaitForCompletion(load_ad_future, "LoadAd");
+  } else {
+    // Run in automated test mode: don't fail if NoFill occurred.
+    WaitForCompletion(load_ad_future,
+		      "LoadAd (ignoring NoFill error)",
+		      {firebase::gma::kAdErrorCodeNone,
+		       firebase::gma::kAdErrorCodeNoFill});
+  }
+  if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
+    const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+    ASSERT_NE(result_ptr, nullptr);
+    EXPECT_TRUE(result_ptr->is_successful());
+    EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+    EXPECT_FALSE(
+		 result_ptr->response_info().mediation_adapter_class_name().empty());
+    EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+    EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+  }
 
   load_ad_future.Release();
   delete interstitial;
@@ -1759,16 +1772,27 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
   firebase::Future<firebase::gma::AdResult> load_ad_future =
       interstitial->LoadAd(kInterstitialAdUnit, request);
 
-  WaitForCompletion(load_ad_future, "LoadAd");
-  const firebase::gma::AdResult* result_ptr = load_ad_future.result();
-  ASSERT_NE(result_ptr, nullptr);
-  EXPECT_TRUE(result_ptr->is_successful());
-  EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
-  EXPECT_FALSE(
-      result_ptr->response_info().mediation_adapter_class_name().empty());
-  EXPECT_FALSE(result_ptr->response_info().response_id().empty());
-  EXPECT_FALSE(result_ptr->response_info().ToString().empty());
-
+  // This test behaves differently if it's running in UI mode
+  // (manually on a device) or in non-UI mode (via automated tests).
+  if (ShouldRunUITests()) {
+    // Run in manual mode: fail if any error occurs.
+    WaitForCompletion(load_ad_future, "LoadAd");
+  } else {
+    // Run in automated test mode: don't fail if NoFill occurred.
+    WaitForCompletion(load_ad_future,
+		      "LoadAd (ignoring NoFill error)",
+		      {firebase::gma::kAdErrorCodeNone,
+		       firebase::gma::kAdErrorCodeNoFill});
+  }
+  if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
+    const firebase::gma::AdResult* result_ptr = load_ad_future.result();
+    ASSERT_NE(result_ptr, nullptr);
+    EXPECT_TRUE(result_ptr->is_successful());
+    EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
+    EXPECT_FALSE(result_ptr->response_info().mediation_adapter_class_name().empty());
+    EXPECT_FALSE(result_ptr->response_info().response_id().empty());
+    EXPECT_FALSE(result_ptr->response_info().ToString().empty());
+  }
   load_ad_future.Release();
   delete interstitial;
 }

--- a/gma/integration_test/src/integration_test.cc
+++ b/gma/integration_test/src/integration_test.cc
@@ -880,10 +880,9 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletion(load_ad_future,
-		      "LoadAd (ignoring NoFill error)",
-		      {firebase::gma::kAdErrorCodeNone,
-		       firebase::gma::kAdErrorCodeNoFill});
+    WaitForCompletion(
+        load_ad_future, "LoadAd (ignoring NoFill error)",
+        {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
@@ -891,7 +890,7 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoad) {
     EXPECT_TRUE(result_ptr->is_successful());
     EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
     EXPECT_FALSE(
-		 result_ptr->response_info().mediation_adapter_class_name().empty());
+        result_ptr->response_info().mediation_adapter_class_name().empty());
     EXPECT_FALSE(result_ptr->response_info().response_id().empty());
     EXPECT_FALSE(result_ptr->response_info().ToString().empty());
   }
@@ -920,10 +919,9 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoad) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletion(load_ad_future,
-		      "LoadAd (ignoring NoFill error)",
-		      {firebase::gma::kAdErrorCodeNone,
-		       firebase::gma::kAdErrorCodeNoFill});
+    WaitForCompletion(
+        load_ad_future, "LoadAd (ignoring NoFill error)",
+        {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     // In UI mode, or in non-UI mode if a NoFill error didn't occur, check that
@@ -955,9 +953,9 @@ TEST_F(FirebaseGmaTest, TestNativeAdLoad) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
-		    {firebase::gma::kAdErrorCodeNone,
-		     firebase::gma::kAdErrorCodeNoFill});
+  WaitForCompletion(
+      load_ad_future, "LoadAd (ignoring NoFill error)",
+      {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
 
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
@@ -1779,17 +1777,17 @@ TEST_F(FirebaseGmaTest, TestInterstitialAdLoadEmptyRequest) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletion(load_ad_future,
-		      "LoadAd (ignoring NoFill error)",
-		      {firebase::gma::kAdErrorCodeNone,
-		       firebase::gma::kAdErrorCodeNoFill});
+    WaitForCompletion(
+        load_ad_future, "LoadAd (ignoring NoFill error)",
+        {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
     ASSERT_NE(result_ptr, nullptr);
     EXPECT_TRUE(result_ptr->is_successful());
     EXPECT_FALSE(result_ptr->response_info().adapter_responses().empty());
-    EXPECT_FALSE(result_ptr->response_info().mediation_adapter_class_name().empty());
+    EXPECT_FALSE(
+        result_ptr->response_info().mediation_adapter_class_name().empty());
     EXPECT_FALSE(result_ptr->response_info().response_id().empty());
     EXPECT_FALSE(result_ptr->response_info().ToString().empty());
   }
@@ -1967,10 +1965,9 @@ TEST_F(FirebaseGmaTest, TestRewardedAdLoadEmptyRequest) {
     WaitForCompletion(load_ad_future, "LoadAd");
   } else {
     // Run in automated test mode: don't fail if NoFill occurred.
-    WaitForCompletion(load_ad_future,
-		      "LoadAd (ignoring NoFill error)",
-		      {firebase::gma::kAdErrorCodeNone,
-		       firebase::gma::kAdErrorCodeNoFill});
+    WaitForCompletion(
+        load_ad_future, "LoadAd (ignoring NoFill error)",
+        {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
   }
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     // In UI mode, or in non-UI mode if a NoFill error didn't occur, check that
@@ -2144,9 +2141,9 @@ TEST_F(FirebaseGmaTest, TestNativeAdLoadEmptyRequest) {
       native_ad->LoadAd(kNativeAdUnit, request);
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
-		      {firebase::gma::kAdErrorCodeNone,
-		       firebase::gma::kAdErrorCodeNoFill});
+  WaitForCompletion(
+      load_ad_future, "LoadAd (ignoring NoFill error)",
+      {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
     const firebase::gma::AdResult* result_ptr = load_ad_future.result();
     ASSERT_NE(result_ptr, nullptr);
@@ -2178,9 +2175,9 @@ TEST_F(FirebaseGmaTest, TestNativeRecordImpression) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
-		    {firebase::gma::kAdErrorCodeNone,
-		     firebase::gma::kAdErrorCodeNoFill});
+  WaitForCompletion(
+      load_ad_future, "LoadAd (ignoring NoFill error)",
+      {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
 
   // Proceed verifying the RecordImpression, only when loadAd is successful.
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {
@@ -2229,9 +2226,9 @@ TEST_F(FirebaseGmaTest, TestNativePerformClick) {
       native_ad->LoadAd(kNativeAdUnit, GetAdRequest());
 
   // Don't fail loadAd, if NoFill occurred.
-  WaitForCompletion(load_ad_future, "LoadAd (ignoring NoFill error)",
-		    {firebase::gma::kAdErrorCodeNone,
-		     firebase::gma::kAdErrorCodeNoFill});
+  WaitForCompletion(
+      load_ad_future, "LoadAd (ignoring NoFill error)",
+      {firebase::gma::kAdErrorCodeNone, firebase::gma::kAdErrorCodeNoFill});
 
   // Proceed verifying the PerformClick, only when loadAd is successful.
   if (load_ad_future.error() == firebase::gma::kAdErrorCodeNone) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Clean up handling of NoFill errors in two ways:
1. Use the new WaitForCompletion syntax to allow both error codes.
2. Add NoFill handling to InterstitialAd tests.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
