### PR TITLE
Kendal/cxx exception handling

### DIFF
--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -47,7 +47,11 @@ jobs:
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
       - name: Install firebase
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release --target install
-
+      - name: Install firebase (manual)
+        run: |
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/firestore_errors.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/firestore_errors.h"
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/geo_point.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/geo_point.h"
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/timestamp.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/timestamp.h"
       - uses: actions/upload-artifact@v3
         with:
           name: firebase-windows-amd64

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -231,9 +231,26 @@ jobs:
             </files>
           </package>
           "@ | Out-File -Encoding UTF8 firebase.nuspec
-          nuget pack -Properties BUILDROOT=${{ github.workspace }}\BuildRoot\Library\firebase -Suffix (git log -1 --format=%h) firebase.nuspec
+          nuget pack -Properties BUILDROOT=${{ github.workspace }}\BuildRoot\Library\firebase -Suffix (git -C ${{ github.workspace }}/SourceCache/firebase-cpp-sdk log -1 --format=%h) firebase.nuspec
         shell: pwsh
       - uses: actions/upload-artifact@v3
         with:
           name: windows-${{ matrix.arch }}.nupkg
           path: com.google.firebase.windows.${{ matrix.arch }}.*.nupkg
+
+      - name: Publish NuGet Packages
+        env:
+          NUGET_SOURCE_NAME: TheBrowserCompany
+          NUGET_SOURCE_URL: https://nuget.pkg.github.com/thebrowsercompany/index.json
+          NUGET_SOURCE_USERNAME: thebrowsercompany-bot2
+          NUGET_SOURCE_PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          NUGET_API_KEY: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ((nuget sources List | Select-String "${env:NUGET_SOURCE_NAME}").Count -gt 0) {
+            nuget sources Remove -Name "${env:NUGET_SOURCE_NAME}"
+          }
+          nuget sources Add -Name ${env:NUGET_SOURCE_NAME} -Source ${env:NUGET_SOURCE_URL} -Username ${env:NUGET_SOURCE_USERNAME} -Password ${env:NUGET_SOURCE_PASSWORD} -StorePasswordInClearText
+          nuget setApiKey ${env:NUGET_API_KEY} -Source ${env:NUGET_SOURCE_URL}
+          $pkgs = Get-ChildItem -Path com.google.firebase.windows.${{ matrix.arch }}.*.nupkg
+          nuget push $pkgs[0].Name -Source ${env:NUGET_SOURCE_URL} -SkipDuplicate
+        shell: pwsh

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -60,7 +60,6 @@ jobs:
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
                 -D BUILD_SHARED_LIBS=NO `
-                -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
                 -G "Visual Studio 17 2022" `
                 -A ${{ matrix.platform }} `
@@ -73,6 +72,7 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
       - name: Build firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -20,6 +20,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 1
+          path: ${{ github.workspace }}/SourceCache/flatbuffers
+          ref: master
+          repository: google/flatbuffers
+
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
           ref: refs/heads/compnerd/swift
           repository: thebrowsercompany/firebase-cpp-sdk
@@ -39,6 +46,16 @@ jobs:
       - name: Install absl-py
         run: pip install absl-py
 
+      - name: Configure flatbuffers
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/flatbuffers `
+                -D CMAKE_BUILD_TYPE=Release `
+                -G "Visual Studio 17 2022" `
+                -A x64 `
+                -S ${{ github.workspace }}/SourceCache/flatbuffers
+      - name: Build flatc
+        run: cmake --build ${{ github.workspace }}/BinaryCache/flatbuffers --config Release --target flatc
+
       - name: Configure firebase
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
@@ -56,7 +73,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }}
+                -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
+                -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
       - name: Build firebase
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
       - name: Install firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -160,6 +160,7 @@ jobs:
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_auth.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_firestore.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_rest_lib.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_util.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_core.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_nanopb.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_protos_nanopb.lib" target="lib" />

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -60,6 +60,7 @@ jobs:
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
                 -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
                 -G "Visual Studio 17 2022" `
                 -A ${{ matrix.platform }} `

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -55,7 +55,7 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
-                -D Python3_EXECUTABLE=${{ steps.python.outputs.python-path }}
+                -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }}
       - name: Build firebase
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
       - name: Install firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -7,6 +7,15 @@ jobs:
   windows:
     runs-on: windows-latest
 
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: 'amd64'
+            platform: 'x64'
+          - arch: 'arm64'
+            platform: 'ARM64'
+
     steps:
       - uses: actions/checkout@v3
         with:
@@ -18,8 +27,8 @@ jobs:
       - uses: compnerd/gha-setup-vsdevenv@main
         with:
           host_arch: amd64
-          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
-          arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64;Microsoft.VisualStudio.Component.VC.Tools.ARM64'
+          arch: ${{ matrix.arch }}
 
       - uses: actions/setup-python@v4
         with:
@@ -36,7 +45,7 @@ jobs:
                 -D CMAKE_BUILD_TYPE=Release `
                 -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
                 -G "Visual Studio 17 2022" `
-                -A x64 `
+                -A ${{ matrix.platform }} `
                 -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
                 -D FIREBASE_CPP_BUILD_PACKAGE=YES `
                 -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
