### PR TITLE
Internal updates

### DIFF
--- a/gma/src/ios/FADNativeDelegate.h
+++ b/gma/src/ios/FADNativeDelegate.h
@@ -32,7 +32,7 @@ class NativeAdInternalIOS;
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface FADNativeDelegate : NSObject <GADNativeAdLoaderDelegate, GADAdLoaderDelegate>
+@interface FADNativeDelegate : NSObject <GADNativeAdLoaderDelegate, GADAdLoaderDelegate, GADNativeAdDelegate>
 
 /// Returns a FADNativeDelegate object with NativeAdInternalIOS.
 - (FADNativeDelegate *)initWithInternalNativeAd:

--- a/gma/src/ios/native_ad_internal_ios.mm
+++ b/gma/src/ios/native_ad_internal_ios.mm
@@ -220,6 +220,7 @@ Future<AdResult> NativeAdInternalIOS::LoadAd(const char *ad_unit_id, const AdReq
 
 void NativeAdInternalIOS::NativeAdDidReceiveAd(GADNativeAd *ad) {
   firebase::MutexLock lock(mutex_);
+  ad.delegate = native_ad_delegate_;
   native_ad_ = ad;
 
   NSObject *gad_icon = ad.icon;


### PR DESCRIPTION
### Description
Bug fix for AdListener support for NativeAd on iOS.

### Testing
N/A

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes

Ad event listener delegate is set on nativeAd object in iOS which is different from android where ad event listener is set on adloader.
