### PR TITLE
Add null checks in Messaging task completions

### DIFF
--- a/messaging/src/android/cpp/messaging.cc
+++ b/messaging/src/android/cpp/messaging.cc
@@ -826,8 +826,12 @@ static void CompleteVoidCallback(JNIEnv* env, jobject result,
   FutureHandle handle(future_id);
   Error error =
       (result_code == util::kFutureResultSuccess) ? kErrorNone : kErrorUnknown;
-  ReferenceCountedFutureImpl* api = FutureData::Get()->api();
-  api->Complete(handle, error, status_message);
+  if (FutureData::Get() && FutureData::Get()->api()) {
+    ReferenceCountedFutureImpl* api = FutureData::Get()->api();
+    api->Complete(handle, error, status_message);
+  } else {
+    LogWarning("Failed to complete Future as it was likely already deleted.");
+  }
   if (result) env->DeleteLocalRef(result);
 }
 
@@ -843,8 +847,12 @@ static void CompleteStringCallback(JNIEnv* env, jobject result,
   SafeFutureHandle<std::string>* handle =
       reinterpret_cast<SafeFutureHandle<std::string>*>(callback_data);
   Error error = success ? kErrorNone : kErrorUnknown;
-  ReferenceCountedFutureImpl* api = FutureData::Get()->api();
-  api->CompleteWithResult(*handle, error, status_message, result_value);
+  if (FutureData::Get() && FutureData::Get()->api()) {
+    ReferenceCountedFutureImpl* api = FutureData::Get()->api();
+    api->CompleteWithResult(*handle, error, status_message, result_value);
+  } else {
+    LogWarning("Failed to complete Future as it was likely already deleted.");
+  }
   delete handle;
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Add some null checks in the Android Task completion callbacks that finish Futures.  Based on the callstack from https://github.com/firebase/firebase-unity-sdk/issues/1030, my guess is while there is a pending Android task, Messaging is getting cleaned up, and then when the Android task completes it does the callback, but the Future has been deleted.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
