### PR TITLE
Fix Storage usage of invalid pointers.

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -633,8 +633,8 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
-    - Storage (iOS): Fix invalid pointer in `GetFile()` when running in a
-      secondary thread
+    - Storage (iOS): Fix invalid pointer in `StorageReference::GetFile()` when
+      running in a secondary thread
       ([#1570](https://github.com/firebase/firebase-cpp-sdk/issues/1570)).
 
 ### 11.10.0

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -634,7 +634,8 @@ code.
 ### Upcoming Release
 -   Changes
     - Storage (iOS): Fix invalid pointer in `GetFile()` when running in a
-      secondary thread.
+      secondary thread
+      ([#1570](https://github.com/firebase/firebase-cpp-sdk/issues/1570)).
 
 ### 11.10.0
 -   Changes

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -631,6 +631,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    - Storage (iOS): Fix invalid pointer in `GetFile()` when running in a
+      secondary thread.
+
 ### 11.10.0
 -   Changes
     - General (Android): Update to Firebase Android BoM version 32.8.1.

--- a/storage/src/ios/storage_reference_ios.mm
+++ b/storage/src/ios/storage_reference_ios.mm
@@ -142,11 +142,12 @@ Future<size_t> StorageReferenceInternal::GetFile(const char* path, Listener* lis
   // Cache a copy of the impl and storage, in case this is destroyed before the thread runs.
   FIRStorageReference* my_impl = impl();
   StorageInternal* storage = storage_;
+  NSURL* local_file_url = [NSURL URLWithString:@(path)];
   util::DispatchAsyncSafeMainQueue(^() {
       FIRStorageDownloadTask *download_task;
       {
         MutexLock mutex(controller_init_mutex_);
-        download_task = [my_impl writeToFile:[NSURL URLWithString:@(path)] completion:completion];
+        download_task = [my_impl writeToFile:local_file_url completion:completion];
         local_controller->AssignTask(storage, download_task);
       }
       if (listener) {


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

As reported in #1570, if `StorageReference::GetFile()` is called from a non-UI thread, the `const char* path` passed in is not preserved and could have been deleted by the calling code once the `FIRStorage` native call occurs in the main thread later.

Fix this by creating the URL from the local file path outside outside of the thread dispatch block. (Similar to what `PutFile()` already does.)

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Integration tests in this PR.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
