### PR TITLE
Preserve Messaging token until a Listener is set

### DIFF
--- a/messaging/src/common.cc
+++ b/messaging/src/common.cc
@@ -93,7 +93,8 @@ Listener* SetListener(Listener* listener) {
     g_prev_token_received = new std::string;
   }
   g_listener = listener;
-  // If we have a pending token, send it before notifying other systems about the listener.
+  // If we have a pending token, send it before notifying other systems about
+  // the listener.
   if (g_listener && g_has_pending_token && g_prev_token_received) {
     g_listener->OnTokenReceived(g_prev_token_received->c_str());
     g_has_pending_token = false;

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -631,6 +631,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming Release
+-   Changes
+    - Messaging: Changed SetListener to send the last token received
+      before the listener was set.
+
 ### 12.2.0
 -   Changes
     - General (iOS): Update to Firebase Cocoapods version 11.0.0.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Preserve the Messaging token if one is received when a Listener isn't set, and then send that token to the Listener when it is set.  Normally we recommend setting the Listener with Initialize, which avoids this issue, but there are some use cases, like the Unity SDK, where there is a gap of time between Initialize and SetListener.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Running the Unity testapp locally
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