@@ -53,18 +62,15 @@ jobs:
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/geo_point.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/geo_point.h"
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/timestamp.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/timestamp.h"
 
-          Write-Host "Copying .lib files into place..."
-          $sourceDirectory = "${{ github.workspace }}/BinaryCache/firebase"
-          $destinationDirectory = "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows"
-
-          $libFiles = Get-ChildItem -Path $sourceDirectory -File -Recurse -Filter *.lib
-
-          foreach ($file in $libFiles) {
-            $destinationPath = Join-Path -Path $destinationDirectory -ChildPath $file.Name
-            Copy-Item -Path $file.FullName -Destination $destinationPath -Force
-            Write-Host "Copy operation completed for ${destinationPath}"
+          Write-Host "Copying static libraries ..."
+          $source = "${{ github.workspace }}/BinaryCache/firebase"
+          $libraries = Get-ChildItem -Path $source -File -Recurse -Filter *.lib
+          foreach ($library in $libraries) {
+            $destination = Join-Path -Path "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows" -ChildPath $library.Name
+            Copy-Item -Path $library.FullName -Destination $destination -Force
+            Write-Host "... copied ${destination}"
           }
       - uses: actions/upload-artifact@v3
         with:
-          name: firebase-windows-amd64
+          name: firebase-windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/flatbuffers
-          ref: master
+          ref: 99aa1ef21dd9dc3f9d4fb0eb82f4b59d0bb5e4c5
           repository: google/flatbuffers
 
       - uses: actions/checkout@v3

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -160,10 +160,10 @@ jobs:
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_auth.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_firestore.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firebase_rest_lib.lib" target="lib" />
-              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_util.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_core.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_nanopb.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\firestore_protos_nanopb.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firestore_util.lib" target="lib" />
               <!-- dependencies -->
               <file src="`$BUILDROOT`$\usr\libs\windows\absl_bad_optional_access.lib" target="lib" />
               <file src="`$BUILDROOT`$\usr\libs\windows\absl_bad_variant_access.lib" target="lib" />

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -132,6 +132,18 @@ jobs:
           name: firebase-windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/firebase
 
+      - name: Create Release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          Compress-Archive -Path "${{ github.workspace }}/BuildRoot/Library/firebase" -DestinationPath firebase-windows-${{ matrix.arch }}.zip
+          $SHA256 = Get-FileHash -Path firebase-windows-${{ matrix.arch }}.zip -Algorithm SHA256 > firebase-windows-${{ matrix.arch }}.zip.sha256
+          $Date = Get-Date -Format 'yyyyMMdd'
+          $Release = $(gh release list -R ${{ github.repository }} | Select-String -Pattern $Date -AllMatches).Count
+          gh release create "$Date.$Release" -R ${{ github.repository }}
+          gh release upload "$Date.$Release" firebase-windows-${{ matrix.arch }}.zip -R ${{ github.repository }}
+          gh release upload "$Date.$Release" firebase-windows-${{ matrix.arch }}.zip.sha256 -R ${{ github.repository }}
+
       - name: Package firebase-cpp-sdk
         run: |
           @"

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,9 +76,9 @@ jobs:
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
       - name: Build firebase
-        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config RelWithDebInfo
       - name: Install firebase
-        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release --target install
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config RelWithDebInfo --target install
       - name: Install firebase (manual)
         run: |
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/firestore_errors.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/firestore_errors.h"
@@ -91,6 +91,13 @@ jobs:
           foreach ($library in $libraries) {
             $destination = Join-Path -Path "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows" -ChildPath $library.Name
             Copy-Item -Path $library.FullName -Destination $destination -Force
+            Write-Host "... copied ${destination}"
+          }
+
+          $pdbs = Get-ChildItem -Path $source -File -Recurse -Filter *.pdb
+          foreach ($pdb in $pdbs) {
+            $destination = Join-Path -Path "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows" -ChildPath $pdb.Name
+            Copy-Item -Path $pdb.FullName -Destination $destination -Force
             Write-Host "... copied ${destination}"
           }
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -98,3 +98,142 @@ jobs:
         with:
           name: firebase-windows-${{ matrix.arch }}
           path: ${{ github.workspace }}/BuildRoot/Library/firebase
+
+      - name: Package firebase-cpp-sdk
+        run: |
+          @"
+          <?xml version="1.0" encoding="utf-8"?>
+          <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+            <metadata>
+              <id>com.google.firebase.windows.${{ matrix.arch }}</id>
+              <version>0.0.0.0</version>
+              <title>Firebase C++ SDK</title>
+              <description>C++ Firebase SDK</description>
+              <authors>Google, Inc.</authors>
+              <projectUrl>https://firebase.google.com</projectUrl>
+              <repository type="git" url="https://github.com/google/firebase-cpp-sdk" branch="main" />
+            </metadata>
+            <files>
+              <file src="`$BUILDROOT`$\usr\include\firebase\app.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\auth.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\future.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\log.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\util.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\variant.h" target="include/firebase" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\auth\credential.h" target="include/firebase/auth" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\auth\types.h" target="include/firebase/auth" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\auth\user.h" target="include/firebase/auth" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\aggregate_query.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\aggregate_query_snapshot.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\aggregate_source.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\collection_reference.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\document_change.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\document_reference.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\document_snapshot.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\field_path.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\field_value.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\firestore_errors.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\geo_point.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\listener_registration.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\load_bundle_task_progress.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\map_field_value.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\metadata_changes.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\query.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\query_snapshot.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\settings.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\set_options.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\snapshot_metadata.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\source.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\timestamp.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\transaction.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\transaction_options.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\firestore\write_batch.h" target="include/firebase/firestore" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\common.h" target="include/firebase/internal" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\future_impl.h" target="include/firebase/internal" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\mutex.h" target="include/firebase/include/internal" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\platform.h" target="include/firebase/internal" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\type_traits.h" target="include/firebase/internal" />
+              <!-- FIXME(compnerd) is this header actually required? -->
+              <file src="`$BUILDROOT`$\usr\include\google_play_services\availability.h" target="include/google_play_services" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_app.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_auth.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_firestore.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firebase_rest_lib.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firestore_core.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firestore_nanopb.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\firestore_protos_nanopb.lib" target="lib" />
+              <!-- dependencies -->
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_bad_optional_access.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_bad_variant_access.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_base.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_city.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_civil_time.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_cord.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_cord_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_cordz_functions.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_cordz_handle.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_cordz_info.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_debugging_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_demangle_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_exponential_biased.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_graphcycles_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_hash.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_hashtablez_sampler.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_int128.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_log_severity.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_low_level_hash.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_malloc_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_distributions.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_seed_material.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_platform.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_pool_urbg.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_randen.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_randen_hwaes.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_randen_hwaes_impl.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_internal_randen_slow.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_seed_gen_exception.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_random_seed_sequences.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_raw_hash_set.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_raw_logging_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_spinlock_wait.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_stacktrace.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_status.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_statusor.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_str_format_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_strerror.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_strings.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_strings_internal.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_symbolize.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_synchronization.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_throw_delegate.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_time.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\absl_time_zone.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\address_sorting.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\cares.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\crypto.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\fipsmodule.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\flatbuffers.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\gpr.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\grpc.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\grpc++.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\leveldb.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\libcurl.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\libprotobuf.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\libuWS.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\protobuf-nanopb.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\re2.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\snappy.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\ssl.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\upb.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\uv_a.lib" target="lib" />
+              <file src="`$BUILDROOT`$\usr\libs\windows\zlibstatic.lib" target="lib" />
+            </files>
+          </package>
+          "@ | Out-File -Encoding UTF8 firebase.nuspec
+          nuget pack -Properties BUILDROOT=${{ github.workspace }}\BuildRoot\Library\firebase -Suffix (git log -1 --format=%h) firebase.nuspec
+        shell: pwsh
+      - uses: actions/upload-artifact@v3
+        with:
+          name: windows-${{ matrix.arch }}.nupkg
+          path: com.google.firebase.windows.${{ matrix.arch }}.*.nupkg

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -151,7 +151,7 @@ jobs:
               <file src="`$BUILDROOT`$\usr\include\firebase\firestore\write_batch.h" target="include/firebase/firestore" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\common.h" target="include/firebase/internal" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\future_impl.h" target="include/firebase/internal" />
-              <file src="`$BUILDROOT`$\usr\include\firebase\internal\mutex.h" target="include/firebase/include/internal" />
+              <file src="`$BUILDROOT`$\usr\include\firebase\internal\mutex.h" target="include/firebase/internal" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\platform.h" target="include/firebase/internal" />
               <file src="`$BUILDROOT`$\usr\include\firebase\internal\type_traits.h" target="include/firebase/internal" />
               <!-- FIXME(compnerd) is this header actually required? -->

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -31,6 +31,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - uses: actions/setup-python@v4
+        id: python
         with:
           python-version: 3.9
           architecture: 'x64'
@@ -53,7 +54,8 @@ jobs:
                 -D FIREBASE_INCLUDE_AUTH=YES `
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
-                -D MSVC_RUNTIME_LIBRARY_STATIC=NO
+                -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D Python3_EXECUTABLE=${{ steps.python.outputs.python-path }}
       - name: Build firebase
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
       - name: Install firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -13,7 +13,7 @@ jobs:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
           ref: refs/heads/compnerd/swift
-          repository: firebase/firebase-cpp-sdk
+          repository: thebrowsercompany/firebase-cpp-sdk
 
       - uses: compnerd/gha-setup-vsdevenv@main
         with:

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -52,9 +52,18 @@ jobs:
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/firestore_errors.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/firestore_errors.h"
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/geo_point.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/geo_point.h"
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/timestamp.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/timestamp.h"
-          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_nanopb.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_nanopb.lib"
-          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_util.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_util.lib"
-          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_core.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_core.lib"
+
+          Write-Host "Copying .lib files into place..."
+          $sourceDirectory = "${{ github.workspace }}/BinaryCache/firebase"
+          $destinationDirectory = "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows"
+
+          $libFiles = Get-ChildItem -Path $sourceDirectory -File -Recurse -Filter *.lib
+
+          foreach ($file in $libFiles) {
+            $destinationPath = Join-Path -Path $destinationDirectory -ChildPath $file.Name
+            Copy-Item -Path $file.FullName -Destination $destinationPath -Force
+            Write-Host "Copy operation completed for ${destinationPath}"
+          }
       - uses: actions/upload-artifact@v3
         with:
           name: firebase-windows-amd64

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -48,10 +48,12 @@ jobs:
                 -A ${{ matrix.platform }} `
                 -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
                 -D FIREBASE_CPP_BUILD_PACKAGE=YES `
+                -D FIREBASE_GITHUB_ACTION_BUILD=YES `
                 -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
                 -D FIREBASE_INCLUDE_AUTH=YES `
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
-                -D FIREBASE_USE_BORINGSSL=YES
+                -D FIREBASE_USE_BORINGSSL=YES `
+                -D MSVC_RUNTIME_LIBRARY_STATIC=NO
       - name: Build firebase
         run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
       - name: Install firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -12,7 +12,7 @@ jobs:
         with:
           fetch-depth: 1
           path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
-          ref: refs/heads/main
+          ref: refs/heads/compnerd/swift
           repository: firebase/firebase-cpp-sdk
 
       - uses: compnerd/gha-setup-vsdevenv@main

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -93,13 +93,6 @@ jobs:
             Copy-Item -Path $library.FullName -Destination $destination -Force
             Write-Host "... copied ${destination}"
           }
