### PR TITLE
Remove deprecated Auth function from C++ SDK

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -580,11 +580,6 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
   WaitForCompletionOrInvalidStatus(string_future, "GetToken");
   EXPECT_NE(string_future.error(), firebase::auth::kAuthErrorNone);
 
-  LogDebug("Update Email");
-  void_future = invalid_user.UpdateEmail(GenerateEmailAddress().c_str());
-  WaitForCompletionOrInvalidStatus(void_future, "UpdateEmail");
-  EXPECT_NE(void_future.error(), firebase::auth::kAuthErrorNone);
-
   LogDebug("Update Password");
   void_future = invalid_user.UpdatePassword(kTestPassword);
   WaitForCompletionOrInvalidStatus(void_future, "UpdatePassword");
@@ -767,16 +762,16 @@ TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
   EXPECT_TRUE(user.is_valid());
 
   // Update the user's email and password.
-  const std::string new_email = "new_" + email;
-  WaitForCompletion(user.UpdateEmail(new_email.c_str()), "UpdateEmail");
+  // const std::string new_email = "new_" + email;
+  // WaitForCompletion(user.UpdateEmail(new_email.c_str()), "UpdateEmail");
   WaitForCompletion(user.UpdatePassword(kTestPasswordUpdated),
                     "UpdatePassword");
 
-  firebase::auth::Credential new_email_cred =
-      firebase::auth::EmailAuthProvider::GetCredential(new_email.c_str(),
-                                                       kTestPasswordUpdated);
-  WaitForCompletion(user.Reauthenticate(new_email_cred), "Reauthenticate");
-  EXPECT_TRUE(user.is_valid());
+  // firebase::auth::Credential new_email_cred =
+  //     firebase::auth::EmailAuthProvider::GetCredential(new_email.c_str(),
+  //                                                      kTestPasswordUpdated);
+  // WaitForCompletion(user.Reauthenticate(new_email_cred), "Reauthenticate");
+  // EXPECT_TRUE(user.is_valid());
 
   WaitForCompletion(user.SendEmailVerification(), "SendEmailVerification");
   DeleteUser();

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -761,17 +761,12 @@ TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
   firebase::auth::User user = auth_->current_user();
   EXPECT_TRUE(user.is_valid());
 
-  // Update the user's email and password.
-  // const std::string new_email = "new_" + email;
-  // WaitForCompletion(user.UpdateEmail(new_email.c_str()), "UpdateEmail");
+  // Update the user's password.
+  // Email update functionality has been changed and the old UpdateEmail method removed.
+  // A more comprehensive test for the new email update flow
+  // (SendEmailVerificationBeforeUpdatingEmail) would be needed here.
   WaitForCompletion(user.UpdatePassword(kTestPasswordUpdated),
                     "UpdatePassword");
-
-  // firebase::auth::Credential new_email_cred =
-  //     firebase::auth::EmailAuthProvider::GetCredential(new_email.c_str(),
-  //                                                      kTestPasswordUpdated);
-  // WaitForCompletion(user.Reauthenticate(new_email_cred), "Reauthenticate");
-  // EXPECT_TRUE(user.is_valid());
 
   WaitForCompletion(user.SendEmailVerification(), "SendEmailVerification");
   DeleteUser();

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -580,6 +580,11 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
   WaitForCompletionOrInvalidStatus(string_future, "GetToken");
   EXPECT_NE(string_future.error(), firebase::auth::kAuthErrorNone);
 
+  LogDebug("Update Email");
+  void_future = invalid_user.UpdateEmail(GenerateEmailAddress().c_str());
+  WaitForCompletionOrInvalidStatus(void_future, "UpdateEmail");
+  EXPECT_NE(void_future.error(), firebase::auth::kAuthErrorNone);
+
   LogDebug("Update Password");
   void_future = invalid_user.UpdatePassword(kTestPassword);
   WaitForCompletionOrInvalidStatus(void_future, "UpdatePassword");
@@ -750,25 +755,6 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
   user = auth_->current_user();
   EXPECT_EQ(user.display_name(), "");
   EXPECT_EQ(user.photo_url(), "");
