### PR TITLE
Implement setDefaultEventParameters method in C++ Analytics API

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -298,47 +298,58 @@ TEST_F(FirebaseAnalyticsTest, TestLogEventWithComplexParameters) {
 }
 
 TEST_F(FirebaseAnalyticsTest, TestSetConsent) {
-  // On Android, this test must be performed at the end, after all the tests for
-  // session ID and instance ID. This is because once you call SetConsent to
-  // deny consent on Android, calling it again to grant consent may not take
-  // effect until the app restarts, thus breaking any of those tests that are
-  // run after this one.
-  //
-  // If this test does happen to run earlier (due to randomizing test order, for
-  // example), the tests that could fail will be skipped (on Android).
+    // On Android, this test must be performed at the end, after all the tests for
+    // session ID and instance ID. This is because once you call SetConsent to
+    // deny consent on Android, calling it again to grant consent may not take
+    // effect until the app restarts, thus breaking any of those tests that are
+    // run after this one.
+    //
+    // If this test does happen to run earlier (due to randomizing test order, for
+    // example), the tests that could fail will be skipped (on Android).
 
-  // Can't confirm that these do anything but just run them all to ensure the
-  // app doesn't crash.
-  std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
-      consent_settings_allow = {
-          {firebase::analytics::kConsentTypeAnalyticsStorage,
-           firebase::analytics::kConsentStatusGranted},
-          {firebase::analytics::kConsentTypeAdStorage,
-           firebase::analytics::kConsentStatusGranted},
-          {firebase::analytics::kConsentTypeAdUserData,
-           firebase::analytics::kConsentStatusGranted},
-          {firebase::analytics::kConsentTypeAdPersonalization,
-           firebase::analytics::kConsentStatusGranted}};
-  std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
-      consent_settings_deny = {
-          {firebase::analytics::kConsentTypeAnalyticsStorage,
-           firebase::analytics::kConsentStatusDenied},
-          {firebase::analytics::kConsentTypeAdStorage,
-           firebase::analytics::kConsentStatusDenied},
-          {firebase::analytics::kConsentTypeAdUserData,
-           firebase::analytics::kConsentStatusDenied},
-          {firebase::analytics::kConsentTypeAdPersonalization,
-           firebase::analytics::kConsentStatusDenied}};
-  std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
-      consent_settings_empty;
-  firebase::analytics::SetConsent(consent_settings_empty);
-  ProcessEvents(1000);
-  firebase::analytics::SetConsent(consent_settings_deny);
-  ProcessEvents(1000);
-  firebase::analytics::SetConsent(consent_settings_allow);
-  ProcessEvents(1000);
+    // Can't confirm that these do anything but just run them all to ensure the
+    // app doesn't crash.
+    std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
+        consent_settings_allow = {
+            {firebase::analytics::kConsentTypeAnalyticsStorage,
+             firebase::analytics::kConsentStatusGranted},
+            {firebase::analytics::kConsentTypeAdStorage,
+             firebase::analytics::kConsentStatusGranted},
+            {firebase::analytics::kConsentTypeAdUserData,
+             firebase::analytics::kConsentStatusGranted},
+            {firebase::analytics::kConsentTypeAdPersonalization,
+             firebase::analytics::kConsentStatusGranted}};
+    std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
+        consent_settings_deny = {
+            {firebase::analytics::kConsentTypeAnalyticsStorage,
+             firebase::analytics::kConsentStatusDenied},
+            {firebase::analytics::kConsentTypeAdStorage,
+             firebase::analytics::kConsentStatusDenied},
+            {firebase::analytics::kConsentTypeAdUserData,
+             firebase::analytics::kConsentStatusDenied},
+            {firebase::analytics::kConsentTypeAdPersonalization,
+             firebase::analytics::kConsentStatusDenied}};
+    std::map<firebase::analytics::ConsentType, firebase::analytics::ConsentStatus>
+        consent_settings_empty;
+    firebase::analytics::SetConsent(consent_settings_empty);
+    ProcessEvents(1000);
+    firebase::analytics::SetConsent(consent_settings_deny);
+    ProcessEvents(1000);
+    firebase::analytics::SetConsent(consent_settings_allow);
+    ProcessEvents(1000);
 
-  did_test_setconsent_ = true;
+    did_test_setconsent_ = true;
 }
 
