### PR TITLE
Remove unnecessary cmake quotes

### DIFF
--- a/cmake/external_rules.cmake
+++ b/cmake/external_rules.cmake
@@ -167,7 +167,7 @@ function(build_external_dependencies)
     # Propagate MacOS build flags.
     if(CMAKE_OSX_ARCHITECTURES)
       set(CMAKE_SUB_CONFIGURE_OPTIONS ${CMAKE_SUB_CONFIGURE_OPTIONS}
-          -DCMAKE_OSX_ARCHITECTURES="${CMAKE_OSX_ARCHITECTURES}")
+          -DCMAKE_OSX_ARCHITECTURES=${CMAKE_OSX_ARCHITECTURES})
     endif()
   elseif(MSVC)
     # Propagate MSVC build flags.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GHA machines updated cmake versions, which seems to have a problem when passing in the CMAKE_OSX_ARCHITECTURES with quotes, so remove them.  Note that normally when we do the call from scripts, we don't have the quotes, this is just in the part where we have cmake trigger itself for downloads.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

https://github.com/firebase/firebase-unity-sdk/actions/runs/9882221217
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
