### PR TITLE
Add explicit SDK version to messaging AAR.

### DIFF
--- a/messaging/messaging_java/build.gradle
+++ b/messaging/messaging_java/build.gradle
@@ -43,6 +43,11 @@ android {
   }
   compileSdkVersion 33
 
+  defaultConfig {
+    minSdkVersion 19
+    targetSdkVersion 28
+  }
+
   sourceSets {
     main {
       manifest.srcFile '../src/android/java/LibraryManifest.xml'

--- a/messaging/messaging_java/build.gradle
+++ b/messaging/messaging_java/build.gradle
@@ -44,8 +44,7 @@ android {
   compileSdkVersion 33
 
   defaultConfig {
-    minSdkVersion 19
-    targetSdkVersion 28
+    minSdkVersion 14
   }
 
   sourceSets {

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -636,6 +636,8 @@ code.
     - Dynamic Links: The Dynamic Links SDK is now deprecated. See the [support
       documentation](https://firebase.google.com/support/dynamic-links-faq)
       for more information.
+    - Messaging (Android): Fixed minSdkVersion in the firebase_messaging.aar
+      manifest file.
 
 ### 11.7.0
 -   Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Since updating Gradle, omitting this sets the minimum SDK to 1 instead of 14, and adds a host of other issues.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Manually tested receiving notification in the integration_test app on Android emulator.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
