### PR TITLE
Fix iOS simulator device to use the one that's available

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -223,7 +223,7 @@ TEST_DEVICES = {
   ],
   "simulator_min": [ {"type": "virtual", "name":"iPhone SE (3rd generation)", "version":"17.0.1"} ],
   "simulator_target": [ {"type": "virtual", "name":"iPhone 15", "version":"17.2"} ],
-  "simulator_latest": [ {"type": "virtual", "name":"iPad Pro (12.9-inch) (6th generation)", "version":"17.4"} ],
+  "simulator_latest": [ {"type": "virtual", "name":"iPad (10th generation)", "version":"17.4"} ],
   "tvos_simulator": [ {"type": "virtual", "name":"Apple TV", "version":"16.1"} ],
 }
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -223,7 +223,7 @@ TEST_DEVICES = {
   ],
   "simulator_min": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.0.1"} ],
   "simulator_target": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.2"} ],
-  "simulator_latest": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.4"} ],
+  "simulator_latest": [ {"type": "virtual", "name":"iPhone 15 Plus", "version":"17.4"} ],
   "tvos_simulator": [ {"type": "virtual", "name":"Apple TV", "version":"16.1"} ],
 }
 

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -221,9 +221,9 @@ TEST_DEVICES = {
       {"type": "ftl", "device": "model=iphone8,version=16.6"},
       {"type": "ftl", "device": "model=ipad10,version=16.6"},
   ],
-  "simulator_min": [ {"type": "virtual", "name":"iPhone SE (3rd generation)", "version":"17.0.1"} ],
-  "simulator_target": [ {"type": "virtual", "name":"iPhone 15", "version":"17.2"} ],
-  "simulator_latest": [ {"type": "virtual", "name":"iPad (10th generation)", "version":"17.4"} ],
+  "simulator_min": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.0.1"} ],
+  "simulator_target": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.2"} ],
+  "simulator_latest": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.4"} ],
   "tvos_simulator": [ {"type": "virtual", "name":"Apple TV", "version":"16.1"} ],
 }
 


### PR DESCRIPTION
Runners only have 17.4 on the the 10th-gen iPad by default.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
