### PR TITLE
Make UpdateUserProfile consistent on clearing fields on Android

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -691,19 +691,19 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
   firebase::auth::User::UserProfile user_profile_null;
   user_profile_null.display_name = kDisplayName;
-  user_profile_null.photo_url = null;
+  user_profile_null.photo_url = nullptr;
   firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
   WaitForCompletion(user_profile_null, "UpdateUserProfileNull");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), null);
+  EXPECT_EQ(user.photo_url(), nullptr);
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
       "SignInWithEmailAndPassword");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), null);
+  EXPECT_EQ(user.photo_url(), nullptr);
   DeleteUser();
 }
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -696,14 +696,14 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   WaitForCompletion(update_profile_null, "UpdateUserProfileNull");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), nullptr);
+  EXPECT_EQ(user.photo_url(), "");
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
       "SignInWithEmailAndPassword");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), nullptr);
+  EXPECT_EQ(user.photo_url(), "");
   DeleteUser();
 }
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -693,7 +693,8 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   firebase::auth::User::UserProfile user_profile_null;
   user_profile_null.display_name = nullptr;
   user_profile_null.photo_url = nullptr;
-  firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
+  firebase::Future<void> update_profile_null =
+      user.UpdateUserProfile(user_profile_null);
   WaitForCompletion(update_profile_null, "UpdateUserProfileNull");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
@@ -730,7 +731,8 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   firebase::auth::User::UserProfile user_profile_empty;
   user_profile_empty.display_name = "";
   user_profile_empty.photo_url = "";
-  firebase::Future<void> update_profile_empty = user.UpdateUserProfile(user_profile_empty);
+  firebase::Future<void> update_profile_empty =
+      user.UpdateUserProfile(user_profile_empty);
   WaitForCompletion(update_profile_empty, "UpdateUserProfileEmpty");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), "");

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -693,7 +693,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   user_profile_null.display_name = kDisplayName;
   user_profile_null.photo_url = nullptr;
   firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
-  WaitForCompletion(user_profile_null, "UpdateUserProfileNull");
+  WaitForCompletion(update_profile_null, "UpdateUserProfileNull");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), nullptr);
@@ -729,7 +729,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   user_profile_null.display_name = kDisplayName;
   user_profile_null.photo_url = "";
   firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
-  WaitForCompletion(user_profile_null, "UpdateUserProfileEmpty");
+  WaitForCompletion(update_profile_null, "UpdateUserProfileEmpty");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), "");

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -671,6 +671,78 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfile) {
   DeleteUser();
 }
 
+TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
+  std::string email = GenerateEmailAddress();
+  firebase::Future<firebase::auth::AuthResult> create_user =
+      auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
+  WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
+  EXPECT_TRUE(auth_->current_user().is_valid());
+  // Set some user profile properties.
+  firebase::auth::User user = create_user.result()->user;
+  const char kDisplayName[] = "Hello World";
+  const char kPhotoUrl[] = "http://example.com/image.jpg";
+  firebase::auth::User::UserProfile user_profile;
+  user_profile.display_name = kDisplayName;
+  user_profile.photo_url = kPhotoUrl;
+  firebase::Future<void> update_profile = user.UpdateUserProfile(user_profile);
+  WaitForCompletion(update_profile, "UpdateUserProfile");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), kPhotoUrl);
+  firebase::auth::User::UserProfile user_profile_null;
+  user_profile_null.display_name = kDisplayName;
+  user_profile_null.photo_url = null;
+  firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
+  WaitForCompletion(user_profile_null, "UpdateUserProfileNull");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), null);
+  SignOut();
+  WaitForCompletion(
+      auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
+      "SignInWithEmailAndPassword");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), null);
+  DeleteUser();
+}
+
+TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
+  std::string email = GenerateEmailAddress();
+  firebase::Future<firebase::auth::AuthResult> create_user =
+      auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
+  WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
+  EXPECT_TRUE(auth_->current_user().is_valid());
+  // Set some user profile properties.
+  firebase::auth::User user = create_user.result()->user;
+  const char kDisplayName[] = "Hello World";
+  const char kPhotoUrl[] = "http://example.com/image.jpg";
+  firebase::auth::User::UserProfile user_profile;
+  user_profile.display_name = kDisplayName;
+  user_profile.photo_url = kPhotoUrl;
+  firebase::Future<void> update_profile = user.UpdateUserProfile(user_profile);
+  WaitForCompletion(update_profile, "UpdateUserProfile");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), kPhotoUrl);
+  firebase::auth::User::UserProfile user_profile_null;
+  user_profile_null.display_name = kDisplayName;
+  user_profile_null.photo_url = "";
+  firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
+  WaitForCompletion(user_profile_null, "UpdateUserProfileEmpty");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), "");
+  SignOut();
+  WaitForCompletion(
+      auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
+      "SignInWithEmailAndPassword");
+  user = auth_->current_user();
+  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.photo_url(), "");
+  DeleteUser();
+}
+
 TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
   std::string email = GenerateEmailAddress();
   WaitForCompletion(

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -649,6 +649,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfile) {
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
   EXPECT_TRUE(auth_->current_user().is_valid());
+
   // Set some user profile properties.
   firebase::auth::User user = create_user.result()->user;
   const char kDisplayName[] = "Hello World";
@@ -661,6 +662,8 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfile) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
+
+  // Validate that the new properties are present after signing out and in.
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
@@ -677,6 +680,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
   EXPECT_TRUE(auth_->current_user().is_valid());
