### PR TITLE
Update Android test framework polling

### DIFF
--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -62,7 +62,8 @@ bool ProcessEvents(int msec) {
       source->process(g_app_state, source);
     }
     msec = 0;
-  } while (looperId >= 0 && !g_destroy_requested && !g_restarted);
+  } while ((looperId >= 0 || looperId == ALOOPER_POLL_CALLBACK) &&
+           !g_destroy_requested && !g_restarted);
   return g_destroy_requested | g_restarted;
 }
 

--- a/testing/sample_framework/src/android/android_app_framework.cc
+++ b/testing/sample_framework/src/android/android_app_framework.cc
@@ -56,13 +56,13 @@ bool ProcessEvents(int msec) {
   do {
     struct android_poll_source* source = nullptr;
     int events;
-    looperId = ALooper_pollAll(msec, nullptr, &events,
-                               reinterpret_cast<void**>(&source));
+    looperId = ALooper_pollOnce(msec, nullptr, &events,
+                                reinterpret_cast<void**>(&source));
     if (looperId >= 0 && source) {
       source->process(g_app_state, source);
     }
-  } while (looperId != ALOOPER_POLL_TIMEOUT && !g_destroy_requested &&
-           !g_restarted);
+    msec = 0;
+  } while (looperId >= 0 && !g_destroy_requested && !g_restarted);
   return g_destroy_requested | g_restarted;
 }
 


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

ALooper_pollAll has been deprecated and removed in newer NDK versions. Switch to use ALooper_pollOnce instead.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
