### PR TITLE
ci: free up disk space on macOS runners by deleting unused Xcode versions

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -313,6 +313,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install Desktop SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -624,6 +630,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install iOS SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -743,6 +755,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install tvOS SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -884,6 +902,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:
@@ -1157,6 +1181,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:
@@ -1343,6 +1373,12 @@ jobs:
           sudo xcode-select -s /Applications/Xcode_${{ env.xcodeVersion }}.app/Contents/Developer
           # Remove default Xcode version to prevent the wrong SDK from being used.
           rm -rf /Applications/Xcode.app
+          # Free up disk space by removing unused Xcode versions
+          for app in /Applications/Xcode_*.app; do
+            if [ "$app" != "/Applications/Xcode_${{ env.xcodeVersion }}.app" ]; then
+              sudo rm -rf "$app" || true
+            fi
+          done
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -319,6 +319,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install Desktop SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -636,6 +640,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install iOS SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -761,6 +769,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install tvOS SDK & integration tests prerequisites
         uses: nick-invision/retry@v2
         with:
@@ -908,6 +920,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:
@@ -1187,6 +1203,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:
@@ -1379,6 +1399,10 @@ jobs:
               sudo rm -rf "$app" || true
             fi
           done
+          # Free up disk space by removing unused tools
+          sudo rm -rf /usr/local/share/dotnet || true
+          sudo rm -rf /Users/runner/hostedtoolcache/CodeQL || true
+          sudo rm -rf /Users/runner/Library/Android/sdk || true
       - name: Install prerequisites for testing
         uses: nick-invision/retry@v2
         with:


### PR DESCRIPTION
The iOS integration test builds on `macos-14` are failing due to running out of disk space (`System.IO.IOException: No space left on device`).

This PR adds a step to delete unused Xcode versions on macOS runners during the `setup default Xcode version` step, which should free up enough disk space to allow the builds to complete successfully. This is applied to iOS, tvOS, and desktop macOS jobs.