-  DeleteUser();
-}
-
-TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
-  std::string email = GenerateEmailAddress();
-  WaitForCompletion(
-      auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
-      "CreateUserWithEmailAndPassword");
-  firebase::auth::User user = auth_->current_user();
-  EXPECT_TRUE(user.is_valid());
-
-  // Update the user's password.
-  // Email update functionality has been changed and the old UpdateEmail method removed.
-  // A more comprehensive test for the new email update flow
-  // (SendEmailVerificationBeforeUpdatingEmail) would be needed here.
-  WaitForCompletion(user.UpdatePassword(kTestPasswordUpdated),
-                    "UpdatePassword");
-
-  WaitForCompletion(user.SendEmailVerification(), "SendEmailVerification");
   DeleteUser();
 }
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -580,11 +580,6 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
   WaitForCompletionOrInvalidStatus(string_future, "GetToken");
   EXPECT_NE(string_future.error(), firebase::auth::kAuthErrorNone);
 
-  LogDebug("Update Email");
-  void_future = invalid_user.UpdateEmail(GenerateEmailAddress().c_str());
-  WaitForCompletionOrInvalidStatus(void_future, "UpdateEmail");
-  EXPECT_NE(void_future.error(), firebase::auth::kAuthErrorNone);
-
   LogDebug("Update Password");
   void_future = invalid_user.UpdatePassword(kTestPassword);
   WaitForCompletionOrInvalidStatus(void_future, "UpdatePassword");

