### PR TITLE
Fix: Prevent SetDefaultEventParameters from clearing params with all-…

### DIFF
--- a/analytics/src/analytics_ios.mm
+++ b/analytics/src/analytics_ios.mm
@@ -403,6 +403,15 @@ void SetDefaultEventParameters(const std::map<std::string, Variant>& default_par
                pair.first.c_str(), Variant::TypeName(value.type()));
     }
   }
+  // If ns_default_parameters is empty at this point, it means all input
+  // parameters were invalid or the input map itself was empty.
+  // In this case, we should not call the native SDK, as passing an empty
+  // NSDictionary might clear existing parameters, which is not the intent
+  // if all inputs were simply invalid.
+  if ([ns_default_parameters count] == 0) {
+    LogDebug("SetDefaultEventParameters: No valid parameters to set, skipping native call.");
+    return;
+  }
   [FIRAnalytics setDefaultEventParameters:ns_default_parameters];
 }
 


### PR DESCRIPTION
…invalid input

Addresses code review feedback regarding the behavior of SetDefaultEventParameters when all provided parameters are of invalid types.

Previously, if all parameters in the C++ map were invalid, an empty NSDictionary/Bundle would be passed to the native iOS/Android setDefaultEventParameters method. According to documentation, passing nil/null (for iOS/Android respectively) clears all default parameters. While passing an empty dictionary/bundle is a valid operation, it could lead to unintentionally clearing parameters if that was the state before, or it might be a no-op if parameters were already set.

This change modifies the iOS and Android implementations to explicitly check if the processed native parameter collection (NSDictionary for iOS, Bundle for Android) is empty after filtering for valid types. If it is empty, the call to the native SDK's setDefaultEventParameters method is skipped.

This ensures that providing a C++ map containing exclusively invalid parameters (or an empty map) to SetDefaultEventParameters will be a true no-op from the C++ SDK's perspective, preventing any accidental modification or clearing of existing default parameters on the native side.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
