### PR TITLE
Use system zlib for build tools

### DIFF
--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -121,7 +121,7 @@ jobs:
           mv ./binutils-${{ matrix.binutils_version }} ./binutils-src
           mkdir /tmp/binutils-output
           cd binutils-src
-          ./configure --enable-targets=all --prefix=/tmp/binutils-output
+          ./configure --enable-targets=all --with-system-zlib --prefix=/tmp/binutils-output
           make -j2
           make install
           cd -


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

After updating to the newer mac runners, the binutil tool has been failing to build correctly because of the zlib version. The zlib version isn't that important to this use case, so use the system one instead.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

https://github.com/firebase/firebase-cpp-sdk/actions/runs/26471027607
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
