### PR TITLE
Move SetConsent test to the end to not break GetAnalyticsInstanceId tests.

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -249,6 +249,15 @@ TEST_F(FirebaseAnalyticsTest, TestLogEventWithMultipleParameters) {
 }
 
 TEST_F(FirebaseAnalyticsTest, TestSetConsent) {
+  // On Android, this test must be performed at the end, after all the tests for
+  // session ID and instance ID. This is because once you call SetConsent to
+  // deny consent on Android, calling it again to grant consent may not take
+  // effect until the app restarts, thus breaking any of those tests that are
+  // run after this one.
+  //
+  // If this test does happen to run earlier (due to randomizing test order, for
+  // example), the tests that could fail will be skipped (on Android).
+
   // Can't confirm that these do anything but just run them all to ensure the
   // app doesn't crash.
   std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>

--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -108,7 +108,8 @@ TEST_F(FirebaseAnalyticsTest, TestGetAnalyticsInstanceID) {
   LogInfo("Google Play services version: %d", GetGooglePlayServicesVersion());
   if (did_test_setconsent_) {
     LogInfo(
-        "Skipping %s after TestSetConsent, as the test may fail until the app is restarted.",
+        "Skipping %s after TestSetConsent, as the test may fail until the app "
+        "is restarted.",
         ::testing::UnitTest::GetInstance()->current_test_info()->name());
     GTEST_SKIP();
     return;
@@ -141,7 +142,8 @@ TEST_F(FirebaseAnalyticsTest, TestGetSessionID) {
   LogInfo("Google Play services version: %d", GetGooglePlayServicesVersion());
   if (did_test_setconsent_) {
     LogInfo(
-        "Skipping %s after TestSetConsent, as the test may fail until the app is restarted.",
+        "Skipping %s after TestSetConsent, as the test may fail until the app "
+        "is restarted.",
         ::testing::UnitTest::GetInstance()->current_test_info()->name());
     GTEST_SKIP();
     return;
@@ -181,7 +183,8 @@ TEST_F(FirebaseAnalyticsTest, TestResettingGivesNewInstanceId) {
   LogInfo("Google Play services version: %d", GetGooglePlayServicesVersion());
   if (did_test_setconsent_) {
     LogInfo(
-        "Skipping %s after TestSetConsent, as the test may fail until the app is restarted.",
+        "Skipping %s after TestSetConsent, as the test may fail until the app "
+        "is restarted.",
         ::testing::UnitTest::GetInstance()->current_test_info()->name());
     GTEST_SKIP();
     return;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On Android, once SetConsent is called denying consent, calling it again allowing consent doesn't always take affect until the app restarts.

So move SetConsent to the end of the tests, and ensure that if it's  run earlier (due to test order being randomized), skip the tests that can fail.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
