### PR TITLE
Add --branch argument to print_github_reviews.py

### DIFF
--- a/scripts/print_github_reviews.py
+++ b/scripts/print_github_reviews.py
@@ -233,6 +233,12 @@ def main():
         help="Pull request number. If not provided, script attempts to find the latest open PR for the current git branch."
     )
     parser.add_argument(
+        "--branch",
+        type=str,
+        default=None,
+        help="Branch name to find the latest open PR for. Mutually exclusive with --pull_number. If neither --pull_number nor --branch is provided, uses the current git branch."
+    )
+    parser.add_argument(
         "--url",
         type=str,
         default=None,
@@ -355,26 +361,40 @@ def main():
         sys.exit(1)
 
     pull_request_number = args.pull_number
-    current_branch_for_pr_check = None # Store branch name if auto-detecting PR
+    branch_to_find_pr_for = None
+
+    if args.pull_number and args.branch:
+        sys.stderr.write(f"Error: --pull_number and --branch are mutually exclusive.{error_suffix}\n")
+        sys.exit(1)
+
     if not pull_request_number:
-        sys.stderr.write("Pull number not specified, attempting to find PR for current branch...\n")
-        current_branch_for_pr_check = get_current_branch_name()
-        if current_branch_for_pr_check:
-            sys.stderr.write(f"Current git branch is: {current_branch_for_pr_check}\n")
-            pull_request_number = get_latest_pr_for_branch(args.token, OWNER, REPO, current_branch_for_pr_check)
-            if pull_request_number:
-                sys.stderr.write(f"Found PR #{pull_request_number} for branch {current_branch_for_pr_check}.\n")
-            else:
-                sys.stderr.write(f"No open PR found for branch {current_branch_for_pr_check} in {OWNER}/{REPO}.\n") # Informational
+        if args.branch:
+            branch_to_find_pr_for = args.branch
+            sys.stderr.write(f"Pull number not specified, attempting to find PR for branch: {branch_to_find_pr_for}...\n")
         else:
-            sys.stderr.write(f"Error: Could not determine current git branch. Cannot find PR automatically.{error_suffix}\n")
-            sys.exit(1)
+            sys.stderr.write("Pull number and branch not specified, attempting to find PR for current git branch...\n")
+            branch_to_find_pr_for = get_current_branch_name()
+            if branch_to_find_pr_for:
+                sys.stderr.write(f"Current git branch is: {branch_to_find_pr_for}\n")
+            else:
+                sys.stderr.write(f"Error: Could not determine current git branch. Cannot find PR automatically.{error_suffix}\n")
+                sys.exit(1)
+
+        if branch_to_find_pr_for: # This will be true if args.branch was given, or if get_current_branch_name() succeeded
+            pull_request_number = get_latest_pr_for_branch(args.token, OWNER, REPO, branch_to_find_pr_for)
+            if pull_request_number:
+                sys.stderr.write(f"Found PR #{pull_request_number} for branch {branch_to_find_pr_for}.\n")
+            else:
+                sys.stderr.write(f"No open PR found for branch {branch_to_find_pr_for} in {OWNER}/{REPO}.\n")
+        # If branch_to_find_pr_for is None here, it means get_current_branch_name() failed and we already exited.
 
     if not pull_request_number: # Final check for PR number
-        error_message = "Error: Pull request number is required."
-        if not args.pull_number and current_branch_for_pr_check: # Auto-detect branch ok, but no PR found
-            error_message = f"Error: Pull request number not specified and no open PR found for branch {current_branch_for_pr_check}."
-        # The case where current_branch_for_pr_check is None (git branch fail) is caught and exited above.
+        error_message = "Error: Pull request number could not be determined."
+        if args.branch: # Specific error if --branch was used
+            error_message = f"Error: No open PR found for specified branch '{args.branch}'."
+        elif not args.pull_number and branch_to_find_pr_for: # Auto-detect current branch ok, but no PR found
+             error_message = f"Error: Pull request number not specified and no open PR found for current branch '{branch_to_find_pr_for}'."
+        # The case where current_branch_for_pr_check (now branch_to_find_pr_for) is None (git branch fail) is caught and exited above.
         sys.stderr.write(f"{error_message}{error_suffix}\n")
         sys.exit(1)
 


### PR DESCRIPTION
This change allows the script to find a pull request based on a specified branch name, in addition to the existing methods of using a pull request number or the current git branch.

The --branch argument is mutually exclusive with --pull_number. If neither --pull_number nor --branch is provided, the script defaults to finding the latest PR for the current git branch.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
