### PR TITLE
Downgrade CMake to 3.31.x on our runners.

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -51,6 +51,9 @@ jobs:
         architecture: ${{ fromJson(needs.prepare_matrix.outputs.matrix_architecture) }}
         python_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_python_version) }}
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: lukka/get-cmake@latest
         with:
-        cmakeVersion: "~3.31.0"  # <--= optional, use most recent 3.31.x version
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           submodules: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -51,6 +51,9 @@ jobs:
     # This check succeeds if Doxygen documentation generates without errors.
     runs-on: ubuntu-22.04
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+        cmakeVersion: "~3.31.0"  # <--= optional, use most recent 3.31.x version
       - uses: actions/checkout@v3
         with:
           submodules: false

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -90,6 +90,9 @@ jobs:
           # Binutils 2.35.1 released Sep 19, 2020
           binutils_version: "2.35.1"
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: setup Xcode version (macos)
         if: runner.os == 'macOS'
         run: sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
@@ -188,6 +191,9 @@ jobs:
     runs-on: macos-13
     if: ${{ github.event.inputs.downloadPublicVersion == '' && github.event.inputs.downloadPreviousRun == '' }}
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
         shell: bash
@@ -248,6 +254,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Force Java 11
         shell: bash
         run: echo "JAVA_HOME=${JAVA_HOME_11_X64}" >> $GITHUB_ENV
@@ -352,6 +361,9 @@ jobs:
           architecture: "arm64"
 
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
         shell: bash

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -95,6 +95,9 @@ jobs:
           - xcode_version: "11.7"
             architecture: "arm64"
     steps:                
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
         shell: bash
@@ -296,6 +299,9 @@ jobs:
     strategy:
       fail-fast: false
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -286,6 +286,9 @@ jobs:
           ssl_variant: openssl
           arch: arm64
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
@@ -424,6 +427,9 @@ jobs:
       matrix:
         os: ${{ fromJson(needs.check_and_prepare.outputs.matrix_os) }}
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
@@ -535,6 +541,9 @@ jobs:
       matrix:
         os: [macos-13]
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
@@ -640,6 +649,9 @@ jobs:
       matrix:
         os: [macos-13]
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - uses: actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -44,6 +44,9 @@ jobs:
         os: [ 'macos-13' ]
         xcode_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_xcode_version) }}
     steps:
+      - uses: lukka/get-cmake@latest
+        with:
+          cmakeVersion: "~3.31.0"
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
         shell: bash


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

GitHub runners updated CMake to CMake 4, which breaks our build. Install an explicit version of CMake instead.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Tests/checks here and packaging workflow [here](https://github.com/firebase/firebase-cpp-sdk/actions/runs/14225991890).
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
