### PR TITLE
Implement UseUserAccessGroup for Firebase Auth C++ SDK

### DIFF
--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -575,6 +575,11 @@ void Auth::UseEmulator(std::string host, uint32_t port) {
   auth_impl->assigned_emulator_url.append(std::to_string(port));
 }
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  // This is an iOS-only feature. No-op on other platforms.
+  return kAuthErrorNone;
+}
+
 void InitializeTokenRefresher(AuthData* auth_data) {
   auto auth_impl = static_cast<AuthImpl*>(auth_data->auth_impl);
   auth_impl->token_refresh_thread.Initialize(auth_data);

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -517,6 +517,21 @@ class Auth {
   /// not available on the current device.
   static Auth* GetAuth(App* app, InitResult* init_result_out = nullptr);
 
+  /// @brief Specifies a user access group for iCloud keychain access.
+  ///
+  /// This method is only functional on iOS. On other platforms, it is a no-op
+  /// and will always return `kAuthErrorNone`.
+  ///
+  /// If you are using iCloud keychain synchronization, you will need to call
+  /// this method to set the user access group.
+  ///
+  /// @param[in] access_group The user access group to use. Set to `nullptr` or
+  /// an empty string to use the default access group.
+  ///
+  /// @return `kAuthErrorNone` on success, or an AuthError code if an error
+  /// occurred.
+  AuthError UseUserAccessGroup(const char* access_group);
+
  private:
   /// @cond FIREBASE_APP_INTERNAL
   friend class ::firebase::App;

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -608,5 +608,23 @@ void DisableTokenAutoRefresh(AuthData *auth_data) {}
 void InitializeTokenRefresher(AuthData *auth_data) {}
 void DestroyTokenRefresher(AuthData *auth_data) {}
 
+AuthError Auth::UseUserAccessGroup(const char* access_group_str) {
+  if (!auth_data_) {
+    return kAuthErrorUninitialized;
+  }
+  NSString* access_group_ns_str = nil;
+  if (access_group_str != nullptr && strlen(access_group_str) > 0) {
+    access_group_ns_str = [NSString stringWithUTF8String:access_group_str];
+  }
+
+  NSError* error = nil;
+  BOOL success = [AuthImpl(auth_data_) useUserAccessGroup:access_group_ns_str error:&error];
+  if (success) {
+    return kAuthErrorNone;
+  } else {
+    return AuthErrorFromNSError(error);
+  }
+}
+
 }  // namespace auth
 }  // namespace firebase


### PR DESCRIPTION
This commit introduces the `UseUserAccessGroup` method to the Firebase Authentication C++ SDK.

This method allows developers to specify a user access group for iCloud keychain access on iOS. It calls the underlying Objective-C method `[FIRAuth useUserAccessGroup:error:]`.

On other platforms (Desktop, Android), this method is a no-op and returns `kAuthErrorNone` as the feature is iOS-specific.

Key changes:
- Added `UseUserAccessGroup` declaration to `firebase::auth::Auth` in `auth/src/include/firebase/auth.h` with Doxygen comments.
- Implemented the iOS-specific logic in `auth/src/ios/auth_ios.mm`, including error handling and string conversion.
- Added a stub implementation in `auth/src/desktop/auth_desktop.cc` for non-iOS platforms.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
