### PR TITLE
Fix issues with Auth integration tests

### DIFF
--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -445,9 +445,7 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
 #endif
 
 static std::string GenerateEmailAddress(const std::string& test_name) {
-  char time_string[22];
-  snprintf(time_string, sizeof(time_string), "%lld",
-           app_framework::GetCurrentTimeInMicroseconds());
+  std::string time_string = std::to_string(app_framework::GetCurrentTimeInMicroseconds());
 
   std::string sanitized_test_name = test_name;
   for (char& c : sanitized_test_name) {
@@ -460,14 +458,11 @@ static std::string GenerateEmailAddress(const std::string& test_name) {
     sanitized_test_name = sanitized_test_name.substr(0, 25);
   }
 
-  std::string email = "user_";
-  email.append(INTEGRATION_TEST_PLATFORM_NAME);
-  email.append("_");
-  email.append(sanitized_test_name);
-  email.append("_");
-  email.append(time_string);
-  email.append("@gmail.com");
+  std::string email = "user_" + std::string(INTEGRATION_TEST_PLATFORM_NAME) + "_" +
+                 sanitized_test_name + "_" + time_string + "@gmail.com";
 
+  // The backend generally returns the string as lowercase, so just make it lowercase
+  // to avoid confusion when comparing later.
   std::transform(email.begin(), email.end(), email.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -841,28 +841,23 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
   WaitForCompletion(user.LinkWithCredential(credential), "LinkWithCredential");
-  WaitForCompletion(user.Unlink(credential.provider().c_str()), "Unlink");
-  SignOut();
-  WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
-  user = auth_->current_user();
-  EXPECT_TRUE(user.is_valid());
+
+  // At this point, the user is linked to email, so linking again should fail.
   std::string email1 = GenerateEmailAddress("LinkAnonEmail1");
   firebase::auth::Credential credential1 =
       firebase::auth::EmailAuthProvider::GetCredential(email1.c_str(),
                                                        kTestPassword);
   WaitForCompletion(user.LinkWithCredential(credential1),
-                    "LinkWithCredential 1");
-  user = auth_->current_user();
+                    "LinkWithCredential (ProviderAlreadyLinked)",
+                    firebase::auth::kAuthErrorProviderAlreadyLinked);
+
+  // Next, we unlink the first provider, then link again.
+  WaitForCompletion(user.Unlink(credential.provider().c_str()), "Unlink");
+  WaitForCompletion(user.LinkWithCredential(credential1),
+                    "LinkWithCredential (Second attempt)");
   EXPECT_TRUE(user.is_valid());
 
-  std::string email2 = GenerateEmailAddress("LinkAnonEmail2");
-  firebase::auth::Credential credential2 =
-      firebase::auth::EmailAuthProvider::GetCredential(email2.c_str(),
-                                                       kTestPassword);
-  WaitForCompletion(user.LinkWithCredential(credential2),
-                    "LinkWithCredential 2",
-                    firebase::auth::kAuthErrorProviderAlreadyLinked);
-  WaitForCompletion(user.Unlink(credential.provider().c_str()), "Unlink 2");
+  // Finally, delete the user.
   DeleteUser();
 
   // In case any operations failed, force signout before retrying the test.
@@ -885,13 +880,6 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithBadCredential) {
   EXPECT_TRUE(auth_->current_user().is_valid());
   EXPECT_EQ(auth_->current_user().uid(), pre_link_user.uid());
   DeleteUser();
-}
-
-TEST_F(FirebaseAuthTest, TestSignInWithBadEmailFails) {
-  WaitForCompletion(
-      auth_->SignInWithEmailAndPassword(kTestEmailBad, kTestPassword),
-      "SignInWithEmailAndPassword", firebase::auth::kAuthErrorUserNotFound);
-  EXPECT_FALSE(auth_->current_user().is_valid());
 }
 
 TEST_F(FirebaseAuthTest, TestSignInWithBadPasswordFails) {

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -15,6 +15,7 @@
 #include <inttypes.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
@@ -425,19 +426,52 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
                     ElementsAre("", Not(""), Not(""), Not(""), "")));
 }
 
