### PR TITLE
Add SetDefaultEventParameters and ClearDefaultEventParameters to Analytics C++ SDK.

### DIFF
--- a/analytics/integration_test/src/integration_test.cc
+++ b/analytics/integration_test/src/integration_test.cc
@@ -341,4 +341,61 @@ TEST_F(FirebaseAnalyticsTest, TestSetConsent) {
   did_test_setconsent_ = true;
 }
 
+TEST_F(FirebaseAnalyticsTest, TestDefaultEventParametersUsage) {
+  LogInfo("Testing SetDefaultEventParameters with initial values, then updating with Null.");
+
+  std::map<std::string, firebase::analytics::Variant> initial_defaults;
+  initial_defaults["initial_key"] = "initial_value";
+  initial_defaults["key_to_be_nulled"] = "text_before_null";
+  initial_defaults["numeric_default"] = 12345LL;
+
+  LogInfo("Setting initial default event parameters.");
+  firebase::analytics::SetDefaultEventParameters(initial_defaults);
+  // Log an event that would pick up these defaults.
+  firebase::analytics::LogEvent("event_with_initial_defaults");
+  LogInfo("Logged event_with_initial_defaults.");
+  ProcessEvents(500); // Short pause for event logging, if it matters for backend.
+
+  std::map<std::string, firebase::analytics::Variant> updated_defaults;
+  updated_defaults["key_to_be_nulled"] = firebase::analytics::Variant::Null();
+  updated_defaults["another_key"] = "another_value";
+  // "initial_key" should persist if not overwritten.
+  // "numeric_default" should persist.
+
+  LogInfo("Updating default event parameters, setting key_to_be_nulled to Null.");
+  firebase::analytics::SetDefaultEventParameters(updated_defaults);
+  // Log an event that would pick up the updated defaults.
+  firebase::analytics::LogEvent("event_after_nulling_and_adding");
+  LogInfo("Logged event_after_nulling_and_adding.");
+  ProcessEvents(500);
+
+  // For this C++ SDK integration test, we primarily ensure API calls complete.
+  // Actual parameter presence on logged events would be verified by backend/native tests.
+  LogInfo("TestDefaultEventParametersUsage completed. Calls were made successfully.");
+}
+
+TEST_F(FirebaseAnalyticsTest, TestClearDefaultEventParametersFunctionality) {
+  LogInfo("Testing ClearDefaultEventParameters.");
+
+  std::map<std::string, firebase::analytics::Variant> defaults_to_clear;
+  defaults_to_clear["default_one"] = "will_be_cleared";
+  defaults_to_clear["default_two"] = 9876LL;
+
+  LogInfo("Setting default parameters before clearing.");
+  firebase::analytics::SetDefaultEventParameters(defaults_to_clear);
+  // Log an event that would pick up these defaults.
+  firebase::analytics::LogEvent("event_before_global_clear");
+  LogInfo("Logged event_before_global_clear.");
+  ProcessEvents(500);
+
+  LogInfo("Calling ClearDefaultEventParameters.");
+  firebase::analytics::ClearDefaultEventParameters();
+  // Log an event that should not have the previous defaults.
+  firebase::analytics::LogEvent("event_after_global_clear");
+  LogInfo("Logged event_after_global_clear.");
+  ProcessEvents(500);
+
+  LogInfo("TestClearDefaultEventParametersFunctionality completed. Call was made successfully.");
+}
+
 }  // namespace firebase_testapp_automated

--- a/analytics/src/analytics_stub.cc
+++ b/analytics/src/analytics_stub.cc
@@ -142,6 +142,17 @@ void SetSessionTimeoutDuration(int64_t /*milliseconds*/) {
   FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
 }
 
