### PR TITLE
Hide some private friend functions from swig

### DIFF
--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -669,10 +669,12 @@ class Auth {
   friend class UserDesktopTest;
   friend class AuthDesktopTest;
 
+#ifndef SWIG
   friend void EnableTokenAutoRefresh(AuthData* authData);
   friend void DisableTokenAutoRefresh(AuthData* authData);
   friend void ResetTokenRefreshCounter(AuthData* authData);
   friend void LogHeartbeat(Auth* auth);
+#endif  // not SWIG
   /// @endcond
 
   // Find Auth instance using App.  Return null if the instance does not exist.

--- a/database/src/include/firebase/database.h
+++ b/database/src/include/firebase/database.h
@@ -181,8 +181,10 @@ class Database {
   LogLevel log_level() const;
 
  private:
+#ifndef SWIG
   friend Database* GetDatabaseInstance(::firebase::App* app, const char* url,
                                        InitResult* init_result_out);
+#endif  // not SWIG
   Database(::firebase::App* app, internal::DatabaseInternal* internal);
   Database(const Database& src);
   Database& operator=(const Database& src);

--- a/database/src/include/firebase/database/mutable_data.h
+++ b/database/src/include/firebase/database/mutable_data.h
@@ -148,7 +148,9 @@ class MutableData {
   friend class internal::DatabaseInternal;
   friend class internal::MutableDataInternal;
   friend class internal::Repo;
+#ifndef SWIG
   friend MutableData GetInvalidMutableData();
+#endif  // not SWIG
   /// @endcond
 
   explicit MutableData(internal::MutableDataInternal* internal);

--- a/firestore/src/include/firebase/firestore/aggregate_query_snapshot.h
+++ b/firestore/src/include/firebase/firestore/aggregate_query_snapshot.h
@@ -126,8 +126,10 @@ class AggregateQuerySnapshot {
 
   friend bool operator==(const AggregateQuerySnapshot& lhs,
                          const AggregateQuerySnapshot& rhs);
+#ifndef SWIG
   friend std::size_t AggregateQuerySnapshotHash(
       const AggregateQuerySnapshot& snapshot);
+#endif  // not SWIG
   friend struct ConverterImpl;
   friend class AggregateQuerySnapshotTest;
 

--- a/firestore/src/include/firebase/firestore/document_change.h
+++ b/firestore/src/include/firebase/firestore/document_change.h
@@ -176,7 +176,9 @@ class DocumentChange {
   std::size_t Hash() const;
 
   friend bool operator==(const DocumentChange& lhs, const DocumentChange& rhs);
+#ifndef SWIG
   friend std::size_t DocumentChangeHash(const DocumentChange& change);
+#endif  // not SWIG
 
   friend class FirestoreInternal;
   friend class Wrapper;

--- a/firestore/src/include/firebase/firestore/document_snapshot.h
+++ b/firestore/src/include/firebase/firestore/document_snapshot.h
@@ -265,7 +265,9 @@ class DocumentSnapshot {
 
   friend bool operator==(const DocumentSnapshot& lhs,
                          const DocumentSnapshot& rhs);
+#ifndef SWIG
   friend std::size_t DocumentSnapshotHash(const DocumentSnapshot& snapshot);
+#endif  // not SWIG
 
   friend class DocumentChangeInternal;
   friend class EventListenerInternal;

--- a/firestore/src/include/firebase/firestore/query.h
+++ b/firestore/src/include/firebase/firestore/query.h
@@ -678,7 +678,9 @@ class Query {
   size_t Hash() const;
 
   friend bool operator==(const Query& lhs, const Query& rhs);
+#ifndef SWIG
   friend size_t QueryHash(const Query& query);
+#endif  // not SWIG
 
   friend class FirestoreInternal;
   friend class QueryInternal;

--- a/firestore/src/include/firebase/firestore/query_snapshot.h
+++ b/firestore/src/include/firebase/firestore/query_snapshot.h
@@ -167,7 +167,9 @@ class QuerySnapshot {
   std::size_t Hash() const;
 
   friend bool operator==(const QuerySnapshot& lhs, const QuerySnapshot& rhs);
+#ifndef SWIG
   friend std::size_t QuerySnapshotHash(const QuerySnapshot& snapshot);
+#endif  // not SWIG
 
   friend class EventListenerInternal;
   friend class FirestoreInternal;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Hide some private friend methods from swig, since it is trying to generate C# based on them, when it shouldn't be.  This is because a new version of SWIG came out that does this.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

https://github.com/firebase/firebase-unity-sdk/actions/runs/8563655507
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
