### PR TITLE
Reduce Android minSdkVersion back to 23

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/analytics/integration_test/build.gradle
+++ b/analytics/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.analytics.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/analytics/integration_test/build.gradle
+++ b/analytics/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/app/app_resources/build.gradle
+++ b/app/app_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/app/google_api_resources/build.gradle
+++ b/app/google_api_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/app/integration_test/build.gradle
+++ b/app/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.analytics.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/app/integration_test/build.gradle
+++ b/app/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/app/invites_resources/build.gradle
+++ b/app/invites_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/app/test_resources/build.gradle
+++ b/app/test_resources/build.gradle
@@ -36,7 +36,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/app_check/app_check_resources/build.gradle
+++ b/app_check/app_check_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/app_check/build.gradle
+++ b/app_check/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/app_check/integration_test/build.gradle
+++ b/app_check/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/app_check/integration_test/build.gradle
+++ b/app_check/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.appcheck.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/auth/auth_resources/build.gradle
+++ b/auth/auth_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/auth/build.gradle
+++ b/auth/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/auth/integration_test/build.gradle
+++ b/auth/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.auth.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/auth/integration_test/build.gradle
+++ b/auth/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/database/build.gradle
+++ b/database/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/database/database_resources/build.gradle
+++ b/database/database_resources/build.gradle
@@ -36,7 +36,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/database/integration_test/build.gradle
+++ b/database/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.database.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/database/integration_test/build.gradle
+++ b/database/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/dynamic_links/build.gradle
+++ b/dynamic_links/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/dynamic_links/integration_test/build.gradle
+++ b/dynamic_links/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.dynamiclinks.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/dynamic_links/integration_test/build.gradle
+++ b/dynamic_links/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/firestore/build.gradle
+++ b/firestore/build.gradle
@@ -49,7 +49,7 @@ android {
 
   defaultConfig {
     // Jelly Bean is the minimum supported version needed by Firebase.
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/firestore/firestore_resources/build.gradle
+++ b/firestore/firestore_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/firestore/integration_test/build.gradle
+++ b/firestore/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.firestore.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/firestore/integration_test/build.gradle
+++ b/firestore/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/firestore/integration_test_internal/build.gradle
+++ b/firestore/integration_test_internal/build.gradle
@@ -63,7 +63,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.firestore.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/firestore/integration_test_internal/build.gradle
+++ b/firestore/integration_test_internal/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/functions/build.gradle
+++ b/functions/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/functions/integration_test/build.gradle
+++ b/functions/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.functions.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/functions/integration_test/build.gradle
+++ b/functions/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/gma/build.gradle
+++ b/gma/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/gma/gma_resources/build.gradle
+++ b/gma/gma_resources/build.gradle
@@ -41,7 +41,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/gma/integration_test/build.gradle
+++ b/gma/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.admob.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/gma/integration_test/build.gradle
+++ b/gma/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/installations/build.gradle
+++ b/installations/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/installations/integration_test/build.gradle
+++ b/installations/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.fis.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/installations/integration_test/build.gradle
+++ b/installations/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/messaging/build.gradle
+++ b/messaging/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/messaging/integration_test/build.gradle
+++ b/messaging/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/messaging/integration_test/build.gradle
+++ b/messaging/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.messaging.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/messaging/messaging_java/build.gradle
+++ b/messaging/messaging_java/build.gradle
@@ -46,7 +46,7 @@ android {
 
   defaultConfig {
     targetSdkVersion 34
-    minSdkVersion 24
+    minSdkVersion 23
   }
 
   sourceSets {

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -633,6 +633,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
+    - General (Android): Reduced minSdkVersion back to 23.
     - Auth (Android): Setting photo_url to empty string with UpdateUserProfile
       clears the field, making it consistent with the other platforms.
 

--- a/remote_config/build.gradle
+++ b/remote_config/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/remote_config/integration_test/build.gradle
+++ b/remote_config/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.android.remoteconfig.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/remote_config/integration_test/build.gradle
+++ b/remote_config/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/remote_config/remote_config_resources/build.gradle
+++ b/remote_config/remote_config_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
 

--- a/scripts/gha/ui_testing/uitest_android/app/build.gradle
+++ b/scripts/gha/ui_testing/uitest_android/app/build.gradle
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId "com.google.firebase.uitest"
-        minSdkVersion 24
+        minSdkVersion 23
         targetSdkVersion 34
         versionCode 1
         versionName "1.0"

--- a/storage/build.gradle
+++ b/storage/build.gradle
@@ -48,7 +48,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"

--- a/storage/integration_test/build.gradle
+++ b/storage/integration_test/build.gradle
@@ -55,7 +55,7 @@ android {
 
   defaultConfig {
     applicationId 'com.google.firebase.cpp.storage.testapp'
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName '1.0'

--- a/storage/integration_test/build.gradle
+++ b/storage/integration_test/build.gradle
@@ -21,6 +21,9 @@ buildscript {
   }
   dependencies {
     classpath 'com.android.tools.build:gradle:7.4.2'
+    // r8 on this version of the Android tools has a bug,
+    // so specify a different version to use.
+    classpath 'com.android.tools:r8:8.3.37'
     classpath 'com.google.gms:google-services:4.4.1'
   }
 }

--- a/storage/storage_resources/build.gradle
+++ b/storage/storage_resources/build.gradle
@@ -40,7 +40,7 @@ android {
   buildToolsVersion '32.0.0'
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
   }
   sourceSets {

--- a/testing/build.gradle
+++ b/testing/build.gradle
@@ -49,7 +49,7 @@ android {
   }
 
   defaultConfig {
-    minSdkVersion 24
+    minSdkVersion 23
     targetSdkVersion 34
     versionCode 1
     versionName "1.0"


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

As part of the Android tools update, we had bumped the minSdkVersion to 24.  This was to workaround a bug with dexing, but there are a couple other workarounds, including using proguard or specifying a different r8 version to use.  So, this change reduces the version back to 23, and adds the r8 change to the integration tests.

For some more info, see https://github.com/googlesamples/unity-jar-resolver/issues/703
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