+void SetDefaultEventParameters(
+    const std::map<std::string, Variant>& /*default_parameters*/) {
+  FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
+  // This is a stub implementation. No operation needed.
+}
+
+void ClearDefaultEventParameters() {
+  FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
+  // This is a stub implementation. No operation needed.
+}
+
 void ResetAnalyticsData() {
   FIREBASE_ASSERT_RETURN_VOID(internal::IsInitialized());
   g_fake_instance_id++;

--- a/analytics/src/include/firebase/analytics.h
+++ b/analytics/src/include/firebase/analytics.h
@@ -558,6 +558,23 @@ void SetSessionTimeoutDuration(int64_t milliseconds);
 /// instance id.
 void ResetAnalyticsData();
 
+/// @brief Sets the default event parameters.
+///
+/// These parameters will be automatically logged with all calls to `LogEvent`.
+/// Default parameters are overridden by parameters supplied to the `LogEvent`
+/// method.
+///
+/// When a value in the `default_parameters` map is
+/// `firebase::Variant::Null()`, it signifies that the default parameter for
+/// that specific key should be cleared.
+///
+/// @param[in] default_parameters A map of parameter names to Variant values.
+void SetDefaultEventParameters(
+    const std::map<std::string, Variant>& default_parameters);
+
+/// @brief Clears all default event parameters.
+void ClearDefaultEventParameters();
+
 /// Get the instance ID from the analytics service.
 ///
 /// @note This is *not* the same ID as the ID returned by

--- a/analytics/src_ios/fake/FIRAnalytics.h
+++ b/analytics/src_ios/fake/FIRAnalytics.h
@@ -37,4 +37,6 @@
 
 + (void)resetAnalyticsData;
 
++ (void)setDefaultEventParameters:(nullable NSDictionary<NSString *, id> *)parameters;
+
 @end

--- a/analytics/src_ios/fake/FIRAnalytics.mm
+++ b/analytics/src_ios/fake/FIRAnalytics.mm
@@ -21,6 +21,9 @@
 @implementation FIRAnalytics
 
 + (NSString *)stringForValue:(id)value {
+  if (value == [NSNull null]) {
+    return @"<NSNull>";
+  }
   return [NSString stringWithFormat:@"%@", value];
 }
 
@@ -92,6 +95,16 @@
 
 + (void)resetAnalyticsData {
   FakeReporter->AddReport("+[FIRAnalytics resetAnalyticsData]", {});
+}
+
++ (void)setDefaultEventParameters:(nullable NSDictionary<NSString *, id> *)parameters {
+  if (parameters == nil) {
+    FakeReporter->AddReport("+[FIRAnalytics setDefaultEventParameters:]", {"nil"});
+  } else {
+    NSString *parameterString = [self stringForParameters:parameters];
+    FakeReporter->AddReport("+[FIRAnalytics setDefaultEventParameters:]",
+                            { [parameterString UTF8String] });
+  }
 }
 
 @end

--- a/analytics/src_java/fake/com/google/firebase/analytics/FirebaseAnalytics.java
+++ b/analytics/src_java/fake/com/google/firebase/analytics/FirebaseAnalytics.java
@@ -79,4 +79,30 @@ public final class FirebaseAnalytics {
     FakeReporter.addReport(
         "FirebaseAnalytics.setSessionTimeoutDuration", Long.toString(milliseconds));
   }
+
+  public void setDefaultEventParameters(Bundle bundle) {
+    if (bundle == null) {
+        FakeReporter.addReport("FirebaseAnalytics.setDefaultEventParameters", "null");
+    } else {
+        StringBuilder paramsString = new StringBuilder();
+        // Sort keys for predictable ordering.
+        for (String key : new TreeSet<>(bundle.keySet())) {
+            paramsString.append(key);
+            paramsString.append("=");
+            Object value = bundle.get(key); // Get as Object first
+            if (value == null) {
+                // This case handles when bundle.putString(key, null) was called.
+                paramsString.append("<null_string_value>");
+            } else {
+                paramsString.append(value.toString());
+            }
+            paramsString.append(",");
+        }
+        // Remove trailing comma if paramsString is not empty
+        if (paramsString.length() > 0) {
+            paramsString.setLength(paramsString.length() - 1);
+        }
+        FakeReporter.addReport("FirebaseAnalytics.setDefaultEventParameters", paramsString.toString());
+    }
+  }
 }

--- a/analytics/tests/analytics_test.cc
+++ b/analytics/tests/analytics_test.cc
@@ -296,5 +296,89 @@ TEST_F(AnalyticsTest, TestGetAnalyticsInstanceId) {
   EXPECT_EQ(std::string("FakeAnalyticsInstanceId0"), *result.result());
 }
 