-static std::string GenerateEmailAddress() {
+#if FIREBASE_PLATFORM_ANDROID
+#define INTEGRATION_TEST_PLATFORM_NAME "Android"
+#elif FIREBASE_PLATFORM_IOS
+#define INTEGRATION_TEST_PLATFORM_NAME "iOS"
+#elif FIREBASE_PLATFORM_TVOS
+#define INTEGRATION_TEST_PLATFORM_NAME "tvOS"
+#elif FIREBASE_PLATFORM_OSX
+#define INTEGRATION_TEST_PLATFORM_NAME "MacOS"
+#elif FIREBASE_PLATFORM_WINDOWS
+#define INTEGRATION_TEST_PLATFORM_NAME "Windows"
+#elif FIREBASE_PLATFORM_LINUX
+#define INTEGRATION_TEST_PLATFORM_NAME "Linux"
+#else
+#define INTEGRATION_TEST_PLATFORM_NAME "Unknown"
+#endif
+
+static std::string GenerateEmailAddress(const std::string& test_name) {
   char time_string[22];
   snprintf(time_string, sizeof(time_string), "%lld",
            app_framework::GetCurrentTimeInMicroseconds());
-  std::string email = "random_user_";
+
+  std::string sanitized_test_name = test_name;
+  for (char& c : sanitized_test_name) {
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != '_') {
+      c = '_';
+    }
+  }
+
+  if (sanitized_test_name.length() > 25) {
+    sanitized_test_name = sanitized_test_name.substr(0, 25);
+  }
+
+  std::string email = "user_";
+  email.append(INTEGRATION_TEST_PLATFORM_NAME);
+  email.append("_");
+  email.append(sanitized_test_name);
+  email.append("_");
   email.append(time_string);
   email.append("@gmail.com");
+
   LogDebug("Generated email address: %s", email.c_str());
   return email;
 }
 
 TEST_F(FirebaseAuthTest, TestEmailAndPasswordSignin) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("EmailAndPasswordSignin");
   // Register a random email and password. This signs us in as that user.
   std::string password = kTestPassword;
   firebase::Future<firebase::auth::AuthResult> auth_result_future =
@@ -529,7 +563,7 @@ TEST_F(FirebaseAuthTest, TestCopyUser) {
 }
 
 TEST_F(FirebaseAuthTest, TestRetainedUser) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("RetainedUser");
   // Register a random email and password. This signs us in as that user.
   std::string password = kTestPassword;
   firebase::Future<firebase::auth::AuthResult> auth_result_future =
@@ -546,7 +580,7 @@ TEST_F(FirebaseAuthTest, TestRetainedUser) {
   EXPECT_EQ(retained_user.email(), "");
 
   // Sign in a new account.
-  email = GenerateEmailAddress();
+  email = GenerateEmailAddress("RetainedUserNew");
   auth_result_future =
       auth_->CreateUserWithEmailAndPassword(email.c_str(), password.c_str());
   WaitForCompletion(auth_result_future, "CreateUserWithEmailAndPassword");
@@ -587,7 +621,8 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
 
   firebase::auth::Credential email_cred =
       firebase::auth::EmailAuthProvider::GetCredential(
-          GenerateEmailAddress().c_str(), kTestPasswordUpdated);
+          GenerateEmailAddress("InvalidUserReauth").c_str(),
+          kTestPasswordUpdated);
   LogDebug("Reauthenticate");
   void_future = invalid_user.Reauthenticate(email_cred);
   WaitForCompletionOrInvalidStatus(void_future, "Reauthenticate");
@@ -606,7 +641,7 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
 
   LogDebug("SendEmailVerificationBeforeUpdatingEmail");
   void_future = invalid_user.SendEmailVerificationBeforeUpdatingEmail(
-      GenerateEmailAddress().c_str());
+      GenerateEmailAddress("InvalidUserVerify").c_str());
   WaitForCompletionOrInvalidStatus(void_future,
                                    "SendEmailVerificationBeforeUpdatingEmail");
   EXPECT_NE(void_future.error(), firebase::auth::kAuthErrorNone);
@@ -639,7 +674,7 @@ TEST_F(FirebaseAuthTest, TestOperationsOnInvalidUser) {
 }
 
 TEST_F(FirebaseAuthTest, TestUpdateUserProfile) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("UpdateUserProfile");
   firebase::Future<firebase::auth::AuthResult> create_user =
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
@@ -670,7 +705,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfile) {
 }
 
 TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("UpdateUserProfileNull");
   firebase::Future<firebase::auth::AuthResult> create_user =
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
@@ -712,7 +747,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileNull) {
 }
 
 TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("UpdateUserProfileEmpty");
   firebase::Future<firebase::auth::AuthResult> create_user =
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword);
   WaitForCompletion(create_user, "CreateUserWithEmailAndPassword");
@@ -754,7 +789,7 @@ TEST_F(FirebaseAuthTest, TestUpdateUserProfileEmpty) {
 }
 
 TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("UpdateEmailAndPassword");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword");
@@ -773,7 +808,7 @@ TEST_F(FirebaseAuthTest, TestUpdateEmailAndPassword) {
 }
 
 TEST_F(FirebaseAuthTest, TestVerifyBeforeUpdatingEmail) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("VerifyBeforeUpdatingEmail");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword");
@@ -796,7 +831,7 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
 
   firebase::auth::User user = auth_->current_user();
   EXPECT_TRUE(user.is_valid());
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("LinkAnonEmail");
   firebase::auth::Credential credential =
       firebase::auth::EmailAuthProvider::GetCredential(email.c_str(),
                                                        kTestPassword);
@@ -806,7 +841,7 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
   WaitForCompletion(auth_->SignInAnonymously(), "SignInAnonymously");
   user = auth_->current_user();
   EXPECT_TRUE(user.is_valid());
