### PR TITLE
Handle retries in build reporting

### DIFF
--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -482,8 +482,13 @@ def main(argv):
           sorted_artifacts = sorted(artifacts, key=lambda art: dateutil.parser.parse(art['created_at']), reverse=True)
 
           with tempfile.TemporaryDirectory() as tmpdir:
+            downloaded_artifact_names = set()
             for a in sorted_artifacts: # Iterate over sorted artifacts
               if 'log-artifact' in a['name']:
+                if a['name'] in downloaded_artifact_names:
+                  logging.debug("Skipping older attempt of artifact: %s (ID: %s, Created: %s)", a['name'], a['id'], a['created_at'])
+                  continue
+                downloaded_artifact_names.add(a['name'])
                 logging.debug("Attempting to download artifact: %s (ID: %s, Created: %s)", a['name'], a['id'], a['created_at'])
                 # Pass tmpdir to download_artifact to save directly
                 artifact_downloaded_path = os.path.join(tmpdir, f"{a['id']}.zip")


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The report_build_status script already sorts CI runs new to old, but was accidentally overriding newer attempts with older attempts because of this. Add logic to ignore older runs of the same name to handle this.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running it locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