+
   // Set some user profile properties.
   firebase::auth::User user = create_user.result()->user;
   const char kDisplayName[] = "Hello World";
@@ -689,6 +693,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
+
   // Setting the entries to null should leave the old values
   firebase::auth::User::UserProfile user_profile_null;
   user_profile_null.display_name = nullptr;
@@ -699,6 +704,8 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
+
+  // Validate that the new properties are present after signing out and in.
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
@@ -715,6 +722,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
   EXPECT_TRUE(auth_->current_user().is_valid());
+
   // Set some user profile properties.
   firebase::auth::User user = create_user.result()->user;
   const char kDisplayName[] = "Hello World";
@@ -727,6 +735,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
+
   // Setting the fields to empty should clear it.
   firebase::auth::User::UserProfile user_profile_empty;
   user_profile_empty.display_name = "";
@@ -737,6 +746,8 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), "");
   EXPECT_EQ(user.photo_url(), "");
+
+  // Validate that the properties are cleared out after signing out and in.
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -689,21 +689,22 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
+  // Setting the entries to null should leave the old values
   firebase::auth::User::UserProfile user_profile_null;
-  user_profile_null.display_name = kDisplayName;
+  user_profile_null.display_name = nullptr;
   user_profile_null.photo_url = nullptr;
   firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
   WaitForCompletion(update_profile_null, "UpdateUserProfileNull");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), "");
+  EXPECT_EQ(user.photo_url(), kPhotoUrl);
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
       "SignInWithEmailAndPassword");
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
-  EXPECT_EQ(user.photo_url(), "");
+  EXPECT_EQ(user.photo_url(), kPhotoUrl);
   DeleteUser();
 }
 
@@ -725,20 +726,21 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), kDisplayName);
   EXPECT_EQ(user.photo_url(), kPhotoUrl);
-  firebase::auth::User::UserProfile user_profile_null;
-  user_profile_null.display_name = kDisplayName;
-  user_profile_null.photo_url = "";
-  firebase::Future<void> update_profile_null = user.UpdateUserProfile(user_profile_null);
-  WaitForCompletion(update_profile_null, "UpdateUserProfileEmpty");
+  // Setting the fields to empty should clear it.
+  firebase::auth::User::UserProfile user_profile_empty;
+  user_profile_empty.display_name = "";
+  user_profile_empty.photo_url = "";
+  firebase::Future<void> update_profile_empty = user.UpdateUserProfile(user_profile_empty);
+  WaitForCompletion(update_profile_empty, "UpdateUserProfileEmpty");
   user = auth_->current_user();
-  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.display_name(), "");
   EXPECT_EQ(user.photo_url(), "");
   SignOut();
   WaitForCompletion(
       auth_->SignInWithEmailAndPassword(email.c_str(), kTestPassword),
       "SignInWithEmailAndPassword");
   user = auth_->current_user();
-  EXPECT_EQ(user.display_name(), kDisplayName);
+  EXPECT_EQ(user.display_name(), "");
   EXPECT_EQ(user.photo_url(), "");
   DeleteUser();
 }

--- a/auth/src/android/user_android.cc
+++ b/auth/src/android/user_android.cc
@@ -425,7 +425,10 @@ Future<void> User::UpdateUserProfile(const UserProfile& profile) {
 
   // Extra painfully call UserProfileChangeRequest.Builder.setPhotoUri.
   if (error == kAuthErrorNone && profile.photo_url != nullptr) {
-    jobject j_uri = CharsToJniUri(env, profile.photo_url);
+    jobject j_uri = nullptr;
+    if (strlen(profile.photo_url) > 0) {
+      j_uri = CharsToJniUri(env, profile.photo_url);
+    }
     jobject j_builder_discard = env->CallObjectMethod(
         j_user_profile_builder,
         userprofilebuilder::GetMethodId(userprofilebuilder::kSetPhotoUri),
@@ -434,7 +437,9 @@ Future<void> User::UpdateUserProfile(const UserProfile& profile) {
     if (j_builder_discard) {
       env->DeleteLocalRef(j_builder_discard);
     }
-    env->DeleteLocalRef(j_uri);
+    if (j_uri) {
+      env->DeleteLocalRef(j_uri);
+    }
   }
 
   jobject j_user_profile_request = nullptr;

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -631,10 +631,10 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
-### Upcoming
+### Upcoming Release
 -   Changes
-    - Auth (Android): Setting photo_url to empty string clears the field,
-      making it consistent with the other platforms.
+    - Auth (Android): Setting photo_url to empty string with UpdateUserProfile
+      clears the field, making it consistent with the other platforms.
 
 ### 12.3.0
 -   Changes

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -631,6 +631,11 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming
+-   Changes
+    - Auth (Android): Setting photo_url to empty string clears the field,
+      making it consistent with the other platforms.
+
 ### 12.3.0
 -   Changes
     - General (iOS): Update to Firebase Cocoapods version 11.2.0.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

On iOS and Desktop, setting photo_url to nullptr resulted in no change to the user, and empty string resulted in clearing the field on user.  On Android, both resulted in no change in the user.  Make it consistently clear the field with an empty string, and do no change with nullptr.  And added tests to verify.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