+TEST_F(FirebaseAnalyticsTest, TestSetDefaultEventParameters) {
+    std::map<std::string, firebase::Variant> default_params = {
+      {"key1", firebase::Variant("value1")},
+      {"key2", firebase::Variant(12345)},
+      {"key3", firebase::Variant(1.01)},
+      {"key4", firebase::Variant("my_value")},
+      {"key5", firebase::Variant(true)},
+      {"key6", firebase::Variant::EmptyMap()},
+  };
+    firebase::analytics::SetDefaultEventParameters(default_params);
+}
 }  // namespace firebase_testapp_automated

--- a/analytics/src/analytics_android.cc
+++ b/analytics/src/analytics_android.cc
@@ -736,5 +736,65 @@ Future<int64_t> GetSessionIdLastResult() {
           internal::kAnalyticsFnGetSessionId));
 }
 
+// Sets the default parameters to be sent with each event.
+void SetDefaultEventParameters(const std::map<std::string, Variant>& parameters) {
+    FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
+    JNIEnv* env = g_app->GetJNIEnv();
+
+    jobject map =
+            env->NewObject(util::hash_map::GetClass(),
+                           util::hash_map::GetMethodId(util::hash_map::kConstructor));
+    util::CheckAndClearJniExceptions(env);
+
+    jmethodID put_method_id = util::map::GetMethodId(util::map::kPut);
+
+    for (const auto& pair : parameters) {
+        jstring key_string = env->NewStringUTF(pair.first.c_str());
+        jobject jni_value;
+        if (pair.second.is_int64()) {
+            jni_value = env->NewObject(util::integer_java_class_type::GetClass(),
+                                          util::bundle::GetMethodId(util::bundle::kConstructor));
+        }
+        else if (pair.second.is_double()){
+             jni_value = env->NewObject(util::double_java_class_type::GetClass(),
+                                       util::bundle::GetMethodId(util::bundle::kConstructor));
+        }else if (pair.second.is_string()) {
+            jni_value = env->NewObject(util::string_java_class_type::GetClass(),
+                                                     util::bundle::GetMethodId(util::bundle::kConstructor));
+        }
+        else if(pair.second.is_map()){
+            jobject jni_bundle = MapToBundle(env,pair.second.map());
+            jobject previous_value = env->CallObjectMethod(
+                    bundle, put_method_id, env->NewStringUTF(key_string.c_str()), jni_bundle);
+            util::CheckAndClearJniExceptions(env);
+            if (previous_value) {
+                env->DeleteLocalRef(previous_value);
+            }
+
+        }else {
+            // A Variant type that couldn't be handled was passed in.
+            LogError(
+                "LogEvent(%s): %s is not a valid parameter value type. "
+                "No event was logged.",
+                pair.first.c_str(), Variant::TypeName(pair.second.type()));
+            continue;
+        }
+        jobject previous_value = env->CallObjectMethod(
+                map, put_method_id, key_string, jni_value);
+        util::CheckAndClearJniExceptions(env);
+        env->DeleteLocalRef(jni_value);
+        env->DeleteLocalRef(key_string);
+
+    }
+
+    env->CallVoidMethod(g_analytics_class_instance,
+                        analytics::GetMethodId(analytics::kSetDefaultEventParameters),
+                        map);
+
+    util::CheckAndClearJniExceptions(env);
+    env->DeleteLocalRef(map);
+
+}
+
 }  // namespace analytics
 }  // namespace firebase

--- a/analytics/src/analytics_ios.mm
+++ b/analytics/src/analytics_ios.mm
@@ -438,5 +438,22 @@ Future<int64_t> GetSessionIdLastResult() {
       internal::FutureData::Get()->api()->LastResult(internal::kAnalyticsFnGetSessionId));
 }
 
