### PR TITLE
Change the GHA to use client-id, instead of app-id

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -30,7 +30,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Use expanded matrix
         if: github.event.inputs.use_expanded_matrix == '1'
         run: |
@@ -95,7 +94,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: true
-          persist-credentials: false
 
       - name: Set env variables for subsequent steps (all)
         shell: bash

--- a/.github/workflows/build-report.yml
+++ b/.github/workflows/build-report.yml
@@ -32,7 +32,6 @@ jobs:
     - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
       with:
         fetch-depth: 0
-        persist-credentials: false
     - name: Install Desktop SDK prerequisites
       uses: nick-invision/retry@14672906e672a08bd6eeb15720e9ed3ce869cdd4 # ratchet:nick-invision/retry@v2
       with:

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -25,7 +25,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -67,7 +66,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -107,7 +105,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Run check_copyright.sh
         run: |
           set -e
@@ -123,7 +120,6 @@ jobs:
         with:
           fetch-depth: 0
           submodules: false
-          persist-credentials: false
       - name: Check whether release notes have been updated
         # Skip this if the PR has the skipReleaseNotes label or if it's a merge to other than main.
         if: ${{!contains(github.event.pull_request.labels.*.name, env.skipReleaseNotesLabel) && (github.event.pull_request.base.ref == 'main')}}

--- a/.github/workflows/checks_secure.yml
+++ b/.github/workflows/checks_secure.yml
@@ -32,7 +32,6 @@ jobs:
         if: steps.check.outputs.has-permission != 1 || github.event.pull_request.head.repo.full_name != github.repository
         with:
           submodules: false
-          persist-credentials: false
       - name: Setup python
         if: steps.check.outputs.has-permission != 1 || github.event.pull_request.head.repo.full_name != github.repository
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -144,7 +144,6 @@ jobs:
           repository: llvm/llvm-project
           path: llvm-src
           ref: ${{ env.llvmVer }}
-          persist-credentials: false
 
       - name: Build LLVM (Mac only) 
         # Only build LLVM if we don't already have binaries from the cache.
@@ -167,7 +166,6 @@ jobs:
           repository: nico/demumble
           path: demumble-src
           ref: ${{ env.demumbleVer }}
-          persist-credentials: false
 
       - name: build demumble
         run: |
@@ -214,7 +212,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           path: sdk-src
-          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
@@ -270,7 +267,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           path: sdk-src
-          persist-credentials: false
 
       - name: Store git credentials for all git commands
         # Forces all git commands to use authenticated https, to prevent throttling.
@@ -385,7 +381,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: true
-          persist-credentials: false
 
       - name: Set env variables for subsequent steps (all)
         shell: bash
@@ -529,7 +524,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           path: sdk-src
-          persist-credentials: false
 
       - name: download packaging-tool artifacts
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
@@ -740,7 +734,6 @@ jobs:
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           path: sdk-src
-          persist-credentials: false
 
       - name: download artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
@@ -866,8 +859,6 @@ jobs:
     steps:
     - name: Checkout repo
       uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
-      with:
-        persist-credentials: false
 
     - name: Setup python
       uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
@@ -942,8 +933,6 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
-        with:
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:

--- a/.github/workflows/cpp-packaging.yml
+++ b/.github/workflows/cpp-packaging.yml
@@ -887,8 +887,7 @@ jobs:
       uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
       id: generate-token
       with:
-        # we should migrate to client-id
-        app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+        client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
         private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
         permission-actions: write
     - name: Use GitHub API to start workflow
@@ -956,8 +955,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Retry failed tests

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -32,7 +32,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Use expanded matrix
         if: github.event.inputs.expanded_matrix == '1'
         run: |
@@ -119,7 +118,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: true
-          persist-credentials: false
       
       - name: Set env vars (ubuntu)
         if: startsWith(matrix.os, 'ubuntu')
@@ -331,7 +329,6 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
-          persist-credentials: false
       - name: Cache vcpkg C++ dependencies
         id: cache_vcpkg
         uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c # ratchet:actions/cache@v3

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -1526,8 +1526,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           permission-pull-requests: write
       - name: Update PR label and comment
