### PR TITLE
Disable new Messaging test on Desktop and Emulator

### DIFF
--- a/messaging/integration_test/src/integration_test.cc
+++ b/messaging/integration_test/src/integration_test.cc
@@ -560,6 +560,9 @@ TEST_F(FirebaseMessagingTest, TestRegistrationOnInitEnabled) {
 
 TEST_F(FirebaseMessagingTest, TestRegisterAndUnregister) {
   TEST_REQUIRES_USER_INTERACTION_ON_IOS;
+  SKIP_TEST_ON_DESKTOP;
+  SKIP_TEST_ON_ANDROID_EMULATOR;
+
   EXPECT_TRUE(RequestPermission());
 
   // Note that these methods should only work if the newer registration

--- a/release_build_files/readme.md
+++ b/release_build_files/readme.md
@@ -613,13 +613,16 @@ workflow use only during the development of your app, not for publicly shipping
 code.
 
 ## Release Notes
+### Upcoming
+- Changes
+    - Messaging: Added new Registration methods using Installation Ids.
+      Deprecated old Token based methods.
+
 ### 13.11.0
 - Changes
     - General (Android): Update to Firebase Android BoM version 34.17.0.
     - General (iOS): Update to Firebase Cocoapods version 12.17.0.
     - Realtime Database (Desktop): Fixed an intermittent use-after-free crash (`ACCESS_VIOLATION`) when detaching a listener while a WebSocket listen response is pending.
-    - Messaging: Added new Registration methods using Installation Ids.
-    Deprecated old Token based methods.
 
 ### 13.10.0
 - Changes


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Disable the new Messaging test on Desktop and Android Emulator. The functionality is stubbed out on Desktop, and Android Emulators behave differently. This is inline with most other tests in the file. Also, moving the readme line to upcoming.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
