### PR TITLE
Explicitly set curl to build statically

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,12 +426,12 @@ endif()
 # Some of the external libraries are not used for mobile.
 if(DESKTOP)
   # Build curl as a static library
-  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static libraries")
-  set(BUILD_CURL_EXE OFF CACHE BOOL "Disable curl executable")
-  set(CURL_STATICLIB ON CACHE BOOL "")
+  set(BUILD_SHARED_LIBS OFF)
+  set(BUILD_CURL_EXE OFF)
+  set(CURL_STATICLIB ON)
   if (WIN32)
     # Enable Windows native SSL/TLS in libcurl.
-    set(CMAKE_USE_SCHANNEL ON CACHE BOOL "")
+    set(CMAKE_USE_SCHANNEL ON)
   endif()
 
   # Current Curl library defaults to requiring some dependencies we don't need, disable them.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -426,6 +426,8 @@ endif()
 # Some of the external libraries are not used for mobile.
 if(DESKTOP)
   # Build curl as a static library
+  set(BUILD_SHARED_LIBS OFF CACHE BOOL "Build static libraries")
+  set(BUILD_CURL_EXE OFF CACHE BOOL "Disable curl executable")
   set(CURL_STATICLIB ON CACHE BOOL "")
   if (WIN32)
     # Enable Windows native SSL/TLS in libcurl.


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Explicitly set CMake flags to make curl build as a static library. Note that this should effectively be a no-op, since these flags are set by the underlying iOS Firestore CMake logic, the problem only occurs when building without enabling Firestore.
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.

Building locally, and checking the resulting bundle symbols.
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [x] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.