@@ -1601,8 +1600,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           permission-actions: write
       - name: Retry failed tests

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -158,7 +158,6 @@ jobs:
         ref: ${{steps.set_outputs.outputs.github_ref}}
         fetch-depth: 0
         submodules: false
-        persist-credentials: false
     - name: Setup python
       uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
       with:
@@ -312,7 +311,6 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -486,7 +484,6 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
-          persist-credentials: false
       - run: df -h
       - name: Free Disk Space (Ubuntu)
         if: runner.os == 'Linux'
@@ -631,7 +628,6 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -754,7 +750,6 @@ jobs:
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
           submodules: true
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -894,7 +889,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Download Desktop integration tests artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
@@ -1025,7 +1019,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Download Android integration tests artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
@@ -1171,7 +1164,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Download iOS integration tests artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
@@ -1357,7 +1349,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Download tvOS integration tests artifact
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # ratchet:actions/download-artifact@v4
         with:
@@ -1507,7 +1498,6 @@ jobs:
         with:
 
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:
@@ -1588,7 +1578,6 @@ jobs:
         with:
 
           ref: ${{needs.check_and_prepare.outputs.github_ref}}
-          persist-credentials: false
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4
         with:

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -26,7 +26,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
-          persist-credentials: false
       - name: Use expanded matrix
         if: github.event.inputs.use_expanded_matrix == '1'
         run: |
@@ -62,7 +61,6 @@ jobs:
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: true
-          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -17,12 +17,10 @@ jobs:
           repository: cpplint/cpplint
           ref: "1.5.5"
           path: cpplint
-          persist-credentials: false
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
         with:
           submodules: false
           path: firebase
-          persist-credentials: false
 
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4

--- a/.github/workflows/retry-test-failures.yml
+++ b/.github/workflows/retry-test-failures.yml
@@ -16,8 +16,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           permission-actions: write
 

--- a/.github/workflows/retry-test-failures.yml
+++ b/.github/workflows/retry-test-failures.yml
@@ -30,7 +30,6 @@ jobs:
           ref: ${{ matrix.branch_name }}
           fetch-depth: 0
           submodules: false
-          persist-credentials: false
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -48,7 +48,6 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.inputs.baseBranch }}
-          persist-credentials: false
 
       - name: Install prerequisites
         run: |

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,14 +30,12 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Get token for firebase-workflow-trigger
-        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
+        uses: tibdex/github-app-token@v1
         id: generate-token
         with:
           # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
-          private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
-          permission-contents: write
-          permission-pull-requests: write
+          app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
 
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4

--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -30,12 +30,13 @@ jobs:
     runs-on: macos-15
     steps:
       - name: Get token for firebase-workflow-trigger
-        uses: tibdex/github-app-token@v1
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app_id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
-          private_key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
+          private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Setup python
         uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c # ratchet:actions/setup-python@v4

--- a/.github/workflows/update-feature-branches.yml
+++ b/.github/workflows/update-feature-branches.yml
@@ -77,8 +77,7 @@ jobs:
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # ratchet:actions/create-github-app-token@v1
         id: generate-token
         with:
-          # we should migrate to client-id
-          app-id: ${{ secrets.WORKFLOW_TRIGGER_APP_ID }}
+          client-id: ${{ secrets.WORKFLOW_TRIGGER_CLIENT_ID }}
           private-key: ${{ secrets.WORKFLOW_TRIGGER_APP_PRIVATE_KEY }}
           permission-contents: write
           permission-pull-requests: write

--- a/.github/workflows/update-feature-branches.yml
+++ b/.github/workflows/update-feature-branches.yml
@@ -33,8 +33,6 @@ jobs:
       - name: Check out repo (if needed)
         if: ${{ github.event.inputs.branch_list == '' }}
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # ratchet:actions/checkout@v3
-        with:
-          persist-credentials: false
 
       - name: Get list of feature branches
         id: get-branches
@@ -92,7 +90,6 @@ jobs:
           ref: ${{ matrix.branch_name }}
           fetch-depth: 0
           submodules: false
-          persist-credentials: false
 
       - name: Install prerequisites
         run: |


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

app-id is deprecated in the greate-github-app-token workflow, so switch to client-id.  Also, remove the "persist-credentials: false" across the workflows, as they cause a lot of issues.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
