### PR TITLE
[Messaging] Fix subscription not completing sometimes

### DIFF
--- a/messaging/src/android/cpp/messaging.cc
+++ b/messaging/src/android/cpp/messaging.cc
@@ -724,6 +724,11 @@ static void InstallationsGetToken() {
 
   result.OnCompletion(
       [](const Future<std::string>& result, void* voidptr) {
+        if (g_registration_token_mutex) {
+          MutexLock lock(*g_registration_token_mutex);
+          g_registration_token_received = true;
+          HandlePendingSubscriptions();
+        }
         NotifyListenerOnTokenReceived(result.result()->c_str());
       },
       nullptr);
@@ -868,6 +873,9 @@ static const char kErrorMessageNoRegistrationToken[] =
     "Cannot update subscription when SetTokenRegistrationOnInitEnabled is set "
     "to false.";
 
+static const char kErrorMessageSubscriptionUnknown[] =
+"Cannot update subscription for unknown reason.";
+
 Future<void> Subscribe(const char* topic) {
   FIREBASE_ASSERT_MESSAGE_RETURN(Future<void>(), internal::IsInitialized(),
                                  kMessagingNotInitializedError);
@@ -882,6 +890,10 @@ Future<void> Subscribe(const char* topic) {
                   kErrorMessageNoRegistrationToken);
   } else if (g_pending_subscriptions) {
     g_pending_subscriptions->push_back(PendingTopic(topic, handle));
+  } else {
+    // This shouldn't happen, since g_pending_subscriptions should be valid if here,
+    // but handle it to prevent abandoning the Future in case something happens.
+    api->Complete(handle, kErrorUnknown, kErrorMessageSubscriptionUnknown);
   }
   return MakeFuture(api, handle);
 }
@@ -907,6 +919,10 @@ Future<void> Unsubscribe(const char* topic) {
                   kErrorMessageNoRegistrationToken);
   } else if (g_pending_unsubscriptions) {
     g_pending_unsubscriptions->push_back(PendingTopic(topic, handle));
+  } else {
+    // This shouldn't happen, since g_pending_unsubscriptions should be valid if here,
+    // but handle it to prevent abandoning the Future in case something happens.
+    api->Complete(handle, kErrorUnknown, kErrorMessageSubscriptionUnknown);
   }
   return MakeFuture(api, handle);
 }

--- a/messaging/src/android/cpp/messaging.cc
+++ b/messaging/src/android/cpp/messaging.cc
@@ -874,7 +874,7 @@ static const char kErrorMessageNoRegistrationToken[] =
     "to false.";
 
 static const char kErrorMessageSubscriptionUnknown[] =
-"Cannot update subscription for unknown reason.";
+    "Cannot update subscription for unknown reason.";
 
 Future<void> Subscribe(const char* topic) {
   FIREBASE_ASSERT_MESSAGE_RETURN(Future<void>(), internal::IsInitialized(),
@@ -891,8 +891,9 @@ Future<void> Subscribe(const char* topic) {
   } else if (g_pending_subscriptions) {
     g_pending_subscriptions->push_back(PendingTopic(topic, handle));
   } else {
-    // This shouldn't happen, since g_pending_subscriptions should be valid if here,
-    // but handle it to prevent abandoning the Future in case something happens.
+    // This shouldn't happen, since g_pending_subscriptions should be valid if
+    // here, but handle it to prevent abandoning the Future in case something
+    // happens.
     api->Complete(handle, kErrorUnknown, kErrorMessageSubscriptionUnknown);
   }
   return MakeFuture(api, handle);
@@ -920,8 +921,9 @@ Future<void> Unsubscribe(const char* topic) {
   } else if (g_pending_unsubscriptions) {
     g_pending_unsubscriptions->push_back(PendingTopic(topic, handle));
   } else {
-    // This shouldn't happen, since g_pending_unsubscriptions should be valid if here,
-    // but handle it to prevent abandoning the Future in case something happens.
+    // This shouldn't happen, since g_pending_unsubscriptions should be valid if
+    // here, but handle it to prevent abandoning the Future in case something
+    // happens.
     api->Complete(handle, kErrorUnknown, kErrorMessageSubscriptionUnknown);
   }
   return MakeFuture(api, handle);

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -664,6 +664,8 @@ code.
       library and to the firebase::ump namespace. The version in the
       GMA library (in firebase::gma::ump) has been deprecated and will
       be removed soon.
+    - Messaging (Android): Fix issue with the Subscribe Future not completing
+      when a cached token is available.
 
 ### 12.7.0
 -   Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

If the messaging token is received via Installations, which can happen if it is cached, it wasn't setting the flags to allow subscriptions to work correctly, causing them to hang. Set the flags, and resolve any pending subscriptions when the token is received via that mechanic.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running locally.
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
