### PR TITLE
Fix RemoteConfig info initialization issues

### DIFF
--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -635,6 +635,8 @@ code.
 -   Changes
     - Messaging: Changed SetListener to send the last token received
       before the listener was set.
+    - Remote Config: Fixed ConfigInfo fields to default to 0 when
+      not throttled or having previous fetch data.
 
 ### 12.2.0
 -   Changes

--- a/remote_config/src/android/remote_config_android.cc
+++ b/remote_config/src/android/remote_config_android.cc
@@ -496,8 +496,14 @@ static void JConfigInfoToConfigInfo(JNIEnv* env, jobject jinfo,
                                     ConfigInfo* info) {
   FIREBASE_DEV_ASSERT(env->IsInstanceOf(jinfo, config_info::GetClass()));
 
-  info->fetch_time = env->CallLongMethod(
+  int64_t fetch_time = env->CallLongMethod(
       jinfo, config_info::GetMethodId(config_info::kGetFetchTimeMillis));
+  // The C++ fetch_time is a uint64_t, so if we are given a negative number,
+  // use 0 instead, to prevent getting a very large number.
+  if (fetch_time < 0) {
+    fetch_time = 0;
+  }
+  info->fetch_time = fetch_time;
   int64_t status_code = env->CallIntMethod(
       jinfo, config_info::GetMethodId(config_info::kGetLastFetchStatus));
   switch (status_code) {

--- a/remote_config/src/android/remote_config_android.cc
+++ b/remote_config/src/android/remote_config_android.cc
@@ -504,6 +504,7 @@ static void JConfigInfoToConfigInfo(JNIEnv* env, jobject jinfo,
     fetch_time = 0;
   }
   info->fetch_time = fetch_time;
+  util::CheckAndClearJniExceptions(env);
   int64_t status_code = env->CallIntMethod(
       jinfo, config_info::GetMethodId(config_info::kGetLastFetchStatus));
   switch (status_code) {

--- a/remote_config/src/include/firebase/remote_config.h
+++ b/remote_config/src/include/firebase/remote_config.h
@@ -94,7 +94,7 @@ struct ConfigUpdate {
 /// Normally returned as a result of the GetInfo() function.
 struct ConfigInfo {
   /// @brief The time (in milliseconds since the epoch) that the last fetch
-  /// operation completed.
+  /// operation completed. 0 if no fetch attempt has been made yet.
   uint64_t fetch_time;
 
   /// @brief The status of the last fetch request.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On Android, handle the underlying SDK returning a negative fetch time. On iOS, fix throttled_time initialization issues.

Fixes this Unity issue, since the incorrect values were getting added to TimeSpans, which caused exceptions to be thrown: https://github.com/firebase/firebase-unity-sdk/issues/1058
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Testing locally
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
