### PR TITLE
Support Auth requests when Appcheck is enabled for windows applications

### DIFF
--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -20,12 +20,18 @@
 #include <string>
 
 #include "app/src/app_common.h"
+#include "app/src/function_registry.h"
 #include "app/src/heartbeat/heartbeat_controller_desktop.h"
 #include "app/src/include/firebase/app.h"
+#include "app/src/include/firebase/future.h"
 #include "app/src/include/firebase/internal/mutex.h"
 #include "auth/src/desktop/auth_desktop.h"
 #include "auth/src/include/firebase/auth.h"
 #include "firebase/log.h"
+
+namespace {
+const int kAppCheckTokenTimeoutMs = 10000;
+}  // namespace
 
 namespace firebase {
 namespace auth {
@@ -48,6 +54,19 @@ AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
         add_header(app_common::kApiClientHeader, payload.c_str());
         add_header(app_common::kXFirebaseGmpIdHeader, gmp_app_id.c_str());
       }
+    }
+  }
+
+  // Add AppCheck attestation token if available.
+  // This is required when AppCheck enforcement is enabled on the project.
+  Future<std::string> app_check_future;
+  bool succeeded = app.function_registry()->CallFunction(
+      ::firebase::internal::FnAppCheckGetTokenAsync, &app, nullptr,
+      &app_check_future);
+  if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
+    const std::string* token = app_check_future.Await(kAppCheckTokenTimeoutMs);
+    if (token) {
+      add_header("X-Firebase-AppCheck", token->c_str());
     }
   }
 }

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -62,11 +62,12 @@ AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
   ::firebase::internal::FunctionRegistry* registry = app.function_registry();
   if (registry) {
     Future<std::string> app_check_future;
-    bool succeeded = registry->CallFunction(
-        ::firebase::internal::FnAppCheckGetTokenAsync, &app, nullptr,
-        &app_check_future);
+    bool succeeded =
+        registry->CallFunction(::firebase::internal::FnAppCheckGetTokenAsync,
+                               &app, nullptr, &app_check_future);
     if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
-      const std::string* token = app_check_future.Await(kAppCheckTokenTimeoutMs);
+      const std::string* token =
+          app_check_future.Await(kAppCheckTokenTimeoutMs);
       if (token && app_check_future.error() == 0 && !token->empty()) {
         add_header("X-Firebase-AppCheck", token->c_str());
       }

--- a/auth/src/desktop/rpcs/auth_request.cc
+++ b/auth/src/desktop/rpcs/auth_request.cc
@@ -59,14 +59,17 @@ AuthRequest::AuthRequest(::firebase::App& app, const char* schema,
 
   // Add AppCheck attestation token if available.
   // This is required when AppCheck enforcement is enabled on the project.
-  Future<std::string> app_check_future;
-  bool succeeded = app.function_registry()->CallFunction(
-      ::firebase::internal::FnAppCheckGetTokenAsync, &app, nullptr,
-      &app_check_future);
-  if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
-    const std::string* token = app_check_future.Await(kAppCheckTokenTimeoutMs);
-    if (token) {
-      add_header("X-Firebase-AppCheck", token->c_str());
+  ::firebase::internal::FunctionRegistry* registry = app.function_registry();
+  if (registry) {
+    Future<std::string> app_check_future;
+    bool succeeded = registry->CallFunction(
+        ::firebase::internal::FnAppCheckGetTokenAsync, &app, nullptr,
+        &app_check_future);
+    if (succeeded && app_check_future.status() != kFutureStatusInvalid) {
+      const std::string* token = app_check_future.Await(kAppCheckTokenTimeoutMs);
+      if (token && app_check_future.error() == 0 && !token->empty()) {
+        add_header("X-Firebase-AppCheck", token->c_str());
+      }
     }
   }
 }

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -617,6 +617,7 @@ code.
 - Changes
     - General (iOS, tvOS, Desktop): iOS, tvOS, and macOS SDKs are now built
       using Xcode 26.2.
+    - Auth (Windows): Fixes Auth requests when Appcheck is enabled.
 
 ### 13.7.0
 - Changes 


### PR DESCRIPTION
### Description

Fixes Auth requests when Appcheck is enabled for desktop applications. Without it, Auth requests are rejected.

Adds X-Firebase-AppCheck with token header to Authorization requests.

***
### Testing

Have tested Auth requests in flutter application running in windows with debug tokens in firebase.

***

### Type of Change
- [x] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [ ] Other, such as a build process or documentation change.
***