### PR TITLE
Upgrade JUnit 4 to 4.13.2 to resolve CVE-2020-15250

### DIFF
--- a/scripts/gha/integration_testing/gameloop_android/app/build.gradle
+++ b/scripts/gha/integration_testing/gameloop_android/app/build.gradle
@@ -29,7 +29,9 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    // 1.1.5 is used instead of newer versions (e.g. 1.3.0) to maintain compatibility
+    // with the project's older Kotlin (1.3.72) and Gradle (7.4.2) versions.
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/scripts/gha/ui_testing/uitest_android/app/build.gradle
+++ b/scripts/gha/ui_testing/uitest_android/app/build.gradle
@@ -40,8 +40,10 @@ android {
 dependencies {
     implementation fileTree(dir: "libs", include: ["*.jar"])
     implementation 'androidx.appcompat:appcompat:1.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.1'
+    testImplementation 'junit:junit:4.13.2'
+    // 1.1.5 is used instead of newer versions (e.g. 1.3.0) to maintain compatibility
+    // with the project's older Kotlin and Gradle versions.
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
     androidTestImplementation 'androidx.test:runner:' + rootProject.runnerVersion
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:' + rootProject.uiautomatorVersion


### PR DESCRIPTION
### Description
Upgraded 'androidx.test.ext:junit' from '1.1.1' to '1.1.5', which transitively pulls in the patched 'junit:junit:4.13.2'.

Note: We chose '1.1.5' over newer versions (like '1.3.0') to avoid dependency conflicts with the project's older Kotlin (1.3.72) and Gradle (7.4.2) configurations.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Run full set of integration test
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
