### PR TITLE
Implemented Auth::UseUserAccessGroup for iOS and stubbed for other pl…

### DIFF
--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -676,5 +676,9 @@ void DisableTokenAutoRefresh(AuthData* auth_data) {}
 void InitializeTokenRefresher(AuthData* auth_data) {}
 void DestroyTokenRefresher(AuthData* auth_data) {}
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  return kAuthErrorUnimplemented;
+}
+
 }  // namespace auth
 }  // namespace firebase

--- a/auth/src/auth.cc
+++ b/auth/src/auth.cc
@@ -373,5 +373,14 @@ AUTH_RESULT_FN(Auth, SignInWithEmailAndPassword, AuthResult)
 
 AUTH_RESULT_FN(Auth, CreateUserWithEmailAndPassword, AuthResult)
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  if (!auth_data_) return kAuthErrorUninitialized;
+#if FIREBASE_PLATFORM_IOS
+  return UseUserAccessGroupInternal(auth_data_, access_group);
+#else
+  return kAuthErrorUnimplemented;
+#endif  // FIREBASE_PLATFORM_IOS
+}
+
 }  // namespace auth
 }  // namespace firebase

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -632,6 +632,10 @@ void DestroyUserDataPersist(AuthData* auth_data) {
   auth_data->auth->RemoveAuthStateListener(auth_impl->user_data_persist.get());
 }
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  return kAuthErrorUnimplemented;
+}
+
 void LoadFinishTriggerListeners(AuthData* auth_data) {
   MutexLock destructing_lock(auth_data->destructing_mutex);
   if (auth_data->destructing) {

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -497,6 +497,17 @@ class Auth {
   /// emulator.
   ///
   void UseEmulator(std::string host, uint32_t port);
+
+  /// @brief Sets the user access group to use for data sharing.
+  ///
+  /// This method is only functional on iOS. On other platforms, it will
+  /// immediately return kAuthErrorUnimplemented.
+  ///
+  /// @param[in] access_group The access group to use.
+  ///
+  /// @return kAuthErrorNone on success, or an AuthError code if an error
+  /// occurred.
+  AuthError UseUserAccessGroup(const char* access_group);
 #endif  //! defined(DOXYGEN), to hide the api from public documentation.
 
   /// Gets the App this auth object is connected to.

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -608,5 +608,15 @@ void DisableTokenAutoRefresh(AuthData *auth_data) {}
 void InitializeTokenRefresher(AuthData *auth_data) {}
 void DestroyTokenRefresher(AuthData *auth_data) {}
 
+AuthError UseUserAccessGroupInternal(AuthData* auth_data, const char* access_group) {
+  NSString* access_group_ns_string = access_group ? @(access_group) : nil;
+  NSError* error = nil;
+  BOOL success = [AuthImpl(auth_data) useUserAccessGroup:access_group_ns_string error:&error];
+  if (!success) {
+    return AuthErrorFromNSError(error);
+  }
+  return kAuthErrorNone;
+}
+
 }  // namespace auth
 }  // namespace firebase

--- a/auth/src/ios/common_ios.h
+++ b/auth/src/ios/common_ios.h
@@ -137,6 +137,9 @@ void SignInCallback(FIRUser *_Nullable user, NSError *_Nullable error,
 /// like user interaction errors, they are actually caused by bad provider ids.
 NSError *RemapBadProviderIDErrors(NSError *_Nonnull error);
 
+// iOS-specific implementation of Auth::UseUserAccessGroup.
+AuthError UseUserAccessGroupInternal(AuthData* auth_data, const char* access_group);
+
 }  // namespace auth
 }  // namespace firebase
 


### PR DESCRIPTION
…atforms.

This method allows specifying a Keychain Access Group for sharing user authentication data across multiple apps on iOS. It is a no-op on Android and desktop platforms.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