-
-          $pdbs = Get-ChildItem -Path $source -File -Recurse -Filter *.pdb
-          foreach ($pdb in $pdbs) {
-            $destination = Join-Path -Path "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows" -ChildPath $pdb.Name
-            Copy-Item -Path $pdb.FullName -Destination $destination -Force
-            Write-Host "... copied ${destination}"
-          }
       - uses: actions/upload-artifact@v3
         with:
           name: firebase-windows-${{ matrix.arch }}

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -1,0 +1,54 @@
+name: firebase
+
+on:
+  workflow_dispatch:
+
+jobs:
+  windows:
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 1
+          path: ${{ github.workspace }}/SourceCache/firebase-cpp-sdk
+          ref: refs/heads/main
+          repository: firebase/firebase-cpp-sdk
+
+      - uses: compnerd/gha-setup-vsdevenv@main
+        with:
+          host_arch: amd64
+          components: 'Microsoft.VisualStudio.Component.VC.Tools.x86.x64'
+          arch: amd64
+
+      - uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+          architecture: 'x64'
+
+      - name: Install absl-py
+        run: pip install absl-py
+
+      - name: Configure firebase
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/firebase `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
+                -G "Visual Studio 17 2022" `
+                -A x64 `
+                -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
+                -D FIREBASE_CPP_BUILD_PACKAGE=YES `
+                -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
+                -D FIREBASE_INCLUDE_AUTH=YES `
+                -D FIREBASE_INCLUDE_FIRESTORE=YES `
+                -D FIREBASE_USE_BORINGSSL=YES
+      - name: Build firebase
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release
+      - name: Install firebase
+        run: cmake --build ${{ github.workspace }}/BinaryCache/firebase --config Release --target install
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: firebase-windows-amd64
+          path: ${{ github.workspace }}/BuildRoot/Library/firebase

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -56,7 +56,40 @@ jobs:
       - name: Build flatc
         run: cmake --build ${{ github.workspace }}/BinaryCache/flatbuffers --config Release --target flatc
 
