### PR TITLE
Update the tvOS simulator version used by tests

### DIFF
--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -223,7 +223,7 @@ TEST_DEVICES = {
   "simulator_min": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.2"} ],
   "simulator_target": [ {"type": "virtual", "name":"iPhone 15 Pro Max", "version":"17.2"} ],
   "simulator_latest": [ {"type": "virtual", "name":"iPhone 15 Pro", "version":"17.4"} ],
-  "tvos_simulator": [ {"type": "virtual", "name":"Apple TV", "version":"16.1"} ],
+  "tvos_simulator": [ {"type": "virtual", "name":"Apple TV", "version":"17.2"} ],
 }
 
 # Easy accesssor for getting a TEST_DEVICES entry. Note that once a device model


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The GHA runners no longer have tvOS 16.1 available by default, so change to 17.2 instead.
https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#installed-simulators
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


[replace this line]: # (Describe your testing in detail.)
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
