### PR TITLE
Pin build to windows 2022

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -52,7 +52,7 @@ jobs:
         python_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_python_version) }}
         exclude:
         # Do not attempt to use arm64 on Windows or Linux.
-        - os: windows-latest
+        - os: windows-2022
           architecture: arm64
         - os: ubuntu-22.04
           architecture: arm64

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -320,17 +320,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest, ubuntu-22.04, macos-15]
+        os: [windows-2022, ubuntu-22.04, macos-15]
         build_type: ["Release", "Debug"]
         architecture: ["x64", "x86", "arm64"]
         msvc_runtime: ["static", "dynamic"]
         linux_abi: ["legacy", "c++11"]
         python_version: [3.9]
         include:
-        - os: windows-latest
+        - os: windows-2022
           vcpkg_triplet_suffix: "windows-static"
           sdk_platform: "windows"
-        - os: windows-latest
+        - os: windows-2022
           msvc_runtime: "dynamic"
           vcpkg_triplet_suffix: "windows-static-md"
           sdk_platform: "windows"
@@ -344,7 +344,7 @@ jobs:
           sdk_platform: "darwin"
 
         exclude:
-        - os: windows-latest
+        - os: windows-2022
           linux_abi: "c++11"
         - os: macos-15
           architecture: "x86"
@@ -360,7 +360,7 @@ jobs:
           build_type: "Debug"
         - os: ubuntu-22.04
           architecture: "arm64"
-        - os: windows-latest
+        - os: windows-2022
           architecture: "arm64"
 
     steps:

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -60,11 +60,11 @@ jobs:
         python_version: ${{ fromJson(needs.prepare_matrix.outputs.matrix_python_version) }}
         include:
           # More Windows combinations are in the expanded matrix. 
-          - os: windows-latest
+          - os: windows-2022
             build_type: "Release"
             architecture: "x64"
             msvc_runtime: "static"
-          - os: windows-latest
+          - os: windows-2022
             build_type: "Debug"
             architecture: "x86"
             msvc_runtime: "dynamic"
@@ -82,16 +82,16 @@ jobs:
           # Xcode excludes -- allow only one on osx and linux
           - os: ubuntu-22.04
             xcode_version: "11.7"
-          - os: windows-latest
+          - os: windows-2022
             xcode_version: "11.7"
           - os: ubuntu-22.04
             xcode_version: "12.5.1"
-          - os: windows-latest
+          - os: windows-2022
             xcode_version: "12.5.1"
           # arm64 is only for macos
           - os: ubuntu-22.04
             architecture: "arm64"
-          - os: windows-latest
+          - os: windows-2022
             architecture: "arm64"
           # arm64 can't be built on Xcode 11
           - xcode_version: "11.7"
@@ -189,6 +189,7 @@ jobs:
         with:
           python-version: ${{ matrix.python_version }}
           architecture: ${{ matrix.architecture }}
+
 
       - name: Install Desktop SDK prerequisites
         uses: nick-invision/retry@v2

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -21,7 +21,7 @@ on:
         required: true
       operating_systems:
         description: 'CSV of VMs to run on'
-        default: 'ubuntu-22.04,windows-latest,macos-15'
+        default: 'ubuntu-22.04,windows-2022,macos-15'
         required: true
       desktop_ssl_variants:
         description: 'CSV of desktop SSL variants to use'
@@ -278,7 +278,7 @@ jobs:
         # places.
         exclude:
         # Do not attempt to use arm64 on Windows or Linux.
-        - os: windows-latest
+        - os: windows-2022
           arch: arm64
         - os: ubuntu-22.04
           arch: arm64
@@ -289,7 +289,7 @@ jobs:
         # system's openssl when cross-compiling, except on Linux. Builds on Linux
         # happen on x64 machines, so x86 is technically cross-compiling. Builds on
         # Mac happen on arm64 machines, so x64 is technically cross-compiling.
-        - os: windows-latest
+        - os: windows-2022
           ssl_variant: openssl
           arch: x86
         - os: macos-15
@@ -848,7 +848,7 @@ jobs:
         # places.
         exclude:
         # Do not attempt to use arm64 on Windows or Linux.
-        - os: windows-latest
+        - os: windows-2022
           arch: arm64
         - os: ubuntu-22.04
           arch: arm64
@@ -859,7 +859,7 @@ jobs:
         # system's openssl when cross-compiling, except on Linux. Builds on Linux
         # happen on x64 machines, so x86 is technically cross-compiling. Builds on
         # Mac happen on arm64 machines, so x64 is technically cross-compiling.
-        - os: windows-latest
+        - os: windows-2022
           ssl_variant: openssl
           arch: x86
         - os: macos-15

--- a/scripts/gha/print_matrix_configuration.py
+++ b/scripts/gha/print_matrix_configuration.py
@@ -81,7 +81,7 @@ PARAMETERS = {
       "python_version": ["3.9"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-22.04", "macos-15", "windows-latest"],
+        "os": ["ubuntu-22.04", "macos-15", "windows-2022"],
         "xcode_version": ["26.2"],
       }
     }
@@ -89,19 +89,19 @@ PARAMETERS = {
 
   "android": {
     "matrix": {
-      "os": ["ubuntu-22.04", "macos-15", "windows-latest"],
+      "os": ["ubuntu-22.04", "macos-15", "windows-2022"],
       "architecture": ["x64", "arm64"],
       "python_version": ["3.9"],
 
       EXPANDED_KEY: {
-        "os": ["ubuntu-22.04", "macos-15", "windows-latest"]
+        "os": ["ubuntu-22.04", "macos-15", "windows-2022"]
       }
     }
   },
 
   "integration_tests": {
     "matrix": {
-      "os": ["ubuntu-22.04", "macos-15", "windows-latest"],
+      "os": ["ubuntu-22.04", "macos-15", "windows-2022"],
       "platform": ["Desktop", "Android", "iOS", "tvOS"],
       "ssl_lib": ["openssl"],
       "android_device": ["android_target", "emulator_ftl_target"],


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

The latest windows github runner windows 2026 comes with visual studio 18. Which need an updated version of Cmake (4.2+) to work. The generators concept introduced does not work with older version of cmake. Firestore still depend on Cmake 3.x feature so we cannot update Cmake While we wait for firestore updates pin windows to 2022 version.

See https://github.com/actions/runner-images/issues/14017 for more details
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Run github runners
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