+      - name: Adjust cmake build settings for debugging
+        run: powershell ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/build_scripts/windows/fix_cmake_debugflags.ps1 ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/CMakeLists.txt
+
       - name: Configure firebase
+        run:
+          cmake -B ${{ github.workspace }}/BinaryCache/firebase `
+                -D BUILD_SHARED_LIBS=NO `
+                -D CMAKE_BUILD_TYPE=Release `
+                -D CMAKE_INSTALL_PREFIX=${{ github.workspace }}/BuildRoot/Library/firebase/usr `
+                -G "Visual Studio 17 2022" `
+                -A ${{ matrix.platform }} `
+                -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
+                -D FLATBUFFERS_BUILD_FLATC=NO `
+                -D FIREBASE_CPP_BUILD_PACKAGE=YES `
+                -D FIREBASE_GITHUB_ACTION_BUILD=YES `
+                -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `
+                -D FIREBASE_INCLUDE_AUTH=YES `
+                -D FIREBASE_INCLUDE_FIRESTORE=YES `
+                -D FIREBASE_USE_BORINGSSL=YES `
+                -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
+                -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
+                -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe
+
+      - name: Adjust external project build settings for debugging
+        run: |
+          $names = Get-ChildItem -Path "${{ github.workspace }}/BinaryCache/firebase" -File -Recurse -Filter CMakeLists.txt
+          foreach ($name in $names) {
+            $fullName = $name.FullName
+            powershell ${{ github.workspace }}/SourceCache/firebase-cpp-sdk/build_scripts/windows/fix_cmake_debugflags.ps1 $fullName
+            Write-Host "... fixed up debug options for ${fullName}"
+          }
+
+      - name: Configure firebase after build setting adjustments
         run:
           cmake -B ${{ github.workspace }}/BinaryCache/firebase `
                 -D BUILD_SHARED_LIBS=NO `

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -48,6 +48,7 @@ jobs:
                 -G "Visual Studio 17 2022" `
                 -A ${{ matrix.platform }} `
                 -S ${{ github.workspace }}/SourceCache/firebase-cpp-sdk `
