### PR TITLE
feat: Remove trackingID from iOS

### DIFF
--- a/app/src/app_ios.mm
+++ b/app/src/app_ios.mm
@@ -71,10 +71,6 @@ static void PlatformOptionsToAppOptions(FIROptions* platform_options, AppOptions
     const char* value = platform_options.databaseURL.UTF8String;
     if (value) app_options->set_database_url(value);
   }
-  if (!strlen(app_options->ga_tracking_id())) {
-    const char* value = platform_options.trackingID.UTF8String;
-    if (value) app_options->set_ga_tracking_id(value);
-  }
   if (!strlen(app_options->storage_bucket())) {
     const char* value = platform_options.storageBucket.UTF8String;
     if (value) app_options->set_storage_bucket(value);
@@ -106,9 +102,6 @@ static FIROptions* AppOptionsToPlatformOptions(const AppOptions& app_options) {
   }
   if (strlen(app_options.database_url())) {
     platform_options.databaseURL = @(app_options.database_url());
-  }
-  if (strlen(app_options.ga_tracking_id())) {
-    platform_options.trackingID = @(app_options.ga_tracking_id());
   }
   if (strlen(app_options.storage_bucket())) {
     platform_options.storageBucket = @(app_options.storage_bucket());

--- a/app/tests/app_test.cc
+++ b/app/tests/app_test.cc
@@ -207,11 +207,13 @@ TEST_F(AppTest, TestSetDatabaseUrl) {
   EXPECT_STREQ("http://abc-xyz-123.firebaseio.com", options.database_url());
 }
 
+#ifndef __APPLE__
 TEST_F(AppTest, TestSetGaTrackingId) {
   AppOptions options;
   options.set_ga_tracking_id("UA-12345678-1");
   EXPECT_STREQ("UA-12345678-1", options.ga_tracking_id());
 }
+#endif  // __APPLE__
 
 TEST_F(AppTest, TestSetStorageBucket) {
   AppOptions options;
@@ -241,10 +243,12 @@ TEST_F(AppTest, LoadDefault) {
   EXPECT_STREQ("fake messaging sender id from resource",
                options.messaging_sender_id());
   EXPECT_STREQ("fake database url from resource", options.database_url());
+#ifndef __APPLE__
 #if FIREBASE_PLATFORM_IOS || FIREBASE_PLATFORM_TVOS
   // GA tracking ID can currently only be configured on iOS.
   EXPECT_STREQ("fake ga tracking id from resource", options.ga_tracking_id());
 #endif  // FIREBASE_PLATFORM_IOS
+#endif // __APPLE__
   EXPECT_STREQ("fake storage bucket from resource", options.storage_bucket());
   EXPECT_STREQ("fake project id from resource", options.project_id());
 #if !FIREBASE_PLATFORM_IOS


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Firebase 12 Apple SDK has been released and has removed the deprecated, unused `trackingID` property.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Did not test locally, relying on CI for full coverage.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
