### PR TITLE
Increase valid starting times for github report

### DIFF
--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -129,7 +129,6 @@ _MISSING_TEXT = "Missing"
 
 general_test_hour = 9
 firestore_test_hour = 10
-test_time_minute_range = 59
 
 def rename_key(old_dict,old_name,new_name):
     """Rename a key in a dictionary, preserving the order."""
@@ -388,9 +387,9 @@ def main(argv):
         if run['day'] < start_date or run['day'] > end_date: continue
         run['duration'] = dateutil.parser.parse(run['updated_at'], ignoretz=True) - run['date']
         compare_test_hour = firestore_test_hour if FLAGS.firestore else general_test_hour
-        # The general test should start at 9:00, and firestore at 10:00, but we give it a range
-        # because the tests can take a few minutes before starting.
-        if run['date'].hour == compare_test_hour and run['date'].minute <= test_time_minute_range:
+        # The scheduled time is at the top of the hour (e.g. 09:00 or 10:00).
+        # We allow for some delay in GitHub Actions starting the job, as long as it starts in the same hour.
+        if run['date'].hour == compare_test_hour:
           source_tests[day] = run
           all_days.add(day)
 

--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -129,7 +129,7 @@ _MISSING_TEXT = "Missing"
 
 general_test_hour = 9
 firestore_test_hour = 10
-test_time_minute_range = 20
+test_time_minute_range = 59
 
 def rename_key(old_dict,old_name,new_name):
     """Rename a key in a dictionary, preserving the order."""


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The github actions that run as a part of our nightly reports often start later than expected. We previously allowed for a 20 minute delay. Now we should just care about which hour in which the job was started. Recently we have had delays up to 45 minutes.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

... 
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