+TEST_F(AnalyticsTest, TestSetDefaultEventParameters) {
+  // Android part is not tested here as it's about iOS fakes.
+  // This test focuses on the iOS fake reporting.
+  // Android: AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {"my_param_bool=true,my_param_double=3.14,my_param_int=123,my_param_string=hello"});
+  AddExpectationApple("+[FIRAnalytics setDefaultEventParameters:]",
+                      {"my_param_bool=1,my_param_double=3.14,my_param_int=123,my_param_string=hello"});
+
+  std::map<std::string, Variant> default_params;
+  default_params["my_param_string"] = "hello";
+  default_params["my_param_double"] = 3.14;
+  default_params["my_param_int"] = 123;
+  default_params["my_param_bool"] = true; // Note: [NSNumber numberWithBool:YES] stringifies to 1
+
+  SetDefaultEventParameters(default_params);
+}
+
+TEST_F(AnalyticsTest, TestSetDefaultEventParametersWithNull) {
+  // Android: AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {"key_to_clear=null,other_key=value"});
+  AddExpectationApple("+[FIRAnalytics setDefaultEventParameters:]",
+                      {"key_to_clear=<NSNull>,other_key=value"});
+
+  std::map<std::string, Variant> default_params;
+  default_params["key_to_clear"] = Variant::Null();
+  default_params["other_key"] = "value";
+
+  SetDefaultEventParameters(default_params);
+}
+
+TEST_F(AnalyticsTest, TestSetDefaultEventParametersEmpty) {
+  // Android: AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {""}); // Or however an empty bundle is represented
+  AddExpectationApple("+[FIRAnalytics setDefaultEventParameters:]", {""});
+
+  std::map<std::string, Variant> default_params;
+  SetDefaultEventParameters(default_params);
+}
+
+TEST_F(AnalyticsTest, TestClearDefaultEventParameters) {
+  // Android: AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {"null"}); // Passing null bundle
+  AddExpectationApple("+[FIRAnalytics setDefaultEventParameters:]", {"nil"});
+
+  ClearDefaultEventParameters();
+}
+
+TEST_F(AnalyticsTest, TestSetDefaultEventParametersAndroid) {
+  AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters",
+                        {"my_bool=true,my_double=3.14,my_int=123,my_string=hello"});
+
+  std::map<std::string, Variant> default_params;
+  default_params["my_string"] = "hello";
+  default_params["my_double"] = 3.14;
+  default_params["my_int"] = 123;
+  default_params["my_bool"] = true;
+
+  SetDefaultEventParameters(default_params);
+  WaitForMainThreadTask();
+}
+
+TEST_F(AnalyticsTest, TestSetDefaultEventParametersWithNullValueAndroid) {
+  AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters",
+                        {"key_to_clear=<null_string_value>,other_key=value"});
+
+  std::map<std::string, Variant> default_params;
+  default_params["key_to_clear"] = Variant::Null();
+  default_params["other_key"] = "value";
+
+  SetDefaultEventParameters(default_params);
+  WaitForMainThreadTask();
+}
+
+TEST_F(AnalyticsTest, TestSetDefaultEventParametersEmptyAndroid) {
+  AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {""});
+
+  std::map<std::string, Variant> default_params;
+  SetDefaultEventParameters(default_params);
+  WaitForMainThreadTask();
+}
+
+TEST_F(AnalyticsTest, TestClearDefaultEventParametersAndroid) {
+  AddExpectationAndroid("FirebaseAnalytics.setDefaultEventParameters", {"null"});
+
+  ClearDefaultEventParameters();
+  WaitForMainThreadTask();
+}
+
 }  // namespace analytics
 }  // namespace firebase


### PR DESCRIPTION
This change introduces two new C++ Analytics SDK functions:
- `SetDefaultEventParameters(const std::map<std::string, Variant>& params)`: Allows setting default parameters that will be included in all subsequent `LogEvent` calls. If a `Variant::Null()` is provided as a value for a key, that specific default parameter will be cleared/removed.
- `ClearDefaultEventParameters()`: Clears all currently set default event parameters.

Platform implementations:
- iOS: Uses `[FIRAnalytics setDefaultEventParameters:]`. `Variant::Null()` maps to `[NSNull null]` for clearing individual parameters. Calling with `nil` clears all.
- Android: Uses `FirebaseAnalytics.setDefaultEventParameters(Bundle)`. `Variant::Null()` results in `Bundle.putString(key, null)`. Calling with a `null` Bundle clears all.
- Stub: Implemented as no-ops.

Unit tests and integration tests have been updated to cover these new functionalities, including the null-value handling for clearing specific parameters and the overall clearing of all parameters.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