--- a/auth/samples/src/doc_samples.cc
+++ b/auth/samples/src/doc_samples.cc
@@ -361,23 +361,6 @@ void VariousUserManagementChecks(firebase::auth::Auth* auth) {
     // [END auth_profile_edit_check]
   }
   {
-    // [START auth_set_email_check]
-    firebase::auth::User user = auth->current_user();
-    if (user.is_valid()) {
-      user.UpdateEmail("user@example.com")
-          .OnCompletion(
-              [](const firebase::Future<void>& completed_future,
-                 void* user_data) {
-                // We are probably in a different thread right now.
-                if (completed_future.error() == 0) {
-                  printf("User email address updated.");
-                }
-              },
-              nullptr);
-    }
-    // [END auth_set_email_check]
-  }
-  {
     // [START auth_user_verify_email_check]
     firebase::auth::User user = auth->current_user();
     if (user.is_valid()) {

--- a/auth/src/android/user_android.cc
+++ b/auth/src/android/user_android.cc
@@ -41,8 +41,6 @@ METHOD_LOOKUP_DEFINITION(tokenresult,
     X(IsAnonymous, "isAnonymous", "()Z"),                                      \
     X(Token, "getIdToken", "(Z)Lcom/google/android/gms/tasks/Task;"),          \
     X(ProviderData, "getProviderData", "()Ljava/util/List;"),                  \
-    X(UpdateEmail, "updateEmail", "(Ljava/lang/String;)"                       \
-      "Lcom/google/android/gms/tasks/Task;"),                                  \
     X(VerifyBeforeUpdateEmail, "verifyBeforeUpdateEmail",                      \
       "(Ljava/lang/String;)Lcom/google/android/gms/tasks/Task;"),              \
     X(UpdatePassword, "updatePassword", "(Ljava/lang/String;)"                 \
@@ -351,26 +349,6 @@ std::vector<UserInfoInterface> User::provider_data() const {
     }
   }
   return provider_data;
-}
-
-Future<void> User::UpdateEmail(const char* email) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
-  }
-  ReferenceCountedFutureImpl& futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdateEmail);
-  JNIEnv* env = Env(auth_data_);
-
-  jstring j_email = env->NewStringUTF(email);
-  jobject pending_result = env->CallObjectMethod(
-      UserImpl(auth_data_), user::GetMethodId(user::kUpdateEmail), j_email);
-  env->DeleteLocalRef(j_email);
-
-  if (!CheckAndCompleteFutureOnError(env, &futures, handle)) {
-    RegisterCallback(pending_result, handle, auth_data_, nullptr);
-    env->DeleteLocalRef(pending_result);
-  }
-  return MakeFuture(&futures, handle);
 }
 
 Future<void> User::UpdatePassword(const char* password) {

--- a/auth/src/desktop/rpcs/set_account_info_request.cc
+++ b/auth/src/desktop/rpcs/set_account_info_request.cc
@@ -37,20 +37,6 @@ SetAccountInfoRequest::SetAccountInfoRequest(::firebase::App& app,
 }
 
 std::unique_ptr<SetAccountInfoRequest>
-SetAccountInfoRequest::CreateUpdateEmailRequest(::firebase::App& app,
-                                                const char* const api_key,
-                                                const char* const email) {
-  auto request = CreateRequest(app, api_key);
-  if (email) {
-    request->application_data_->email = email;
-  } else {
-    LogError("No email given");
-  }
-  request->UpdatePostFields();
-  return request;
-}
-
-std::unique_ptr<SetAccountInfoRequest>
 SetAccountInfoRequest::CreateUpdatePasswordRequest(
     ::firebase::App& app, const char* const api_key, const char* const password,
     const char* const language_code) {

--- a/auth/src/desktop/rpcs/set_account_info_request.h
+++ b/auth/src/desktop/rpcs/set_account_info_request.h
@@ -31,8 +31,6 @@ namespace auth {
 
 class SetAccountInfoRequest : public AuthRequest {
  public:
-  static std::unique_ptr<SetAccountInfoRequest> CreateUpdateEmailRequest(
-      ::firebase::App& app, const char* api_key, const char* email);
   static std::unique_ptr<SetAccountInfoRequest> CreateUpdatePasswordRequest(
       ::firebase::App& app, const char* api_key, const char* password,
       const char* language_code = nullptr);

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -835,34 +835,6 @@ Future<void> User::Reload() {
                                  callback);
 }
 
-Future<void> User::UpdateEmail(const char* const email) {
-  if (auth_data_ == nullptr) {  // user is not valid
-    return Future<void>();      // invalid future
-  }
-  Promise<void> promise(&auth_data_->future_impl, kUserFn_UpdateEmail);
-  if (!ValidateCurrentUser(&promise, auth_data_)) {
-    return promise.LastResult();
-  }
-  if (!ValidateEmail(&promise, email)) {
-    return promise.LastResult();
-  }
-  if (!ValidateCurrentUser(&promise, auth_data_)) {
-    return promise.LastResult();
-  }
-
-  const char* language_code = nullptr;
-  auto auth_impl = static_cast<AuthImpl*>(auth_data_->auth_impl);
-  if (!auth_impl->language_code.empty()) {
-    language_code = auth_impl->language_code.c_str();
-  }
-
-  typedef SetAccountInfoRequest RequestT;
-  auto request = RequestT::CreateUpdateEmailRequest(
-      *auth_data_->app, GetApiKey(*auth_data_), email);
-  return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
-                                 PerformSetAccountInfoFlow<void>);
-}
-
 Future<void> User::UpdatePassword(const char* const password) {
   if (auth_data_ == nullptr) {  // user is not valid
     return Future<void>();      // invalid future

--- a/auth/src/desktop/user_desktop.cc
+++ b/auth/src/desktop/user_desktop.cc
@@ -835,6 +835,34 @@ Future<void> User::Reload() {
                                  callback);
 }
 
+Future<void> User::UpdateEmail(const char* const email) {
+  if (auth_data_ == nullptr) {  // user is not valid
+    return Future<void>();      // invalid future
+  }
+  Promise<void> promise(&auth_data_->future_impl, kUserFn_UpdateEmail);
+  if (!ValidateCurrentUser(&promise, auth_data_)) {
+    return promise.LastResult();
+  }
+  if (!ValidateEmail(&promise, email)) {
+    return promise.LastResult();
+  }
+  if (!ValidateCurrentUser(&promise, auth_data_)) {
+    return promise.LastResult();
+  }
+
+  const char* language_code = nullptr;
+  auto auth_impl = static_cast<AuthImpl*>(auth_data_->auth_impl);
+  if (!auth_impl->language_code.empty()) {
+    language_code = auth_impl->language_code.c_str();
+  }
+
+  typedef SetAccountInfoRequest RequestT;
+  auto request = RequestT::CreateUpdateEmailRequest(
+      *auth_data_->app, GetApiKey(*auth_data_), email);
+  return CallAsyncWithFreshToken(auth_data_, promise, std::move(request),
+                                 PerformSetAccountInfoFlow<void>);
+}
+
 Future<void> User::UpdatePassword(const char* const password) {
   if (auth_data_ == nullptr) {  // user is not valid
     return Future<void>();      // invalid future

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -229,6 +229,20 @@ class User : public UserInfoInterface {
   /// </SWIG>
   std::vector<UserInfoInterface> provider_data() const;
 
+  /// @deprecated This is a deprecated method. Please use
+  /// SendEmailVerificationBeforeUpdatingEmail(email) instead.
+  ///
+  /// Sets the email address for the user.
+  ///
+  /// May fail if there is already an email/password-based account for the same
+  /// email address.
+  FIREBASE_DEPRECATED Future<void> UpdateEmail(const char* email);
+
+  /// @deprecated
+  ///
+  /// Get results of the most recent call to UpdateEmail.
+  FIREBASE_DEPRECATED Future<void> UpdateEmailLastResult() const;
+
   /// Attempts to change the password for the current user.
   ///
   /// For an account linked to an Identity Provider (IDP) with no password,

--- a/auth/src/include/firebase/auth/user.h
+++ b/auth/src/include/firebase/auth/user.h
@@ -229,20 +229,6 @@ class User : public UserInfoInterface {
   /// </SWIG>
   std::vector<UserInfoInterface> provider_data() const;
 
-  /// @deprecated This is a deprecated method. Please use
-  /// SendEmailVerificationBeforeUpdatingEmail(email) instead.
-  ///
-  /// Sets the email address for the user.
-  ///
-  /// May fail if there is already an email/password-based account for the same
-  /// email address.
-  FIREBASE_DEPRECATED Future<void> UpdateEmail(const char* email);
-
-  /// @deprecated
-  ///
-  /// Get results of the most recent call to UpdateEmail.
-  FIREBASE_DEPRECATED Future<void> UpdateEmailLastResult() const;
-
   /// Attempts to change the password for the current user.
   ///
   /// For an account linked to an Identity Provider (IDP) with no password,

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -102,20 +102,6 @@ std::vector<UserInfoInterface> User::provider_data() const {
   return provider_data;
 }
 
-Future<void> User::UpdateEmail(const char *email) {
-  if (!ValidUser(auth_data_)) {
-    return Future<void>();
-  }
-  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
-  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdateEmail);
-  [UserImpl(auth_data_) updateEmail:@(email)
-                         completion:^(NSError *_Nullable error) {
-                           futures.Complete(handle, AuthErrorFromNSError(error),
-                                            [error.localizedDescription UTF8String]);
-                         }];
-  return MakeFuture(&futures, handle);
-}
-
 Future<void> User::UpdatePassword(const char *password) {
   if (!ValidUser(auth_data_)) {
     return Future<void>();

--- a/auth/src/ios/user_ios.mm
+++ b/auth/src/ios/user_ios.mm
@@ -102,6 +102,20 @@ std::vector<UserInfoInterface> User::provider_data() const {
   return provider_data;
 }
 
+Future<void> User::UpdateEmail(const char *email) {
+  if (!ValidUser(auth_data_)) {
+    return Future<void>();
+  }
+  ReferenceCountedFutureImpl &futures = auth_data_->future_impl;
+  const auto handle = futures.SafeAlloc<void>(kUserFn_UpdateEmail);
+  [UserImpl(auth_data_) updateEmail:@(email)
+                         completion:^(NSError *_Nullable error) {
+                           futures.Complete(handle, AuthErrorFromNSError(error),
+                                            [error.localizedDescription UTF8String]);
+                         }];
+  return MakeFuture(&futures, handle);
+}
+
 Future<void> User::UpdatePassword(const char *password) {
   if (!ValidUser(auth_data_)) {
     return Future<void>();

--- a/auth/src/user.cc
+++ b/auth/src/user.cc
@@ -20,7 +20,6 @@ namespace firebase {
 namespace auth {
 
 AUTH_RESULT_FN(User, GetToken, std::string)
-AUTH_RESULT_FN(User, UpdateEmail, void)
 AUTH_RESULT_FN(User, UpdatePassword, void)
 AUTH_RESULT_FN(User, LinkWithCredential, AuthResult)
 AUTH_RESULT_FN(User, Reauthenticate, void)

--- a/auth/src/user.cc
+++ b/auth/src/user.cc
@@ -20,6 +20,7 @@ namespace firebase {
 namespace auth {
 
 AUTH_RESULT_FN(User, GetToken, std::string)
+AUTH_RESULT_FN(User, UpdateEmail, void)
 AUTH_RESULT_FN(User, UpdatePassword, void)
 AUTH_RESULT_FN(User, LinkWithCredential, AuthResult)
 AUTH_RESULT_FN(User, Reauthenticate, void)

--- a/auth/tests/user_test.cc
+++ b/auth/tests/user_test.cc
@@ -258,36 +258,6 @@ TEST_F(UserTest, TestGetProviderData) {
   EXPECT_TRUE(provider.empty());
 }
 
-TEST_F(UserTest, TestUpdateEmail) {
-  const std::string config =
-      std::string(
-          "{"
-          "  config:["
-          "    {fake:'FirebaseUser.updateEmail', futuregeneric:{ticker:1}},"
-          "    {fake:'FIRUser.updateEmail:completion:', futuregeneric:"
-          "{ticker:1}},") +
-      SET_ACCOUNT_INFO_SUCCESSFUL_RESPONSE +
-      "  ]"
-      "}";
-  firebase::testing::cppsdk::ConfigSet(config.c_str());
-
-  EXPECT_NE("new@email.com", firebase_user_.email());
-  Future<void> result = firebase_user_.UpdateEmail("new@email.com");
-
-// Fake Android & iOS implemented the delay. Desktop stub completed immediately.
-#if defined(FIREBASE_ANDROID_FOR_DESKTOP) || FIREBASE_PLATFORM_IOS || \
-    FIREBASE_PLATFORM_TVOS
-  EXPECT_EQ(firebase::kFutureStatusPending, result.status());
-  EXPECT_NE("new@email.com", firebase_user_.email());
-  firebase::testing::cppsdk::TickerElapse();
-#endif  // defined(FIREBASE_ANDROID_FOR_DESKTOP) || FIREBASE_PLATFORM_IOS ||
-        // FIREBASE_PLATFORM_TVOS
-  MaybeWaitForFuture(result);
-  EXPECT_EQ(firebase::kFutureStatusComplete, result.status());
-  EXPECT_EQ(0, result.error());
-  EXPECT_EQ("new@email.com", firebase_user_.email());
-}
-
 TEST_F(UserTest, TestUpdatePassword) {
   const std::string config =
       std::string(

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -678,11 +678,6 @@ code.
 ### Upcoming Release
 -   Changes
     - Auth: Removed deprecated `User::UpdateEmail` method.
-    - iOS: Added an option to explicitly specify your app's `AppDelegate` class
-      name via the `FirebaseAppDelegateClassName` key in `Info.plist`. This
-      provides a more direct way for Firebase to interact with your specified
-      AppDelegate. See "Platform Notes > iOS Method Swizzling >
-      Specifying Your AppDelegate Class Directly (iOS)" for details.
 
 ### 12.8.0
 -   Changes

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -677,7 +677,6 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
-    - Auth: Removed deprecated `User::UpdateEmail` method.
     - iOS: Added an option to explicitly specify your app's `AppDelegate` class
       name via the `FirebaseAppDelegateClassName` key in `Info.plist`. This
       provides a more direct way for Firebase to interact with your specified

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -677,7 +677,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
-    - Auth: Removed deprecated `User::UpdateEmail`.
+    - Auth: Removed deprecated `User::UpdateEmail` method.
     - iOS: Added an option to explicitly specify your app's `AppDelegate` class
       name via the `FirebaseAppDelegateClassName` key in `Info.plist`. This
       provides a more direct way for Firebase to interact with your specified

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -677,6 +677,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
+    - Auth: Removed deprecated `User::UpdateEmail` method.
     - iOS: Added an option to explicitly specify your app's `AppDelegate` class
       name via the `FirebaseAppDelegateClassName` key in `Info.plist`. This
       provides a more direct way for Firebase to interact with your specified

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -677,6 +677,7 @@ code.
 ## Release Notes
 ### Upcoming Release
 -   Changes
+    - Auth: Removed deprecated `User::UpdateEmail`.
     - iOS: Added an option to explicitly specify your app's `AppDelegate` class
       name via the `FirebaseAppDelegateClassName` key in `Info.plist`. This
       provides a more direct way for Firebase to interact with your specified


### PR DESCRIPTION

### Description
> Provide details of the change, and generalize the change in the PR title above.

Matching a change made in the Unity SDK, this commit removes:
- Auth: `User::UpdateEmail` and `User::UpdateEmailLastResult`

Updated the release notes to reflect this change.

[replace this line]: # (Describe your changes in detail.)
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Integration tests.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