+/// @brief Sets the default parameters to be sent with each event.
+///
+/// @param[in] parameters The parameters to send with each event.
+void SetDefaultEventParameters(const std::map<std::string, Variant>& parameters) {
+  FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
+  NSMutableDictionary* parameters_dict =
+      [[NSMutableDictionary alloc] initWithCapacity:parameters.size()];
+    for (const auto& pair : parameters) {
+      NSString* key = SafeString(pair.first.c_str());
+      if (!AddVariantToDictionary(parameters_dict, key, pair.second)) {
+          LogError("SetDefaultEventParameters: Unsupported type (%s) within map with key %s.",
+                   Variant::TypeName(pair.second.type()), key);
+      }
+    }
+    [FIRAnalytics setDefaultEventParameters:parameters_dict];
+}
+
 }  // namespace analytics
 }  // namespace firebase

--- a/analytics/src/analytics_stub.cc
+++ b/analytics/src/analytics_stub.cc
@@ -186,5 +186,10 @@ Future<int64_t> GetSessionIdLastResult() {
           internal::kAnalyticsFnGetSessionId));
 }
 
+// Sets the default parameters to be sent with each event.
+void SetDefaultEventParameters(const std::map<std::string, Variant>& parameters) {
+  FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
+}
+
 }  // namespace analytics
 }  // namespace firebase

--- a/analytics/src/include/firebase/analytics.h
+++ b/analytics/src/include/firebase/analytics.h
@@ -591,6 +591,11 @@ Future<int64_t> GetSessionId();
 /// app session.
 Future<int64_t> GetSessionIdLastResult();
 
+/// @brief Sets the default parameters to be sent with each event.
+///
+/// @param[in] parameters The parameters to send with each event.
+void SetDefaultEventParameters(const std::map<std::string, Variant>& parameters);
+
 }  // namespace analytics
 }  // namespace firebase
 

--- a/analytics/tests/analytics_test.cc
+++ b/analytics/tests/analytics_test.cc
@@ -296,5 +296,23 @@ TEST_F(AnalyticsTest, TestGetAnalyticsInstanceId) {
   EXPECT_EQ(std::string("FakeAnalyticsInstanceId0"), *result.result());
 }
 
+TEST_F(AnalyticsTest, TestSetDefaultEventParameters) {
+  std::map<std::string, firebase::Variant> parameters = {
+      {"key1", firebase::Variant("value1")},
+      {"key2", firebase::Variant(12345)},
+      {"key3", firebase::Variant(1.01)},
+      {"key4", firebase::Variant("my_value")},
+      {"key5", firebase::Variant(true)},
+      {"key6", firebase::Variant::EmptyMap()},
+  };
+
+  AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters",
+                      {"key1=value1,key2=12345,key3=1.01,key4=my_value,key5=1"});
+  AddExpectationApple("+[FIRAnalytics setDefaultEventParameters:]",
+                      {"key1=value1,key2=12345,key3=1.01,key4=my_value,key5=1"});
+
+  SetDefaultEventParameters(parameters);
+}
+
 }  // namespace analytics
 }  // namespace firebase

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -631,6 +631,14 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Next Release (12.7.0)
+-   Changes
+    - Analytics: Added support for default parameters to be sent with each event.
+      This change lets you use `SetDefaultEventParameters` to set default
+      parameters to be sent with each event.
+    - General (iOS): Update to Firebase Cocoapods version 11.9.0.
+    - General (Android): Update to Firebase Android BoM version 33.10.0.
+
 ### 12.6.0
 -   Changes
     - General (iOS): Update to Firebase Cocoapods version 11.8.1.


### PR DESCRIPTION
### Description
This commit adds the  method to the C++
Analytics API. This method allows setting default event parameters, mirroring functionality in the iOS and Android SDKs.

The implementation covers:
- iOS: Using Objective-C++
- Android: Using JNI
- Desktop: A stub implementation for other platforms.

***
### Testing
Unit tests and integration tests were added to ensure the change works as intended.



### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [X] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