+                -D FLATBUFFERS_BUILD_FLATC=NO `
                 -D FIREBASE_CPP_BUILD_PACKAGE=YES `
                 -D FIREBASE_GITHUB_ACTION_BUILD=YES `
                 -D FIREBASE_INCLUDE_LIBRARY_DEFAULT=OFF `

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -52,6 +52,9 @@ jobs:
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/firestore_errors.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/firestore_errors.h"
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/geo_point.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/geo_point.h"
           Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore/Firestore/core/include/firebase/firestore/timestamp.h" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/include/firebase/firestore/timestamp.h"
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_nanopb.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_nanopb.lib"
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_util.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_util.lib"
+          Copy-Item "${{ github.workspace }}/BinaryCache/firebase/external/src/firestore-build/Firestore/core/Release/firestore_core.lib" "${{ github.workspace }}/BuildRoot/Library/firebase/usr/libs/windows/firestore_core.lib"
       - uses: actions/upload-artifact@v3
         with:
           name: firebase-windows-amd64

--- a/.github/workflows/bcny-firebase.yml
+++ b/.github/workflows/bcny-firebase.yml
@@ -76,6 +76,8 @@ jobs:
                 -D FIREBASE_INCLUDE_FIRESTORE=YES `
                 -D FIREBASE_USE_BORINGSSL=YES `
                 -D MSVC_RUNTIME_LIBRARY_STATIC=NO `
+                -D CMAKE_C_FLAGS="/EHsc" `
+                -D CMAKE_CXX_FLAGS="/EHsc" `
                 -D CMAKE_MSVC_DEBUG_INFORMATION_FORMAT=Embedded `
                 -D FIREBASE_PYTHON_HOST_EXECUTABLE:FILEPATH=${{ steps.python.outputs.python-path }} `
                 -D FLATBUFFERS_FLATC_EXECUTABLE=${{ github.workspace }}/BinaryCache/flatbuffers/Release/flatc.exe

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@
 
 # Top level CMake file that defines the entire Firebase C++ SDK build.
 
+if(POLICY CMP0141)
+  cmake_policy(SET CMP0141 NEW)
+endif()
+
 cmake_minimum_required (VERSION 3.1)
 
 set (CMAKE_CXX_STANDARD 14)

--- a/app/src/include/firebase/future.h
+++ b/app/src/include/firebase/future.h
@@ -407,6 +407,11 @@ class Future : public FutureBase {
   /// when you set up the callback.
   typedef void (*TypedCompletionCallback)(const Future<ResultType>& result_data,
                                           void* user_data);
+#if defined(__swift__)
+  // TODO(apple/swift#67662) indirect block parameters are unsupported
+  typedef void (*TypedCompletionCallback_SwiftWorkaround)(
+      const Future<ResultType>* result_data, void* user_data);
+#endif
 
   /// Construct a future.
   Future() {}
@@ -463,6 +468,16 @@ class Future : public FutureBase {
   /// registered one will run.
   inline void OnCompletion(TypedCompletionCallback callback,
                            void* user_data) const;
+
+#if defined(__swift__)
+  // TODO(apple/swift#67662) indirect block parameters are unsupported
+  inline void OnCompletion_SwiftWorkaround(
+      TypedCompletionCallback_SwiftWorkaround callback, void* user_data) const {
+    OnCompletion([callback, user_data](const Future<ResultType>& future) {
+      callback(&future, user_data);
+    });
+  }
+#endif
 
 #if defined(FIREBASE_USE_STD_FUNCTION) || defined(DOXYGEN)
   /// Register a single callback that will be called at most once, when the

--- a/auth/CMakeLists.txt
+++ b/auth/CMakeLists.txt
@@ -51,6 +51,7 @@ build_flatbuffers("${flatbuffer_schemas}"
 # Common source files used by all platforms
 set(common_SRCS
     src/auth.cc
+    src/auth_swift.cc
     src/credential.cc
     src/common.cc
     src/common.h

--- a/auth/src/auth_swift.cc
+++ b/auth/src/auth_swift.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2023 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define __swift__ 50000
+#include "auth/src/include/firebase/auth.h"
+
+#if FIREBASE_PLATFORM_WINDOWS
+namespace firebase {
+namespace auth {
+Auth::Auth(const Auth &) noexcept = default;
+}
+}  // namespace firebase
+#endif

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -148,6 +148,13 @@ class Auth {
 
   ~Auth();
 
+#if defined(__swift__)
+#if FIREBASE_PLATFORM_WINDOWS
+  // TODO(apple/swift#67288) support trivial C++ types with non-trivial dtors
+  Auth(const Auth&) noexcept;
+#endif
+#endif
+
   /// Synchronously gets the cached current user, or returns an object where
   /// is_valid() == false if there is none.
   ///

--- a/build_scripts/windows/fix_cmake_debugflags.ps1
+++ b/build_scripts/windows/fix_cmake_debugflags.ps1
@@ -1,0 +1,33 @@
+# Path to the CMakeLists.txt file
+$filePath = $args[0]
+
+# Lines to add after the line starting with "cmake_minimum_required"
+$newLines = @(
+    'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")',
+    'string(REPLACE "/Zi" "/Z7" CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO}")'
+)
+
+# Read the content of the file
+$content = Get-Content -Path $filePath
+
+# New content holder
+$newContent = @()
+
+# Flag to check if lines are added
+$linesAdded = $false
+
+foreach ($line in $content) {
+    # Add the current line to new content
+    $newContent += $line
+
+    # Check if the line starts with "cmake_minimum_required" and add new lines after it
+    if ($line -match '^cmake_minimum_required' -and -not $linesAdded) {
+        $newContent += $newLines
+        $linesAdded = $true
+    }
+}
+
+# Write the new content back to the file
+$newContent | Set-Content -Path $filePath

--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -235,6 +235,10 @@ function(build_external_dependencies)
   # Propagate the PIC setting, as the dependencies need to match it
   set(CMAKE_SUB_CONFIGURE_OPTIONS ${CMAKE_SUB_CONFIGURE_OPTIONS}
       -DCMAKE_POSITION_INDEPENDENT_CODE=${CMAKE_POSITION_INDEPENDENT_CODE})
+  if(Python3_EXECUTABLE)
+    set(CMAKE_SUB_CONFIGURE_OPTIONS ${CMAKE_SUB_CONFIGURE_OPTIONS}
+      -DPython3_EXECUTABLE=${Python3_EXECUTABLE})
+  endif()
   message(STATUS "Sub-configure options: ${CMAKE_SUB_CONFIGURE_OPTIONS}")
   message(STATUS "Sub-build options: ${CMAKE_SUB_BUILD_OPTIONS}")
 

--- a/firestore/CMakeLists.txt
+++ b/firestore/CMakeLists.txt
@@ -34,6 +34,7 @@ set(common_SRCS
     src/common/field_path.cc
     src/common/field_value.cc
     src/common/firestore.cc
+    src/common/firestore_swift.cc
     src/common/firestore_exceptions_common.h
     src/common/futures.cc
     src/common/futures.h
@@ -340,7 +341,7 @@ if(IOS)
   set(FIREBASE_FIRESTORE_CORE_HEADER_DIR
     ${FIREBASE_POD_DIR}/Pods/FirebaseFirestore/Firestore/core/include
   )
-  
+
 else()
   # Desktop and Android get their public headers from the CMake build in
   # firebase-ios-sdk.

--- a/firestore/src/common/firestore_swift.cc
+++ b/firestore/src/common/firestore_swift.cc
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2020 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#define __swift__ 50000
+#include "firestore/src/include/firebase/firestore.h"
+
+#if FIREBASE_PLATFORM_WINDOWS
+namespace firebase {
+namespace firstore {
+Firestore::Firestore(const Firestore&) noexcept = default;
+}
+}  // namespace firebase
+#endif

--- a/firestore/src/common/firestore_swift.cc
+++ b/firestore/src/common/firestore_swift.cc
@@ -19,8 +19,8 @@
 
 #if FIREBASE_PLATFORM_WINDOWS
 namespace firebase {
-namespace firstore {
-Firestore::Firestore(const Firestore&) noexcept = default;
+namespace firestore {
+Firestore::Firestore(const Firestore &) noexcept = default;
 }
 }  // namespace firebase
 #endif

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -194,7 +194,14 @@ class Firestore {
    * Deleted copy constructor; Firestore must be created with
    * Firestore::GetInstance().
    */
+#if defined(__swift__)
+#if FIREBASE_PLATFORM_WINDOWS
+  Firestore(const Firestore& src) noexcept;
+#else
   Firestore(const Firestore& src) = delete;
+#else
+  Firestore(const Firestore& src) = delete;
+#endif
 
   /**
    * Deleted copy assignment operator; Firestore must be created with

--- a/firestore/src/include/firebase/firestore.h
+++ b/firestore/src/include/firebase/firestore.h
@@ -199,6 +199,7 @@ class Firestore {
   Firestore(const Firestore& src) noexcept;
 #else
   Firestore(const Firestore& src) = delete;
+#endif
 #else
   Firestore(const Firestore& src) = delete;
 #endif

--- a/firestore/src/include/firebase/firestore/map_field_value.h
+++ b/firestore/src/include/firebase/firestore/map_field_value.h
@@ -31,6 +31,15 @@ using MapFieldValue = std::unordered_map<std::string, FieldValue>;
 /** @brief A map of `FieldValue`s indexed by field paths. */
 using MapFieldPathValue = std::unordered_map<FieldPath, FieldValue>;
 
+#if defined(__swift__)
+// Reference the following types so that they are included in the CXX
+// module. A workaround for deserialization cross reference compiler
+// crashes https://github.com/apple/swift/issues/70253
+using FieldValueVector = std::vector<FieldValue>;
+using FieldValueVectorConstIterator = std::_Vector_const_iterator<std::_Vector_val<std::_Simple_types<FieldValue>>>;
+using StringVectorConstIterator = std::vector<std::string>::const_iterator;
+#endif
+
 }  // namespace firestore
 }  // namespace firebase
 

--- a/scripts/git/patches/boringssl/0001-disable-warnings.patch
+++ b/scripts/git/patches/boringssl/0001-disable-warnings.patch
@@ -1,6 +1,6 @@
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -197,6 +197,11 @@ elseif(MSVC)
+@@ -197,6 +197,14 @@ elseif(MSVC)
                # possible loss of data
        "C4244" # 'function' : conversion from 'int' to 'uint8_t',
                # possible loss of data

--- a/scripts/git/patches/boringssl/0001-disable-warnings.patch
+++ b/scripts/git/patches/boringssl/0001-disable-warnings.patch
@@ -9,6 +9,9 @@
 +      "C4191" # 'operator/operation' : unsafe conversion from 'type of
 +              # expression' to 'type required'
 +      "C5264" # 'const' variable is not used
++      "C4746" # volatile access of 'label' is subject to /volatile:<iso|ms>
++              # setting; consider using __iso_volatile_load/store intrinsic
++              # functions
        "C4267" # conversion from 'size_t' to 'int', possible loss of data
        "C4371" # layout of class may have changed from a previous version of the
                # compiler due to better packing of member '...'


### PR DESCRIPTION
### Description

This should fix an error in the windows CI builds:

```
C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vector(1041,13): error C2220: the following warning is treated as an error [D:\a\firebase-cpp-sdk\firebase-cpp-sdk\BinaryCache\firebase\external\src\flatbuffers-build\flatbuffers.vcxproj]
2024-03-29T16:16:17.4249396Z   (compiling source file '../flatbuffers/src/reflection.cpp')
2024-03-29T16:16:17.4250101Z   
2024-03-29T16:16:17.4252975Z C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Tools\MSVC\14.38.33130\include\vector(1041,13): warning C4530: C++ exception handler used, but unwind semantics are not enabled. Specify /EHsc [D:\a\firebase-cpp-sdk\firebase-cpp-sdk\BinaryCache\firebase\external\src\flatbuffers-build\flatbuffers.vcxproj]
```