### PR TITLE
Update the python version used by GHA runners

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install prerequisites
         run: python scripts/gha/install_prereqs_desktop.py
       - name: log clang format version
@@ -62,7 +62,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install prerequisites
         run: |
           python scripts/gha/install_prereqs_desktop.py

--- a/.github/workflows/checks_secure.yml
+++ b/.github/workflows/checks_secure.yml
@@ -33,7 +33,7 @@ jobs:
         if: steps.check.outputs.has-permission != 1 || github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install prerequisites
         if: steps.check.outputs.has-permission != 1 || github.event.pull_request.head.repo.full_name != github.repository
         run: pip install -r scripts/gha/python_requirements.txt

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -100,7 +100,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Fetch and build binutils
         run: |
@@ -213,7 +213,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: install prerequisites
         run: sdk-src/build_scripts/ios/install_prereqs.sh
@@ -322,7 +322,7 @@ jobs:
         architecture: ["x64", "x86", "arm64"]
         msvc_runtime: ["static", "dynamic"]
         linux_abi: ["legacy", "c++11"]
-        python_version: [3.8]
+        python_version: [3.9]
         include:
         - os: windows-latest
           vcpkg_triplet_suffix: "windows-static"
@@ -535,7 +535,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Install prerequisites
         run: |
@@ -854,7 +854,7 @@ jobs:
     - name: Setup python
       uses: actions/setup-python@v4
       with:
-        python-version: '3.8'
+        python-version: '3.9'
     - name: Use expanded matrix
       if: github.event_name == 'schedule' || github.event.inputs.use_expanded_matrix == '1'
       run: |
@@ -923,7 +923,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install python deps
         run: pip install -r scripts/gha/python_requirements.txt
       # The default token can't run workflows, so get an alternate token.

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -48,7 +48,7 @@ env:
   triggerLabelPrefix: "tests-requested: "
   triggerLabelFull: "tests-requested: full"
   triggerLabelQuick: "tests-requested: quick"
-  pythonVersion: '3.8'
+  pythonVersion: '3.9'
   xcodeVersion: '16.2'
   logArtifactRetentionDays: 90
   binaryArtifactRetentionDays: 7

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
           architecture: "arm64"
 
       - name: Install prerequisites

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install prerequisites
         run: |
           cd firebase

--- a/.github/workflows/retry-test-failures.yml
+++ b/.github/workflows/retry-test-failures.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - name: Check out base branch
         uses: actions/checkout@v3

--- a/.github/workflows/update-feature-branches.yml
+++ b/.github/workflows/update-feature-branches.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Setup python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: 3.9
 
       - uses: actions/checkout@v3
         with:

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -78,7 +78,7 @@ PARAMETERS = {
       "architecture": ["x64", "x86", "arm64"],
       "msvc_runtime": ["static","dynamic"],
       "xcode_version": ["16.2"],
-      "python_version": ["3.8"],
+      "python_version": ["3.9"],
 
       EXPANDED_KEY: {
         "os": ["ubuntu-22.04", "macos-14", "windows-latest"],
@@ -91,7 +91,7 @@ PARAMETERS = {
     "matrix": {
       "os": ["ubuntu-22.04", "macos-14", "windows-latest"],
       "architecture": ["x64", "arm64"],
-      "python_version": ["3.8"],
+      "python_version": ["3.9"],
 
       EXPANDED_KEY: {
         "os": ["ubuntu-22.04", "macos-14", "windows-latest"]


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

It seems like gcloud is requiring Python 3.9, so update the runners to just use that consistently across.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
