### PR TITLE
Change nightly status script to not depend on time

### DIFF
--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -379,17 +379,16 @@ def main(argv):
         run['date'] = dateutil.parser.parse(run['created_at'], ignoretz=True)
         run['day'] = run['date'].date()
         day = str(run['date'].date())
-        if not FLAGS.firestore and day in source_tests: continue
-        if day in source_tests:
-          prev_date = source_tests[day]['date'].date()
-          # Non-Firestore wants to keep the earliest, otherwise the latest
-          if not FLAGS.firestore and prev_date < run['date'].date():
-            continue
-          elif FLAGS.firestore and prev_date > run['date'].date():
-            continue
         if run['event'] != 'schedule': continue
         if run['status'] != 'completed': continue
         if run['day'] < start_date or run['day'] > end_date: continue
+        if day in source_tests:
+          prev_date = source_tests[day]['date']
+          # Non-Firestore wants to keep the earliest, otherwise the latest
+          if not FLAGS.firestore and prev_date < run['date']:
+            continue
+          elif FLAGS.firestore and prev_date > run['date']:
+            continue
         run['duration'] = dateutil.parser.parse(run['updated_at'], ignoretz=True) - run['date']
         source_tests[day] = run
         all_days.add(day)

--- a/scripts/gha/report_build_status.py
+++ b/scripts/gha/report_build_status.py
@@ -127,9 +127,6 @@ _FAILURE_TEXT = "Failure"
 _FLAKY_TEXT = "Pass (flaky)"
 _MISSING_TEXT = "Missing"
 
-general_test_hour = 9
-firestore_test_hour = 10
-
 def rename_key(old_dict,old_name,new_name):
     """Rename a key in a dictionary, preserving the order."""
     new_dict = {}
@@ -382,16 +379,20 @@ def main(argv):
         run['date'] = dateutil.parser.parse(run['created_at'], ignoretz=True)
         run['day'] = run['date'].date()
         day = str(run['date'].date())
-        if day in source_tests: continue
+        if not FLAGS.firestore and day in source_tests: continue
+        if day in source_tests:
+          prev_date = source_tests[day]['date'].date()
+          # Non-Firestore wants to keep the earliest, otherwise the latest
+          if not FLAGS.firestore and prev_date < run['date'].date():
+            continue
+          elif FLAGS.firestore and prev_date > run['date'].date():
+            continue
+        if run['event'] != 'schedule': continue
         if run['status'] != 'completed': continue
         if run['day'] < start_date or run['day'] > end_date: continue
         run['duration'] = dateutil.parser.parse(run['updated_at'], ignoretz=True) - run['date']
-        compare_test_hour = firestore_test_hour if FLAGS.firestore else general_test_hour
-        # The scheduled time is at the top of the hour (e.g. 09:00 or 10:00).
-        # We allow for some delay in GitHub Actions starting the job, as long as it starts in the same hour.
-        if run['date'].hour == compare_test_hour:
-          source_tests[day] = run
-          all_days.add(day)
+        source_tests[day] = run
+        all_days.add(day)
 
       workflow_id = _WORKFLOW_PACKAGING
       all_runs = firebase_github.list_workflow_runs(FLAGS.token, workflow_id, _BRANCH, 'schedule', _LIMIT)


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The nightly report routinely fails to find source tests because it is relying on the time, which is inconsistent. Instead, check if the run was invoked via a schedule, and the determine if it is Firestore by using the time.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Running it locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
