### PR TITLE
Reduce the Windows packaging task size by deleting the .tgz and not building tests.

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -541,6 +541,7 @@ jobs:
           if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
             verbose_flag=-v
           fi
+	  du -skch || true
           declare -a additional_flags
           tar -xvzf artifacts/packaging-tools-${tools_platform}/packaging-tools.tgz -C bin
           chmod -R u+x bin
@@ -567,6 +568,7 @@ jobs:
               # Windows x86: force input and output target format
               additional_flags+=(-f pe-i386,pe-bigobj-i386)
             fi
+            du -skch || true
             sdk-src/build_scripts/desktop/package.sh -D -b ${pkg} -o firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package -p ${{ matrix.sdk_platform }} -t bin -d ${variant} -P python3 -j ${additional_flags[*]}
           done
           if [[ "${{ matrix.sdk_platform }}" == "darwin" ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -541,8 +541,6 @@ jobs:
           if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
             verbose_flag=-v
           fi
-          du -skch || true
-          df -h || true
           declare -a additional_flags
           tar -xvzf artifacts/packaging-tools-${tools_platform}/packaging-tools.tgz -C bin
           rm -rf artifacts/packaging-tools-*.tgz
@@ -554,8 +552,6 @@ jobs:
               rm  -rf "${pkg}"
             fi
           done
-          du -skch || true
-          df -h || true
           for pkg in artifacts/firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}*-build/*.tgz; do
             # determine the build variant based on the artifact filename
             variant=$(sdk-src/build_scripts/desktop/get_variant.sh "${pkg}")
@@ -572,8 +568,6 @@ jobs:
               # Windows x86: force input and output target format
               additional_flags+=(-f pe-i386,pe-bigobj-i386)
             fi
-            du -skch || true
-            df -h || true
             sdk-src/build_scripts/desktop/package.sh -D -b ${pkg} -o firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package -p ${{ matrix.sdk_platform }} -t bin -d ${variant} -P python3 -j ${additional_flags[*]}
           done
           if [[ "${{ matrix.sdk_platform }}" == "darwin" ]]; then

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -567,7 +567,7 @@ jobs:
               # Windows x86: force input and output target format
               additional_flags+=(-f pe-i386,pe-bigobj-i386)
             fi
-            sdk-src/build_scripts/desktop/package.sh -b ${pkg} -o firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package -p ${{ matrix.sdk_platform }} -t bin -d ${variant} -P python3 -j ${additional_flags[*]}
+            sdk-src/build_scripts/desktop/package.sh -D -b ${pkg} -o firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package -p ${{ matrix.sdk_platform }} -t bin -d ${variant} -P python3 -j ${additional_flags[*]}
           done
           if [[ "${{ matrix.sdk_platform }}" == "darwin" ]]; then
             # Darwin has a final step after all the variants are done,

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -314,12 +314,12 @@ jobs:
         include:
         - os: windows-latest
           vcpkg_triplet_suffix: "windows-static"
-          additional_build_flags: "--build_tests"
+          #additional_build_flags: "--build_tests"
           sdk_platform: "windows"
         - os: windows-latest
           msvc_runtime: "dynamic"
           vcpkg_triplet_suffix: "windows-static-md"
-          additional_build_flags: "--build_tests"
+          #additional_build_flags: "--build_tests"
           sdk_platform: "windows"
         - os: ubuntu-20.04
           vcpkg_triplet_suffix: "linux"

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -541,7 +541,7 @@ jobs:
           if [[ -n "${{ github.event.inputs.verboseBuild }}" && "${{ github.event.inputs.verboseBuild }}" -ne 0 ]]; then
             verbose_flag=-v
           fi
-	  du -skch || true
+          du -skch || true
           declare -a additional_flags
           tar -xvzf artifacts/packaging-tools-${tools_platform}/packaging-tools.tgz -C bin
           chmod -R u+x bin

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -314,12 +314,10 @@ jobs:
         include:
         - os: windows-latest
           vcpkg_triplet_suffix: "windows-static"
-          #additional_build_flags: "--build_tests"
           sdk_platform: "windows"
         - os: windows-latest
           msvc_runtime: "dynamic"
           vcpkg_triplet_suffix: "windows-static-md"
-          #additional_build_flags: "--build_tests"
           sdk_platform: "windows"
         - os: ubuntu-20.04
           vcpkg_triplet_suffix: "linux"

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -542,8 +542,10 @@ jobs:
             verbose_flag=-v
           fi
           du -skch || true
+          df -h || true
           declare -a additional_flags
           tar -xvzf artifacts/packaging-tools-${tools_platform}/packaging-tools.tgz -C bin
+          rm -rf artifacts/packaging-tools-*.tgz
           chmod -R u+x bin
           # To save space, delete any artifacts that we don't need for packaging.
           for pkg in artifacts/firebase-cpp-sdk-*; do
@@ -552,6 +554,8 @@ jobs:
               rm  -rf "${pkg}"
             fi
           done
+          du -skch || true
+          df -h || true
           for pkg in artifacts/firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}*-build/*.tgz; do
             # determine the build variant based on the artifact filename
             variant=$(sdk-src/build_scripts/desktop/get_variant.sh "${pkg}")
@@ -569,6 +573,7 @@ jobs:
               additional_flags+=(-f pe-i386,pe-bigobj-i386)
             fi
             du -skch || true
+            df -h || true
             sdk-src/build_scripts/desktop/package.sh -D -b ${pkg} -o firebase-cpp-sdk-${{ matrix.sdk_platform }}${{ matrix.suffix }}-package -p ${{ matrix.sdk_platform }} -t bin -d ${variant} -P python3 -j ${additional_flags[*]}
           done
           if [[ "${{ matrix.sdk_platform }}" == "darwin" ]]; then

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -204,10 +204,10 @@ else
     ext='a'
 fi
 
-if [[ ${delete_files_after_using} -eq 1 ]]; then
-    # Delete all non-library, non-header files.
-    find "${built_sdk_path}" -not -name "*.${ext}" -and -not -name "*.h" -print0 | xargs -0 rm
-fi
+#if [[ ${delete_files_after_using} -eq 1 ]]; then
+#    # Delete all non-library, non-header files.
+#    find "${built_sdk_path}" -type f -not -name "*.${ext}" -and -not -name "*.h" -print0 | xargs -0 rm
+#fi
 
 # Library dependencies to merge. Each should be a whitespace-delimited list of path globs.
 readonly deps_firebase_app="

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -371,6 +371,9 @@ for product in ${product_list[*]}; do
       --scan_libs=\"${allfiles}\" \\
       --hide_c_symbols=\"${deps_hidden}\" \\
       \"${libfile_src}\" ${deps[*]}" >> "${merge_libraries_tmp}/merge_${product}.sh"
+    if [[ ${delete_files_after_using} -eq 1 ]]; then
+	echo "rm -f ${deps[*]}" >>  "${merge_libraries_tmp}/merge_${product}.sh"
+    fi
     chmod u+x "${merge_libraries_tmp}/merge_${product}.sh"
     if [[ ${run_in_parallel} -eq 0 ]]; then
       # Run immediately if not set to run in parallel.

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -204,11 +204,6 @@ else
     ext='a'
 fi
 
-#if [[ ${delete_files_after_using} -eq 1 ]]; then
-#    # Delete all non-library, non-header files.
-#    find "${built_sdk_path}" -type f -not -name "*.${ext}" -and -not -name "*.h" -print0 | xargs -0 rm
-#fi
-
 # Library dependencies to merge. Each should be a whitespace-delimited list of path globs.
 readonly deps_firebase_app="
 */${prefix}firebase_rest_lib.${ext}

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -162,10 +162,10 @@ if [[ ! -d "${built_sdk_path}" && -f "${built_sdk_path}" ]]; then
     trap "rm -rf \"\${temp_dir}\"" SIGKILL SIGTERM SIGQUIT EXIT
     echo "Uncompressing tarfile into temporary directory..."
     tar -xf "${built_sdk_path}" -C "${temp_dir}"
-    built_sdk_path="${temp_dir}"
     if [[ ${delete_files_after_using} -eq 1 ]]; then
 	rm -f "${built_sdk_path}"
     fi
+    built_sdk_path="${temp_dir}"
 fi
 
 if [[ ! -r "${built_sdk_path}/CMakeCache.txt" ]]; then

--- a/build_scripts/desktop/package.sh
+++ b/build_scripts/desktop/package.sh
@@ -204,6 +204,11 @@ else
     ext='a'
 fi
 
+if [[ ${delete_files_after_using} -eq 1 ]]; then
+    # Delete all non-library, non-header files.
+    find "${built_sdk_path}" -not -name "*.${ext}" -and -not -name "*.h" -print0 | xargs -0 rm
+fi
+
 # Library dependencies to merge. Each should be a whitespace-delimited list of path globs.
 readonly deps_firebase_app="
 */${prefix}firebase_rest_lib.${ext}


### PR DESCRIPTION
Packaging was failing on Windows Debug due to disk space limitations, this PR reduces the space required for packaging.

### Description
> Provide details of the change, and generalize the change in the PR title above.

https://github.com/firebase/firebase-cpp-sdk/actions/runs/9504804792
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
