### PR TITLE
Fix macOS Firestore linker error by adding Network framework dependency

### DIFF
--- a/firestore/integration_test/CMakeLists.txt
+++ b/firestore/integration_test/CMakeLists.txt
@@ -207,6 +207,7 @@ else()
       "-framework CoreFoundation"
       "-framework Foundation"
       "-framework GSS"
+      "-framework Network"
       "-framework Security"
       "-framework SystemConfiguration"
     )

--- a/firestore/integration_test_internal/CMakeLists.txt
+++ b/firestore/integration_test_internal/CMakeLists.txt
@@ -371,6 +371,7 @@ else()
       "-framework CoreFoundation"
       "-framework Foundation"
       "-framework GSS"
+      "-framework Network"
       "-framework Security"
       "-framework SystemConfiguration"
     )


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Fix macOS Firestore linker error by adding Network framework dependency
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Will verify firestore build works
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [CX] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
