### PR TITLE
Set Storage Desktop REST requests to have no timeout.

### DIFF
--- a/app/rest/request_options.h
+++ b/app/rest/request_options.h
@@ -45,7 +45,8 @@ struct RequestOptions {
   bool stream_post_fields;
   // Stores key-value pairs in header.
   std::map<std::string, std::string> header;
-  // The maximum time in milliseconds to allow the request and response.
+  // The maximum time in milliseconds to allow the request and response
+  // (or 0 for no timeout).
   int64_t timeout_ms;
 
   // Set true to make the library display more verbose info to help debug. Does

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -639,6 +639,7 @@ code.
       GoogleUserMessagingPlatform version 2.3.0.
     - GMA (Android): Updated dependency to play-services-ads version 23.0.0 and
       user-messaging-platform version 2.2.0.
+    - Storage (Desktop): Removed 5-minute timeout for uploads and downloads.
 
 ### 11.9.0
 -   Changes

--- a/storage/src/desktop/storage_reference_desktop.cc
+++ b/storage/src/desktop/storage_reference_desktop.cc
@@ -238,6 +238,9 @@ void StorageReferenceInternal::PrepareRequestBlocking(
   request->set_url(url);
   request->set_method(method);
 
+  // Set this request to have no timeout.
+  request->options().timeout_ms = 0;
+
   // Fetch auth token and apply it, if there is one:
   std::string token = storage_->GetAuthToken();
   if (token.length() > 0) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Our REST implementation has a default timeout of 5 minutes. This overrides this timeout with 0, which tells libcurl to have no timeout for the connection.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Integration tests in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [X] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