-  std::string email1 = GenerateEmailAddress();
+  std::string email1 = GenerateEmailAddress("LinkAnonEmail1");
   firebase::auth::Credential credential1 =
       firebase::auth::EmailAuthProvider::GetCredential(email1.c_str(),
                                                        kTestPassword);
@@ -815,7 +850,7 @@ TEST_F(FirebaseAuthTest, TestLinkAnonymousUserWithEmailCredential) {
   user = auth_->current_user();
   EXPECT_TRUE(user.is_valid());
 
-  std::string email2 = GenerateEmailAddress();
+  std::string email2 = GenerateEmailAddress("LinkAnonEmail2");
   firebase::auth::Credential credential2 =
       firebase::auth::EmailAuthProvider::GetCredential(email2.c_str(),
                                                        kTestPassword);
@@ -855,7 +890,7 @@ TEST_F(FirebaseAuthTest, TestSignInWithBadEmailFails) {
 }
 
 TEST_F(FirebaseAuthTest, TestSignInWithBadPasswordFails) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("SignInBadPassword");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword");
@@ -875,7 +910,7 @@ TEST_F(FirebaseAuthTest, TestSignInWithBadPasswordFails) {
 }
 
 TEST_F(FirebaseAuthTest, TestCreateUserWithExistingEmailFails) {
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("CreateUserExistingEmail");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword 1");
@@ -996,7 +1031,7 @@ TEST_F(FirebaseAuthTest, TestGameCenterSignIn) {
 
 TEST_F(FirebaseAuthTest, TestSendPasswordResetEmail) {
   // Test Auth::SendPasswordResetEmail().
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("SendPasswordResetEmail");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword");
@@ -1059,7 +1094,7 @@ TEST_F(FirebaseAuthTest, TestAuthPersistenceWithEmailSignin) {
 
   FLAKY_TEST_SECTION_BEGIN();
 
-  std::string email = GenerateEmailAddress();
+  std::string email = GenerateEmailAddress("AuthPersistenceEmail");
   WaitForCompletion(
       auth_->CreateUserWithEmailAndPassword(email.c_str(), kTestPassword),
       "CreateUserWithEmailAndPassword");

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -445,7 +445,8 @@ TEST_F(FirebaseAuthTest, TestTokensAndAuthStateListeners) {
 #endif
 
 static std::string GenerateEmailAddress(const std::string& test_name) {
-  std::string time_string = std::to_string(app_framework::GetCurrentTimeInMicroseconds());
+  std::string time_string =
+      std::to_string(app_framework::GetCurrentTimeInMicroseconds());
 
   std::string sanitized_test_name = test_name;
   for (char& c : sanitized_test_name) {
@@ -458,11 +459,12 @@ static std::string GenerateEmailAddress(const std::string& test_name) {
     sanitized_test_name = sanitized_test_name.substr(0, 25);
   }
 
-  std::string email = "user_" + std::string(INTEGRATION_TEST_PLATFORM_NAME) + "_" +
-                 sanitized_test_name + "_" + time_string + "@gmail.com";
+  std::string email = "user_" + std::string(INTEGRATION_TEST_PLATFORM_NAME) +
+                      "_" + sanitized_test_name + "_" + time_string +
+                      "@gmail.com";
 
-  // The backend generally returns the string as lowercase, so just make it lowercase
-  // to avoid confusion when comparing later.
+  // The backend generally returns the string as lowercase, so just make it
+  // lowercase to avoid confusion when comparing later.
   std::transform(email.begin(), email.end(), email.begin(),
                  [](unsigned char c) { return std::tolower(c); });
 

--- a/auth/integration_test/src/integration_test.cc
+++ b/auth/integration_test/src/integration_test.cc
@@ -297,6 +297,8 @@ void FirebaseAuthTest::DeleteUser() {
     FirebaseTest::WaitForCompletion(auth_->current_user().Delete(),
                                     "Delete User");
     ProcessEvents(100);
+  } else {
+    LogDebug("Failed to Delete User, not Signed In");
   }
 }
 
@@ -465,6 +467,9 @@ static std::string GenerateEmailAddress(const std::string& test_name) {
   email.append("_");
   email.append(time_string);
   email.append("@gmail.com");
+
+  std::transform(email.begin(), email.end(), email.begin(),
+                 [](unsigned char c) { return std::tolower(c); });
 
   LogDebug("Generated email address: %s", email.c_str());
   return email;


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

There are two noticeable issues in the nightly tests:
SignInWithBadEmail would regularly fail because the backend thought it was suspicious, which resulted in the wrong error. Just deleting that test, since that behavior doesn't really need to be tested anyway.
LinkAnonymousUserWithEmailCredential was not properly cleaning up the users it created, resulting in leftover users on the backend that needed to be cleaned up. Refactored the test to address it.

Also adjusted the generated emails, so that they can be more easily tracked back if they are not cleaned up properly.

***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

https://github.com/firebase/firebase-cpp-sdk/actions/runs/25352154658
***

### Type of Change
Place an `x` the applicable box:
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
