### PR TITLE
Chore: Remove _LIBCPP_DISABLE_AVAILABILITY build flag

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -491,7 +491,6 @@ if(DESKTOP)
         -DUSE_LIBUV=1
       )
     elseif(APPLE)
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D_LIBCPP_DISABLE_AVAILABILITY")
       set(websockets_additional_defines
         ${websockets_additional_defines}
         -DUSE_LIBUV=1


### PR DESCRIPTION
### Description
> Provide details of the change, and generalize the change in the PR title above.

Chore: Remove _LIBCPP_DISABLE_AVAILABILITY build flag 
This was added in while trying to get some swift code to compile on older ios devices ~iOS 15. The root issue was a missing c++ function on the older devices that has since been added in #1877 
***
### Testing
> Describe how you've tested these changes. Link any manually triggered `Integration tests` or `CPP binary SDK Packaging` Github Action workflows, if applicable.


Ran the build locally and test on various ios simulators versions 15.2 and 26.3.1.
Test with the analytics test app as that was the product that needed the symbol. 
***

### Type of Change
Place an `x` the applicable box:
- [ ] Bug fix. Add the issue # below if applicable.
- [ ] New feature. A non-breaking change which adds functionality.
- [X] Other, such as a build process or documentation change.
***

#### Notes
- Bug fixes and feature changes require an update to the `Release Notes` section of `release_build_files/readme.md`.
- Read the contribution guidelines [CONTRIBUTING.md](https://github.com/firebase/firebase-cpp-sdk/blob/main/CONTRIBUTING.md).
- Changes to the public API require an internal API review. If you'd like to help us make Firebase APIs better, please propose your change in a feature request so that we can discuss it together.

Relevant to #1887 