### PR TITLE
Implement Firebase Auth UseUserAccessGroup for C++ iOS SDK

### DIFF
--- a/auth/src/android/auth_android.cc
+++ b/auth/src/android/auth_android.cc
@@ -670,6 +670,12 @@ void Auth::UseEmulator(std::string host, uint32_t port) {
   SetEmulatorJni(auth_data_, host.c_str(), port);
 }
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  (void)access_group;  // Unused on Android.
+  // This is an iOS-only feature, so it's a no-op on Android.
+  return kAuthErrorNone;
+}
+
 // Not implemented for Android.
 void EnableTokenAutoRefresh(AuthData* auth_data) {}
 void DisableTokenAutoRefresh(AuthData* auth_data) {}

--- a/auth/src/desktop/auth_desktop.cc
+++ b/auth/src/desktop/auth_desktop.cc
@@ -575,6 +575,12 @@ void Auth::UseEmulator(std::string host, uint32_t port) {
   auth_impl->assigned_emulator_url.append(std::to_string(port));
 }
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  (void)access_group;  // Unused on desktop.
+  // This is an iOS-only feature, so it's a no-op on desktop.
+  return kAuthErrorNone;
+}
+
 void InitializeTokenRefresher(AuthData* auth_data) {
   auto auth_impl = static_cast<AuthImpl*>(auth_data->auth_impl);
   auth_impl->token_refresh_thread.Initialize(auth_data);

--- a/auth/src/include/firebase/auth.h
+++ b/auth/src/include/firebase/auth.h
@@ -502,6 +502,25 @@ class Auth {
   /// Gets the App this auth object is connected to.
   App& app();
 
+  /// @brief Modifies this Auth instance to use the specified keychain access
+  /// group.
+  ///
+  /// Accessing the keychain requires that the application has the keychain
+  /// sharing capability and that the level of entitling access to the keychain
+  /// is `any` (런타임에 여러 앱에서 키체인 항목을 공유하도록 허용). See
+  /// https://developer.apple.com/documentation/security/keychain_services/keychain_items/sharing_access_to_keychain_items_among_a_collection_of_apps
+  /// for more details.
+  ///
+  /// @note This method is only functional on iOS. On other platforms, it's a
+  /// no-op and will return kAuthErrorNone.
+  ///
+  /// @param[in] access_group The keychain access group to use. Set to @c nullptr
+  /// to use the default app bundle ID access group.
+  ///
+  /// @return kAuthErrorNone on success, or an AuthError code if an error
+  /// occurred.
+  AuthError UseUserAccessGroup(const char* access_group);
+
   /// Returns the Auth object for an App. Creates the Auth if required.
   ///
   /// To get the Auth object for the default app, use,

--- a/auth/src/ios/auth_ios.mm
+++ b/auth/src/ios/auth_ios.mm
@@ -590,6 +590,19 @@ void Auth::UseEmulator(std::string host, uint32_t port) {
   SetEmulatorJni(auth_data_, host.c_str(), port);
 }
 
+AuthError Auth::UseUserAccessGroup(const char* access_group) {
+  if (!auth_data_) {
+    return kAuthErrorUninitialized;
+  }
+  NSString* ns_access_group = access_group ? @(access_group) : nil;
+  NSError* error = nil;
+  BOOL success = [AuthImpl(auth_data_) useUserAccessGroup:ns_access_group error:&error];
+  if (!success) {
+    return AuthErrorFromNSError(error);
+  }
+  return kAuthErrorNone;
+}
+
 // Remap iOS SDK errors reported by the UIDelegate. While these errors seem like
 // user interaction errors, they are actually caused by bad provider ids.
 NSError *RemapBadProviderIDErrors(NSError *_Nonnull error) {


### PR DESCRIPTION
This commit introduces the `UseUserAccessGroup` method to the Firebase Authentication C++ SDK.

This method is specific to iOS and allows developers to specify a keychain access group for user data. It calls the underlying Objective-C method `[FIRAuth useUserAccessGroup:error:]`.

On Android and desktop platforms, this method is a no-op stub and returns `kAuthErrorNone` as per its documented behavior for non-iOS platforms.

Key changes:
- Added `Auth::UseUserAccessGroup(const char* access_group)` to the public header `auth/src/include/firebase/auth.h` with Doxygen comments.
- Implemented the iOS-specific logic in `auth/src/ios/auth_ios.mm`, including error conversion from `NSError` to `AuthError`.
- Added stub implementations in `auth/src/desktop/auth_desktop.cc` and `auth/src/android/auth_android.cc` returning `kAuthErrorNone`.

### Description
> Provide details of the change, and generalize the change in the PR title above.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
