### PR TITLE
Improve --auto_diff mode for when GMA is the only changed SDK.

### DIFF
--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -27,7 +27,7 @@ def firebaseDependenciesMap = [
   'dynamic_links' : ['com.google.firebase:firebase-dynamic-links'],
   'firestore' : ['com.google.firebase:firebase-firestore'],
   'functions' : ['com.google.firebase:firebase-functions'],
-  'gma' : ['com.google.android.gms:play-services-ads:23.0.0',
+  'gma' : ['com.google.android.gms:play-services-ads:23.1.0',
            'com.google.android.ump:user-messaging-platform:2.2.0'],
   'installations' : ['com.google.firebase:firebase-installations'],
   'invites' : ['com.google.firebase:firebase-invites'],

--- a/Android/firebase_dependencies.gradle
+++ b/Android/firebase_dependencies.gradle
@@ -27,7 +27,7 @@ def firebaseDependenciesMap = [
   'dynamic_links' : ['com.google.firebase:firebase-dynamic-links'],
   'firestore' : ['com.google.firebase:firebase-firestore'],
   'functions' : ['com.google.firebase:firebase-functions'],
-  'gma' : ['com.google.android.gms:play-services-ads:23.1.0',
+  'gma' : ['com.google.android.gms:play-services-ads:23.0.0',
            'com.google.android.ump:user-messaging-platform:2.2.0'],
   'installations' : ['com.google.firebase:firebase-installations'],
   'invites' : ['com.google.firebase:firebase-invites'],

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -354,8 +354,8 @@ def filter_values_on_diff(parm_key, value, auto_diff):
       "Android": None,
       # Uncomment the two below lines when debugging this script, or GitHub
       # actions related to auto-diff mode.
-      ".github": None,
-      "scripts": None,
+      #".github": None,
+      #"scripts": None,
       # Top-level directories listed below trigger additional APIs being tested.
       # For example, if auth is touched by a PR, we also need to test functions,
       # database, firestore, and storage.

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -325,7 +325,7 @@ def scan_changes_in_file(parm_key, auto_diff, path, requested_api_list):
       changed_apis.update(requested_api_list)
       break
   changed_apis.intersection_update(requested_api_list)
-  return ",".join(changed_apis)
+  return ",".join(sorted(changed_apis)) if changed_apis else None
 
 def filter_values_on_diff(parm_key, value, auto_diff):
   """Filter the given key based on a branch diff.
@@ -355,8 +355,8 @@ def filter_values_on_diff(parm_key, value, auto_diff):
       "Android": None,
       # Uncomment the two below lines when debugging this script, or GitHub
       # actions related to auto-diff mode.
-      #".github": None,
-      #"scripts": None,
+      # ".github": None,
+      # "scripts": None,
       # Top-level directories listed below trigger additional APIs being tested.
       # For example, if auth is touched by a PR, we also need to test functions,
       # database, firestore, and storage.
@@ -390,7 +390,7 @@ def filter_values_on_diff(parm_key, value, auto_diff):
         sys.stderr.write("Path '%s' is outside known directories, defaulting to all APIs: %s\n" % (path, value))
         return value
     sys.stderr.write("::warning::Autodetected APIs: %s\n" % ','.join(sorted(filtered_api_list)))
-    return ','.join(sorted(filtered_api_list))
+    return ','.join(sorted(filtered_api_list if filtered_api_list else requested_api_list))
   elif parm_key == 'platform':
     # Quick and dirty check:
     # For each file:

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -323,6 +323,7 @@ def scan_changes_in_file(parm_key, auto_diff, path, requested_api_list):
       changed_apis.add("gma")
     else:
       changed_apis.update(requested_api_list)
+      break
   changed_apis.intersection_update(requested_api_list)
   return ",".join(changed_apis)
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

If Android/firebase_dependencies.gradle and ios_pod/Podfile only have changed lines referencing GMA or UMP packages, then allow auto_diff to only specify GMA.

This should greatly speed up "quick" tests when updating only GMA dependencies.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
