### PR TITLE
Guard remote config response parsing from empty FlatBuffer

### DIFF
--- a/remote_config/src/desktop/remote_config_response.cc
+++ b/remote_config/src/desktop/remote_config_response.cc
@@ -95,7 +95,7 @@ void RemoteConfigResponse::MarkCompleted() {
     return;
   }
   const flatbuffers::FlatBufferBuilder& builder = parser_->builder_;
-  if (builder.GetSize() == 0 || builder.GetBufferPointer() == nullptr) {
+  if (builder.GetSize() < sizeof(flatbuffers::uoffset_t) || builder.GetBufferPointer() == nullptr) {
     return;
   }
   const fbs::Response* body_fbs =


### PR DESCRIPTION
### Description

Guard RemoteConfigResponse::MarkCompleted() from attempting to read a FlatBuffer when the builder holds no data, preventing the desktop Remote Config client from crashing on empty responses.

Fixes #1433.

———

### Testing

Not run (Remote Config desktop integration tests depend on internal credentials; change is limited to an early-exit guard).

———

### Type of Change

- [x] Bug fix. Add the issue # below if applicable. — #1433
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.

———