### PR TITLE
Add explicit device logic to the iOS build script

### DIFF
--- a/scripts/gha/build_ios_tvos.py
+++ b/scripts/gha/build_ios_tvos.py
@@ -483,10 +483,14 @@ def cmake_configure(source_path, build_path, toolchain, archive_output_path,
     cmd.append('-DCMAKE_SYSTEM_NAME=iOS')
     if platform_variant == 'simulator':
       cmd.append('-DCMAKE_OSX_SYSROOT=iphonesimulator')
+    elif platform_variant == 'device':
+      cmd.append('-DCMAKE_OSX_SYSROOT=iphoneos')
   elif apple_os == 'tvos':
     cmd.append('-DCMAKE_SYSTEM_NAME=tvOS')
     if platform_variant == 'simulator':
       cmd.append('-DCMAKE_OSX_SYSROOT=appletvsimulator')
+    elif platform_variant == 'device':
+      cmd.append('-DCMAKE_OSX_SYSROOT=appletvos')
   cmd.append('-DCMAKE_ARCHIVE_OUTPUT_DIRECTORY={0}'.format(archive_output_path))
   cmd.append('-DCMAKE_LIBRARY_OUTPUT_DIRECTORY={0}'.format(archive_output_path))
   cmd.append('-DCMAKE_RUNTIME_OUTPUT_DIRECTORY={0}'.format(archive_output_path))


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

When building for iOS and tvOS device, set the appropriate CMAKE_OSX_SYSROOT value. Seems to be necessary based on Xcode and Cmake versions.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building locally.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
